### PR TITLE
fix(minibf): add max scan limit for paginated endpoints

### DIFF
--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -174,6 +174,11 @@ impl DoubleEndedIterator for EmptyBlockIter {
     }
 }
 
+impl crate::archive::Skippable for EmptyBlockIter {
+    fn skip_forward(&mut self, _n: usize) {}
+    fn skip_backward(&mut self, _n: usize) {}
+}
+
 /// Empty iterator for log queries.
 pub struct EmptyLogIter;
 

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -190,6 +190,7 @@ where
     Option<AccountState>: From<D::Entity>,
 {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
     let account_key = parse_account_key_param(&stake_address)?;
     let end_slot = domain.get_tip_slot()?;
 
@@ -506,6 +507,7 @@ where
     Option<AccountState>: From<D::Entity>,
 {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
 
     let items = by_stake_actions::<D, _, AccountDelegationContentInner>(
         &stake_address,
@@ -527,6 +529,7 @@ where
     Option<AccountState>: From<D::Entity>,
 {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
 
     let items = by_stake_actions::<D, _, AccountRegistrationContentInner>(
         &stake_address,

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -345,6 +345,7 @@ pub async fn transactions<D: Domain>(
     State(domain): State<Facade<D>>,
 ) -> Result<Json<Vec<AddressTransactionsContentInner>>, Error> {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
     let end_slot = domain.get_tip_slot()?;
 
     let (blocks, address) = blocks_for_address(&domain.inner, &address, 0, end_slot)?;
@@ -373,6 +374,7 @@ pub async fn txs<D: Domain>(
     State(domain): State<Facade<D>>,
 ) -> Result<Json<Vec<String>>, Error> {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
     let end_slot = domain.get_tip_slot()?;
 
     let (blocks, address) = blocks_for_address(&domain.inner, &address, 0, end_slot)?;

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -735,6 +735,7 @@ pub async fn by_subject_transactions<D: Domain>(
     State(domain): State<Facade<D>>,
 ) -> Result<Json<Vec<AssetTransactionsInner>>, Error> {
     let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit()?;
 
     let subject = hex::decode(&subject).map_err(|_| Error::InvalidAsset)?;
     let end_slot = domain.get_tip_slot()?;

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -5,7 +5,9 @@ use axum::{
 };
 use blockfrost_openapi::models::block_content::BlockContent;
 use dolos_cardano::ChainSummary;
-use dolos_core::{ArchiveStore as _, BlockBody, Domain, QueryHelpers as _};
+use dolos_core::{
+    archive::Skippable as _, ArchiveStore as _, BlockBody, Domain, QueryHelpers as _,
+};
 use itertools::Either;
 use pallas::ledger::{
     configs::{byron, shelley},
@@ -189,12 +191,13 @@ pub async fn by_hash_or_number_previous<D: Domain>(
 
     let curr = MultiEraBlock::decode(&curr).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let iter = domain
+    let mut iter = domain
         .archive()
         .get_range(None, Some(curr.slot()))
-        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
-        .rev()
-        .enumerate();
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Skip past pages we don't need using key-only traversal (no block data read).
+    iter.skip_backward(pagination.from());
 
     let (_, tip) = domain
         .archive()
@@ -206,13 +209,9 @@ pub async fn by_hash_or_number_previous<D: Domain>(
 
     let mut output = vec![];
 
-    for (i, (_, body)) in iter {
-        if pagination.includes(i) {
-            let model = build_block_model(&domain, &body, &tip, &chain)?;
-            output.push(model);
-        } else if i > pagination.to() {
-            break;
-        }
+    for (_, body) in iter.rev().take(pagination.count) {
+        let model = build_block_model(&domain, &body, &tip, &chain)?;
+        output.push(model);
     }
 
     // Insert block 0 only in preview
@@ -254,8 +253,11 @@ pub async fn by_hash_or_number_next<D: Domain>(
         .get_range(Some(curr.slot()), None)
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
 
-    // Discard first block.
-    let _ = iterator.next();
+    // Discard first block (the reference block itself).
+    iterator.skip_forward(1);
+
+    // Skip past pages we don't need using key-only traversal (no block data read).
+    iterator.skip_forward(pagination.from());
 
     let (_, tip) = domain
         .archive()
@@ -267,13 +269,9 @@ pub async fn by_hash_or_number_next<D: Domain>(
 
     let mut output = vec![];
 
-    for (i, (_, body)) in iterator.enumerate() {
-        if pagination.includes(i) {
-            let model = build_block_model(&domain, &body, &tip, &chain)?;
-            output.push(model);
-        } else if i > pagination.to() {
-            break;
-        }
+    for (_, body) in iterator.take(pagination.count) {
+        let model = build_block_model(&domain, &body, &tip, &chain)?;
+        output.push(model);
     }
     let output = match pagination.order {
         Order::Asc => output,

--- a/crates/minibf/src/routes/metadata.rs
+++ b/crates/minibf/src/routes/metadata.rs
@@ -128,6 +128,7 @@ async fn by_label<D: Domain>(
 ) -> Result<MetadataHistoryModelBuilder, Error> {
     let label: u64 = label.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
     let pagination = Pagination::try_from(pagination)?;
+    pagination.enforce_max_scan_limit()?;
     let end_slot = domain.get_tip_slot()?;
 
     let mut blocks = domain

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -991,6 +991,24 @@ impl DoubleEndedIterator for ArchiveRangeIter {
     }
 }
 
+impl dolos_core::archive::Skippable for ArchiveRangeIter {
+    fn skip_forward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.range.next().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn skip_backward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.range.next_back().is_none() {
+                break;
+            }
+        }
+    }
+}
+
 pub struct ArchiveSparseIter(
     ReadTransaction,
     indexes::SlotKeyIterator,

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -556,6 +556,22 @@ impl DoubleEndedIterator for ArchiveBlockIterBackend {
     }
 }
 
+impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
+    fn skip_forward(&mut self, n: usize) {
+        match self {
+            Self::Redb(iter) => iter.skip_forward(n),
+            Self::NoOp(iter) => iter.skip_forward(n),
+        }
+    }
+
+    fn skip_backward(&mut self, n: usize) {
+        match self {
+            Self::Redb(iter) => iter.skip_backward(n),
+            Self::NoOp(iter) => iter.skip_backward(n),
+        }
+    }
+}
+
 pub enum ArchiveLogIterBackend {
     Redb(<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::LogIter),
     NoOp(EmptyLogIter),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination scan limit enforcement to prevent excessive item scanning across multiple endpoints.
  
* **Refactor**
  * Improved pagination handling in blocks, epochs, accounts, addresses, assets, and metadata endpoints for better performance and resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->