### PR TITLE
chore(minibf): Implement /pools/pool/history

### DIFF
--- a/crates/cardano/src/model.rs
+++ b/crates/cardano/src/model.rs
@@ -82,10 +82,31 @@ pub struct RewardLog {
 
 entity_boilerplate!(RewardLog, "rewards");
 
-#[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, Default)]
+#[derive(Debug, Clone, PartialEq, Decode, Encode, Default)]
 pub struct StakeLog {
     #[n(0)]
-    pub amount: u64,
+    /// Number of blocks created by pool
+    pub blocks_minted: u32,
+
+    #[n(1)]
+    /// Active (Snapshot of live stake 2 epochs ago) stake in Lovelaces
+    pub active_stake: u64,
+
+    #[n(2)]
+    /// Pool size (percentage) of overall active stake at that epoch
+    pub active_size: f64,
+
+    #[n(3)]
+    /// Number of delegators for epoch
+    pub delegators_count: u64,
+
+    #[n(4)]
+    /// Total rewards received before distribution to delegators
+    pub rewards: u64,
+
+    #[n(5)]
+    /// Pool operator rewards
+    pub fees: u64,
 }
 
 entity_boilerplate!(StakeLog, "stakes");

--- a/crates/cardano/src/sweep/mod.rs
+++ b/crates/cardano/src/sweep/mod.rs
@@ -115,6 +115,10 @@ impl DelegatorMap {
     ) -> impl Iterator<Item = (&AccountId, &u64)> {
         self.0.get(entity_id).into_iter().flatten()
     }
+
+    pub fn amount(&self, pool_id: &PoolId) -> u64 {
+        self.0.get(pool_id).map(|x| x.len() as u64).unwrap_or(0)
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/cardano/src/sweep/transition.rs
+++ b/crates/cardano/src/sweep/transition.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use crate::{
     sweep::{hacks, AccountId, BoundaryWork, PoolId, ProposalId},
     AccountState, CardanoDelta, CardanoEntity, FixedNamespace as _, PParamValue, PoolState,
-    Proposal, StakeLog,
+    Proposal,
 };
 
 fn should_enact_proposal(ctx: &mut BoundaryWork, proposal: &Proposal) -> bool {
@@ -223,10 +223,6 @@ impl BoundaryVisitor {
     fn change(&mut self, delta: impl Into<CardanoDelta>) {
         self.deltas.push(delta.into());
     }
-
-    fn log(&mut self, key: EntityKey, log: impl Into<CardanoEntity>) {
-        self.logs.push((key, log.into()));
-    }
 }
 
 impl super::BoundaryVisitor for BoundaryVisitor {
@@ -236,16 +232,9 @@ impl super::BoundaryVisitor for BoundaryVisitor {
         id: &PoolId,
         _: &PoolState,
     ) -> Result<(), ChainError> {
-        let ending_stake = ctx.ending_snapshot.get_pool_stake(id);
+        let ending_stake = ctx.active_snapshot.get_pool_stake(id);
 
         self.change(PoolTransition::new(id.clone(), ending_stake));
-
-        self.log(
-            id.clone(),
-            StakeLog {
-                amount: ending_stake,
-            },
-        );
 
         Ok(())
     }

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -368,6 +368,10 @@ where
                 "/pools/{id}/delegators",
                 get(routes::pools::by_id_delegators::<D>),
             )
+            .route(
+                "/pools/{id}/history",
+                get(routes::pools::by_id_history::<D>),
+            )
             .route("/pools/extended", get(routes::pools::all_extended::<D>))
             .route(
                 "/governance/dreps/{drep_id}",

--- a/crates/minibf/src/routes/pools.rs
+++ b/crates/minibf/src/routes/pools.rs
@@ -200,11 +200,16 @@ where
     let summary = domain.get_chain_summary()?;
     let (epoch, _) = summary.slot_epoch(tip);
 
-    let rewards = domain
+    let mut entries = domain
         .iter_cardano_logs_per_epoch::<StakeLog>(operator.into(), 0..epoch)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let mapped: Vec<_> = rewards
+    // Apply order before pagination
+    if matches!(pagination.order, crate::pagination::Order::Desc) {
+        entries.reverse()
+    };
+
+    let mapped: Vec<_> = entries
         .into_iter()
         .skip(pagination.skip())
         .take(pagination.count)

--- a/crates/minibf/src/routes/pools.rs
+++ b/crates/minibf/src/routes/pools.rs
@@ -4,9 +4,13 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
-    pool_delegators_inner::PoolDelegatorsInner, pool_list_extended_inner::PoolListExtendedInner,
+    pool_delegators_inner::PoolDelegatorsInner, pool_history_inner::PoolHistoryInner,
+    pool_list_extended_inner::PoolListExtendedInner,
 };
-use dolos_cardano::model::{AccountState, PoolState};
+use dolos_cardano::{
+    model::{AccountState, PoolState},
+    StakeLog,
+};
 use dolos_core::{BlockSlot, Domain};
 use itertools::Itertools;
 use pallas::{
@@ -178,6 +182,44 @@ where
         })
         .collect::<Result<_, _>>()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(mapped))
+}
+
+pub async fn by_id_history<D: Domain>(
+    Path(id): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<PoolHistoryInner>>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+{
+    let operator = decode_pool_id(&id)?;
+    let pagination = Pagination::try_from(params)?;
+    let tip = domain.get_tip_slot()?;
+    let summary = domain.get_chain_summary()?;
+    let (epoch, _) = summary.slot_epoch(tip);
+
+    let rewards = domain
+        .iter_cardano_logs_per_epoch::<StakeLog>(operator.into(), 0..epoch)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mapped: Vec<_> = rewards
+        .into_iter()
+        .skip(pagination.skip())
+        .take(pagination.count)
+        .map(|(epoch, log)| {
+            Ok(PoolHistoryInner {
+                epoch: epoch as i32,
+                blocks: log.blocks_minted as i32,
+                active_stake: log.active_stake.to_string(),
+                active_size: log.active_size,
+                delegators_count: log.delegators_count as i32,
+                rewards: log.rewards.to_string(),
+                fees: log.fees.to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, StatusCode>>()?;
 
     Ok(Json(mapped))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a paginated pool history endpoint (/pools/{id}/history) returning per-epoch data: blocks minted, active stake, active size, delegators count, rewards, and fees.

- Bug Fixes
  - Improved accuracy of ending stake used in pool transition calculations, which may slightly adjust reported history metrics.

- Chores
  - Streamlined internal logging and added a lightweight delegator-count query used by pool history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->