### PR TITLE
fix(cardano): use entity streaming for mem-heavy work units

### DIFF
--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -1,9 +1,8 @@
 //! Commit logic for epoch start (estart) work unit.
 //!
-//! This module uses a streaming pattern that writes entities one-by-one during
-//! iteration, avoiding the need to collect all entities in memory. This is safe
-//! with Redb's MVCC: read iterators see the pre-commit snapshot while writes
-//! are isolated until commit.
+//! This module uses a streaming pattern that processes entities one-by-one,
+//! applying deltas and writing immediately without accumulating all entities
+//! in memory.
 
 use dolos_core::{
     ArchiveStore, ArchiveWriter, BlockSlot, BrokenInvariant, ChainError, ChainPoint, Domain,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal commit operations to use streaming architecture for improved memory efficiency and performance during entity processing, while maintaining data integrity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->