### PR TITLE
experiment: build indexes for utxoset with a different command

### DIFF
--- a/crates/cardano/src/estart/mod.rs
+++ b/crates/cardano/src/estart/mod.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use dolos_core::{
     batch::WorkDeltas, config::CardanoConfig, BlockSlot, ChainError, Domain, EntityKey, Genesis,
 };
-use tracing::{debug, info, instrument};
+use tracing::{info, instrument};
 
 use crate::{
     AccountState, CardanoDelta, CardanoEntity, CardanoLogic, DRepState, EpochState, EraProtocol,
@@ -104,13 +104,14 @@ pub fn execute<D: Domain>(
     _config: &CardanoConfig,
     genesis: Arc<Genesis>,
 ) -> Result<(), ChainError> {
+    let started = Instant::now();
     info!("executing ESTART work unit");
 
     let mut work = WorkContext::load::<D>(state, genesis)?;
 
     work.commit::<D>(state, archive, slot)?;
 
-    debug!("ESTART work unit committed");
+    info!(elapsed =? started.elapsed(), "ESTART work unit committed");
 
     Ok(())
 }

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -1,13 +1,13 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::Arc, time::Instant,
 };
 
 use dolos_core::{
     batch::WorkDeltas, config::CardanoConfig, BlockSlot, ChainError, Domain, EntityKey, Genesis,
 };
 use pallas::ledger::primitives::conway::DRep;
