### PR TITLE
feat: compute epoch length from byron genesis

### DIFF
--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -74,14 +74,14 @@ fn from_conway_drep_voting_thresholds(
     }
 }
 
-// AFAIK, Byron epoch length is a constant and not available via Genesis files.
-const FIVE_DAYS_IN_SECONDS: u64 = 5 * 24 * 60 * 60;
+// Byron epochs last 10k slots (10 * k) per cardano-node, where k is protocol_consts.k from Byron genesis.
+const BYRON_EPOCH_SLOTS_PER_K: u64 = 10;
 
 pub fn from_byron_genesis(byron: &byron::GenesisFile) -> PParamsSet {
     let version = &byron.block_version_data;
 
     let slot_length_in_secs = version.slot_duration / 1000;
-    let epoch_length = FIVE_DAYS_IN_SECONDS / slot_length_in_secs;
+    let epoch_length = BYRON_EPOCH_SLOTS_PER_K * byron.protocol_consts.k as u64;
 
     PParamsSet::default()
         .with(Val::ProtocolVersion((0, 0)))
@@ -273,7 +273,7 @@ pub fn protocol_constants(version: u16, genesis: &Genesis) -> ProtocolConstants 
     match version {
         x if x < 2 => {
             let slot_length_in_secs = genesis.byron.block_version_data.slot_duration / 1000;
-            let epoch_length = FIVE_DAYS_IN_SECONDS / slot_length_in_secs;
+            let epoch_length = BYRON_EPOCH_SLOTS_PER_K * genesis.byron.protocol_consts.k as u64;
 
             ProtocolConstants {
                 epoch_length,


### PR DESCRIPTION
This pull request updates how Byron epoch length is calculated in the Cardano codebase to use the correct slot-based formula instead of a fixed time-based value. The changes ensure that epoch length is now determined by the number of slots per epoch as specified in the Byron genesis protocol constants, improving accuracy and alignment with the official Cardano node implementation. Source of information for the [formula](https://github.com/input-output-hk/cardano-node-wiki/blob/57dc5b7b831fa42be88ab47ba9093b8d1ed78640/docs/reference/create-cardano.md?plain=1#L60).

Byron epoch length calculation updates:

* Replaced the time-based constant `FIVE_DAYS_IN_SECONDS` with the slot-based constant `BYRON_EPOCH_SLOTS_PER_K` in `crates/cardano/src/forks.rs`, reflecting that Byron epochs last 10k slots per protocol constant `k` from the genesis file.
* Updated the epoch length calculation in both `from_byron_genesis` and `protocol_constants` functions to use `BYRON_EPOCH_SLOTS_PER_K * k` instead of dividing by slot duration, ensuring correctness and consistency with Cardano node behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Byron epoch length calculation to use dynamic values based on protocol parameters instead of a fixed constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->