### PR TITLE
ci: Use github ARM runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
             args: "--locked --release"
 
           - release_for: Linux-arm64
-            build_on: buildjet-2vcpu-ubuntu-2204-arm
+            build_on: ubuntu-22.04-arm
             target: "aarch64-unknown-linux-gnu"
             args: "--locked --release"
 


### PR DESCRIPTION
Github ARM runnners are now free for public repos: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/