### PR TITLE
fix(serve): grpc endpoint search utxo `UtxOPredicate` asset_name was pointing to policy_id function

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -117,9 +117,9 @@ impl LedgerStore {
         }
     }
 
-    pub fn get_utxo_by_asset(&self, policy: &[u8]) -> Result<UtxoSet, LedgerError> {
+    pub fn get_utxo_by_asset(&self, asset: &[u8]) -> Result<UtxoSet, LedgerError> {
         match self {
-            LedgerStore::Redb(x) => x.get_utxo_by_asset(policy),
+            LedgerStore::Redb(x) => x.get_utxo_by_asset(asset),
         }
     }
 

--- a/src/state/redb/mod.rs
+++ b/src/state/redb/mod.rs
@@ -226,7 +226,7 @@ impl LedgerStore {
 
     pub fn get_utxo_by_asset(&self, asset: &[u8]) -> Result<UtxoSet, LedgerError> {
         match self {
-            LedgerStore::SchemaV2(x) => Ok(x.get_utxos_by_policy(asset)?),
+            LedgerStore::SchemaV2(x) => Ok(x.get_utxos_by_asset(asset)?),
             _ => Err(LedgerError::QueryNotSupported),
         }
     }


### PR DESCRIPTION
This PR fixes the `search_utxo` endpoint for grpc.

Because `UTxOPredicate` `asset_name` query was pointing to `policy_id` db lookup function instead