### PR TITLE
fix: correct condition for notifying tip events

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -96,7 +96,7 @@ impl Domain for DomainAdapter {
     }
 
     fn notify_tip(&self, tip: TipEvent) {
-        if !self.tip_broadcast.receiver_count() == 0 {
+        if self.tip_broadcast.receiver_count() > 0 {
             self.tip_broadcast.send(tip).unwrap();
         }
     }


### PR DESCRIPTION
This pull request makes a small update to the logic for broadcasting tip notifications in the `DomainAdapter` implementation. The change ensures that tip events are only sent if there are receivers available.

* The condition in `notify_tip` was corrected to check if `receiver_count` is greater than zero before broadcasting the tip event, preventing unnecessary or failed sends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tip notification logic to properly broadcast only when there are active receivers, preventing unnecessary notification attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->