### PR TITLE
fix: Remove wal from snapshot

### DIFF
--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -131,13 +131,13 @@ pub fn run(
 
     let mut stores = crate::common::open_data_stores(config)?;
 
-    prepare_wal(stores.wal, &pb)?;
+    // prepare_wal(stores.wal, &pb)?;
 
     let root = crate::common::ensure_storage_path(config)?;
 
-    let path = root.join("wal");
+    // let path = root.join("wal");
 
-    append_path_filtered(&mut archive, &path, Path::new("wal"))?;
+    // append_path_filtered(&mut archive, &path, Path::new("wal"))?;
 
     // prepare_archive requires direct redb access
     match &mut stores.archive {

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -89,21 +89,6 @@ fn append_dir_filtered(
     Ok(())
 }
 
-fn prepare_wal(
-    mut wal: dolos::adapters::WalAdapter,
-    pb: &crate::feedback::ProgressBar,
-) -> miette::Result<()> {
-    let db = wal.db_mut().unwrap();
-
-    pb.set_message("compacting wal");
-    db.compact().into_diagnostic()?;
-
-    pb.set_message("checking wal integrity");
-    db.check_integrity().into_diagnostic()?;
-
-    Ok(())
-}
-
 fn prepare_archive(
     archive: &mut dolos_redb3::archive::ArchiveStore,
     pb: &crate::feedback::ProgressBar,
@@ -130,14 +115,7 @@ pub fn run(
     let mut archive = Builder::new(encoder);
 
     let mut stores = crate::common::open_data_stores(config)?;
-
-    // prepare_wal(stores.wal, &pb)?;
-
     let root = crate::common::ensure_storage_path(config)?;
-
-    // let path = root.join("wal");
-
-    // append_path_filtered(&mut archive, &path, Path::new("wal"))?;
 
     // prepare_archive requires direct redb access
     match &mut stores.archive {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed WAL export functionality from the data export process. Archive, state, and index export paths remain fully operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->