### PR TITLE
fix(cardano): use new pparam field for gov changes

### DIFF
--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -202,12 +202,10 @@ pub fn into_conway(previous: &PParamsSet, genesis: &conway::GenesisFile) -> PPar
 }
 
 /// Increments the protocol version by 1 without changing any other fields
-pub fn intra_era_hardfork(current: &PParamsSet) -> PParamsSet {
-    let version = current.protocol_major_or_default();
-
+pub fn intra_era_hardfork(current: &PParamsSet, target: u16) -> PParamsSet {
     current
         .clone()
-        .with(PParamValue::ProtocolVersion((version as u64 + 1, 0)))
+        .with(PParamValue::ProtocolVersion((target as u64, 0)))
 }
 
 // Source: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0059/feature-table.md
@@ -222,25 +220,25 @@ pub fn migrate_pparams_version(
     match (from, to) {
         // Protocol starts at version 0;
         // There was one intra-era "hard fork" in byron (even though they weren't called that yet)
-        (0, 1) => intra_era_hardfork(current),
+        (0, 1) => intra_era_hardfork(current, to),
         // Protocol version 2 transitions from Byron to Shelley
         (1, 2) => from_shelley_genesis(&genesis.shelley),
         // Two intra-era hard forks, named Allegra (3) and Mary (4); we don't have separate types
         // for these eras
-        (2, 3) => intra_era_hardfork(current),
-        (3, 4) => intra_era_hardfork(current),
+        (2, 3) => intra_era_hardfork(current, to),
+        (3, 4) => intra_era_hardfork(current, to),
         // Protocol version 5 transitions from Shelley (Mary, technically) to Alonzo
         (4, 5) => into_alonzo(current, &genesis.alonzo),
         // One intra-era hard-fork in alonzo at protocol version 6
-        (5, 6) => intra_era_hardfork(current),
+        (5, 6) => intra_era_hardfork(current, to),
         // Protocol version 7 transitions from Alonzo to Babbage
         (6, 7) => into_babbage(current, &genesis.alonzo),
         // One intra-era hard-fork in babbage at protocol version 8
-        (7, 8) => intra_era_hardfork(current),
+        (7, 8) => intra_era_hardfork(current, to),
         // Protocol version 9 transitions from Babbage to Conway
         (8, 9) => into_conway(current, &genesis.conway),
         // One intra-era hard-fork in conway at protocol version 10
-        (9, 10) => intra_era_hardfork(current),
+        (9, 10) => intra_era_hardfork(current, to),
         (from, to) => {
             unimplemented!("don't know how to bump from version {from} to {to}",)
         }

--- a/crates/cardano/src/genesis/mod.rs
+++ b/crates/cardano/src/genesis/mod.rs
@@ -63,7 +63,7 @@ fn bootrap_epoch<D: Domain>(state: &D::State, genesis: &Genesis) -> Result<Epoch
     let mut nonces = None;
 
     if let Some(force_protocol) = genesis.force_protocol {
-        pparams = crate::forks::evolve_pparams(&pparams, genesis, force_protocol as u16)?;
+        pparams = crate::forks::force_pparams_version(&pparams, genesis, 0, force_protocol as u16)?;
 
         // TODO: why do we set nonces only if there's a force protocol?
         nonces = Some(Nonces::bootstrap(genesis.shelley_hash));

--- a/crates/cardano/src/model.rs
+++ b/crates/cardano/src/model.rs
@@ -231,7 +231,7 @@ pub struct AccountState {
 
     #[n(9)]
     pub drep: EpochValue<Option<DRep>>,
-    
+
     #[n(10)]
     pub vote_delegated_at: Option<BlockSlot>,
 
@@ -760,6 +760,10 @@ macro_rules! ensure_pparam {
 }
 
 impl PParamsSet {
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
     pub fn get(&self, kind: PParamKind) -> Option<&PParamValue> {
         self.values.iter().find(|value| value.kind() == kind)
     }

--- a/crates/cardano/src/sweep/compute.rs
+++ b/crates/cardano/src/sweep/compute.rs
@@ -132,7 +132,8 @@ impl BoundaryWork {
         let pparams = self
             .next_pparams
             .as_ref()
-            .ok_or(ChainError::from(BrokenInvariant::EpochBoundaryIncomplete))?;
+            .ok_or(ChainError::from(BrokenInvariant::EpochBoundaryIncomplete))?
+            .clone();
 
         // HACK: we can't explain why the epoch 2 generates a surplus of unspendable
         // rewards. Everything in the data looks correct, rewards should be there, but
@@ -151,7 +152,6 @@ impl BoundaryWork {
 
         let deposits = self.ending_state.deposits;
         let utxos = self.ending_state.utxos;
-        let pparams = pparams.clone();
         let nonces = self.define_starting_nonces()?;
 
         let state = EpochState {
@@ -161,9 +161,7 @@ impl BoundaryWork {
             reserves,
             treasury,
             pparams,
-            largest_stable_slot: self
-                .active_era
-                .epoch_start(self.ending_state.number + 2)
+            largest_stable_slot: self.active_era.epoch_start(self.ending_state.number + 2)
                 - nonce_stability_window(self.active_protocol.into(), genesis),
             nonces,
 

--- a/crates/cardano/src/sweep/transition.rs
+++ b/crates/cardano/src/sweep/transition.rs
@@ -190,9 +190,10 @@ macro_rules! handle_update {
                     value =? converted,
                     "applying new pparam value on ending state"
                 );
+
                 $ctx.ending_state
-                    .pparams
-                    .set(PParamValue::$variant(converted))
+                    .pparams_update
+                    .set(PParamValue::$variant(converted));
             }
         }
     };
@@ -264,7 +265,7 @@ impl super::BoundaryVisitor for BoundaryVisitor {
                     "applying proposed hardfork on ending state"
                 );
                 ctx.ending_state
-                    .pparams
+                    .pparams_update
                     .set(PParamValue::ProtocolVersion(*version));
             }
             GovAction::ParameterChange(_, update, _) => {
@@ -307,12 +308,14 @@ impl super::BoundaryVisitor for BoundaryVisitor {
                         value =? updated,
                         "applying new pparam value on ending state"
                     );
-                    ctx.ending_state.pparams.set(PParamValue::MaxTxExUnits(
-                        pallas::ledger::primitives::ExUnits {
-                            mem: updated.mem,
-                            steps: updated.steps,
-                        },
-                    ))
+                    ctx.ending_state
+                        .pparams_update
+                        .set(PParamValue::MaxTxExUnits(
+                            pallas::ledger::primitives::ExUnits {
+                                mem: updated.mem,
+                                steps: updated.steps,
+                            },
+                        ))
                 }
                 if let Some(updated) = update.max_block_ex_units {
                     debug!(
@@ -320,12 +323,14 @@ impl super::BoundaryVisitor for BoundaryVisitor {
                         value =? updated,
                         "applying new pparam value on ending state"
                     );
-                    ctx.ending_state.pparams.set(PParamValue::MaxBlockExUnits(
-                        pallas::ledger::primitives::ExUnits {
-                            mem: updated.mem,
-                            steps: updated.steps,
-                        },
-                    ))
+                    ctx.ending_state
+                        .pparams_update
+                        .set(PParamValue::MaxBlockExUnits(
+                            pallas::ledger::primitives::ExUnits {
+                                mem: updated.mem,
+                                steps: updated.steps,
+                            },
+                        ))
                 }
                 if let Some(updated) = update.minfee_refscript_cost_per_byte.as_ref() {
                     debug!(
@@ -334,7 +339,7 @@ impl super::BoundaryVisitor for BoundaryVisitor {
                         "applying new pparam value on ending state"
                     );
                     ctx.ending_state
-                        .pparams
+                        .pparams_update
                         .set(PParamValue::MinFeeRefScriptCostPerByte(RationalNumber {
                             numerator: updated.numerator,
                             denominator: updated.denominator,
@@ -347,7 +352,7 @@ impl super::BoundaryVisitor for BoundaryVisitor {
                         "applying new pparam value on ending state"
                     );
                     ctx.ending_state
-                        .pparams
+                        .pparams_update
                         .set(PParamValue::ExecutionCosts(ExUnitPrices {
                             mem_price: updated.mem_price.clone(),
                             step_price: updated.step_price.clone(),
@@ -363,22 +368,22 @@ impl super::BoundaryVisitor for BoundaryVisitor {
 
                     if let Some(v1) = updated.plutus_v1.as_ref() {
                         ctx.ending_state
-                            .pparams
+                            .pparams_update
                             .set(PParamValue::CostModelsPlutusV1(v1.clone()));
                     }
                     if let Some(v2) = updated.plutus_v2.as_ref() {
                         ctx.ending_state
-                            .pparams
+                            .pparams_update
                             .set(PParamValue::CostModelsPlutusV2(v2.clone()));
                     }
                     if let Some(v3) = updated.plutus_v3.as_ref() {
                         ctx.ending_state
-                            .pparams
+                            .pparams_update
                             .set(PParamValue::CostModelsPlutusV3(v3.clone()));
                     }
                     if !updated.unknown.is_empty() {
                         ctx.ending_state
-                            .pparams
+                            .pparams_update
                             .set(PParamValue::CostModelsUnknown(updated.unknown.clone()));
                     }
                 }

--- a/src/bin/dolos/data/dump_logs.rs
+++ b/src/bin/dolos/data/dump_logs.rs
@@ -59,6 +59,7 @@ impl TableRow for EpochState {
             "rewards",
             "rewards (unspendable)",
             "blocks minted",
+            "pparams",
         ]
     }
 
@@ -76,6 +77,7 @@ impl TableRow for EpochState {
             format!("{}", self.effective_rewards.unwrap_or_default()),
             format!("{}", self.unspendable_rewards.unwrap_or_default()),
             format!("{}", self.blocks_minted),
+            format!("{}", self.pparams.len()),
         ]
     }
 }

--- a/src/bin/dolos/data/dump_state.rs
+++ b/src/bin/dolos/data/dump_state.rs
@@ -82,6 +82,7 @@ impl TableRow for EpochState {
             "treasury tax",
             "rewards",
             "rewards (unspendable)",
+            "pparams",
             "nonce",
         ]
     }
@@ -99,6 +100,7 @@ impl TableRow for EpochState {
             format!("{}", self.treasury_tax.unwrap_or_default()),
             format!("{}", self.effective_rewards.unwrap_or_default()),
             format!("{}", self.unspendable_rewards.unwrap_or_default()),
+            format!("{}", self.pparams.len()),
             format!(
                 "{}",
                 self.nonces


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Performance
  * Reduced redundant data copying to lower memory use and improve processing efficiency.

* Reliability
  * More robust handling of protocol-parameter updates and era transitions; safer early-exit behavior and clearer error paths.

* New Features
  * Added informational logging when protocol-version changes occur.
  * Epoch state display now includes a new "pparams" column showing parameter count.

* Refactor
  * Simplified stable-slot calculation logic without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->