### PR TITLE
chore: Formalize internal storage version upgrade

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -304,6 +304,7 @@ pub enum StorageVersion {
     #[default]
     V0,
     V1,
+    V2,
 }
 
 impl<'de> Deserialize<'de> for StorageVersion {
@@ -316,6 +317,7 @@ impl<'de> Deserialize<'de> for StorageVersion {
             Some(version) => match version.as_str() {
                 "v0" => Ok(StorageVersion::V0),
                 "v1" => Ok(StorageVersion::V1),
+                "v2" => Ok(StorageVersion::V2),
                 _ => Err(<D::Error as serde::de::Error>::custom("Invalid version")),
             },
             None => Ok(StorageVersion::V0),
@@ -331,6 +333,7 @@ impl Display for StorageVersion {
             match self {
                 Self::V0 => "v0",
                 Self::V1 => "v1",
+                Self::V2 => "v2",
             }
         )
     }

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -400,8 +400,8 @@ impl ConfigEditor {
     }
 
     fn prompt_storage_upgrade(mut self) -> miette::Result<Self> {
-        if self.0.storage.version == StorageVersion::V0 {
-            self.0.storage.version = StorageVersion::V1;
+        if self.0.storage.version != StorageVersion::V2 {
+            self.0.storage.version = StorageVersion::V2;
             let delete = Confirm::new("Your storage is incompatible with current version. Do you want to delete data and bootstrap?")
                 .with_default(true)
                 .prompt()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for storage version V2, including displaying the version as “v2”.
  - Improved upgrade flow: the app now prompts to upgrade storage to V2 from any older version, streamlining setup and ensuring compatibility.
  - Upgrade prompt is skipped when already on V2 for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->