### PR TITLE
Improve WAL IO Error

### DIFF
--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -111,7 +111,7 @@ pub enum WalError {
     #[error("slot not found in chain {0}")]
     SlotNotFound(BlockSlot),
 
-    #[error("IO error")]
+    #[error("IO error: {0}")]
     IO(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 


### PR DESCRIPTION
The current error message for IO issues lacks detail, making it difficult to debug effectively:

```
2024-12-15T16:40:33.698231Z ERROR stage{stage="ledger"}:bootstrap: gasket::framework: x=IO error
2024-12-15T16:40:33.698239Z ERROR stage{stage="pull"}:bootstrap: gasket::framework: x=IO error
2024-12-15T16:40:33.698280Z ERROR stage{stage="ledger"}: gasket::runtime: stage should stop retry=Retry(None)
2024-12-15T16:40:33.698290Z  INFO stage{stage="ledger"}: gasket::runtime: switching stage phase prev_phase=Bootstrap next_phase=Ended
2024-12-15T16:40:33.698292Z ERROR stage{stage="pull"}: gasket::runtime: stage should stop retry=Retry(None)
2024-12-15T16:40:33.698311Z  INFO stage{stage="pull"}: gasket::runtime: switching stage phase prev_phase=Bootstrap next_phase=Ended
2024-12-15T16:40:33.698475Z ERROR stage{stage="roll"}:schedule: gasket::framework: x=error receiving work unit through input port
2024-12-15T16:40:33.698507Z ERROR stage{stage="roll"}: gasket::runtime: stage should stop retry=Retry(None)
```

This change forwards the error from `redb`.

