### PR TITLE
fix: Handle default logvalue on devnet

### DIFF
--- a/src/sync/emulator.rs
+++ b/src/sync/emulator.rs
@@ -30,7 +30,9 @@ impl Worker {
         current: Option<RawBlock>,
     ) -> Result<(Tip, RawBlock), WorkerError> {
         let (block_number, slot, prev_hash) = match current {
-            Some(raw) => {
+            Some(raw) => if raw.is_empty() {
+                (1, self.block_production_interval_seconds, None)
+            } else {
                 let block = MultiEraBlock::decode(&raw).unwrap();
                 (
                     block.number() + 1,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block production handling during synchronization to properly manage empty blocks. When encountered, the system now correctly resets the block sequence with appropriate starting configuration to ensure proper block sequencing and maintain continuity throughout the production cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->