### PR TITLE
add a metrics endpoint

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -230,6 +230,7 @@ where
         let app = Router::new()
             .route("/", get(routes::root::<D>))
             .route("/health", get(routes::health::naked))
+            .route("/metrics", get(routes::metrics::metrics::<D>))
             .route("/health/clock", get(routes::health::clock))
             .route("/genesis", get(routes::genesis::naked::<D>))
             .route("/network", get(routes::network::naked::<D>))

--- a/crates/minibf/src/routes/metrics.rs
+++ b/crates/minibf/src/routes/metrics.rs
@@ -1,0 +1,34 @@
+use axum::{extract::State, http::StatusCode, Json};
+use crate::{Config, Facade};
+use dolos_core::{ArchiveStore as _, BlockBody, Domain};
+use pallas::{
+    codec::{minicbor, utils::Bytes},
+    crypto::hash::{Hash, Hasher},
+    ledger::{
+        addresses::{Address, Network, ShelleyPaymentPart, StakeAddress, StakePayload},
+        primitives::{
+            alonzo::{self, Certificate as AlonzoCert},
+            conway::{Certificate as ConwayCert, DRep, DatumOption, RedeemerTag, ScriptRef},
+            ExUnitPrices, StakeCredential,
+        },
+        traverse::{
+            ComputeHash, MultiEraBlock, MultiEraCert, MultiEraHeader, MultiEraInput,
+            MultiEraOutput, MultiEraRedeemer, MultiEraTx, MultiEraValue, OriginalHash,
+        },
+    },
+};
+
+pub async fn metrics<D: Domain> (
+    State(domain): State<Facade<D>>,
+) -> Result<String, StatusCode> {
+    let (_, tip) = domain
+        .archive()
+        .get_tip()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let block = MultiEraBlock::decode(&tip).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let slot = block.slot();
+    let number = block.number();
+    Ok(format!("dolos_slot {}\ndolos_block_number {}", slot, number))
+}

--- a/crates/minibf/src/routes/mod.rs
+++ b/crates/minibf/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod scripts;
 pub mod tx;
 pub mod txs;
 pub mod utxos;
+pub mod metrics;
 
 use std::env;
 


### PR DESCRIPTION
this adds a /metrics endpoint to the existing http server, which provides the slot number and block height as prometheus metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/metrics` HTTP endpoint that returns repository tip info (slot and block number). Responds with HTTP 200 on success, 503 if tip is unavailable, and 500 for internal errors.

* **Chores**
  * Registered the new metrics route in the router.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->