### PR TITLE
feat(wal): version on-disk schema and force-reset on incompatibility

### DIFF
--- a/crates/core/src/bootstrap.rs
+++ b/crates/core/src/bootstrap.rs
@@ -76,9 +76,19 @@ fn check_wal_in_sync_with_state<D: Domain>(domain: &D) -> Result<(), DomainError
                 state: Some(state.clone()),
             });
         }
+        (None, Some(ref state)) if state.is_fully_defined() => {
+            // WAL is empty but state has a fully-defined cursor — likely a
+            // post-bootstrap or post-version-wipe situation. Auto-reseed the
+            // WAL from the state cursor so the node can resume syncing
+            // without manual intervention.
+            warn!(%state, "WAL is empty but state cursor is fully defined; reseeding WAL from state");
+            domain.wal().reset_to(state)?;
+        }
         (None, Some(ref state)) => {
-            // WAL is missing but state exists (e.g. after import without WAL seeding).
-            error!(%state, "WAL is empty but state exists");
+            // State cursor is partially defined (e.g. only a slot, no hash):
+            // we can't safely reseed without a chain hash. Surface as an
+            // error so the user can recover deliberately.
+            error!(%state, "WAL is empty but state cursor is not fully defined");
             return Err(DomainError::InconsistentState {
                 wal: None,
                 state: Some(state.clone()),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -308,6 +308,9 @@ pub enum WalError {
     #[error("slot not found in chain {0}")]
     SlotNotFound(BlockSlot),
 
+    #[error("WAL version is incompatible: found {found}, expected {expected}")]
+    IncompatibleVersion { found: u32, expected: u32 },
+
     #[error("IO error: {0}")]
     Internal(#[source] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/crates/redb3/src/wal/mod.rs
+++ b/crates/redb3/src/wal/mod.rs
@@ -1,6 +1,6 @@
 use bincode;
 use itertools::Itertools;
-use redb::{Range, ReadableDatabase, TableDefinition};
+use redb::{Range, ReadableDatabase, ReadableTableMetadata, TableDefinition};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{marker::PhantomData, ops::RangeBounds, path::Path, sync::Arc};
 use thiserror::Error;
@@ -175,6 +175,17 @@ where
 
 const WAL: TableDefinition<DbChainPoint, DbLogValue> = TableDefinition::new("wal");
 
+const WAL_METADATA: TableDefinition<&str, u32> = TableDefinition::new("wal_metadata");
+
+const WAL_METADATA_VERSION_KEY: &str = "version";
+
+/// Current WAL on-disk schema version.
+///
+/// Bump this whenever the serialized format of WAL entries changes in a way
+/// that breaks reading older data. On open, an older or missing version
+/// triggers an automatic wipe; a newer version triggers a refusal to start.
+pub const CURRENT_WAL_VERSION: u32 = 1;
+
 pub struct LogIter<'a, T>(Range<'a, DbChainPoint, DbLogValue>, PhantomData<T>);
 
 impl<'a, T> From<Range<'a, DbChainPoint, DbLogValue>> for LogIter<'a, T>
@@ -272,6 +283,9 @@ where
     }
 
     pub fn is_empty(&self) -> Result<bool, RedbWalError> {
+        // "Empty" here refers to absence of WAL data entries. The metadata
+        // table is always present after `ensure_version()`, so an empty WAL
+        // can still have a populated `wal_metadata` table.
         let wr = self.db.begin_read()?;
 
         let tables = wr.list_tables()?;
@@ -300,6 +314,7 @@ where
         };
 
         out.ensure_initialized()?;
+        out.ensure_version()?;
 
         Ok(out)
     }
@@ -317,6 +332,7 @@ where
         };
 
         out.ensure_initialized()?;
+        out.ensure_version()?;
 
         Ok(out)
     }
@@ -331,6 +347,106 @@ where
         wx.open_table(WAL)?;
         wx.commit()?;
         Ok(())
