### PR TITLE
chore: Nest minikupo on '/v1' prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,13 +1371,11 @@ dependencies = [
  "bech32 0.11.1",
  "dolos-cardano",
  "dolos-core",
- "dolos-testing",
  "hex",
  "pallas",
  "serde",
  "serde_json",
  "tokio",
- "tower 0.4.13",
  "tower-http 0.6.6",
  "tracing",
 ]

--- a/crates/minikupo/Cargo.toml
+++ b/crates/minikupo/Cargo.toml
@@ -24,7 +24,3 @@ axum = { version = "0.8.4" }
 
 dolos-core = { path = "../core" }
 dolos-cardano = { path = "../cardano" }
-
-[dev-dependencies]
-dolos-testing = { path = "../testing" }
-tower = { workspace = true, features = ["util"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined API routing architecture by consolidating endpoint registrations into a shared configuration. All existing endpoints—matches, datums, scripts, metadata, and health—remain fully functional and accessible at both the root path and `/v1`. No changes to middleware, CORS configuration, or external API behavior. This internal reorganization has zero impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->