### PR TITLE
Updated pallas, utxorpc sdk to support utxorpc-spec v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,16 +1921,16 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pallas"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "pallas-addresses",
  "pallas-applying",
- "pallas-codec 0.21.0",
+ "pallas-codec 0.23.0",
  "pallas-configs",
- "pallas-crypto 0.21.0",
+ "pallas-crypto 0.23.0",
  "pallas-hardano",
- "pallas-network 0.21.0",
+ "pallas-network 0.23.0",
  "pallas-primitives",
  "pallas-rolldb",
  "pallas-traverse",
@@ -1932,28 +1941,28 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
  "hex",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "sha3",
  "thiserror",
 ]
 
 [[package]]
 name = "pallas-applying"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "hex",
  "pallas-addresses",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "pallas-primitives",
  "pallas-traverse",
  "rand",
@@ -1973,8 +1982,8 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "hex",
  "minicbor 0.20.0",
@@ -1984,14 +1993,14 @@ dependencies = [
 
 [[package]]
 name = "pallas-configs"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "base64 0.21.5",
  "hex",
  "pallas-addresses",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "serde",
  "serde_json",
 ]
@@ -2012,12 +2021,12 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 0.21.0",
+ "pallas-codec 0.23.0",
  "rand_core 0.6.4",
  "serde",
  "thiserror",
