### PR TITLE
feat(cardano): support forced stop epoch via config

### DIFF
--- a/crates/cardano/src/lib.rs
+++ b/crates/cardano/src/lib.rs
@@ -46,6 +46,7 @@ pub struct TrackConfig {
 pub struct Config {
     #[serde(default)]
     pub track: TrackConfig,
+    pub stop_epoch: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -84,7 +85,7 @@ impl dolos_core::ChainLogic for CardanoLogic {
     }
 
     fn execute_sweep<D: Domain>(&self, domain: &D, at: BlockSlot) -> Result<(), ChainError> {
-        sweep::sweep(domain, at)?;
+        sweep::sweep(domain, at, &self.config)?;
 
         Ok(())
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -469,6 +469,9 @@ pub enum ChainError {
 
     #[error("pparams not found")]
     PParamsNotFound,
+
+    #[error("forced stop epoch reached")]
+    StopEpochReached,
 }
 
 pub trait ChainLogic: Sized + Send + Sync {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable stop epoch parameter: Users can now set a maximum epoch threshold for chain processing operations. When chain processing reaches the specified stop epoch, the system will automatically halt gracefully and return an appropriate error message, providing enhanced control over chain synchronization workflows and establishing fully configurable processing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->