### PR TITLE
refactor(cardano): track total vs epoch minted blocks

### DIFF
--- a/crates/cardano/src/bootstrap/mod.rs
+++ b/crates/cardano/src/bootstrap/mod.rs
@@ -68,6 +68,7 @@ fn bootrap_epoch<D: Domain>(domain: &D) -> Result<EpochState, ChainError> {
         gathered_fees: 0,
         gathered_deposits: 0,
         decayed_deposits: 0,
+        blocks_minted: 0,
         rewards_to_distribute: None,
         rewards_to_treasury: None,
         largest_stable_slot: genesis.shelley.epoch_length.unwrap() as u64 - mutable_slots(genesis),

--- a/crates/cardano/src/model.rs
+++ b/crates/cardano/src/model.rs
@@ -206,7 +206,7 @@ pub struct PoolState {
     pub __live_stake: u64,
 
     #[n(11)]
-    pub blocks_minted: u32,
+    pub blocks_minted_total: u32,
 
     #[n(12)]
     pub register_slot: u64,
@@ -216,6 +216,9 @@ pub struct PoolState {
 
     #[n(14)]
     pub is_retired: bool,
+
+    #[n(15)]
+    pub blocks_minted_epoch: u32,
 }
 
 entity_boilerplate!(PoolState, "pools");
@@ -248,7 +251,8 @@ impl PoolState {
             active_stake: Default::default(),
             wait_stake: Default::default(),
             __live_stake: Default::default(),
-            blocks_minted: Default::default(),
+            blocks_minted_total: Default::default(),
+            blocks_minted_epoch: Default::default(),
             retiring_epoch: None,
             is_retired: false,
         }
@@ -788,6 +792,9 @@ pub struct EpochState {
 
     #[n(13)]
     pub nonces: Option<Nonces>,
+
+    #[n(14)]
+    pub blocks_minted: u32,
 }
 
 impl EpochState {

--- a/crates/cardano/src/roll/epochs.rs
+++ b/crates/cardano/src/roll/epochs.rs
@@ -43,6 +43,8 @@ impl dolos_core::EntityDelta for EpochStatsUpdate {
 
         entity.decayed_deposits +=
             self.stake_deregistration_count * entity.pparams.pool_deposit_or_default();
+
+        entity.blocks_minted += 1;
     }
 
     fn undo(&self, entity: &mut Option<EpochState>) {
@@ -59,6 +61,8 @@ impl dolos_core::EntityDelta for EpochStatsUpdate {
 
         entity.decayed_deposits -=
             self.stake_deregistration_count * entity.pparams.pool_deposit_or_default();
+
+        entity.blocks_minted = entity.blocks_minted.saturating_sub(1);
     }
 }
 

--- a/crates/cardano/src/roll/pools.rs
+++ b/crates/cardano/src/roll/pools.rs
@@ -76,13 +76,15 @@ impl dolos_core::EntityDelta for MintedBlocksInc {
 
     fn apply(&mut self, entity: &mut Option<PoolState>) {
         if let Some(entity) = entity {
-            entity.blocks_minted += self.count;
+            entity.blocks_minted_total += self.count;
+            entity.blocks_minted_epoch += self.count;
         }
     }
 
     fn undo(&self, entity: &mut Option<PoolState>) {
         if let Some(entity) = entity {
-            entity.blocks_minted = entity.blocks_minted.saturating_sub(self.count);
+            entity.blocks_minted_total = entity.blocks_minted_total.saturating_sub(self.count);
+            entity.blocks_minted_epoch = entity.blocks_minted_epoch.saturating_sub(self.count);
         }
     }
 }

--- a/crates/cardano/src/sweep/rewards.rs
+++ b/crates/cardano/src/sweep/rewards.rs
@@ -58,8 +58,8 @@ fn compute_pool_rewards(
     pool_stake: u64,
     k: u32,
     a0: &RationalNumber,
-    _minted_blocks: u32,
-    _blocks_per_epoch: u32,
+    pool_blocks: u32,
+    epoch_blocks: u32,
 ) -> (TotalPoolReward, OperatorShare) {
     // TODO: take into account the pool performance by implementing the required
     // formula. For now, we just return the max pool rewards.
@@ -278,8 +278,8 @@ impl super::BoundaryVisitor for BoundaryVisitor {
             pool_stake,
             ctx.valid_k()?,
             &ctx.valid_a0()?,
-            pool.blocks_minted,
-            0, // TODO: compute blocks per epoch
+            pool.blocks_minted_epoch,
+            ctx.ending_state.blocks_minted,
         );
 
         let delegator_rewards = total_pool_reward - operator_share;

--- a/crates/cardano/src/sweep/transition.rs
+++ b/crates/cardano/src/sweep/transition.rs
@@ -74,6 +74,7 @@ pub struct PoolTransition {
 
     // undo
     prev_stake: Option<u64>,
+    prev_blocks_minted: Option<u32>,
 }
 
 impl PoolTransition {
@@ -82,6 +83,7 @@ impl PoolTransition {
             pool,
             ending_stake,
             prev_stake: None,
+            prev_blocks_minted: None,
         }
     }
 }
@@ -100,10 +102,13 @@ impl dolos_core::EntityDelta for PoolTransition {
 
         // undo info
         self.prev_stake = Some(entity.active_stake);
+        self.prev_blocks_minted = Some(entity.blocks_minted_epoch);
 
         // order matters
         entity.active_stake = entity.wait_stake;
         entity.wait_stake = self.ending_stake;
+
+        entity.blocks_minted_epoch = 0;
     }
 
     fn undo(&self, entity: &mut Option<PoolState>) {
@@ -113,6 +118,8 @@ impl dolos_core::EntityDelta for PoolTransition {
 
         entity.wait_stake = entity.active_stake;
         entity.active_stake = self.prev_stake.unwrap_or(0);
+
+        entity.blocks_minted_epoch = self.prev_blocks_minted.unwrap_or(0);
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tracks minted blocks both per-epoch and lifetime for pools and epochs.
  - Rewards now use per-epoch pool blocks plus epoch-wide totals for improved accuracy.
  - Bootstrap initializes epoch metrics so tracking starts consistently.

- Refactor
  - Internal accounting split into per-epoch and total tallies with apply/undo (undo/redo) support for pool transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->