### PR TITLE
fix: Correctly get epoch parameters

### DIFF
--- a/crates/minibf/src/routes/epochs/mod.rs
+++ b/crates/minibf/src/routes/epochs/mod.rs
@@ -4,9 +4,7 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::epoch_param_content::EpochParamContent;
-
-use dolos_cardano::{EpochState, FixedNamespace, EPOCH_KEY_SET};
-use dolos_core::{ArchiveStore, Domain, StateStore};
+use dolos_core::{ArchiveStore, Domain};
 use pallas::ledger::traverse::MultiEraBlock;
 
 use crate::{
@@ -28,22 +26,14 @@ pub async fn latest_parameters<D: Domain>(
 
     let (epoch, _) = summary.slot_epoch(tip);
 
-    let params = dolos_cardano::load_mark_epoch::<D>(domain.state())
+    let state = dolos_cardano::load_mark_epoch::<D>(domain.state())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let nonce = domain
-        .state()
-        .read_entity_typed::<EpochState>(EpochState::NS, &EPOCH_KEY_SET.into())
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?
-        .nonces
-        .map(|x| x.active.to_string());
 
     let model = mapping::ParametersModelBuilder {
         epoch,
-        params: params.pparams,
+        params: state.pparams,
         genesis: domain.genesis(),
-        nonce,
+        nonce: state.nonces.map(|x| x.active.to_string()),
     };
 
     Ok(model.into_response()?)
@@ -53,11 +43,18 @@ pub async fn by_number_parameters<D: Domain>(
     State(domain): State<Facade<D>>,
     Path(epoch): Path<u32>,
 ) -> Result<Json<EpochParamContent>, Error> {
-    let chain = domain.get_chain_summary()?;
+    let tip = domain.get_tip_slot()?;
+    let summary = domain.get_chain_summary()?;
+    let (curr, _) = summary.slot_epoch(tip);
 
-    let epoch = domain
-        .get_epoch_log(epoch, &chain)?
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let epoch = if epoch == curr {
+        dolos_cardano::load_mark_epoch::<D>(domain.state())
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    } else {
+        domain
+            .get_epoch_log(epoch, &summary)?
+            .ok_or(StatusCode::NOT_FOUND)?
+    };
 
     let model = mapping::ParametersModelBuilder {
         epoch: epoch.number,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parameter endpoints now dynamically source data: use live state for the current epoch and cached logs for past epochs, ensuring up-to-date results.
- Bug Fixes
  - Corrected nonce derivation for parameter responses.
  - Improved handling when requested epoch data is unavailable, returning a clear not-found response.
- Performance
  - Reduced overhead by avoiding unnecessary state reads for past epochs.
- Refactor
  - Streamlined internal dependencies and data flow for epoch parameter retrieval without affecting external APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->