### PR TITLE
fix(minibf): Offset constructor index on datum

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1934,7 +1934,7 @@ impl PlutusDataWrapper {
                 Ok(serde_json::Value::Object(serde_json::Map::from_iter([
                     (
                         "constructor".to_string(),
-                        serde_json::Value::Number(x.tag.into()),
+                        serde_json::Value::Number(x.constr_index().into()),
                     ),
                     ("fields".to_string(), serde_json::Value::Array(values)),
                 ])))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated JSON encoding for constructor values in Plutus data: the "constructor" field now reflects the constructor index rather than the previous value source. The overall JSON structure, including the "fields" array, remains unchanged. Clients consuming this JSON may observe different numeric values for "constructor" while functionality stays consistent. No changes to public APIs or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->