### PR TITLE
fix: final protocol param update not being applied

### DIFF
--- a/src/ledger/pparams/mod.rs
+++ b/src/ledger/pparams/mod.rs
@@ -317,6 +317,7 @@ fn apply_param_update(
             apply_field!(pparams, update, key_deposit);
             apply_field!(pparams, update, pool_deposit);
             apply_field!(pparams, update, desired_number_of_stake_pools);
+            apply_field!(pparams, update, protocol_version);
             apply_field!(pparams, update, min_pool_cost);
             apply_field!(pparams, update, expansion_rate);
             apply_field!(pparams, update, treasury_growth_rate);
@@ -336,6 +337,7 @@ fn apply_param_update(
             apply_field!(pparams, update, key_deposit);
             apply_field!(pparams, update, pool_deposit);
             apply_field!(pparams, update, desired_number_of_stake_pools);
+            apply_field!(pparams, update, protocol_version);
             apply_field!(pparams, update, min_pool_cost);
             apply_field!(pparams, update, ada_per_utxo_byte);
             apply_field!(pparams, update, execution_costs);
@@ -371,6 +373,7 @@ fn apply_param_update(
             apply_field!(pparams, update, key_deposit);
             apply_field!(pparams, update, pool_deposit);
             apply_field!(pparams, update, desired_number_of_stake_pools);
+            apply_field!(pparams, update, protocol_version);
             apply_field!(pparams, update, min_pool_cost);
             apply_field!(pparams, update, ada_per_utxo_byte);
             apply_field!(pparams, update, execution_costs);
@@ -406,6 +409,7 @@ fn apply_param_update(
             apply_field!(pparams, update, key_deposit);
             apply_field!(pparams, update, pool_deposit);
             apply_field!(pparams, update, desired_number_of_stake_pools);
+            apply_field!(pparams, update, protocol_version);
             apply_field!(pparams, update, min_pool_cost);
             apply_field!(pparams, update, ada_per_utxo_byte);
             apply_field!(pparams, update, execution_costs);
@@ -521,7 +525,7 @@ pub fn fold_until_epoch(
         }
     }
 
-    for epoch in 1..for_epoch {
+    for epoch in 1..=for_epoch {
         let epoch_updates: Vec<_> = updates
             .iter()
             .filter(|e| e.epoch() == (epoch - 1))

--- a/src/ledger/pparams/mod.rs
+++ b/src/ledger/pparams/mod.rs
@@ -525,7 +525,7 @@ pub fn fold_until_epoch(
         }
     }
 
-    for epoch in 1..=for_epoch {
+    for epoch in 1..=for_epoch + 1{
         let epoch_updates: Vec<_> = updates
             .iter()
             .filter(|e| e.epoch() == (epoch - 1))


### PR DESCRIPTION
This fixes a bug where the last two protocol parameter updates aren't being applied. The issue arises because the epoch for-loop does not include the last two updates due to how the filtering of the updates works.
This also fixes protocol version param not updating