### PR TITLE
feat(forks): iterative pparams migration for robust version upgrades

### DIFF
--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -219,32 +219,39 @@ pub fn migrate_pparams_version(
 ) -> PParamsSet {
     debug!(from, to, "migrating pparams version");
 
-    match (from, to) {
-        // Protocol starts at version 0;
-        // There was one intra-era "hard fork" in byron (even though they weren't called that yet)
-        (0, 1) => intra_era_hardfork(current, to),
-        // Protocol version 2 transitions from Byron to Shelley
-        (1, 2) => from_shelley_genesis(&genesis.shelley),
-        // Two intra-era hard forks, named Allegra (3) and Mary (4); we don't have separate types
-        // for these eras
-        (2, 3) => intra_era_hardfork(current, to),
-        (3, 4) => intra_era_hardfork(current, to),
-        // Protocol version 5 transitions from Shelley (Mary, technically) to Alonzo
-        (4, 5) => into_alonzo(current, &genesis.alonzo),
-        // One intra-era hard-fork in alonzo at protocol version 6
-        (5, 6) => intra_era_hardfork(current, to),
-        // Protocol version 7 transitions from Alonzo to Babbage
-        (6, 7) => into_babbage(current, &genesis.alonzo),
-        // One intra-era hard-fork in babbage at protocol version 8
-        (7, 8) => intra_era_hardfork(current, to),
-        // Protocol version 9 transitions from Babbage to Conway
-        (8, 9) => into_conway(current, &genesis.conway),
-        // One intra-era hard-fork in conway at protocol version 10
-        (9, 10) => intra_era_hardfork(current, to),
-        (from, to) => {
-            unimplemented!("don't know how to bump from version {from} to {to}",)
-        }
+    let mut params = current.clone();
+    let mut v = from;
+
+    while v < to {
+        let next = v + 1;
+
+        params = match (v, next) {
+            // Protocol starts at version 0;
+            // There was one intra-era "hard fork" in byron (even though they weren't called that yet)
+            (0, 1) => intra_era_hardfork(&params, next),
+            // Protocol version 2 transitions from Byron to Shelley
+            (1, 2) => from_shelley_genesis(&genesis.shelley),
+            // Two intra-era hard forks, named Allegra (3) and Mary (4); we don't have separate types
+            // for these eras
+            (2, 3) => intra_era_hardfork(&params, next),
+            (3, 4) => intra_era_hardfork(&params, next),
+            // Protocol version 5 transitions from Shelley (Mary, technically) to Alonzo
+            (4, 5) => into_alonzo(&params, &genesis.alonzo),
+            // One intra-era hard-fork in alonzo at protocol version 6
+            (5, 6) => intra_era_hardfork(&params, next),
+            // Protocol version 7 transitions from Alonzo to Babbage
+            (6, 7) => into_babbage(&params, &genesis.alonzo), // Babbage uses Alonzo genesis
+            // One intra-era hard-fork in babbage at protocol version 8
+            (7, 8) => intra_era_hardfork(&params, next),
+            // Protocol version 9 transitions from Babbage to Conway
+            (8, 9) => into_conway(&params, &genesis.conway),
+            // One intra-era hard-fork in conway at protocol version 10
+            (9, 10) => intra_era_hardfork(&params, next),
+            (_, target) => intra_era_hardfork(&params, target),
+        };
+        v = next;
     }
+    params
 }
 
 pub fn force_pparams_version(


### PR DESCRIPTION
**Description:**
This PR refactors migrate_pparams_version to handle non-sequential protocol version requests (e.g., requesting a migration from v1 directly to v3) by iteratively applying the necessary intermediate hard fork transitions.

**Context / The Problem:**
While syncing the Vector chain, Dolos encountered a panic at slot 864000:
not implemented: don't know how to bump from version 1 to 3.
Investigation showed that while the chain history itself is sequential (v1 -> v2 -> v3), Dolos's internal state machine seemingly missed the v2 update trigger. When the v3 transition occurred, it attempted to migrate from its last known state (v1) directly to the new target (v3).

**The Solution:**
Instead of panicking on non-adjacent version jumps, the migration logic is now iterative.
If asked to go from v1 to v3, it will:

- Apply transition v1 -> v2 (e.g., from_shelley_genesis)
- Apply transition v2 -> v3 (e.g., intra_era_hardfork)

This makes the PParams migration logic robust against missed internal updates or potential future chains that might genuinely skip versions.

**Changes:**

- Refactored migrate_pparams_version to use a while loop.
- The logic sequentially applies standard transitions (from_shelley_genesis, into_alonzo, intra_era_hardfork, etc.) until the target version is reached.

**Testing:**

- Verified on Vector Mainnet.
- Previously crashed at slot 864000.
- With this fix, the node successfully migrated the parameters and is currently syncing past slot 1,200,000+ without issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced protocol parameter migration logic to process version transitions incrementally through each intermediate step, ensuring more reliable and deterministic parameter updates during version upgrades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->