### PR TITLE
fix(cardano): clear delegators on retiring drep

### DIFF
--- a/crates/cardano/src/pallas_extras.rs
+++ b/crates/cardano/src/pallas_extras.rs
@@ -268,3 +268,13 @@ pub fn default_cost_models() -> CostModels {
         unknown: Default::default(),
     }
 }
+
+pub const DREP_KEY_PREFIX: u8 = 0b00100010;
+pub const DREP_SCRIPT_PREFIX: u8 = 0b00100011;
+
+pub fn stake_cred_to_drep(cred: &StakeCredential) -> DRep {
+    match cred {
+        StakeCredential::AddrKeyhash(key) => DRep::Key(*key),
+        StakeCredential::ScriptHash(key) => DRep::Script(*key),
+    }
+}

--- a/crates/cardano/src/roll/accounts.rs
+++ b/crates/cardano/src/roll/accounts.rs
@@ -196,14 +196,14 @@ impl dolos_core::EntityDelta for VoteDelegation {
         let entity = entity.get_or_insert_default();
 
         // save undo info
-        self.prev_drep_id = entity.drep.clone();
+        self.prev_drep_id = entity.latest_drep.clone();
 
-        entity.drep = Some(self.drep.clone());
+        entity.latest_drep = Some(self.drep.clone());
     }
 
     fn undo(&self, entity: &mut Option<AccountState>) {
         let entity = entity.get_or_insert_default();
-        entity.drep = self.prev_drep_id.clone();
+        entity.latest_drep = self.prev_drep_id.clone();
     }
 }
 
@@ -244,18 +244,18 @@ impl dolos_core::EntityDelta for StakeDeregistration {
         // save undo info
         self.prev_registered_at = entity.registered_at;
         self.prev_pool_id = entity.latest_pool.clone();
-        self.prev_drep = entity.drep.clone();
+        self.prev_drep = entity.latest_drep.clone();
 
         entity.registered_at = None;
         entity.latest_pool = None;
-        entity.drep = None;
+        entity.latest_drep = None;
     }
 
     fn undo(&self, entity: &mut Option<AccountState>) {
         let entity = entity.get_or_insert_default();
         entity.registered_at = self.prev_registered_at;
         entity.latest_pool = self.prev_pool_id.clone();
-        entity.drep = self.prev_drep.clone();
+        entity.latest_drep = self.prev_drep.clone();
     }
 }
 

--- a/crates/cardano/src/sweep/commit.rs
+++ b/crates/cardano/src/sweep/commit.rs
@@ -76,9 +76,8 @@ impl BoundaryWork {
 
             if self.retired_dreps.contains(&key) {
                 state.retired = true;
+                writer.write_entity_typed::<crate::DRepState>(&key, &state)?;
             }
-
-            writer.write_entity_typed::<crate::DRepState>(&key, &state)?;
         }
 
         Ok(())