-use tracing::{debug, info, instrument};
+use tracing::{info, instrument};
 
 use crate::{
     rewards::RewardMap, rupd::RupdWork, AccountState, CardanoDelta, CardanoEntity, CardanoLogic,
@@ -156,13 +156,14 @@ pub fn execute<D: Domain>(
     genesis: Arc<Genesis>,
     rewards: RewardMap<RupdWork>,
 ) -> Result<(), ChainError> {
+    let started = Instant::now();
     info!("executing EWRAP work unit");
 
     let mut boundary = BoundaryWork::load::<D>(state, genesis, rewards)?;
 
     boundary.commit::<D>(state, archive)?;
 
-    debug!("EWRAP work unit committed");
+    info!(elapsed =? started.elapsed(), "EWRAP work unit committed");
 
     Ok(())
 }

--- a/crates/cardano/src/genesis/mod.rs
+++ b/crates/cardano/src/genesis/mod.rs
@@ -118,10 +118,10 @@ pub fn bootstrap_utxos<D: Domain>(
     let writer = state.start_writer()?;
 
     let delta = crate::utxoset::compute_origin_delta(genesis);
-    writer.apply_utxoset(&delta)?;
+    writer.apply_utxoset(&delta, false)?;
 
     let delta = crate::utxoset::build_custom_utxos_delta(config)?;
-    writer.apply_utxoset(&delta)?;
+    writer.apply_utxoset(&delta, false)?;
 
     writer.commit()?;
 

--- a/crates/cardano/src/rewards/mod.rs
+++ b/crates/cardano/src/rewards/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, marker::PhantomData};
+use std::{collections::HashMap, marker::PhantomData, time::Instant};
 
 use dolos_core::ChainError;
 use pallas::ledger::primitives::StakeCredential;
@@ -331,6 +331,7 @@ pub trait RewardsContext {
 
 pub fn define_rewards<C: RewardsContext>(ctx: &C) -> Result<RewardMap<C>, ChainError> {
     let mut map = RewardMap::<C>::new(ctx.incentives().clone());
+    let start = Instant::now();
 
     for pool in ctx.iter_all_pools() {
         let pool_params = ctx.pool_params(pool);
@@ -418,6 +419,8 @@ pub fn define_rewards<C: RewardsContext>(ctx: &C) -> Result<RewardMap<C>, ChainE
             map.include(ctx, &delegator, delegator_reward, pool, false);
         }
     }
+
+    tracing::info!(elapsed =? start.elapsed(), "finished rewards calculation");
 
     Ok(map)
 }

--- a/crates/core/src/batch.rs
+++ b/crates/core/src/batch.rs
@@ -298,7 +298,7 @@ impl<C: ChainLogic> WorkBatch<C> {
         // this into the entity system.
         for block in self.blocks.iter() {
             if let Some(utxo_delta) = &block.utxo_delta {
-                writer.apply_utxoset(utxo_delta)?;
+                writer.apply_utxoset(utxo_delta, false)?;
             }
         }
 

--- a/crates/redb3/src/state/mod.rs
+++ b/crates/redb3/src/state/mod.rs
@@ -112,8 +112,7 @@ impl StateStore {
         &self.db
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn db_mut(&mut self) -> Option<&mut Database> {
+    pub fn db_mut(&mut self) -> Option<&mut Database> {
         Arc::get_mut(&mut self.db)
     }
 

--- a/src/bin/dolos/doctor/build_indexes.rs
+++ b/src/bin/dolos/doctor/build_indexes.rs
@@ -1,0 +1,47 @@
+use std::{sync::Arc};
+
+use dolos_core::config::RootConfig;
+use itertools::Itertools;
+use miette::{Context, IntoDiagnostic};
+
+use dolos::prelude::*;
+
+use crate::feedback::Feedback;
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[arg(short, long, default_value_t = 500)]
+    pub chunk: usize,
+}
+
+#[tokio::main]
+pub async fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {
+    //crate::common::setup_tracing(&config.logging)?;
+
+    let progress = feedback.slot_progress_bar();
+    progress.set_message("building indexes");
+
+    let domain = crate::common::setup_domain(config).await?;
+
+    progress.set_length(domain.state.amount_of_utxos().into_diagnostic().context("getting amount of utxos")?);
+
+    let remaining = domain
+        .state.iter_utxos()
+        .into_diagnostic()
+        .context("iterating over utxos")?;
+
+    for chunk in remaining.chunks(args.chunk).into_iter() {
+        let produced_utxo = chunk.into_iter().map(|x| {
+            let ( k, v ) = x.into_diagnostic().context("decoding utxoset")?;
+            Ok((k, Arc::new(v)))
+        }).collect::<miette::Result<_>>()?;
+        let utxoset = UtxoSetDelta {produced_utxo, ..Default::default()};
+
+        let writer = domain.state.start_writer().into_diagnostic().context("starting writer")?;
+        writer.index_utxoset(&utxoset).into_diagnostic().context("indexing")?;
+
+        progress.inc(args.chunk as u64);
+    }
+
+    Ok(())
+}

--- a/src/bin/dolos/doctor/mod.rs
+++ b/src/bin/dolos/doctor/mod.rs
@@ -3,6 +3,7 @@ use dolos_core::config::RootConfig;
 
 use crate::feedback::Feedback;
 
+mod build_indexes;
 mod catchup_stores;
 mod reset_wal;
 mod rollback;
@@ -32,6 +33,9 @@ pub enum Command {
 
     /// manually updates an entity in the state
     UpdateEntity(update_entity::Args),
+
+    /// catch up store data from WAL records
+    BuildIndexes(build_indexes::Args),
 }
 
 #[derive(Debug, Parser)]
@@ -42,6 +46,7 @@ pub struct Args {
 
 pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {
     match &args.command {
+        Command::BuildIndexes(x) => build_indexes::run(config, x, feedback)?,
         Command::CatchupStores(x) => catchup_stores::run(config, x, feedback)?,
         Command::ResetWal(x) => reset_wal::run(config, x, feedback)?,
         Command::WalIntegrity(x) => wal_integrity::run(config, x)?,

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -61,7 +61,7 @@ where
             let utxo_undo = dolos_cardano::utxoset::compute_undo_delta(blockd, &inputs)
                 .map_err(dolos_core::ChainError::from)?;
 
-            writer.apply_utxoset(&utxo_undo)?;
+            writer.apply_utxoset(&utxo_undo, false)?;
 
             // TODO: we should differ notifications until the we commit the writers
             self.notify_tip(TipEvent::Undo(point.clone(), block));


### PR DESCRIPTION
The idea consists on separating the index construction from the utxoset generation, as to avoid creating the indexes on each step of the bootstrapping process, similar to `defer-indexes` on Kupo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `build_indexes` command to rebuild UTXO indexes in configurable chunks
  * Added support for querying and iterating UTXOs from the state store

* **Improvements**
  * Enhanced UTXO indexing with deferred index application for better control
  * Added performance timing instrumentation across core operations
  * Optimized state preparation workflow in export functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->