### PR TITLE
refactor(cardano): use deltas for the sweep process

### DIFF
--- a/crates/cardano/src/pallas_extras.rs
+++ b/crates/cardano/src/pallas_extras.rs
@@ -31,7 +31,7 @@ pub struct MultiEraPoolRegistration {
     pub pool_metadata: Option<PoolMetadata>,
 }
 
-pub fn cert_to_pool_state(cert: &MultiEraCert) -> Option<MultiEraPoolRegistration> {
+pub fn cert_as_pool_registration(cert: &MultiEraCert) -> Option<MultiEraPoolRegistration> {
     match cert {
         MultiEraCert::AlonzoCompatible(cow) => match cow.deref().deref() {
             AlonzoCert::PoolRegistration {
@@ -283,4 +283,9 @@ pub fn stake_cred_to_drep(cred: &StakeCredential) -> DRep {
         StakeCredential::AddrKeyhash(key) => DRep::Key(*key),
         StakeCredential::ScriptHash(key) => DRep::Script(*key),
     }
+}
+
+pub fn pool_reward_account(reward_account: &[u8]) -> Option<StakeCredential> {
+    let pool_address = Address::from_bytes(reward_account).ok()?;
+    address_as_stake_cred(&pool_address)
 }

--- a/crates/cardano/src/roll/epochs.rs
+++ b/crates/cardano/src/roll/epochs.rs
@@ -228,7 +228,7 @@ impl BlockVisitor for EpochStateVisitor {
                 .stake_deregistration_count += 1;
         }
 
-        if pallas_extras::cert_to_pool_state(cert).is_some() {
+        if pallas_extras::cert_as_pool_registration(cert).is_some() {
             self.stats_delta.as_mut().unwrap().pool_registration_count += 1;
         }
 

--- a/crates/cardano/src/sweep/commit.rs
+++ b/crates/cardano/src/sweep/commit.rs
@@ -132,10 +132,6 @@ impl BoundaryWork {
             warn!(quantity = %self.deltas.entities.len(), "uncommitted deltas");
         }
 
-        // closing epoch
-        // ================================================
-        // rotating to new one
-
         self.drop_active_epoch(&writer)?;
         self.promote_waiting_epoch(&writer)?;
         self.promote_ending_epoch(&writer)?;

--- a/crates/cardano/src/sweep/commit.rs
+++ b/crates/cardano/src/sweep/commit.rs
@@ -1,6 +1,6 @@
 use dolos_core::{
-    BrokenInvariant, ChainError, Domain, Entity, EntityDelta as _, EntityKey, NsKey, StateError,
-    StateStore, StateWriter,
+    BrokenInvariant, ChainError, Domain, Entity, EntityDelta as _, EntityKey, NsKey, StateStore,
+    StateWriter,
 };
 use tracing::{instrument, warn};
 

--- a/crates/cardano/src/sweep/compute.rs
+++ b/crates/cardano/src/sweep/compute.rs
@@ -1,12 +1,13 @@
-use dolos_core::{BrokenInvariant, ChainError, Genesis};
+use dolos_core::{BrokenInvariant, ChainError, Domain, Genesis, StateStore as _};
 use pallas::ledger::primitives::RationalNumber;
 use tracing::{debug, instrument, trace};
 
 use crate::{
     forks,
-    sweep::{BoundaryWork, EraTransition, PoolData, PotDelta, Pots},
+    sweep::{BoundaryVisitor as _, BoundaryWork, EraTransition, PotDelta, Pots},
     utils::nonce_stability_window,
-    DRepState, EpochState, EraProtocol, Nonces, PParamsSet, RewardLog, StakeLog,
+    AccountState, DRepState, EpochState, EraProtocol, FixedNamespace as _, Nonces, PParamsSet,
+    PoolState,
 };
 
 macro_rules! as_ratio {
@@ -81,44 +82,6 @@ pub fn compute_genesis_pots(
     Ok(out)
 }
 
-pub type TotalPoolReward = u64;
-pub type OperatorShare = u64;
-
-fn compute_pool_reward(
-    total_rewards: u64,
-    total_active_stake: u64,
-    pool: &PoolData,
-    pool_stake: u64,
-    k: u32,
-    a0: &RationalNumber,
-) -> (TotalPoolReward, OperatorShare) {
-    let z0 = 1.0 / k as f64;
-    let sigma = pool_stake as f64 / total_active_stake as f64;
-    let s = pool.declared_pledge as f64 / total_active_stake as f64;
-    let sigma_prime = sigma.min(z0);
-
-    let r = total_rewards as f64;
-    let a0 = a0.numerator as f64 / a0.denominator as f64;
-    let r_pool = r * (sigma_prime + s.min(sigma) * a0 * (sigma_prime - sigma));
-
-    let r_pool_u64 = r_pool.round() as u64;
-    let after_cost = r_pool_u64.saturating_sub(pool.fixed_cost);
-    let pool_margin_cost = pool.margin_cost.numerator as f64 / pool.margin_cost.denominator as f64;
-    let operator_share = pool.fixed_cost + ((after_cost as f64) * pool_margin_cost).round() as u64;
-
-    (r_pool_u64, operator_share)
-}
-
-#[allow(unused)]
-fn compute_delegator_reward(
-    available_rewards: u64,
-    total_delegated: u64,
-    delegator_stake: u64,
-) -> u64 {
-    let share = (delegator_stake as f64 / total_delegated as f64) * available_rewards as f64;
-    share.round() as u64
-}
-
 impl BoundaryWork {
     pub fn initial_pots(&self) -> Pots {
         Pots {
@@ -185,7 +148,7 @@ impl BoundaryWork {
     }
 
     /// Check if the starting epoch is still within the byron era.
-    fn still_byron(&self) -> bool {
+    pub fn still_byron(&self) -> bool {
         self.active_protocol < 2 && !self.is_transitioning_to_shelley()
     }
 
@@ -226,65 +189,6 @@ impl BoundaryWork {
         Ok(())
     }
 
-    fn define_pool_rewards(&mut self) -> Result<(), ChainError> {
-        // if we're still in Byron, we just skip the pool rewards computation and assume
-        // zero effective rewards.
-        if self.still_byron() {
-            self.effective_rewards = Some(0);
-            return Ok(());
-        }
-
-        let pot_delta = self
-            .pot_delta
-            .as_ref()
-            .ok_or(ChainError::from(BrokenInvariant::EpochBoundaryIncomplete))?;
-
-        let mut effective_rewards = 0;
-
-        for (id, pool) in self.pools.iter() {
-            let pool_stake = self.active_snapshot.get_pool_stake(id);
-            self.pool_stakes
-                .insert(id.clone(), StakeLog { amount: pool_stake });
-
-            let (total_pool_reward, operator_share) = compute_pool_reward(
-                pot_delta.available_rewards,
-                self.active_snapshot.total_stake,
-                pool,
-                pool_stake,
-                self.valid_k()?,
-                &self.valid_a0()?,
-            );
-
-            self.delegator_rewards.insert(
-                pool.reward_account.clone().into(),
-                RewardLog {
-                    amount: operator_share,
-                    pool_id: id.as_ref().to_vec(),
-                    as_leader: true,
-                },
-            );
-
-            effective_rewards += total_pool_reward;
-            self.pool_rewards.insert(id.clone(), total_pool_reward);
-
-            for (delegator, stake) in self.active_snapshot.accounts_by_pool.iter_delegators(id) {
-                let reward = compute_delegator_reward(total_pool_reward, pool_stake, *stake);
-                self.delegator_rewards.insert(
-                    delegator.clone(),
-                    RewardLog {
-                        amount: reward,
-                        pool_id: id.as_ref().to_vec(),
-                        as_leader: false,
-                    },
-                );
-            }
-        }
-
-        self.effective_rewards = Some(effective_rewards);
-
-        Ok(())
-    }
-
     fn define_starting_nonces(&mut self) -> Result<Option<Nonces>, ChainError> {
         if self.is_transitioning_to_shelley() {
             let initial = Nonces::bootstrap(self.shelley_hash);
@@ -306,14 +210,17 @@ impl BoundaryWork {
         Ok(new_nonces)
     }
 
-    fn define_starting_state(&mut self, genesis: &Genesis) -> Result<(), ChainError> {
+    // TODO: since we don't have a nice way to update epochs via delta given the
+    // race conditions in the fixed keys. We should probably move to sequential
+    // keys for epochs. Ideally, the new epoch should be created via delta.
+    fn define_starting_state(
+        &mut self,
+        genesis: &Genesis,
+        effective_rewards: u64,
+    ) -> Result<(), ChainError> {
         let pot_delta = self
             .pot_delta
             .as_ref()
-            .ok_or(ChainError::from(BrokenInvariant::EpochBoundaryIncomplete))?;
-
-        let effective_rewards = self
-            .effective_rewards
             .ok_or(ChainError::from(BrokenInvariant::EpochBoundaryIncomplete))?;
 
         let unused_rewards = pot_delta
@@ -389,93 +296,60 @@ impl BoundaryWork {
         Ok(())
     }
 
-    pub fn starting_epoch_no(&self) -> u64 {
-        self.ending_state.number as u64 + 1
-    }
-
-    fn should_retire_pool(&self, pool: &PoolData) -> bool {
-        let Some(retiring_epoch) = pool.retiring_epoch else {
-            return false;
-        };
-
-        retiring_epoch <= self.starting_epoch_no()
-    }
-
-    fn retire_pools(&mut self) -> Result<(), ChainError> {
-        for (pool_id, pool) in self.pools.iter() {
-            if !self.should_retire_pool(pool) {
-                continue;
-            }
-
-            let delegators = self
-                .ending_snapshot
-                .accounts_by_pool
-                .iter_delegators(pool_id);
-
-            // TODO: understand if the dropped stake should be redistributed somewhere
-            for (delegator, _stake) in delegators {
-                self.dropped_pool_delegators.insert(delegator.clone());
-            }
-
-            // TODO: return pledge deposit to owners
-        }
-
-        Ok(())
-    }
-
-    fn should_retire_drep(&self, drep: &DRepState) -> Result<bool, ChainError> {
-        let last_activity_slot = drep
-            .last_active_slot
-            .unwrap_or(drep.initial_slot.unwrap_or_default());
-
-        let (last_activity_epoch, _) = self.active_era.slot_epoch(last_activity_slot);
-
-        let retiring_epoch = last_activity_epoch as u64 + self.valid_drep_inactivity_period()?;
-
-        Ok(retiring_epoch <= self.starting_epoch_no())
-    }
-
-    fn retire_dreps(&mut self) -> Result<(), ChainError> {
-        for (drep_id, drep) in self.dreps.iter() {
-            if !self.should_retire_drep(drep)? {
-                continue;
-            }
-
-            debug!(%drep_id, "drep should retire");
-
-            self.retired_dreps.insert(drep_id.clone());
-
-            for (delegator, _) in self
-                .ending_snapshot
-                .accounts_by_drep
-                .iter_delegators(drep_id)
-            {
-                self.dropped_drep_delegators.insert(delegator.clone());
-            }
-        }
-
-        Ok(())
-    }
-
     #[instrument(skip_all)]
-    pub fn compute(&mut self, genesis: &Genesis) -> Result<(), ChainError> {
+    pub fn compute<D: Domain>(&mut self, domain: &D) -> Result<(), ChainError> {
         trace!("defining pot delta");
         self.define_pot_delta()?;
 
-        trace!("retiring pools");
-        self.retire_pools()?;
+        let mut visitor_retires = super::retires::BoundaryVisitor::default();
+        let mut visitor_rewards = super::rewards::BoundaryVisitor::default();
+        let mut visitor_rotate = super::transition::BoundaryVisitor::default();
 
-        trace!("retiring dreps");
-        self.retire_dreps()?;
+        let pools = domain
+            .state()
+            .iter_entities_typed::<PoolState>(PoolState::NS, None)?;
 
-        trace!("defining pool rewards");
-        self.define_pool_rewards()?;
+        for pool in pools {
+            let (pool_id, pool) = pool?;
+
+            visitor_retires.visit_pool(self, &pool_id, &pool)?;
+            visitor_rewards.visit_pool(self, &pool_id, &pool)?;
+            visitor_rotate.visit_pool(self, &pool_id, &pool)?;
+        }
+
+        let dreps = domain
+            .state()
+            .iter_entities_typed::<DRepState>(DRepState::NS, None)?;
+
+        for drep in dreps {
+            let (drep_id, drep) = drep?;
+
+            visitor_retires.visit_drep(self, &drep_id, &drep)?;
+            visitor_rewards.visit_drep(self, &drep_id, &drep)?;
+            visitor_rotate.visit_drep(self, &drep_id, &drep)?;
+        }
+
+        let accounts = domain
+            .state()
+            .iter_entities_typed::<AccountState>(AccountState::NS, None)?;
+
+        for account in accounts {
+            let (account_id, account) = account?;
+
+            visitor_retires.visit_account(self, &account_id, &account)?;
+            visitor_rewards.visit_account(self, &account_id, &account)?;
+            visitor_rotate.visit_account(self, &account_id, &account)?;
+        }
+
+        visitor_retires.flush(self)?;
+        visitor_rewards.flush(self)?;
+        visitor_rotate.flush(self)?;
 
         trace!("defining era transition");
-        self.define_era_transition(genesis)?;
+        self.define_era_transition(domain.genesis())?;
 
         trace!("defining starting state");
-        self.define_starting_state(genesis)?;
+        self.define_starting_state(domain.genesis(), visitor_rewards.total_rewards)?;
 
         Ok(())
     }
@@ -567,25 +441,17 @@ mod tests {
             },
             ending_snapshot: Snapshot::empty(),
             shelley_hash: [0; 32].as_slice().into(),
-            pools: Default::default(),
-            dreps: Default::default(),
 
             // empty until computed
-            dropped_pool_delegators: HashSet::new(),
-            dropped_drep_delegators: HashSet::new(),
-            retired_dreps: HashSet::new(),
-            pool_rewards: Default::default(),
-            delegator_rewards: Default::default(),
+            deltas: Default::default(),
             starting_state: None,
             pot_delta: None,
-            effective_rewards: None,
             era_transition: None,
         };
 
-        let genesis =
-            Genesis::from_file_paths(byron, shelley, alonzo, conway, force_protocol).unwrap();
+        let domain = todo!();
 
-        boundary.compute(&genesis).unwrap();
+        boundary.compute(&domain).unwrap();
 
         let starting_state = boundary.starting_state.unwrap();
 

--- a/crates/cardano/src/sweep/loading.rs
+++ b/crates/cardano/src/sweep/loading.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use dolos_core::{ChainError, Domain, EntityKey, StateStore};
+use dolos_core::{batch::WorkDeltas, ChainError, Domain, EntityKey, StateStore};
 
 use crate::{
-    drep_to_entity_key, load_active_era,
-    sweep::{AccountId, BoundaryWork, DRepId, PoolData, PoolId, Snapshot},
+    drep_to_entity_key, load_active_era, mutable_slots,
+    sweep::{AccountId, BoundaryWork, DRepId, PoolId, Snapshot},
     AccountState, DRepState, FixedNamespace as _, PoolState,
 };
 
@@ -79,42 +79,6 @@ pub fn load_account_data<D: Domain>(
     Ok(())
 }
 
-fn load_pool_params<D: Domain>(domain: &D, boundary: &mut BoundaryWork) -> Result<(), ChainError> {
-    let pools = domain
-        .state()
-        .iter_entities_typed::<PoolState>(PoolState::NS, None)?;
-
-    for record in pools {
-        let (pool_id, pool) = record?;
-
-        let params = PoolData {
-            reward_account: pool.reward_account,
-            fixed_cost: pool.fixed_cost,
-            margin_cost: pool.margin_cost,
-            declared_pledge: pool.declared_pledge,
-            minted_blocks: pool.blocks_minted,
-            retiring_epoch: pool.retiring_epoch,
-        };
-
-        boundary.pools.insert(pool_id, params);
-    }
-
-    Ok(())
-}
-
-fn load_drep_data<D: Domain>(domain: &D, boundary: &mut BoundaryWork) -> Result<(), ChainError> {
-    let dreps = domain
-        .state()
-        .iter_entities_typed::<DRepState>(DRepState::NS, None)?;
-
-    for record in dreps {
-        let (drep_id, drep) = record?;
-        boundary.dreps.insert(drep_id, drep);
-    }
-
-    Ok(())
-}
-
 impl BoundaryWork {
     pub fn load<D: Domain>(domain: &D) -> Result<BoundaryWork, ChainError> {
         let active_state = crate::load_active_epoch(domain)?;
@@ -131,28 +95,18 @@ impl BoundaryWork {
             shelley_hash: domain.genesis().shelley_hash,
 
             // to be loaded right after
-            pools: HashMap::new(),
-            dreps: HashMap::new(),
             active_snapshot: Snapshot::default(),
             ending_snapshot: Snapshot::default(),
 
             // empty until computed
-            pool_rewards: HashMap::new(),
-            pool_stakes: HashMap::new(),
-            delegator_rewards: HashMap::new(),
+            deltas: WorkDeltas::default(),
             pot_delta: None,
             starting_state: None,
-            effective_rewards: None,
             era_transition: None,
-            dropped_pool_delegators: HashSet::new(),
-            dropped_drep_delegators: HashSet::new(),
-            retired_dreps: HashSet::new(),
         };
 
         // order matters
-        load_pool_params(domain, &mut boundary)?;
         load_account_data(domain, &mut boundary)?;
-        load_drep_data(domain, &mut boundary)?;
 
         Ok(boundary)
     }

--- a/crates/cardano/src/sweep/loading.rs
+++ b/crates/cardano/src/sweep/loading.rs
@@ -1,11 +1,9 @@
-use std::collections::{HashMap, HashSet};
-
 use dolos_core::{batch::WorkDeltas, ChainError, Domain, EntityKey, StateStore};
 
 use crate::{
-    drep_to_entity_key, load_active_era, mutable_slots,
+    drep_to_entity_key, load_active_era,
     sweep::{AccountId, BoundaryWork, DRepId, PoolId, Snapshot},
-    AccountState, DRepState, FixedNamespace as _, PoolState,
+    AccountState, FixedNamespace as _,
 };
 
 impl Snapshot {

--- a/crates/cardano/src/sweep/mod.rs
+++ b/crates/cardano/src/sweep/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use dolos_core::{batch::WorkDeltas, BlockSlot, ChainError, Domain, EntityKey};
 use pallas::crypto::hash::Hash;

--- a/crates/cardano/src/sweep/retires.rs
+++ b/crates/cardano/src/sweep/retires.rs
@@ -1,0 +1,261 @@
+use dolos_core::{ChainError, NsKey};
+use pallas::ledger::primitives::conway::DRep;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::{
+    sweep::{AccountId, BoundaryWork, DRepId, PoolId},
+    AccountState, CardanoDelta, DRepState, FixedNamespace as _, PoolState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolRetirement {
+    pool: PoolId,
+}
+
+impl dolos_core::EntityDelta for PoolRetirement {
+    type Entity = PoolState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((PoolState::NS, self.pool.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<PoolState>) {
+        let Some(entity) = entity else {
+            warn!("missing pool");
+            return;
+        };
+
+        debug!(pool=%self.pool, "retiring pool");
+
+        entity.is_retired = true;
+    }
+
+    fn undo(&self, entity: &mut Option<PoolState>) {
+        let Some(entity) = entity else {
+            warn!("missing pool");
+            return;
+        };
+
+        debug!(pool=%self.pool, "restoring retired pool");
+
+        entity.is_retired = false;
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolDelegatorDrop {
+    delegator: AccountId,
+
+    // undo
+    prev_pool_id: Option<Vec<u8>>,
+}
+
+impl dolos_core::EntityDelta for PoolDelegatorDrop {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((AccountState::NS, self.delegator.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator");
+            return;
+        };
+
+        debug!(delegator=%self.delegator, "dropping pool delegator");
+
+        // save undo info
+        self.prev_pool_id = entity.latest_pool.clone();
+
+        // apply changes
+        entity.latest_pool = None;
+    }
+
+    fn undo(&self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator");
+            return;
+        };
+
+        debug!(delegator=%self.delegator, "restoring pool delegator");
+
+        entity.latest_pool = self.prev_pool_id.clone();
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepExpiration {
+    drep_id: DRepId,
+}
+
+impl dolos_core::EntityDelta for DRepExpiration {
+    type Entity = DRepState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((DRepState::NS, self.drep_id.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing drep");
+            return;
+        };
+
+        debug!(drep=%self.drep_id, "expiring drep");
+
+        entity.expired = true;
+    }
+
+    fn undo(&self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing drep");
+            return;
+        };
+
+        debug!(drep=%self.drep_id, "restoring expired drep");
+
+        entity.expired = false;
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepDelegatorDrop {
+    delegator: AccountId,
+
+    // undo
+    prev_drep_id: Option<DRep>,
+}
+
+impl dolos_core::EntityDelta for DRepDelegatorDrop {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((AccountState::NS, self.delegator.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator");
+            return;
+        };
+
+        debug!(delegator=%self.delegator, "dropping drep delegator");
+
+        // save undo info
+        self.prev_drep_id = entity.latest_drep.clone();
+
+        // apply changes
+        entity.latest_drep = None;
+    }
+
+    fn undo(&self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator");
+            return;
+        };
+
+        debug!(delegator=%self.delegator, "restoring drep delegator");
+
+        entity.latest_drep = self.prev_drep_id.clone();
+    }
+}
+
+fn should_retire_pool(ctx: &mut BoundaryWork, pool: &PoolState) -> bool {
+    if pool.is_retired {
+        return false;
+    }
+
+    let Some(retiring_epoch) = pool.retiring_epoch else {
+        return false;
+    };
+
+    retiring_epoch <= ctx.starting_epoch_no()
+}
+
+fn should_expire_drep(ctx: &mut BoundaryWork, drep: &DRepState) -> Result<bool, ChainError> {
+    let last_activity_slot = drep
+        .last_active_slot
+        .unwrap_or(drep.initial_slot.unwrap_or_default());
+
+    let (last_activity_epoch, _) = ctx.active_era.slot_epoch(last_activity_slot);
+
+    let expiring_epoch = last_activity_epoch as u64 + ctx.valid_drep_inactivity_period()?;
+
+    Ok(expiring_epoch <= ctx.starting_epoch_no())
+}
+
+#[derive(Default)]
+pub struct BoundaryVisitor {
+    deltas: Vec<CardanoDelta>,
+}
+
+impl super::BoundaryVisitor for BoundaryVisitor {
+    fn visit_pool(
+        &mut self,
+        ctx: &mut BoundaryWork,
+        id: &PoolId,
+        pool: &PoolState,
+    ) -> Result<(), ChainError> {
+        if !should_retire_pool(ctx, pool) {
+            return Ok(());
+        }
+
+        self.deltas.push(PoolRetirement { pool: id.clone() }.into());
+
+        let delegators = ctx.ending_snapshot.accounts_by_pool.iter_delegators(id);
+
+        for (delegator, _) in delegators {
+            self.deltas.push(
+                PoolDelegatorDrop {
+                    delegator: delegator.clone(),
+                    prev_pool_id: None,
+                }
+                .into(),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn visit_drep(
+        &mut self,
+        ctx: &mut BoundaryWork,
+        id: &DRepId,
+        drep: &DRepState,
+    ) -> Result<(), ChainError> {
+        if !should_expire_drep(ctx, drep)? {
+            return Ok(());
+        }
+
+        self.deltas.push(
+            DRepExpiration {
+                drep_id: id.clone(),
+            }
+            .into(),
+        );
+
+        let delegators = ctx.ending_snapshot.accounts_by_drep.iter_delegators(id);
+
+        for (delegator, _) in delegators {
+            self.deltas.push(
+                DRepDelegatorDrop {
+                    delegator: delegator.clone(),
+                    prev_drep_id: None,
+                }
+                .into(),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self, ctx: &mut BoundaryWork) -> Result<(), ChainError> {
+        for delta in self.deltas.drain(..) {
+            ctx.add_delta(delta);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cardano/src/sweep/rewards.rs
+++ b/crates/cardano/src/sweep/rewards.rs
@@ -1,0 +1,216 @@
+use dolos_core::{ChainError, EntityKey, NsKey};
+use pallas::{
+    codec::minicbor,
+    ledger::primitives::{RationalNumber, StakeCredential},
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::{
+    pallas_extras,
+    sweep::{AccountId, BoundaryWork, PoolId},
+    AccountState, FixedNamespace as _, PoolState,
+};
+
+pub type TotalPoolReward = u64;
+
+pub type OperatorShare = u64;
+
+fn compute_delegator_reward(
+    available_rewards: u64,
+    total_delegated: u64,
+    delegator_stake: u64,
+) -> u64 {
+    let share = (delegator_stake as f64 / total_delegated as f64) * available_rewards as f64;
+    share.round() as u64
+}
+
+fn compute_pool_reward(
+    total_rewards: u64,
+    total_active_stake: u64,
+    pool: &PoolState,
+    pool_stake: u64,
+    k: u32,
+    a0: &RationalNumber,
+) -> (TotalPoolReward, OperatorShare) {
+    let z0 = 1.0 / k as f64;
+    let sigma = pool_stake as f64 / total_active_stake as f64;
+    let s = pool.declared_pledge as f64 / total_active_stake as f64;
+    let sigma_prime = sigma.min(z0);
+
+    let r = total_rewards as f64;
+    let a0 = a0.numerator as f64 / a0.denominator as f64;
+    let r_pool = r * (sigma_prime + s.min(sigma) * a0 * (sigma_prime - sigma));
+
+    let r_pool_u64 = r_pool.round() as u64;
+    let after_cost = r_pool_u64.saturating_sub(pool.fixed_cost);
+    let pool_margin_cost = pool.margin_cost.numerator as f64 / pool.margin_cost.denominator as f64;
+    let operator_share = pool.fixed_cost + ((after_cost as f64) * pool_margin_cost).round() as u64;
+
+    (r_pool_u64, operator_share)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssignPoolRewards {
+    pool: PoolId,
+    pool_reward_account: StakeCredential,
+    operator_share: u64,
+}
+
+impl dolos_core::EntityDelta for AssignPoolRewards {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        let bytes = minicbor::to_vec(&self.pool_reward_account).unwrap();
+        let key = EntityKey::from(bytes);
+        warn!(key=%key, "pool rewards key");
+        NsKey::from((PoolState::NS, key))
+    }
+
+    fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing pool reward account");
+            return;
+        };
+
+        debug!(pool=%self.pool, "assigning pool rewards");
+
+        entity.rewards_sum += self.operator_share;
+    }
+
+    fn undo(&self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing pool reward account");
+            return;
+        };
+
+        debug!(pool=%self.pool, "undoing pool rewards");
+
+        entity.rewards_sum = entity.rewards_sum.saturating_sub(self.operator_share);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssignDelegatorRewards {
+    account: AccountId,
+    reward: u64,
+}
+
+impl dolos_core::EntityDelta for AssignDelegatorRewards {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((AccountState::NS, self.account.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator reward account");
+            return;
+        };
+
+        debug!(account=%self.account, "assigning delegator rewards");
+
+        entity.rewards_sum += self.reward;
+    }
+
+    fn undo(&self, entity: &mut Option<Self::Entity>) {
+        let Some(entity) = entity else {
+            warn!("missing delegator reward account");
+            return;
+        };
+
+        debug!(account=%self.account, "undoing delegator rewards");
+
+        entity.rewards_sum = entity.rewards_sum.saturating_sub(self.reward);
+    }
+}
+
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// pub struct AssignEpochRewards {
+//     rewards: u64,
+// }
+
+// impl dolos_core::EntityDelta for AssignEpochRewards {
+//     type Entity = EpochState;
+
+//     fn key(&self) -> NsKey {
+//         NsKey::from((EpochState::NS, EPOCH_KEY_GO))
+//     }
+
+//     fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+//         if let Some(entity) = entity {
+//             entity.rewards_to_distribute = Some(self.rewards);
+//         }
+//     }
+
+//     fn undo(&self, entity: &mut Option<Self::Entity>) {
+//         if let Some(entity) = entity {
+//             entity.rewards_to_distribute = None;
+//         }
+//     }
+// }
+
+#[derive(Default)]
+pub struct BoundaryVisitor {
+    pub total_rewards: u64,
+}
+
+impl super::BoundaryVisitor for BoundaryVisitor {
+    fn visit_pool(
+        &mut self,
+        ctx: &mut BoundaryWork,
+        id: &PoolId,
+        pool: &PoolState,
+    ) -> Result<(), ChainError> {
+        // if we're still in Byron, we just skip the pool rewards computation and assume
+        // zero effective rewards.
+        if ctx.still_byron() {
+            return Ok(());
+        }
+
+        let pool_stake = ctx.active_snapshot.get_pool_stake(id);
+        let pot_delta = ctx.pot_delta.as_ref().unwrap(); // TODO: pots should be mandatory
+
+        let (total_pool_reward, operator_share) = compute_pool_reward(
+            pot_delta.available_rewards,
+            ctx.active_snapshot.total_stake,
+            pool,
+            pool_stake,
+            ctx.valid_k()?,
+            &ctx.valid_a0()?,
+        );
+
+        self.total_rewards += total_pool_reward;
+
+        if let Some(pool_reward_account) = pallas_extras::pool_reward_account(&pool.reward_account)
+        {
+            debug!(pool=%id, "should assign pool rewards");
+
+            ctx.add_delta(AssignPoolRewards {
+                pool: id.clone(),
+                pool_reward_account,
+                operator_share,
+            });
+        } else {
+            warn!(pool=%id, "missing pool reward account");
+        }
+
+        let mut delegators = vec![];
+
+        for (delegator, stake) in ctx.active_snapshot.accounts_by_pool.iter_delegators(id) {
+            let reward = compute_delegator_reward(total_pool_reward, pool_stake, *stake);
+
+            delegators.push(AssignDelegatorRewards {
+                account: delegator.clone(),
+                reward,
+            });
+        }
+
+        for delta in delegators {
+            ctx.add_delta(delta);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cardano/src/sweep/rewards.rs
+++ b/crates/cardano/src/sweep/rewards.rs
@@ -62,9 +62,7 @@ impl dolos_core::EntityDelta for AssignPoolRewards {
 
     fn key(&self) -> NsKey {
         let bytes = minicbor::to_vec(&self.pool_reward_account).unwrap();
-        let key = EntityKey::from(bytes);
-        warn!(key=%key, "pool rewards key");
-        NsKey::from((PoolState::NS, key))
+        NsKey::from((AccountState::NS, EntityKey::from(bytes)))
     }
 
     fn apply(&mut self, entity: &mut Option<Self::Entity>) {

--- a/crates/cardano/src/sweep/transition.rs
+++ b/crates/cardano/src/sweep/transition.rs
@@ -1,0 +1,222 @@
+use dolos_core::{ChainError, NsKey};
+use pallas::ledger::primitives::conway::DRep;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    sweep::{AccountId, BoundaryWork, DRepId, PoolId},
+    AccountState, CardanoDelta, DRepState, FixedNamespace as _, PoolState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountTransition {
+    account: AccountId,
+
+    // undo
+    prev_pool: Option<Vec<u8>>,
+    prev_drep: Option<DRep>,
+    prev_stake: Option<u64>,
+}
+
+impl dolos_core::EntityDelta for AccountTransition {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((AccountState::NS, self.account.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            return;
+        };
+
+        entity.active_pool = entity.latest_pool.clone();
+        entity.active_drep = entity.latest_drep.clone();
+        entity.active_stake = entity.wait_stake;
+        entity.wait_stake = entity.live_stake();
+    }
+
+    fn undo(&self, entity: &mut Option<AccountState>) {
+        let Some(entity) = entity else {
+            return;
+        };
+
+        entity.latest_drep = entity.active_drep.clone();
+        entity.latest_pool = entity.active_pool.clone();
+        entity.wait_stake = entity.active_stake;
+
+        entity.active_pool = self.prev_pool.clone();
+        entity.active_drep = self.prev_drep.clone();
+        entity.active_stake = self.prev_stake.unwrap_or(0);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolTransition {
+    pool: PoolId,
+    ending_stake: u64,
+
+    // undo
+    prev_stake: Option<u64>,
+}
+
+impl dolos_core::EntityDelta for PoolTransition {
+    type Entity = PoolState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((PoolState::NS, self.pool.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<PoolState>) {
+        let Some(entity) = entity else {
+            return;
+        };
+
+        // order matters
+        entity.active_stake = entity.wait_stake;
+        entity.wait_stake = self.ending_stake;
+    }
+
+    fn undo(&self, entity: &mut Option<PoolState>) {
+        let Some(entity) = entity else {
+            return;
+        };
+
+        entity.wait_stake = entity.active_stake;
+        entity.active_stake = self.prev_stake.unwrap_or(0);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepExpiration {
+    drep_id: DRepId,
+}
+
+impl dolos_core::EntityDelta for DRepExpiration {
+    type Entity = DRepState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((DRepState::NS, self.drep_id.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+        if let Some(entity) = entity {
+            entity.expired = true;
+        }
+    }
+
+    fn undo(&self, entity: &mut Option<Self::Entity>) {
+        if let Some(entity) = entity {
+            entity.expired = false;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepDelegatorDrop {
+    delegator: AccountId,
+
+    // undo
+    prev_drep_id: Option<DRep>,
+}
+
+impl dolos_core::EntityDelta for DRepDelegatorDrop {
+    type Entity = AccountState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((AccountState::NS, self.delegator.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<AccountState>) {
+        if let Some(entity) = entity {
+            // save undo info
+            self.prev_drep_id = entity.latest_drep.clone();
+
+            // apply changes
+            entity.latest_drep = None;
+        }
+    }
+
+    fn undo(&self, entity: &mut Option<AccountState>) {
+        if let Some(entity) = entity {
+            entity.latest_drep = self.prev_drep_id.clone();
+        }
+    }
+}
+
+fn should_retire_pool(ctx: &mut BoundaryWork, pool: &PoolState) -> bool {
+    if pool.is_retired {
+        return false;
+    }
+
+    let Some(retiring_epoch) = pool.retiring_epoch else {
+        return false;
+    };
+
+    retiring_epoch <= ctx.starting_epoch_no()
+}
+
+fn should_expire_drep(ctx: &mut BoundaryWork, drep: &DRepState) -> Result<bool, ChainError> {
+    let last_activity_slot = drep
+        .last_active_slot
+        .unwrap_or(drep.initial_slot.unwrap_or_default());
+
+    let (last_activity_epoch, _) = ctx.active_era.slot_epoch(last_activity_slot);
+
+    let expiring_epoch = last_activity_epoch as u64 + ctx.valid_drep_inactivity_period()?;
+
+    Ok(expiring_epoch <= ctx.starting_epoch_no())
+}
+
+#[derive(Default)]
+pub struct BoundaryVisitor {
+    deltas: Vec<CardanoDelta>,
+}
+
+impl super::BoundaryVisitor for BoundaryVisitor {
+    fn visit_pool(
+        &mut self,
+        ctx: &mut BoundaryWork,
+        id: &PoolId,
+        _: &PoolState,
+    ) -> Result<(), ChainError> {
+        let ending_stake = ctx.ending_snapshot.get_pool_stake(&id);
+
+        self.deltas.push(
+            PoolTransition {
+                pool: id.clone(),
+                ending_stake: ending_stake,
+                prev_stake: None,
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    fn visit_account(
+        &mut self,
+        _: &mut BoundaryWork,
+        id: &AccountId,
+        _: &AccountState,
+    ) -> Result<(), ChainError> {
+        self.deltas.push(
+            AccountTransition {
+                account: id.clone(),
+                prev_pool: None,
+                prev_drep: None,
+                prev_stake: None,
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    fn flush(&mut self, ctx: &mut BoundaryWork) -> Result<(), ChainError> {
+        for delta in self.deltas.drain(..) {
+            ctx.add_delta(delta);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/core/src/batch.rs
+++ b/crates/core/src/batch.rs
@@ -9,6 +9,7 @@ use crate::{
     StateError, StateStore as _, StateWriter as _, TxoRef, UtxoSetDelta, WalStore as _,
 };
 
+#[derive(Debug)]
 pub struct WorkDeltas<C: ChainLogic> {
     pub entities: HashMap<NsKey, Vec<C::Delta>>,
     pub slot: SlotTags,

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -594,7 +594,7 @@ impl<'a> TxModelBuilder<'a> {
                     return Some(dbg!(key_deposit));
                 }
 
-                if pallas_extras::cert_to_pool_state(x).is_some() {
+                if pallas_extras::cert_as_pool_registration(x).is_some() {
                     return Some(dbg!(pool_deposit));
                 }
 

--- a/crates/redb3/src/state/utxoset.rs
+++ b/crates/redb3/src/state/utxoset.rs
@@ -439,7 +439,7 @@ mod tests {
     use dolos_testing::*;
     use pallas::ledger::addresses::{Address, ShelleyDelegationPart};
 
-    use crate::StateStore;
+    use crate::state::StateStore;
 
     fn get_test_address_utxos(store: &StateStore, address: TestAddress) -> UtxoMap {
         let bobs = store.get_utxo_by_address(&address.to_bytes()).unwrap();

--- a/crates/test-vectors/src/build.rs
+++ b/crates/test-vectors/src/build.rs
@@ -115,7 +115,7 @@ pub struct Args {
 #[tokio::main]
 pub async fn run(args: &Args) -> miette::Result<()> {
     let schema = build_schema();
-    let state = dolos_redb3::StateStore::open(
+    let state = dolos_redb3::state::StateStore::open(
         schema,
         args.path.as_ref().unwrap_or(&PathBuf::from("state")),
         args.cache_size,
@@ -164,7 +164,7 @@ pub async fn run(args: &Args) -> miette::Result<()> {
 pub async fn handle_account_state(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -259,7 +259,7 @@ pub async fn handle_account_state(
 pub async fn handle_asset_state(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -329,7 +329,7 @@ pub async fn handle_asset_state(
 pub async fn handle_era_summaries(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -441,7 +441,7 @@ pub async fn handle_era_summaries(
 pub async fn handle_pool_state(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -585,6 +585,7 @@ pub async fn handle_pool_state(
             },
             register_slot: Default::default(), // TODO: add register_slot
             retiring_epoch: Default::default(), // TODO: add retiring_epoch
+            is_retired: Default::default(),    // TODO: add is_retired
         };
 
         writer
@@ -640,7 +641,7 @@ macro_rules! pp_col_ratio {
 pub async fn handle_epoch_state(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -808,7 +809,7 @@ pub async fn handle_epoch_state(
 pub async fn handle_drep_state(
     args: &Args,
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    state: &dolos_redb3::StateStore,
+    state: &dolos_redb3::state::StateStore,
     registry: &Handlebars<'static>,
 ) -> miette::Result<()> {
     let query = registry
@@ -868,6 +869,7 @@ pub async fn handle_drep_state(
             last_active_slot,
             retired,
             __drep_id: Default::default(),
+            expired: Default::default(),
         };
 
         writer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Undoable pool de-registration/retirement and DRep expiration flows; automatic pool reward-account detection and initialization.
  - Reward calculation & distribution to pool operators and delegators at epoch boundaries.
  - Batched epoch boundary transitions for pools, accounts and DReps (atomic, undoable state moves).

- Refactor
  - Domain-driven sweep/commit with batched, namespace-wide delta application for more efficient commits.

- Bug Fixes
  - Improved pool-registration detection during epoch processing and transaction mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->