### PR TITLE
feat(minibf): adjust max scan limit via config

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -626,6 +626,7 @@ pub struct MinibfConfig {
     pub permissive_cors: Option<bool>,
     pub token_registry_url: Option<String>,
     pub url: Option<String>,
+    pub max_scan_items: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -195,7 +195,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
     let account_key = parse_account_key_param(&stake_address)?;
     if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
         return Err(StatusCode::NOT_FOUND.into());
@@ -538,7 +538,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let items = by_stake_actions::<D, _, AccountDelegationContentInner>(
         &stake_address,
@@ -561,7 +561,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let items = by_stake_actions::<D, _, AccountRegistrationContentInner>(
         &stake_address,

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -348,7 +348,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let (start_slot, end_slot) = pagination.start_and_end_slots(&domain).await?;
     let address_str = address.clone();
@@ -412,7 +412,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let (start_slot, end_slot) = pagination.start_and_end_slots(&domain).await?;
     let (stream, address) = blocks_for_address_stream(

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -688,7 +688,7 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let subject = hex::decode(&subject).map_err(|_| Error::InvalidAsset)?;
 

--- a/crates/minibf/src/routes/metadata.rs
+++ b/crates/minibf/src/routes/metadata.rs
@@ -132,7 +132,7 @@ where
 {
     let label: u64 = label.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
     let pagination = Pagination::try_from(pagination)?;
-    pagination.enforce_max_scan_limit()?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items)?;
 
     let (start_slot, end_slot) = pagination.start_and_end_slots(domain).await?;
     let stream = domain.query().blocks_by_metadata_stream(

--- a/crates/minibf/src/test_support.rs
+++ b/crates/minibf/src/test_support.rs
@@ -118,6 +118,7 @@ impl TestApp {
             permissive_cors: None,
             token_registry_url: None,
             url: None,
+            max_scan_items: None,
         };
 
         let facade = Facade {

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -329,6 +329,7 @@ impl ConfigEditor {
                     permissive_cors: Some(true),
                     token_registry_url: None,
                     url: None,
+                    max_scan_items: None,
                 }
                 .into();
             } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum scan item limit for pagination operations, allowing customization of how many items can be scanned per request. The default limit is set to 3,000 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->