### PR TITLE
fix: Resolve reference inputs directly

### DIFF
--- a/src/serve/trp/methods.rs
+++ b/src/serve/trp/methods.rs
@@ -323,9 +323,11 @@ impl tx3_cardano::Ledger for Context {
                 .ledger
                 .get_utxos(
                     refs.iter()
-                        .map(|r#ref| TxoRef {
-                            0: pallas::ledger::primitives::Hash::<32>::from(r#ref.txid.as_slice()),
-                            1: r#ref.index,
+                        .map(|r#ref| {
+                            TxoRef(
+                                pallas::ledger::primitives::Hash::<32>::from(r#ref.txid.as_slice()),
+                                r#ref.index,
+                            )
                         })
                         .collect(),
                 )

--- a/src/serve/trp/methods.rs
+++ b/src/serve/trp/methods.rs
@@ -316,6 +316,28 @@ impl tx3_cardano::Ledger for Context {
             }
         }
 
+        // TODO: think about the position of this block
+        // ref have precedence
+        if let Some(Expression::UtxoRefs(refs)) = &query.r#ref {
+            let utxos = self
+                .ledger
+                .get_utxos(
+                    refs.iter()
+                        .map(|r#ref| TxoRef {
+                            0: pallas::ledger::primitives::Hash::<32>::from(r#ref.txid.as_slice()),
+                            1: r#ref.index,
+                        })
+                        .collect(),
+                )
+                .unwrap()
+                .iter()
+                .map(|(txoref, eracbor)| into_tx3_utxo(txoref, eracbor))
+                .collect::<Result<tx3_lang::UtxoSet, _>>()?;
+            if !utxos.is_empty() {
+                return Ok(utxos);
+            }
+        }
+
         let Some(mut result) = result else {
             return Ok(tx3_lang::UtxoSet::new());
         };


### PR DESCRIPTION
This PR modifies the `resolve_input` function in the `Context` struct to directly resolve reference inputs if they are present in the `InputQuery`.

**Key changes:**

- **Prioritized resolution of reference inputs:**
- **Early return for resolved references:** If reference inputs are successfully resolved, the function returns the resulting `UtxoSet` immediately, bypassing any further filtering or matching logic based on address, datum, or amount.
- **Comment indicating TODO:** A `TODO` comment has been added to indicate that the placement of this reference input resolution logic might need further consideration.

