### PR TITLE
fix: Allow non-Alonzo era when missing total collateral

### DIFF
--- a/crates/cardano/src/roll/epochs.rs
+++ b/crates/cardano/src/roll/epochs.rs
@@ -10,7 +10,7 @@ use pallas::{
             },
             Epoch,
         },
-        traverse::{fees::compute_byron_fee, Era, MultiEraBlock, MultiEraCert, MultiEraTx},
+        traverse::{fees::compute_byron_fee, MultiEraBlock, MultiEraCert, MultiEraTx},
     },
 };
 use serde::{Deserialize, Serialize};
@@ -123,11 +123,12 @@ impl dolos_core::EntityDelta for NoncesUpdate {
 // and Alonzo txs don't even have the total collateral field. This is why we
 // need to compute it by looking at collateral inputs and collateral return.
 // Pallas hides this from us by providing the "consumes" / "produces" facade.
+// Note: This can be called for transactions from any era (Alonzo, Babbage, Conway)
+// when total_collateral is not set.
 fn compute_collateral_value(
     tx: &MultiEraTx,
     utxos: &HashMap<TxoRef, OwnedMultiEraOutput>,
 ) -> Result<Lovelace, ChainError> {
-    debug_assert!(tx.era() == Era::Alonzo);
     debug_assert!(!tx.is_valid());
 
     let mut total = 0;


### PR DESCRIPTION
This field is optional according to the CDDL.

Fixes #775 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Collateral value computation now applies across more transaction eras, improving compatibility with newer and legacy transactions.
  * Relaxed era-specific checks allow collateral to be computed even when explicit collateral fields are absent, preserving existing calculation behavior.
* **Documentation**
  * Clarified that collateral computation is era-agnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->