### PR TITLE
fix(minibf): redeemers fee calculation

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1013,7 +1013,8 @@ impl TxModelBuilder<'_> {
         let unit_mem = redeemer.ex_units().mem;
         let unit_steps = redeemer.ex_units().steps;
 
-        let fee = (unit_mem * mem_price.numerator + unit_steps * step_price.numerator)
+        let fee = (unit_mem * mem_price.numerator * step_price.denominator
+            + unit_steps * step_price.numerator * mem_price.denominator)
             / (mem_price.denominator * step_price.denominator);
 
         let out = TxContentRedeemersInner {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected redeemer fee calculation to properly account for memory and step pricing, resulting in more accurate transaction fees and cost estimates.
  * Aligns fee outcomes with network pricing, reducing discrepancies in reported vs. actual costs.
  * Users may see slight adjustments to displayed or charged fees; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->