### PR TITLE
chore(trp): update tx3 deps to v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,24 +5736,24 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tx3-cardano"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a2074d76a3da98221fd91d64ecd48c37a6b3842b56bfaa93ca9bf1e7038eac"
+checksum = "351417ef718484a6ff3531733f8722da80a4d4a982e50dca65b5b8755f118384"
 dependencies = [
  "hex",
  "pallas",
  "serde",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.16.1",
+ "tx3-tir 0.16.2",
  "utxorpc",
 ]
 
 [[package]]
 name = "tx3-resolver"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552776ebc1bb87109fe4562db27e8a432e2519e8e71db7bc1d5fa3a00fc34171"
+checksum = "bfe29c0ba5b3abf1833328e00967aca6b7ffb6d0680f0c55bc9741a5a523a0db"
 dependencies = [
  "approx",
  "base64 0.22.1",
@@ -5763,7 +5763,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.16.1",
+ "tx3-tir 0.16.2",
 ]
 
 [[package]]
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f696ab4d335127db9b30dfa5cda7dff368184778f18b6d3fba95fa46a94c0b6"
+checksum = "83903c635fb8ab9f5dfb2c16c8bcfbb4c187be4d2f9d58f5d08cafb9bcfe6750"
 dependencies = [
  "ciborium",
  "hex",

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee = { version = "0.24.9", features = ["server"] }
 opentelemetry = "0.30.0"
 opentelemetry_sdk = "0.30.0"
 
-tx3-cardano = "0.16.1"
-tx3-resolver = "0.16.1"
+tx3-cardano = "0.16.2"
+tx3-resolver = "0.16.2"
 
 # tx3-cardano = { path = "../../../../tx3-lang/tx3/crates/tx3-cardano" }
 # tx3-resolver = { path = "../../../../tx3-lang/tx3/crates/tx3-resolver" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates: Upgraded tx3-cardano and tx3-resolver to the latest compatible minor versions. These are backward-compatible maintenance updates that enhance system stability and compatibility. No changes to public APIs, user-facing functionality, or external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->