### PR TITLE
chore: Refactor data export command

### DIFF
--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -4,8 +4,9 @@ use dolos_core::config::RootConfig;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use miette::{bail, IntoDiagnostic as _};
+use std::ffi::OsStr;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tar::Builder;
 
 #[derive(Debug, Parser)]
@@ -14,13 +15,78 @@ pub struct Args {
     #[arg(short, long)]
     output: PathBuf,
 
-    // Whether to include chain
+    // Whether to include archive
     #[arg(long, action)]
-    include_chain: bool,
+    include_archive: bool,
 
     // Whether to include state
     #[arg(long, action)]
     include_state: bool,
+
+    // Whether to include indexes
+    #[arg(long, action)]
+    include_indexes: bool,
+}
+
+fn is_macos_metadata(path: &Path) -> bool {
+    if path
+        .components()
+        .any(|component| component.as_os_str() == OsStr::new("__MACOSX"))
+    {
+        return true;
+    }
+
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    file_name == ".DS_Store" || file_name.starts_with("._")
+}
+
+fn append_path_filtered(
+    archive: &mut Builder<GzEncoder<File>>,
+    source: &Path,
+    name: &Path,
+) -> miette::Result<()> {
+    if source.is_dir() {
+        append_dir_filtered(archive, source, name)?;
+        return Ok(());
+    }
+
+    archive
+        .append_path_with_name(source, name)
+        .into_diagnostic()?;
+
+    Ok(())
+}
+
+fn append_dir_filtered(
+    archive: &mut Builder<GzEncoder<File>>,
+    source: &Path,
+    name: &Path,
+) -> miette::Result<()> {
+    archive.append_dir(name, source).into_diagnostic()?;
+
+    for entry in std::fs::read_dir(source).into_diagnostic()? {
+        let entry = entry.into_diagnostic()?;
+        let path = entry.path();
+
+        if is_macos_metadata(&path) {
+            continue;
+        }
+
+        let entry_name = name.join(entry.file_name());
+
+        if path.is_dir() {
+            append_dir_filtered(archive, &path, &entry_name)?;
+        } else {
+            archive
+                .append_path_with_name(&path, &entry_name)
+                .into_diagnostic()?;
+        }
+    }
+
+    Ok(())
 }
 
 fn prepare_wal(
@@ -38,15 +104,15 @@ fn prepare_wal(
     Ok(())
 }
 
-fn prepare_chain(
+fn prepare_archive(
     archive: &mut dolos_redb3::archive::ArchiveStore,
     pb: &crate::feedback::ProgressBar,
 ) -> miette::Result<()> {
     let db = archive.db_mut();
-    pb.set_message("compacting chain");
+    pb.set_message("compacting archive");
     db.compact().into_diagnostic()?;
 
-    pb.set_message("checking chain integrity");
+    pb.set_message("checking archive integrity");
     db.check_integrity().into_diagnostic()?;
 
     Ok(())
@@ -71,24 +137,20 @@ pub fn run(
 
     let path = root.join("wal");
 
-    archive
-        .append_path_with_name(&path, "wal")
-        .into_diagnostic()?;
+    append_path_filtered(&mut archive, &path, Path::new("wal"))?;
 
-    // prepare_chain requires direct redb access
+    // prepare_archive requires direct redb access
     match &mut stores.archive {
-        ArchiveStoreBackend::Redb(s) => prepare_chain(s, &pb)?,
+        ArchiveStoreBackend::Redb(s) => prepare_archive(s, &pb)?,
         ArchiveStoreBackend::NoOp(_) => {
             bail!("export command is not available for noop archive backend")
         }
     }
 
-    if args.include_chain {
-        let path = root.join("chain");
+    if args.include_archive {
+        let path = root.join("archive");
 
-        archive
-            .append_path_with_name(&path, "chain")
-            .into_diagnostic()?;
+        append_path_filtered(&mut archive, &path, Path::new("archive"))?;
 
         pb.set_message("creating archive");
     }
@@ -96,9 +158,15 @@ pub fn run(
     if args.include_state {
         let path = root.join("state");
 
-        archive
-            .append_path_with_name(&path, "state")
-            .into_diagnostic()?;
+        append_path_filtered(&mut archive, &path, Path::new("state"))?;
+
+        pb.set_message("creating archive");
+    }
+
+    if args.include_indexes {
+        let path = root.join("index");
+
+        append_path_filtered(&mut archive, &path, Path::new("index"))?;
 
         pb.set_message("creating archive");
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export functionality now filters out macOS metadata files from archives automatically
  * Added new option to include or exclude indexes in archive exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->