### PR TITLE
fix(minibf): add guard for inconsistent range params

### DIFF
--- a/crates/minibf/src/pagination.rs
+++ b/crates/minibf/src/pagination.rs
@@ -165,12 +165,12 @@ impl TryFrom<PaginationParameters> for Pagination {
             None => Default::default(),
         };
 
-        let from = match value.from {
+        let from: Option<PaginationNumberAndIndex> = match value.from {
             Some(x) => Some(x.try_into()?),
             None => None,
         };
 
-        let to = match value.to {
+        let to: Option<PaginationNumberAndIndex> = match value.to {
             Some(x) => Some(x.try_into()?),
             None => None,
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation added for pagination inputs to ensure "from" and "to" are in proper order; invalid combinations are rejected with a clear error message: "Invalid (malformed or out of range) from/to parameter(s)."

* **Tests**
  * New asynchronous test added to confirm the invalid pagination case returns the expected JSON error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->