### PR TITLE
feat: Track and ref-count witness-set datum values

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -226,6 +226,8 @@ pub struct UtxoSetDelta {
     pub consumed_utxo: HashMap<TxoRef, Arc<EraCbor>>,
     pub recovered_stxi: HashMap<TxoRef, Arc<EraCbor>>,
     pub undone_utxo: HashMap<TxoRef, Arc<EraCbor>>,
+    pub witness_datums_add: HashMap<Hash<32>, Vec<u8>>,
+    pub witness_datums_remove: HashSet<Hash<32>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
 use itertools::Itertools;
+use pallas::crypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 use crate::{ChainError, ChainPoint, Domain, TxoRef, UtxoMap, UtxoSet, UtxoSetDelta};
@@ -407,6 +408,8 @@ pub trait StateStore: Sized + Send + Sync + Clone {
     fn get_utxo_by_policy(&self, policy: &[u8]) -> Result<UtxoSet, StateError>;
 
     fn get_utxo_by_asset(&self, asset: &[u8]) -> Result<UtxoSet, StateError>;
+
+    fn get_datum(&self, datum_hash: &Hash<32>) -> Result<Option<Vec<u8>>, StateError>;
 }
 
 pub fn load_entity_chunk<D: Domain>(

--- a/crates/redb3/src/state/mod.rs
+++ b/crates/redb3/src/state/mod.rs
@@ -4,6 +4,7 @@ use dolos_core::{
     ChainPoint, EntityKey, EntityValue, Namespace, StateError, StateSchema, TxoRef, UtxoMap,
     UtxoSet,
 };
+use pallas::crypto::hash::Hash;
 
 use redb::{
     Database, Durability, ReadTransaction, ReadableDatabase, TableDefinition, WriteTransaction,
@@ -130,6 +131,7 @@ impl StateStore {
 
         // TODO: refactor into entities model
         utxoset::UtxosTable::initialize(&wx)?;
+        utxoset::DatumsTable::initialize(&wx)?;
         utxoset::FilterIndexes::initialize(&wx)?;
 
         wx.commit()?;
@@ -352,6 +354,13 @@ impl dolos_core::StateStore for StateStore {
     fn get_utxo_by_asset(&self, asset: &[u8]) -> Result<UtxoSet, StateError> {
         let rx = self.db().begin_read().map_err(Error::from)?;
         let out = utxoset::FilterIndexes::get_by_asset(&rx, asset)?;
+
+        Ok(out)
+    }
+
+    fn get_datum(&self, datum_hash: &Hash<32>) -> Result<Option<Vec<u8>>, StateError> {
+        let rx = self.db().begin_read().map_err(Error::from)?;
+        let out = utxoset::DatumsTable::get(&rx, datum_hash)?;
 
         Ok(out)
     }

--- a/crates/redb3/src/state/utxoset.rs
+++ b/crates/redb3/src/state/utxoset.rs
@@ -1,5 +1,8 @@
 use dolos_core::{EraCbor, TxoRef, UtxoMap, UtxoSetDelta};
-use pallas::ledger::{addresses::ShelleyDelegationPart, traverse::MultiEraOutput};
+use pallas::{
+    crypto::hash::Hash,
+    ledger::{addresses::ShelleyDelegationPart, traverse::MultiEraOutput},
+};
 use redb::{
     MultimapTableDefinition, Range, ReadTransaction, ReadableDatabase, ReadableTable as _,
     ReadableTableMetadata as _, TableDefinition, TableStats, WriteTransaction,
@@ -15,6 +18,8 @@ use super::StateStore;
 
 type UtxosKey = (&'static [u8; 32], u32);
 type UtxosValue = (u16, &'static [u8]);
+type DatumKey = &'static [u8; 32];
+type DatumValue = (u64, &'static [u8]);
 
 pub struct UtxosIterator(Range<'static, UtxosKey, UtxosValue>);
 
@@ -99,6 +104,14 @@ impl UtxosTable {
             table.remove(k)?;
         }
 
+        for (datum_hash, datum_value) in delta.witness_datums_add.iter() {
+            DatumsTable::increment(wx, datum_hash, datum_value)?;
+        }
+
+        for datum_hash in delta.witness_datums_remove.iter() {
+            DatumsTable::decrement(wx, datum_hash)?;
+        }
+
         Ok(())
     }
 
@@ -119,6 +132,66 @@ impl UtxosTable {
         let stats = table.stats()?;
 
         Ok(stats)
+    }
+}
+
+pub struct DatumsTable;
+
+impl DatumsTable {
+    pub const DEF: TableDefinition<'static, DatumKey, DatumValue> = TableDefinition::new("datums");
+
+    pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
+        wx.open_table(Self::DEF)?;
+        Ok(())
+    }
+
+    pub fn get(rx: &ReadTransaction, datum_hash: &Hash<32>) -> Result<Option<Vec<u8>>, Error> {
+        let table = rx.open_table(Self::DEF)?;
+        Ok(table.get(&**datum_hash)?.map(|v| v.value().1.to_vec()))
+    }
+
+    pub fn increment(
+        wx: &WriteTransaction,
+        datum_hash: &Hash<32>,
+        datum_value: &[u8],
+    ) -> Result<u64, Error> {
+        let mut table = wx.open_table(Self::DEF)?;
+
+        let current_count = table
+            .get(&**datum_hash)?
+            .map(|entry| entry.value().0)
+            .unwrap_or(0);
+
+        let new_count = current_count + 1;
+        table.insert(&**datum_hash, (new_count, datum_value))?;
+        Ok(new_count)
+    }
+
+    pub fn decrement(wx: &WriteTransaction, datum_hash: &Hash<32>) -> Result<u64, Error> {
+        let mut table = wx.open_table(Self::DEF)?;
+
+        let entry_data: Option<(u64, Vec<u8>)> = table.get(&**datum_hash)?.map(|entry| {
+            let (count, bytes) = entry.value();
+            (count, bytes.to_vec())
+        });
+
+        let Some((count, bytes)) = entry_data else {
+            return Ok(0);
+        };
+
+        if count <= 1 {
+            table.remove(&**datum_hash)?;
+            return Ok(0);
+        }
+
+        let new_count = count - 1;
+        table.insert(&**datum_hash, (new_count, bytes.as_slice()))?;
+        Ok(new_count)
+    }
+
+    pub fn stats(rx: &ReadTransaction) -> Result<TableStats, Error> {
+        let table = rx.open_table(Self::DEF)?;
+        Ok(table.stats()?)
     }
 }
 
@@ -420,11 +493,19 @@ impl StateStore {
         let rx = self.db().begin_read()?;
 
         let utxos = UtxosTable::stats(&rx)?;
+        let datums = DatumsTable::stats(&rx)?;
         let filters = FilterIndexes::stats(&rx)?;
 
-        let all_tables = [("utxos", utxos)].into_iter().chain(filters);
+        let all_tables = [("utxos", utxos), ("datums", datums)]
+            .into_iter()
+            .chain(filters);
 
         Ok(HashMap::from_iter(all_tables))
+    }
+
+    pub fn get_datum(&self, datum_hash: &Hash<32>) -> Result<Option<Vec<u8>>, Error> {
+        let rx = self.db().begin_read()?;
+        DatumsTable::get(&rx, datum_hash)
     }
 }
 


### PR DESCRIPTION
For dApps that use witness datum values, you have to keep the datum values off-chain so that when you build a transaction that spends a utxo containing a datum hash, you can provide the actual datum value to witness it. 

Since dolos is indexing the blockchain anyway, have it index these actual datum values that are represented in the ledger as only a hash.

This makes it easier when building new transactions to just use dolos as the off-chain store for the datum values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and track Plutus datum bytes added/removed during UTXO updates and recovery.
  * Persist datums with reference counting to manage lifecycle and avoid dangling data.
  * Expose datum lookup in the state API so services can retrieve datum bytes.
  * UTXO query responses now enrich outputs with associated datum payloads and emit clearer, operation‑specific warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->