### PR TITLE
chore: Support CORS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -923,6 +923,7 @@ dependencies = [
  "tonic",
  "tonic-reflection",
  "tonic-web",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "trait-variant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ console-subscriber = { version = "0.3.0", optional = true }
 flate2 = "1.0.33"
 tar = "0.4.41"
 reqwest = { version = "0.12.7", features = ["blocking"] }
+tower-http = "0.4.4"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/bin/dolos/init/mod.rs
+++ b/src/bin/dolos/init/mod.rs
@@ -196,6 +196,7 @@ impl ConfigEditor {
                 self.0.serve.grpc = dolos::serve::grpc::Config {
                     listen_address: "[::]:50051".into(),
                     tls_client_ca_root: None,
+                    cors_enabled: true,
                 }
                 .into();
             } else {


### PR DESCRIPTION
Add CORS layer to tonic server. The [`CorsLayer::new()`](https://tidelabs.github.io/tidechain/tower_http/cors/struct.CorsLayer.html#method.new) behaves as having no layer at all. Dynamically adding the layer using the mutable server object ( `let mut server = ...; if cors_enabled { server = server.layer(cors) }`) is not quite possible out of the box, because it is not possible to dynamically add layers to a tonic server (https://github.com/hyperium/tonic/issues/1800)