### PR TITLE
Configure grpc max dump history

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -561,6 +561,7 @@ pub struct GrpcConfig {
     pub listen_address: String,
     pub tls_client_ca_root: Option<PathBuf>,
     pub permissive_cors: Option<bool>,
+    pub max_dump_history_items: Option<u32>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -310,6 +310,7 @@ impl ConfigEditor {
                     listen_address: "[::]:50051".into(),
                     tls_client_ca_root: None,
                     permissive_cors: Some(true),
+                    max_dump_history_items: None,
                 }
                 .into();
             } else {

--- a/src/serve/grpc/mod.rs
+++ b/src/serve/grpc/mod.rs
@@ -28,8 +28,10 @@ where
 
     async fn run(cfg: Self::Config, domain: D, cancel: C) -> Result<(), ServeError> {
         let addr = cfg.listen_address.parse().unwrap();
+        let max_history_items = cfg.max_dump_history_items.unwrap_or(100);
 
-        let sync_service = sync::SyncServiceImpl::new(domain.clone(), cancel.clone());
+        let sync_service =
+            sync::SyncServiceImpl::new(domain.clone(), cancel.clone(), max_history_items);
         let sync_service = u5c::sync::sync_service_server::SyncServiceServer::new(sync_service);
 
         let query_service = query::QueryServiceImpl::new(domain.clone());


### PR DESCRIPTION
This pull request introduces a configurable limit for the maximum number of history items that can be dumped via the gRPC sync service, replacing the previous hardcoded value. The configuration can now be set via the `GrpcConfig` struct, and the relevant logic and tests have been updated accordingly.

**Configuration Improvements:**
* Added an optional `max_dump_history_items` field to the `GrpcConfig` struct, allowing the maximum number of dump history items to be set via configuration.
* Updated the gRPC server startup logic in `src/serve/grpc/mod.rs` to read the new configuration value, defaulting to 100 if not set, and to pass it to the sync service implementation.

**Sync Service Logic Updates:**
* Removed the hardcoded `MAX_DUMP_HISTORY_ITEMS` constant in `src/serve/grpc/sync.rs` and instead made the limit a field of the `SyncServiceImpl` struct, set via its constructor. 
* Updated the validation logic in the sync service to use the configurable `max_history_items` value when checking requests, and improved the error message to reflect the dynamic limit.

**Test Adjustments:**
* Updated tests in `src/serve/grpc/sync.rs` to use the new constructor for `SyncServiceImpl` that accepts the configurable limit, and to validate the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added configuration option for the gRPC service's maximum history retention limit, allowing users to customize the setting with a default of 100 items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->