### PR TITLE
chore: bump tx3 to v0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5756,24 +5756,24 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tx3-cardano"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351417ef718484a6ff3531733f8722da80a4d4a982e50dca65b5b8755f118384"
+checksum = "92f7471954a2f2cd60a261c0eac0c4525a71e20c89a3f069e94573a813d2191e"
 dependencies = [
  "hex",
  "pallas",
  "serde",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.16.2",
+ "tx3-tir 0.16.3",
  "utxorpc",
 ]
 
 [[package]]
 name = "tx3-resolver"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe29c0ba5b3abf1833328e00967aca6b7ffb6d0680f0c55bc9741a5a523a0db"
+checksum = "d772541067ff2b8d3dc43b2b5e73fa99e4576559714ec5ef4391bba3585378c9"
 dependencies = [
  "approx",
  "base64 0.22.1",
@@ -5783,7 +5783,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "trait-variant",
- "tx3-tir 0.16.2",
+ "tx3-tir 0.16.3",
 ]
 
 [[package]]
@@ -5819,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83903c635fb8ab9f5dfb2c16c8bcfbb4c187be4d2f9d58f5d08cafb9bcfe6750"
+checksum = "dc348529158f74bab016ab4ab4b6f01ab79a99d23cb0bb39293a93dc241cc02c"
 dependencies = [
  "ciborium",
  "hex",

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee = { version = "0.24.9", features = ["server"] }
 opentelemetry = "0.30.0"
 opentelemetry_sdk = "0.30.0"
 
-tx3-cardano = "0.16.2"
-tx3-resolver = "0.16.2"
+tx3-cardano = "0.16.3"
+tx3-resolver = "0.16.3"
 
 # tx3-cardano = { path = "../../../../tx3-lang/tx3/crates/tx3-cardano" }
 # tx3-resolver = { path = "../../../../tx3-lang/tx3/crates/tx3-resolver" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to their latest patch versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->