### PR TITLE
Fix race condition between WAL and ledger state synchronization

### DIFF
--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -1,3 +1,4 @@
+use crate::ledger;
 use itertools::Itertools;
 use pallas::network::miniprotocols::Point as PallasPoint;
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,12 @@ impl PartialEq for ChainPoint {
             (Self::Origin, Self::Origin) => true,
             _ => false,
         }
+    }
+}
+
+impl From<ledger::ChainPoint> for ChainPoint {
+    fn from(value: ledger::ChainPoint) -> Self {
+        crate::wal::ChainPoint::Specific(value.0, value.1)
     }
 }
 


### PR DESCRIPTION
Adds a synchronisation check in the `follow_tip` stream to ensure the ledger has processed a block before emitting it to Dolos consumers. This prevents a block being emitted without its corresponding tx inputs.