### PR TITLE
feat(cardano): support genesis bootstrap of custom staking

### DIFF
--- a/crates/cardano/src/genesis/mod.rs
+++ b/crates/cardano/src/genesis/mod.rs
@@ -2,8 +2,7 @@ use dolos_core::{ChainError, Domain, EntityKey, Genesis, StateStore as _, StateW
 
 use crate::{
     pots::Pots, utils::nonce_stability_window, EpochState, EpochValue, EraBoundary, EraSummary,
-    Lovelace, Nonces, PParamsSet, PoolParams, PoolSnapshot, PoolState, RollingStats,
-    CURRENT_EPOCH_KEY,
+    Lovelace, Nonces, PParamsSet, RollingStats, CURRENT_EPOCH_KEY,
 };
 
 mod staking;

--- a/crates/cardano/src/genesis/staking.rs
+++ b/crates/cardano/src/genesis/staking.rs
@@ -82,7 +82,7 @@ fn find_initial_utxo_sum(credential: &StakeCredential, genesis: &Genesis) -> u64
         }
     }
 
-    return 0;
+    0
 }
 
 fn parse_delegation(account: &str, pool: &str, genesis: &Genesis) -> AccountState {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Genesis initialization now sets up staking pools during bootstrap.
  * Staking pools and delegations from genesis are loaded into the state store.
  * Pool parameters (pledge, cost, margin) are applied at initialization.
  * Reward account addresses for pools are constructed from genesis data.
  * Initial stake balances for accounts are derived from genesis UTxO and applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->