### PR TITLE
chore(minibf): Index metadata for endpoint

### DIFF
--- a/crates/cardano/src/roll/txs.rs
+++ b/crates/cardano/src/roll/txs.rs
@@ -5,7 +5,7 @@ use pallas::{
         addresses::Address,
         primitives::{conway::DatumOption, PlutusData},
         traverse::{
-            MultiEraBlock, MultiEraCert, MultiEraInput, MultiEraTx, MultiEraValue,
+            MultiEraBlock, MultiEraCert, MultiEraInput, MultiEraMeta, MultiEraTx, MultiEraValue,
             OriginalHash as _,
         },
     },
@@ -19,6 +19,12 @@ pub struct TxLogVisitor;
 fn unpack_input(tags: &mut SlotTags, input: &MultiEraInput) {
     let txoref: TxoRef = input.into();
     tags.spent_txo.push(txoref.into());
+}
+
+fn unpack_metadata(tags: &mut SlotTags, metadata: &MultiEraMeta) {
+    for (label, _) in metadata.collect::<Vec<_>>().iter() {
+        tags.metadata.push(*label);
+    }
 }
 
 fn unpack_address(tags: &mut SlotTags, address: &Address) {
@@ -100,6 +106,7 @@ impl BlockVisitor for TxLogVisitor {
         tx: &MultiEraTx,
     ) -> Result<(), ChainError> {
         deltas.slot.tx_hashes.push(tx.hash().to_vec());
+        unpack_metadata(&mut deltas.slot, &tx.metadata());
 
         Ok(())
     }

--- a/crates/core/src/archive.rs
+++ b/crates/core/src/archive.rs
@@ -44,6 +44,7 @@ pub struct SlotTags {
     pub stake_addresses: Vec<OpaqueTag>,
     pub spent_txo: Vec<OpaqueTag>,
     pub account_certs: Vec<OpaqueTag>,
+    pub metadata: Vec<u64>,
 }
 
 pub trait ArchiveWriter: Send + Sync + 'static {
@@ -101,6 +102,11 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
     fn iter_blocks_with_account_certs(
         &self,
         account: &[u8],
+    ) -> Result<Self::SparseBlockIter, ArchiveError>;
+
+    fn iter_blocks_with_metadata(
+        &self,
+        metadata: &u64,
     ) -> Result<Self::SparseBlockIter, ArchiveError>;
 
     fn get_range<'a>(

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -34,7 +34,6 @@ mod routes;
 pub struct Config {
     pub listen_address: SocketAddr,
     pub permissive_cors: Option<bool>,
-    pub metadata_max_scan_depth: Option<usize>,
     pub token_registry_url: Option<String>,
     pub url: Option<String>,
 }

--- a/crates/minibf/src/routes/metadata.rs
+++ b/crates/minibf/src/routes/metadata.rs
@@ -120,29 +120,24 @@ impl IntoModel<Vec<TxMetadataLabelCborInner>> for MetadataHistoryModelBuilder {
     }
 }
 
-const MAX_SCAN_DEPTH: usize = 1_500_000;
-
 async fn by_label<D: Domain>(
     label: &str,
     pagination: PaginationParameters,
     domain: &Facade<D>,
-    max_scan_depth: usize,
 ) -> Result<MetadataHistoryModelBuilder, Error> {
     let label: u64 = label.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
     let pagination = Pagination::try_from(pagination)?;
 
-    let mut reverse_blocks = domain
+    let mut blocks = domain
         .archive()
-        .get_range(None, None)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        //.rev()
-        .take(max_scan_depth);
+        .iter_blocks_with_metadata(&label)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut builder =
         MetadataHistoryModelBuilder::new(label, pagination.count, pagination.page as usize);
 
     while builder.needs_more() {
-        let Some((_, cbor)) = reverse_blocks.next() else {
+        let Some(Ok((_, Some(cbor)))) = blocks.next() else {
             return Err(Error::Code(StatusCode::NOT_FOUND));
         };
 
@@ -157,16 +152,7 @@ pub async fn by_label_json<D: Domain>(
     Query(params): Query<PaginationParameters>,
     State(domain): State<Facade<D>>,
 ) -> Result<Json<Vec<TxMetadataLabelJsonInner>>, Error> {
-    let builder = by_label(
-        &label,
-        params,
-        &domain,
-        domain
-            .config
-            .metadata_max_scan_depth
-            .unwrap_or(MAX_SCAN_DEPTH),
-    )
-    .await?;
+    let builder = by_label(&label, params, &domain).await?;
 
     Ok(builder.into_model().map(Json)?)
 }
@@ -176,16 +162,7 @@ pub async fn by_label_cbor<D: Domain>(
     Query(params): Query<PaginationParameters>,
     State(domain): State<Facade<D>>,
 ) -> Result<Json<Vec<TxMetadataLabelCborInner>>, Error> {
-    let builder = by_label(
-        &label,
-        params,
-        &domain,
-        domain
-            .config
-            .metadata_max_scan_depth
-            .unwrap_or(MAX_SCAN_DEPTH),
-    )
-    .await?;
+    let builder = by_label(&label, params, &domain).await?;
 
     Ok(builder.into_model().map(Json)?)
 }

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -144,6 +144,17 @@ impl ArchiveStore for ArchiveAdapter {
         Ok(out.into())
     }
 
+    fn iter_blocks_with_metadata(
+        &self,
+        metadata: &u64,
+    ) -> Result<Self::SparseBlockIter, ArchiveError> {
+        let out = match self {
+            ArchiveAdapter::Redb(x) => x.iter_blocks_with_metadata(metadata)?,
+        };
+
+        Ok(out.into())
+    }
+
     fn get_range<'a>(
         &self,
         from: Option<BlockSlot>,

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -315,7 +315,6 @@ impl ConfigEditor {
                 self.0.serve.minibf = dolos::serve::minibf::Config {
                     listen_address: "[::]:3000".parse().unwrap(),
                     permissive_cors: Some(true),
-                    metadata_max_scan_depth: None,
                     token_registry_url: None,
                     url: None,
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added metadata-aware block filtering and iteration, enabling faster lookups by metadata label.
  - Transaction metadata is now extracted and indexed, improving metadata query results.

- Refactor
  - Simplified minibf metadata endpoints by removing the scan-depth parameter; clients no longer need to provide it.

- Chores
  - Configuration no longer sets metadata_max_scan_depth; defaults are used automatically when enabling minibf.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->