### PR TITLE
chore: bump tx3 to v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,24 +5736,24 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tx3-cardano"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ea4ab925f51c6b2b8261dc5adbee901d2f64a9c90c43d2643c9b9b40722783"
+checksum = "162292b111b4a4799910f7ca1225ac0d4cba181c733ae3bcf0e6aa4abf03af1b"
 dependencies = [
  "hex",
  "pallas",
  "serde",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.14.2",
+ "tx3-tir 0.15.0",
  "utxorpc",
 ]
 
 [[package]]
 name = "tx3-resolver"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5a0a8587191fd2207341ba679a4179d1f1d11f46587a2dc006c26ccded404d"
+checksum = "d8ab1f32e82adabd222962f16e3681f9db54740646b024344b9122c89480bd86"
 dependencies = [
  "approx",
  "base64 0.22.1",
@@ -5763,7 +5763,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.14.2",
+ "tx3-tir 0.15.0",
 ]
 
 [[package]]
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1dfb5f68fde6e552fdb1877e309cec4b9a56469ba94068dabd026660b911c3"
+checksum = "4e7ae5cff46ed59f7148468b60ec1342662b66725e4e53d08940672f70a07ce7"
 dependencies = [
  "ciborium",
  "hex",

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee = { version = "0.24.9", features = ["server"] }
 opentelemetry = "0.30.0"
 opentelemetry_sdk = "0.30.0"
 
-tx3-cardano = "0.14.2"
-tx3-resolver = "0.14.2"
+tx3-cardano = "0.15.0"
+tx3-resolver = "0.15.0"
 
 # tx3-cardano = { path = "../../../../tx3-lang/tx3/crates/tx3-cardano" }
 # tx3-resolver = { path = "../../../../tx3-lang/tx3/crates/tx3-resolver" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tx3-cardano and tx3-resolver dependencies to version 0.15.0

* **Refactor**
  * Consolidated internal type definitions to utilize shared public types from dependencies, improving code consistency and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->