### PR TITLE
fix(minibf): avoid rounding errors on fee calc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,26 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "big-int"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31375ce97b1316b3a92644c2cbc93fa9dcfba06e4aec9a440bce23397af82fd6"
-dependencies = [
- "big-int-proc",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "big-int-proc"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cfa06eb56d71f2bb1874b101a50c3ba29fcf3ff7dd8de274e473929459863b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "binary-layout"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1204,6 @@ dependencies = [
 name = "dolos-cardano"
 version = "1.0.0-beta.4"
 dependencies = [
- "big-int",
  "chrono",
  "dolos-core",
  "hex",
@@ -1272,6 +1251,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "num-bigint",
+ "num-rational",
  "num-traits",
  "pallas 1.0.0-alpha.2 (git+https://github.com/txpipe/pallas.git?rev=38546da)",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,16 @@ inherits = "release"
 lto = "thin"
 
 [workspace]
-members = ["crates/cardano", "crates/core", "crates/testing", "crates/minibf", "crates/redb", "xtask", "crates/redb3", "crates/test-vectors"]
+members = [
+    "crates/cardano",
+    "crates/core",
+    "crates/testing",
+    "crates/minibf",
+    "crates/redb",
+    "xtask",
+    "crates/redb3",
+    "crates/test-vectors",
+]
 
 [workspace.package]
 version = "1.0.0-beta.4"
@@ -154,6 +163,8 @@ bech32 = "0.11.0"
 reqwest = { version = "0.12.7", default-features = false, features = ["blocking", "rustls-tls"] }
 rayon = "1.11.0"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
+num-rational = "0.4.2"
+num-bigint = "0.4.6"
 
 [workspace.metadata.release]
 push = false

--- a/crates/cardano/Cargo.toml
+++ b/crates/cardano/Cargo.toml
@@ -12,6 +12,8 @@ serde.workspace = true
 chrono.workspace = true
 hex.workspace = true
 itertools.workspace = true
+num-rational.workspace = true
+num-bigint.workspace = true
 
 paste = "1.0.15"
 
@@ -20,9 +22,7 @@ rayon = "1.11.0"
 
 serde_json = { workspace = true, optional = true }
 self_cell = "1.2.0"
-num-rational = "0.4.2"
-big-int = "7.0.0"
-num-bigint = "0.4.6"
+
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/minibf/Cargo.toml
+++ b/crates/minibf/Cargo.toml
@@ -14,12 +14,13 @@ tower-http.workspace = true
 itertools.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
+num-rational.workspace = true
+num-bigint.workspace = true
 
 dolos-core = { path = "../core" }
 dolos-cardano = { path = "../cardano" }
 
 axum = { version = "0.8.4", features = ["macros"] }
-num-bigint = "0.4.6"
 num-traits = "0.2.19"
 hex = "0.4.3"
 serde_json = "1.0.140"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction fee accuracy with precise rounding, reducing inconsistencies in fee estimates.
  * Redeemer details now correctly report unit_mem and unit_steps based on actual execution units.

* **Refactor**
  * Centralized fee computation for consistent behavior across components.

* **Chores**
  * Standardized numeric dependencies across the workspace to ensure consistent versions and build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->