### PR TITLE
chore: Add tracing target for minikupo

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -660,6 +660,9 @@ pub struct LoggingConfig {
     pub include_minibf: bool,
 
     #[serde(default)]
+    pub include_minikupo: bool,
+
+    #[serde(default)]
     pub include_otlp: bool,
 
     #[serde(default)]
@@ -675,6 +678,7 @@ impl Default for LoggingConfig {
             include_grpc: Default::default(),
             include_trp: Default::default(),
             include_minibf: Default::default(),
+            include_minikupo: Default::default(),
             include_fjall: Default::default(),
             include_otlp: Default::default(),
         }

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -469,8 +469,29 @@ where
         .with_state(facade)
         .layer(
             trace::TraceLayer::new_for_http()
-                .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
-                .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
+                .make_span_with(|request: &Request<_>| {
+                    tracing::info_span!(
+                        target: "minibf",
+                        "request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                        version = ?request.version(),
+                    )
+                })
+                .on_response(
+                    |response: &axum::http::Response<_>,
+                     latency: std::time::Duration,
+                     span: &tracing::Span| {
+                        tracing::event!(
+                            target: "minibf",
+                            parent: span,
+                            Level::INFO,
+                            status = %response.status(),
+                            latency_ms = latency.as_millis(),
+                            "finished processing request"
+                        );
+                    },
+                ),
         )
         .layer(if permissive_cors {
             CorsLayer::permissive()

--- a/crates/minikupo/src/lib.rs
+++ b/crates/minikupo/src/lib.rs
@@ -119,8 +119,29 @@ where
         .with_state(facade)
         .layer(
             trace::TraceLayer::new_for_http()
-                .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
-                .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
+                .make_span_with(|request: &Request<_>| {
+                    tracing::info_span!(
+                        target: "minikupo",
+                        "request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                        version = ?request.version(),
+                    )
+                })
+                .on_response(
+                    |response: &axum::http::Response<_>,
+                     latency: std::time::Duration,
+                     span: &tracing::Span| {
+                        tracing::event!(
+                            target: "minikupo",
+                            parent: span,
+                            Level::INFO,
+                            status = %response.status(),
+                            latency_ms = latency.as_millis(),
+                            "finished processing request"
+                        );
+                    },
+                ),
         )
         .layer(if permissive_cors {
             CorsLayer::permissive()

--- a/examples/custom-network/dolos.toml
+++ b/examples/custom-network/dolos.toml
@@ -44,3 +44,4 @@ service_name = "dolos"
 max_level = "DEBUG"
 include_pallas = false
 include_grpc = false
+include_minikupo = false

--- a/examples/sync-mainnet/dolos.toml
+++ b/examples/sync-mainnet/dolos.toml
@@ -42,3 +42,4 @@ max_level = "INFO"
 include_tokio = false
 include_pallas = false
 include_grpc = false
+include_minikupo = false

--- a/examples/sync-preprod/dolos.toml
+++ b/examples/sync-preprod/dolos.toml
@@ -42,3 +42,4 @@ max_level = "INFO"
 include_tokio = false
 include_pallas = false
 include_grpc = false
+include_minikupo = false

--- a/examples/sync-preview/dolos.toml
+++ b/examples/sync-preview/dolos.toml
@@ -46,3 +46,4 @@ max_level = "DEBUG"
 include_tokio = false
 include_pallas = false
 include_grpc = false
+include_minikupo = false

--- a/examples/telemetry/dolos.toml
+++ b/examples/telemetry/dolos.toml
@@ -227,3 +227,4 @@ include_pallas = false
 include_grpc = true
 include_trp = false
 include_minibf = false
+include_minikupo = false

--- a/examples/v1/dolos.toml
+++ b/examples/v1/dolos.toml
@@ -78,6 +78,7 @@ include_pallas = false
 include_grpc = false
 include_trp = false
 include_minibf = false
+include_minikupo = false
 include_otlp = false
 include_fjall = false
 

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -134,7 +134,11 @@ pub fn setup_tracing(config: &LoggingConfig, telemetry: &TelemetryConfig) -> mie
     }
 
     if config.include_minibf {
-        filter = filter.with_target("tower_http", level);
+        filter = filter.with_target("minibf", level);
+    }
+
+    if config.include_minikupo {
+        filter = filter.with_target("minikupo", level);
     }
 
     if config.include_fjall {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new logging configuration option to selectively enable minikupo telemetry and observability
  * Enhanced HTTP request tracing with detailed metrics including request method, URI, HTTP version, response status code, and latency measurements

* **Chores**
  * Updated example configurations with new logging option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->