### PR TITLE
Serve up raw-bytes in follow-tip method

### DIFF
--- a/src/serve/grpc/sync.rs
+++ b/src/serve/grpc/sync.rs
@@ -26,6 +26,7 @@ fn raw_to_anychain(mapper: &Mapper<LedgerStore>, raw: &wal::RawBlock) -> u5c::sy
     let block = mapper.map_block_cbor(body);
 
     u5c::sync::AnyChainBlock {
+        native_bytes: body.to_vec().into(),
         chain: u5c::sync::any_chain_block::Chain::Cardano(block).into(),
     }
 }


### PR DESCRIPTION
This allows users to fetch *either* the raw bytes, *or* the parsed object, or both;

Depends on bumping the utxorpc-spec version in pallas, I believe.