@@ -2025,11 +2034,11 @@ dependencies = [
 
 [[package]]
 name = "pallas-hardano"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "binary-layout",
- "pallas-network 0.21.0",
+ "pallas-network 0.23.0",
  "pallas-traverse",
  "tap",
  "thiserror",
@@ -2044,7 +2053,7 @@ checksum = "69d5fb0899c37f74b2b3366d44eef85d44aea2b1cd8e9548263977baa252d9f4"
 dependencies = [
  "byteorder",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "pallas-codec 0.20.0",
  "pallas-crypto 0.20.0",
  "thiserror",
@@ -2054,14 +2063,14 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "byteorder",
  "hex",
- "itertools",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "itertools 0.12.1",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "rand",
  "socket2 0.5.5",
  "thiserror",
@@ -2071,29 +2080,29 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "hex",
  "log",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "pallas-rolldb"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "async-stream",
  "bincode",
  "futures-core",
  "futures-util",
- "pallas-crypto 0.21.0",
+ "pallas-crypto 0.23.0",
  "rocksdb",
  "serde",
  "thiserror",
@@ -2103,13 +2112,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "hex",
  "pallas-addresses",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "pallas-primitives",
  "paste",
  "serde",
@@ -2118,13 +2127,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-txbuilder"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "hex",
  "pallas-addresses",
- "pallas-codec 0.21.0",
- "pallas-crypto 0.21.0",
+ "pallas-codec 0.23.0",
+ "pallas-crypto 0.23.0",
  "pallas-primitives",
  "pallas-traverse",
  "pallas-wallet",
@@ -2135,25 +2144,25 @@ dependencies = [
 
 [[package]]
 name = "pallas-utxorpc"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
- "pallas-codec 0.21.0",
+ "pallas-codec 0.23.0",
  "pallas-primitives",
  "pallas-traverse",
- "utxorpc",
+ "utxorpc-spec",
 ]
 
 [[package]]
 name = "pallas-wallet"
-version = "0.21.0"
-source = "git+https://github.com/txpipe/pallas.git#7b2894e4a26943c974fe90d3ac341fb0b597768d"
+version = "0.23.0"
+source = "git+https://github.com/txpipe/pallas.git#5a44f38e7a5ecce618624b2519113b2f68c9ffa6"
 dependencies = [
  "bech32 0.9.1",
  "bip39",
  "cryptoxide",
  "ed25519-bip32",
- "pallas-crypto 0.21.0",
+ "pallas-crypto 0.23.0",
  "rand",
  "thiserror",
 ]
@@ -2187,7 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "prost",
  "prost-types",
 ]
@@ -2342,7 +2351,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2363,7 +2372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3595,31 +3604,16 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "utxorpc"
 version = "1.0.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1841467f5ca405d4e878be56e1a8c8ae1f6f62b50984988027f6b4859d36c0"
+source = "git+https://github.com/Mercurial/rust-sdk.git?branch=feat/update-dependency-spec-0.3.0#26fd2152bd2185775c372311d68c615aac14f3a5"
 dependencies = [
- "utxorpc-spec-cardano",
- "utxorpc-spec-sync",
+ "utxorpc-spec",
 ]
 
 [[package]]
-name = "utxorpc-spec-cardano"
-version = "1.0.0-alpha.1"
+name = "utxorpc-spec"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1a8c03aef60aa154ae04fe871c9a6fab18c99f468f0ddc096e45c21c5b6814"
-dependencies = [
- "bytes",
- "pbjson",
- "pbjson-types",
- "prost",
- "serde",
-]
-
-[[package]]
-name = "utxorpc-spec-sync"
-version = "1.0.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f7ab73d37f96892e16a5c89f9aa430b9efdcaa5f2a0259a87f99a2eb732ea0"
+checksum = "88f80e24bfe310d0972406d15c0892ff09b6c81ded2cdefc0183aac35cf0514f"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3627,7 +3621,6 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "utxorpc-spec-cardano",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ pallas = { git = "https://github.com/txpipe/pallas.git", features = ["unstable"]
 gasket = { version = "^0.5", features = ["derive"] }
 # gasket = { path = "../../construkts/gasket-rs/gasket", features = ["derive"] }
 
-utxorpc = { version = "1.0.0-alpha.1" }
+utxorpc = { git = "https://github.com/Mercurial/rust-sdk.git",branch = "feat/update-dependency-spec-0.3.0" }
 # utxorpc = { path = "../../utxorpc/rust-sdk" }
 
 hex = "0.4.3"
@@ -46,7 +46,7 @@ tokio-stream = { version = "0.1.14", features = ["sync"] }
 futures-util = "0.3.28"
 async-stream = "0.3.5"
 serde_with = "3.4.0"
-mithril-client = { version = "0.5.7", optional = true }
+mithril-client = { version = "0.5.7", optional = true, features = ["fs"]}
 protoc-wkt = "1.0.0"
 
 [dev-dependencies]

--- a/src/serve/grpc/mod.rs
+++ b/src/serve/grpc/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tonic::transport::{Certificate, Server, ServerTlsConfig};
 
 use tracing::info;
-use utxorpc::proto::sync::v1::chain_sync_service_server::ChainSyncServiceServer;
+use utxorpc::proto::v1alpha::sync::chain_sync_service_server::ChainSyncServiceServer;
 
 use crate::prelude::*;
 
@@ -23,8 +23,8 @@ pub async fn serve(config: Config, wal: wal::Store, chain: chain::Store) -> Resu
     let service = ChainSyncServiceServer::new(service);
 
     let reflection = tonic_reflection::server::Builder::configure()
-        .register_encoded_file_descriptor_set(utxorpc::proto::cardano::v1::FILE_DESCRIPTOR_SET)
-        .register_encoded_file_descriptor_set(utxorpc::proto::sync::v1::FILE_DESCRIPTOR_SET)
+        .register_encoded_file_descriptor_set(utxorpc::proto::v1alpha::cardano::FILE_DESCRIPTOR_SET)
+        .register_encoded_file_descriptor_set(utxorpc::proto::v1alpha::sync::FILE_DESCRIPTOR_SET)
         .register_encoded_file_descriptor_set(protoc_wkt::google::protobuf::FILE_DESCRIPTOR_SET)
         .build()
         .unwrap();

--- a/src/serve/grpc/sync.rs
+++ b/src/serve/grpc/sync.rs
@@ -6,7 +6,11 @@ use pallas::{
 use std::pin::Pin;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
-use utxorpc::proto::sync::v1::*;
+use utxorpc::proto::v1alpha::sync::{
+    chain_sync_service_server, follow_tip_response, AnyChainBlock, BlockRef, DumpHistoryRequest,
+    DumpHistoryResponse, FetchBlockRequest, FetchBlockResponse, FollowTipRequest,
+    FollowTipResponse,
+};
 
 fn bytes_to_hash(raw: &[u8]) -> Hash<32> {
     let array: [u8; 32] = raw.try_into().unwrap();
@@ -22,12 +26,12 @@ fn raw_to_anychain(raw: &[u8]) -> AnyChainBlock {
     let block = pallas::interop::utxorpc::map_block_cbor(raw);
 
     AnyChainBlock {
-        chain: utxorpc::proto::sync::v1::any_chain_block::Chain::Cardano(block).into(),
+        chain: utxorpc::proto::v1alpha::sync::any_chain_block::Chain::Cardano(block).into(),
     }
 }
 
 fn roll_to_tip_response(log: wal::Log) -> FollowTipResponse {
-    utxorpc::proto::sync::v1::FollowTipResponse {
+    utxorpc::proto::v1alpha::sync::FollowTipResponse {
         action: match log {
             wal::Log::Apply(_, _, block) => {
                 follow_tip_response::Action::Apply(raw_to_anychain(&block)).into()


### PR DESCRIPTION
This PR updates dolos to support the new `utxorpc-spec 0.3.0`. 

This uses utxorpc `rust-sdk` temporary branch https://github.com/utxorpc/rust-sdk/pull/2 `Mercurial:feat/update-dependency-spec-0.3.0` 

Most likely should wait for PR to be merged and point to the merged version in `Cargo.toml` instead or a published crate version.