### PR TITLE
fix: Active epoch on pool_updates

### DIFF
--- a/src/serve/o7s_unix/statequery_utils.rs
+++ b/src/serve/o7s_unix/statequery_utils.rs
@@ -721,7 +721,7 @@ pub fn build_stake_snapshots_response<D: Domain>(
         .union(&set_active_pools)
         .cloned()
         .collect();
-    all_pools.extend(go_active_pools.into_iter());
+    all_pools.extend(go_active_pools);
 
     let mark_total = mark_total_active;
     let set_total = set_total_active;


### PR DESCRIPTION
active epoch should be 2 for registrations, 3 for the rest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pool state tracking to improve accuracy of pool metadata handling across transactions

* **Improvements**
  * Better distinction between pool registration and update operations
  * Refined active epoch calculation for pool updates based on operation type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->