### PR TITLE
fix(minibf): add redeemers datum hash

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1037,7 +1037,7 @@ impl TxModelBuilder<'_> {
                 .find_redeemer_script(redeemer)?
                 .map(|x| x.to_string())
                 .unwrap_or_default(),
-            datum_hash: Default::default(),
+            datum_hash: redeemer.data().compute_hash().to_string(),
         };
 
         Ok(out)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly populate the datum hash for redeemers in transactions, replacing previously empty values with the computed redeemer data hash.
  * Improves accuracy of transaction details and prevents blank datum hash fields.
  * Enhances compatibility with downstream tools and validation processes that rely on the presence of a correct datum hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->