### PR TITLE
Enhance DomainAdapter to retrieve missing UTXOs from archive store

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,12 +1,16 @@
 pub mod storage;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use dolos_cardano::CardanoLogic;
 use dolos_core::{
+    archive::ArchiveStore as _,
     config::{StorageConfig, SyncConfig},
+    indexes::IndexStore as _,
     *,
 };
+use pallas::ledger::traverse::MultiEraBlock;
 
 pub use storage::{
     ArchiveStoreBackend, IndexStoreBackend, MempoolBackend, StateStoreBackend, WalStoreBackend,
@@ -180,18 +184,58 @@ impl pallas::interop::utxorpc::LedgerContext for DomainAdapter {
         &self,
         refs: &[pallas::interop::utxorpc::TxoRef],
     ) -> Option<pallas::interop::utxorpc::UtxoMap> {
-        let refs: Vec<_> = refs.iter().map(|x| TxoRef::from(*x)).collect();
+        let dolos_refs: Vec<TxoRef> = refs.iter().map(|x| TxoRef::from(*x)).collect();
+        let mut result: pallas::interop::utxorpc::UtxoMap =
+            dolos_core::StateStore::get_utxos(self.state(), dolos_refs)
+                .ok()?
+                .into_iter()
+                .map(|(k, v)| {
+                    let era = v.0.try_into().expect("era out of range");
+                    (k.into(), (era, v.1.clone()))
+                })
+                .collect();
 
-        let some = dolos_core::StateStore::get_utxos(self.state(), refs)
-            .ok()?
-            .into_iter()
-            .map(|(k, v)| {
-                let era = v.0.try_into().expect("era out of range");
-                (k.into(), (era, v.1.clone()))
-            })
-            .collect();
+        let missing: Vec<_> = refs.iter().filter(|r| !result.contains_key(r)).collect();
+        if missing.is_empty() {
+            return Some(result);
+        }
 
-        Some(some)
+        let mut by_tx: HashMap<Vec<u8>, Vec<&pallas::interop::utxorpc::TxoRef>> = HashMap::new();
+        for txo_ref in &missing {
+            by_tx.entry(txo_ref.0.to_vec()).or_default().push(txo_ref);
+        }
+
+        for (tx_hash_bytes, txo_refs) in by_tx {
+            let Ok(Some(slot)) = self.indexes().slot_by_tx_hash(&tx_hash_bytes) else {
+                continue;
+            };
+            let Ok(Some(block_bytes)) = self.archive().get_block_by_slot(&slot) else {
+                continue;
+            };
+            let Ok(block) = MultiEraBlock::decode(&block_bytes) else {
+                continue;
+            };
+
+            let block_txs = block.txs();
+            let Some(tx) = block_txs
+                .iter()
+                .find(|tx| tx.hash().as_ref() == tx_hash_bytes.as_slice())
+            else {
+                continue;
+            };
+
+            let outputs = tx.outputs();
+            let era = block.era();
+
+            for txo_ref in txo_refs {
+                let Some(output) = outputs.get(txo_ref.1 as usize) else {
+                    continue;
+                };
+                result.insert(*txo_ref, (era, output.encode()));
+            }
+        }
+
+        Some(result)
     }
 
     fn get_slot_timestamp(&self, slot: u64) -> Option<u64> {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -67,39 +67,6 @@ impl DomainAdapter {
         tracing::info!("domain adapter: graceful shutdown complete");
         Ok(())
     }
-
-    pub fn get_historical_utxos(
-        &self,
-        refs: &[pallas::interop::utxorpc::TxoRef],
-    ) -> Option<pallas::interop::utxorpc::UtxoMap> {
-        if refs.is_empty() {
-            return Some(Default::default());
-        }
-
-        let mut result = std::collections::HashMap::new();
-        let refs_set: std::collections::HashSet<_> =
-            refs.iter().copied().map(TxoRef::from).collect();
-
-        let iter = self.wal().iter_logs(None, None).ok()?;
-        for (_, log) in iter.rev() {
-            for (txo_ref, era_cbor) in &log.inputs {
-                if refs_set.contains(txo_ref) {
-                    let era = era_cbor.0.try_into().expect("era out of range");
-                    result.insert(txo_ref.clone().into(), (era, era_cbor.1.clone()));
-                }
-            }
-
-            if result.len() == refs.len() {
-                break;
-            }
-        }
-
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
 }
 
 impl Domain for DomainAdapter {


### PR DESCRIPTION
This pull request enhances the `LedgerContext` implementation for `DomainAdapter` by improving the retrieval of UTXO (Unspent Transaction Output) data. The main improvement is a fallback mechanism that attempts to fetch missing UTXOs directly from archived blocks if they are not found in the state store. This makes UTXO lookups more robust and comprehensive.

Key improvements to UTXO retrieval:

* Added logic to detect missing UTXOs after the initial state store lookup and attempt to recover them by:
  - Grouping missing references by transaction hash.
  - Looking up the block slot containing each transaction via the index store.
  - Fetching the corresponding block from the archive store and decoding it.
  - Extracting the relevant transaction outputs and inserting them into the result set.

Supporting changes:

* Added imports for `HashMap`, `MultiEraBlock`, and trait imports for `ArchiveStore` and `IndexStore` to support the new logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTXO lookup reliability with a multi-stage retrieval that falls back to archived blocks to reconstruct missing outputs, ensuring more complete and consistent access to past transactions.

* **Chores**
  * Removed the legacy WAL-based historical input scanning path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->