--- a/crates/cardano/src/sweep/commit.rs
+++ b/crates/cardano/src/sweep/commit.rs
@@ -36,7 +36,7 @@ impl BoundaryWork {
         for record in accounts {
             let (key, mut state) = record?;
 
-            if self.dropped_delegators.contains(&key) {
+            if self.dropped_pool_delegators.contains(&key) {
                 state.latest_pool = None;
             }
 
@@ -48,7 +48,29 @@ impl BoundaryWork {
 
             state.active_pool = state.latest_pool.clone();
 
+            if self.dropped_drep_delegators.contains(&key) {
+                state.latest_drep = None;
+            }
+
             writer.write_entity_typed::<AccountState>(&key, &state)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_drep_data<W: StateWriter>(
+        &self,
+        writer: &W,
+        dreps: impl Iterator<Item = Result<(EntityKey, crate::DRepState), StateError>>,
+    ) -> Result<(), ChainError> {
+        for record in dreps {
+            let (key, mut state) = record?;
+
+            if self.retired_dreps.contains(&key) {
+                state.retired = true;
+            }
+
+            writer.write_entity_typed::<crate::DRepState>(&key, &state)?;
         }
 
         Ok(())
@@ -138,10 +160,15 @@ impl BoundaryWork {
             .state()
             .iter_entities_typed::<PoolState>(PoolState::NS, None)?;
 
+        let dreps = domain
+            .state()
+            .iter_entities_typed::<crate::DRepState>(crate::DRepState::NS, None)?;
+
         let writer = domain.state().start_writer()?;
 
         self.rotate_pool_stake_data(&writer, pools)?;
         self.rotate_account_stake_data(&writer, accounts)?;
+        self.update_drep_data(&writer, dreps)?;
         self.drop_active_epoch(&writer)?;
         self.promote_waiting_epoch(&writer)?;
         self.promote_ending_epoch(&writer)?;

--- a/crates/cardano/src/sweep/loading.rs
+++ b/crates/cardano/src/sweep/loading.rs
@@ -3,25 +3,38 @@ use std::collections::{HashMap, HashSet};
 use dolos_core::{ChainError, Domain, EntityKey, StateStore};
 
 use crate::{
-    load_active_era, mutable_slots,
-    sweep::{AccountId, BoundaryWork, PoolData, PoolId, Snapshot},
-    AccountState, FixedNamespace as _, PoolState,
+    drep_to_entity_key, load_active_era, mutable_slots,
+    sweep::{AccountId, BoundaryWork, DRepId, PoolData, PoolId, Snapshot},
+    AccountState, DRepState, FixedNamespace as _, PoolState,
 };
 
 impl Snapshot {
-    pub fn insert_account_data(
+    pub fn track_account(
         &mut self,
         account: &AccountId,
-        pool_id: &PoolId,
+        pool_id: Option<PoolId>,
+        drep_id: Option<DRepId>,
         stake: u64,
     ) -> Result<(), ChainError> {
-        self.accounts_by_pool
-            .insert(pool_id.clone(), account.clone(), stake);
+        if let Some(pool_id) = pool_id {
+            self.accounts_by_pool
+                .insert(pool_id.clone(), account.clone(), stake);
 
-        self.pool_stake
-            .entry(pool_id.clone())
-            .and_modify(|x| *x += stake)
-            .or_insert(stake);
+            self.pool_stake
+                .entry(pool_id.clone())
+                .and_modify(|x| *x += stake)
+                .or_insert(stake);
+        }
+
+        if let Some(drep_id) = drep_id {
+            self.accounts_by_drep
+                .insert(drep_id.clone(), account.clone(), stake);
+
+            self.drep_stake
+                .entry(drep_id.clone())
+                .and_modify(|x| *x += stake)
+                .or_insert(stake);
+        }
 
         self.total_stake += stake;
 
@@ -44,25 +57,23 @@ pub fn load_account_data<D: Domain>(
     for record in accounts {
         let (account_id, account) = record?;
 
-        if let Some(pool_id) = account.latest_pool.clone() {
-            let pool_id = EntityKey::from(pool_id);
+        // ending snapshot
+        let pool_id = account.latest_pool.clone().map(EntityKey::from);
+        let drep_id = account.latest_drep.clone().map(drep_to_entity_key);
+        let stake = account.live_stake();
 
-            boundary.ending_snapshot.insert_account_data(
-                &account_id,
-                &pool_id,
-                account.live_stake(),
-            )?;
-        }
+        boundary
+            .ending_snapshot
+            .track_account(&account_id, pool_id, drep_id, stake)?;
 
-        if let Some(pool_id) = account.active_pool.clone() {
-            let pool_id = EntityKey::from(pool_id);
+        // active snapshot
+        let pool_id = account.active_pool.clone().map(EntityKey::from);
+        let drep_id = account.latest_drep.clone().map(drep_to_entity_key);
+        let stake = account.active_stake;
 
-            boundary.active_snapshot.insert_account_data(
-                &account_id,
-                &pool_id,
-                account.active_stake,
-            )?;
-        }
+        boundary
+            .active_snapshot
+            .track_account(&account_id, pool_id, drep_id, stake)?;
     }
 
     Ok(())
@@ -90,6 +101,19 @@ fn load_pool_params<D: Domain>(domain: &D, boundary: &mut BoundaryWork) -> Resul
     Ok(())
 }
 
+fn load_drep_data<D: Domain>(domain: &D, boundary: &mut BoundaryWork) -> Result<(), ChainError> {
+    let dreps = domain
+        .state()
+        .iter_entities_typed::<DRepState>(DRepState::NS, None)?;
+
+    for record in dreps {
+        let (drep_id, drep) = record?;
+        boundary.dreps.insert(drep_id, drep);
+    }
+
+    Ok(())
+}
+
 impl BoundaryWork {
     pub fn load<D: Domain>(domain: &D) -> Result<BoundaryWork, ChainError> {
         let active_state = crate::load_active_epoch(domain)?;
@@ -108,6 +132,7 @@ impl BoundaryWork {
 
             // to be loaded right after
             pools: HashMap::new(),
+            dreps: HashMap::new(),
             active_snapshot: Snapshot::default(),
             ending_snapshot: Snapshot::default(),
 
@@ -118,12 +143,15 @@ impl BoundaryWork {
             starting_state: None,
             effective_rewards: None,
             era_transition: None,
-            dropped_delegators: HashSet::new(),
+            dropped_pool_delegators: HashSet::new(),
+            dropped_drep_delegators: HashSet::new(),
+            retired_dreps: HashSet::new(),
         };
 
         // order matters
         load_pool_params(domain, &mut boundary)?;
         load_account_data(domain, &mut boundary)?;
+        load_drep_data(domain, &mut boundary)?;
 
         Ok(boundary)
     }

--- a/crates/cardano/src/sweep/loading.rs
+++ b/crates/cardano/src/sweep/loading.rs
@@ -68,7 +68,7 @@ pub fn load_account_data<D: Domain>(
 
         // active snapshot
         let pool_id = account.active_pool.clone().map(EntityKey::from);
-        let drep_id = account.latest_drep.clone().map(drep_to_entity_key);
+        let drep_id = account.active_drep.clone().map(drep_to_entity_key);
         let stake = account.active_stake;
 
         boundary

--- a/crates/cardano/src/sweep/mod.rs
+++ b/crates/cardano/src/sweep/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use dolos_core::{BlockSlot, ChainError, Domain, EntityKey};
 use pallas::{crypto::hash::Hash, ledger::primitives::RationalNumber};
 
-use crate::{Config, EpochState, EraProtocol, EraSummary};
+use crate::{Config, DRepState, EpochState, EraProtocol, EraSummary};
 
 pub mod commit;
 pub mod compute;
@@ -30,6 +30,7 @@ pub use compute::compute_genesis_pots;
 
 pub type AccountId = EntityKey;
 pub type PoolId = EntityKey;
+pub type DRepId = EntityKey;
 
 #[derive(Debug)]
 pub struct PoolData {
@@ -64,7 +65,9 @@ impl DelegatorMap {
 pub struct Snapshot {
     pub total_stake: u64,
     pub accounts_by_pool: DelegatorMap,
+    pub accounts_by_drep: DelegatorMap,
     pub pool_stake: HashMap<PoolId, u64>,
+    pub drep_stake: HashMap<DRepId, u64>,
 }
 
 impl Snapshot {
@@ -100,6 +103,7 @@ pub struct BoundaryWork {
     pub ending_state: EpochState,
     pub ending_snapshot: Snapshot,
     pub pools: HashMap<PoolId, PoolData>,
+    pub dreps: HashMap<DRepId, DRepState>,
     pub mutable_slots: u64,
     pub shelley_hash: Hash<32>,
 
@@ -110,7 +114,9 @@ pub struct BoundaryWork {
     pub delegator_rewards: HashMap<AccountId, u64>,
     pub starting_state: Option<EpochState>,
     pub era_transition: Option<EraTransition>,
-    pub dropped_delegators: HashSet<AccountId>,
+    pub dropped_pool_delegators: HashSet<AccountId>,
+    pub dropped_drep_delegators: HashSet<AccountId>,
+    pub retired_dreps: HashSet<DRepId>,
 }
 
 pub fn sweep<D: Domain>(domain: &D, _: BlockSlot, config: &Config) -> Result<(), ChainError> {

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -99,7 +99,7 @@ impl<'a> IntoModel<AccountContent> for AccountModelBuilder<'a> {
 
         let drep_id = self
             .account_state
-            .drep
+            .latest_drep
             .as_ref()
             .map(bech32_drep)
             .transpose()?;

--- a/src/bin/dolos/data/dump_state.rs
+++ b/src/bin/dolos/data/dump_state.rs
@@ -57,7 +57,7 @@ impl TableRow for AccountState {
                     .map(hex::encode)
                     .unwrap_or_default()
             ),
-            format!("{}", self.drep.is_some()),
+            format!("{}", self.latest_drep.is_some()),
         ]
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - DRep tracking added across snapshots and boundary work, exposing per‑DRep state and stake.
  - New mapping utilities to represent DReps consistently in keys and records.

- Improvements
  - Account views and state dumps now show the latest delegated DRep.
  - Delegation rotation and retirement distinguish pool vs. DRep delegators for clearer lifecycle handling.
  - Added validation for the DRep inactivity protocol parameter.

- Bug Fixes
  - Retirements and reward accounting updated to include DRep lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->