### PR TITLE
feat: support shelley genesis utxos

### DIFF
--- a/src/bin/dolos/doctor/rebuild_ledger.rs
+++ b/src/bin/dolos/doctor/rebuild_ledger.rs
@@ -35,7 +35,7 @@ pub fn run(config: &crate::Config, _args: &Args, feedback: &Feedback) -> miette:
     {
         debug!("importing genesis");
 
-        let delta = dolos::ledger::compute_origin_delta(&genesis.byron);
+        let delta = dolos::ledger::compute_origin_delta(&genesis.byron, &genesis.shelley);
 
         light
             .apply(&[delta])

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -48,7 +48,7 @@ impl Stage {
     fn process_origin(&self) -> Result<(), WorkerError> {
         info!("applying origin");
 
-        let delta = crate::ledger::compute_origin_delta(&self.genesis.byron);
+        let delta = crate::ledger::compute_origin_delta(&self.genesis.byron, &self.genesis.shelley);
         self.ledger.apply(&[delta]).or_panic()?;
 
         Ok(())


### PR DESCRIPTION
This uses https://github.com/txpipe/pallas/pull/577 to add the Shelley genesis file UTXOs to dolos on startup

This means you can now query initial utxos created for localhost networks by tools like yaci-devkit in utxorpc