### PR TITLE
chore(minibf): Implement /epochs/epoch/blocks

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -307,6 +307,10 @@ where
                 get(routes::blocks::by_slot::<D>),
             )
             .route(
+                "/epochs/{epoch}/blocks",
+                get(routes::epochs::by_number_blocks::<D>),
+            )
+            .route(
                 "/epochs/{epoch}/parameters",
                 get(routes::epochs::by_number_parameters::<D>),
             )

--- a/crates/minibf/src/routes/epochs/mod.rs
+++ b/crates/minibf/src/routes/epochs/mod.rs
@@ -1,14 +1,20 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
 use blockfrost_openapi::models::epoch_param_content::EpochParamContent;
 
 use dolos_cardano::{EpochState, FixedNamespace, EPOCH_KEY_SET};
-use dolos_core::{Domain, StateStore};
+use dolos_core::{ArchiveStore, Domain, StateStore};
+use pallas::ledger::traverse::MultiEraBlock;
 
-use crate::{error::Error, mapping::IntoModel as _, Facade};
+use crate::{
+    error::Error,
+    mapping::IntoModel as _,
+    pagination::{Order, Pagination, PaginationParameters},
+    Facade,
+};
 
 pub mod cost_models;
 pub mod mapping;
@@ -61,4 +67,36 @@ pub async fn by_number_parameters<D: Domain>(
     };
 
     Ok(model.into_response()?)
+}
+
+pub async fn by_number_blocks<D: Domain>(
+    Path(epoch): Path<u64>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<String>>, Error> {
+    let chain = domain.get_chain_summary()?;
+    let pagination = Pagination::try_from(params)?;
+    let start = chain.epoch_start(epoch);
+    let end = chain.epoch_start(epoch + 1) - 1;
+
+    let iter = domain
+        .archive()
+        .get_range(Some(start), Some(end))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map(|(_, x)| {
+            let block = MultiEraBlock::decode(&x).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            Ok(block.hash().to_string())
+        });
+
+    Ok(Json(match pagination.order {
+        Order::Asc => iter
+            .skip(pagination.skip())
+            .take(pagination.count)
+            .collect::<Result<_, StatusCode>>()?,
+        Order::Desc => iter
+            .rev()
+            .skip(pagination.skip())
+            .take(pagination.count)
+            .collect::<Result<_, _>>()?,
+    }))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint: GET /epochs/{epoch}/blocks to retrieve block hashes for a specific epoch.
  * Supports pagination and ordering (ascending/descending) via query parameters for efficient result navigation.
  * Returns a JSON array of block hashes, enabling easier epoch-level block discovery and integration.

* **Chores**
  * Routing updated to include the new endpoint without affecting existing routes or behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->