+    }
+
+    /// Read the current on-disk WAL schema version.
+    ///
+    /// Returns `Ok(None)` if the metadata table doesn't exist (legacy DB
+    /// predating the versioning mechanism) or has no version key set.
+    fn read_version(&self) -> Result<Option<u32>, RedbWalError> {
+        let rx = self.db.begin_read()?;
+
+        let table = match rx.open_table(WAL_METADATA) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(RedbWalError::from(e)),
+        };
+
+        let value = table
+            .get(WAL_METADATA_VERSION_KEY)?
+            .map(|v| v.value());
+
+        Ok(value)
+    }
+
+    /// Stamp the metadata table with the given version. Used when the WAL
+    /// data table is empty (no destructive action needed).
+    fn stamp_version(&self, version: u32) -> Result<(), RedbWalError> {
+        let mut wx = self.db.begin_write()?;
+        wx.set_quick_repair(true);
+        {
+            let mut metadata = wx.open_table(WAL_METADATA)?;
+            metadata.insert(WAL_METADATA_VERSION_KEY, version)?;
+        }
+        wx.commit()?;
+        Ok(())
+    }
+
+    /// Atomically drain every entry from the WAL data table and stamp the
+    /// metadata with the new version.
+    ///
+    /// This is a single redb transaction, so a crash between the drain and
+    /// the version write cannot leave the DB in a half-upgraded state.
+    fn wipe_and_stamp(&self, version: u32) -> Result<(), RedbWalError> {
+        let mut wx = self.db.begin_write()?;
+        wx.set_quick_repair(true);
+        {
+            let mut wal = wx.open_table(WAL)?;
+            wal.retain(|_, _| false)?;
+        }
+        {
+            let mut metadata = wx.open_table(WAL_METADATA)?;
+            metadata.insert(WAL_METADATA_VERSION_KEY, version)?;
+        }
+        wx.commit()?;
+        Ok(())
+    }
+
+    /// Verify that the on-disk WAL is compatible with `CURRENT_WAL_VERSION`,
+    /// performing a forced wipe + version bump if not.
+    ///
+    /// - Matching version → no-op.
+    /// - Newer on-disk version → returns `WalError::IncompatibleVersion` to
+    ///   prevent an old binary from destroying newer data.
+    /// - Older or missing version with empty data → just stamps the version.
+    /// - Older or missing version with non-empty data → wipes the data and
+    ///   stamps the version (logs a warning).
+    pub fn ensure_version(&self) -> Result<(), RedbWalError> {
+        let found = self.read_version()?;
+
+        match found {
+            Some(v) if v == CURRENT_WAL_VERSION => Ok(()),
+            Some(v) if v > CURRENT_WAL_VERSION => Err(RedbWalError(WalError::IncompatibleVersion {
+                found: v,
+                expected: CURRENT_WAL_VERSION,
+            })),
+            _ => {
+                if self.data_table_is_empty()? {
+                    info!(
+                        version = CURRENT_WAL_VERSION,
+                        "initializing WAL metadata version"
+                    );
+                    self.stamp_version(CURRENT_WAL_VERSION)?;
+                } else {
+                    warn!(
+                        found = ?found,
+                        expected = CURRENT_WAL_VERSION,
+                        "WAL on-disk version is incompatible with running code; wiping WAL data"
+                    );
+                    self.wipe_and_stamp(CURRENT_WAL_VERSION)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Low-level check on whether the WAL data table contains any entries,
+    /// using redb's `is_empty()` directly without deserializing values.
+    /// Safe to call against incompatible on-disk data.
+    fn data_table_is_empty(&self) -> Result<bool, RedbWalError> {
+        let rx = self.db.begin_read()?;
+        let table = rx.open_table(WAL)?;
+        Ok(table.is_empty()?)
     }
 
     /// Prunes the WAL history to maintain a maximum number of slots.
@@ -739,5 +855,145 @@ where
         let iter = RedbWalStore::iter_logs(self, start, end)?;
         let iter = BlockIter::from(iter);
         Ok(iter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dolos_core::{ChainError, Entity, EntityValue, Namespace, NsKey};
+    use serde::{Deserialize, Serialize};
+
+    /// Minimal delta type used by tests to satisfy `RedbWalStore`'s generic
+    /// bounds. Tests in this module never round-trip data through the WAL,
+    /// so the apply/undo/encode/decode methods can be inert.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct TestDelta;
+
+    #[derive(Clone, Debug)]
+    struct TestEntity;
+
+    impl Entity for TestEntity {
+        fn decode_entity(_: Namespace, _: &EntityValue) -> Result<Self, ChainError> {
+            unimplemented!("not exercised in WAL versioning tests")
+        }
+
+        fn encode_entity(_: &Self) -> (Namespace, EntityValue) {
+            unimplemented!("not exercised in WAL versioning tests")
+        }
+    }
+
+    impl EntityDelta for TestDelta {
+        type Entity = TestEntity;
+
+        fn key(&self) -> NsKey {
+            unimplemented!("not exercised in WAL versioning tests")
+        }
+
+        fn apply(&mut self, _: &mut Option<Self::Entity>) {}
+
+        fn undo(&self, _: &mut Option<Self::Entity>) {}
+    }
+
+    type TestStore = RedbWalStore<TestDelta>;
+
+    fn open_test_store(path: &Path) -> Result<TestStore, WalError> {
+        TestStore::open(path, &RedbWalConfig::default())
+    }
+
+    /// Open a redb DB directly (bypassing RedbWalStore::open) so tests can
+    /// simulate legacy on-disk state that predates the metadata table.
+    fn open_raw_db(path: &Path) -> redb::Database {
+        redb::Database::builder().create(path).unwrap()
+    }
+
+    #[test]
+    fn fresh_in_memory_stamps_current_version() {
+        let store = TestStore::memory().unwrap();
+        assert_eq!(store.read_version().unwrap(), Some(CURRENT_WAL_VERSION));
+    }
+
+    #[test]
+    fn fresh_on_disk_stamps_current_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal.redb");
+
+        let store = open_test_store(&path).unwrap();
+        assert_eq!(store.read_version().unwrap(), Some(CURRENT_WAL_VERSION));
+    }
+
+    #[test]
+    fn legacy_db_with_data_gets_wiped_on_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal.redb");
+
+        // Create a legacy DB: WAL table populated, no metadata table.
+        {
+            let db = open_raw_db(&path);
+            let wx = db.begin_write().unwrap();
+            {
+                let mut table = wx.open_table(WAL).unwrap();
+                let key = DbChainPoint::from(ChainPoint::Specific(42, [1u8; 32].into()));
+                table.insert(key, vec![0xDEu8, 0xAD, 0xBE, 0xEF]).unwrap();
+            }
+            wx.commit().unwrap();
+        }
+
+        // Sanity-check the legacy state.
+        {
+            let db = open_raw_db(&path);
+            let rx = db.begin_read().unwrap();
+            let table = rx.open_table(WAL).unwrap();
+            assert!(!table.is_empty().unwrap());
+            assert!(matches!(
+                rx.open_table(WAL_METADATA),
+                Err(redb::TableError::TableDoesNotExist(_))
+            ));
+        }
+
+        let store = open_test_store(&path).unwrap();
+        assert_eq!(store.read_version().unwrap(), Some(CURRENT_WAL_VERSION));
+        assert!(store.data_table_is_empty().unwrap());
+    }
+
+    #[test]
+    fn newer_version_on_disk_refuses_to_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal.redb");
+
+        // Stamp metadata with a version newer than CURRENT_WAL_VERSION.
+        {
+            let db = open_raw_db(&path);
+            let wx = db.begin_write().unwrap();
+            {
+                let mut metadata = wx.open_table(WAL_METADATA).unwrap();
+                metadata
+                    .insert(WAL_METADATA_VERSION_KEY, CURRENT_WAL_VERSION + 1)
+                    .unwrap();
+            }
+            wx.commit().unwrap();
+        }
+
+        let err = open_test_store(&path).unwrap_err();
+        match err {
+            WalError::IncompatibleVersion { found, expected } => {
+                assert_eq!(found, CURRENT_WAL_VERSION + 1);
+                assert_eq!(expected, CURRENT_WAL_VERSION);
+            }
+            other => panic!("expected IncompatibleVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matching_version_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal.redb");
+
+        // First open: stamps current version.
+        open_test_store(&path).unwrap();
+
+        // Second open: should succeed without rewriting (no panic, version intact).
+        let store = open_test_store(&path).unwrap();
+        assert_eq!(store.read_version().unwrap(), Some(CURRENT_WAL_VERSION));
     }
 }

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -62,7 +62,15 @@ pub fn load_config(
 }
 
 pub fn setup_domain(config: &RootConfig) -> miette::Result<DomainAdapter> {
-    let stores = open_data_stores(config)?;
+    let stores = open_data_stores(config).map_err(|e| match e {
+        Error::WalError(WalError::IncompatibleVersion { found, expected }) => miette::miette!(
+            help = format!(
+                "WAL was created by a newer dolos version (v{found}) than this binary supports (v{expected}); upgrade dolos or run `dolos bootstrap --force` to wipe storage and re-bootstrap",
+            ),
+            "incompatible WAL version: found v{found}, expected v{expected}",
+        ),
+        other => miette::miette!("{other}"),
+    })?;
     let genesis = Arc::new(open_genesis_files(&config.genesis)?);
     let mempool = stores.mempool.clone();
     let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);


### PR DESCRIPTION
## Summary
- Adds a `wal_metadata` redb table tracking a schema version (`CURRENT_WAL_VERSION = 1`), checked on `RedbWalStore::open` / `memory()`. Older or missing versions trigger a wipe-and-stamp in a single atomic transaction; a newer on-disk version returns `WalError::IncompatibleVersion` so an old binary can't destroy newer data.
- Auto-reseeds the WAL in `check_wal_in_sync_with_state` when the WAL is empty and the state cursor is fully defined, replacing the manual `dolos doctor reset-wal` step. Partial-cursor cases still error.
- Surfaces `IncompatibleVersion` from `setup_domain` with a help message pointing at `dolos bootstrap --force` for accidental downgrades.

## Motivation
Backward compatibility of the WAL with v1.0.3 broke unexpectedly. Without a version marker, mismatched on-disk data can cause bincode panics or silent corruption. This change makes incompatibility detectable and recoverable: nodes upgrading silently wipe and reseed, nodes downgrading refuse to start.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p dolos-redb3` (5 new tests for fresh init, legacy upgrade, downgrade refusal, idempotent reopen)
- [x] `cargo test --workspace --lib`
- [x] `cargo test --test bootstrap` (existing integration tests pass)
- [ ] Manual: build new binary, point at an existing on-disk v1.0.3 instance, observe wipe + reseed warn logs, verify sync resumes
- [ ] Manual: simulate downgrade by bumping `CURRENT_WAL_VERSION` locally, confirm `IncompatibleVersion` error surfaces in `setup_domain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WAL schema version tracking prevents incompatible database versions from corrupting data by validating compatibility at startup.

* **Bug Fixes**
  * Enhanced WAL state consistency checks with more informative error messages. Users encountering version incompatibilities now receive explicit recovery instructions including upgrade or force bootstrap options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->