### PR TITLE
fix: update min_fee_ref_script_cost_per_byte value from RationalNumber to u64 to match Pallas type update

### DIFF
--- a/src/ledger/pparams/mod.rs
+++ b/src/ledger/pparams/mod.rs
@@ -218,10 +218,7 @@ fn bootstrap_conway_pparams(
         governance_action_deposit: genesis.gov_action_deposit,
         drep_deposit: genesis.d_rep_deposit,
         drep_inactivity_period: genesis.d_rep_activity.into(),
-        minfee_refscript_cost_per_byte: pallas::ledger::primitives::conway::RationalNumber {
-            numerator: genesis.min_fee_ref_script_cost_per_byte,
-            denominator: 1,
-        },
+        minfee_refscript_cost_per_byte: genesis.min_fee_ref_script_cost_per_byte.into(),
     }
 }
 


### PR DESCRIPTION
This updates the min_fee_ref_script_cost_per_byte assignment from Rational to u64 in the Conway parameter bootstrapping to align with the Pallas update.

This change requires the update in [txpipe/pallas#563](https://github.com/txpipe/pallas/pull/563)