### PR TITLE
fix(sync): apply deltas before WAL commit so rollback undo works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bech32 0.11.1",
+ "bincode",
  "chrono",
  "crc",
  "dolos-core",

--- a/crates/cardano/Cargo.toml
+++ b/crates/cardano/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4.3"
 serde_json = "1.0.140"
 dolos-testing = { path = "../testing" }
 proptest = "1.7.0"
+bincode.workspace = true
 
 [features]
 include-genesis = []

--- a/crates/cardano/src/model/accounts.rs
+++ b/crates/cardano/src/model/accounts.rs
@@ -1006,7 +1006,7 @@ impl dolos_core::EntityDelta for AccountTransition {
 mod prop_tests {
     use super::*;
     use super::testing::any_account_state;
-    use crate::model::testing::{self as root, assert_delta_roundtrip};
+    use crate::model::testing::{self as root, assert_delta_roundtrip, assert_delta_serde_roundtrip};
     use proptest::prelude::*;
 
     /// Build an `AccountState` whose `pool.live` is guaranteed to be `PoolDelegation::Pool(..)`.
@@ -1272,6 +1272,72 @@ mod prop_tests {
             delta in any_account_transition(),
         ) {
             assert_delta_roundtrip(Some(entity), delta);
+        }
+
+        // --- WAL serialize → deserialize → undo round-trips ---
+        //
+        // These exercise the path the WAL takes: serialize the (post-apply)
+        // delta with bincode (which is what `crates/redb3/src/wal/mod.rs`
+        // uses), deserialize it, then assert undo still restores the original
+        // entity. The plain `_roundtrip` variants above use the same in-memory
+        // delta instance for apply and undo and so don't catch regressions
+        // where a `prev_*` field isn't `serde`-serialized or where the WAL
+        // row is written before apply runs.
+
+        #[test]
+        fn controlled_amount_inc_serde_roundtrip(
+            entity in prop::option::of(any_account_state()),
+            delta in any_controlled_amount_inc(),
+        ) {
+            assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn controlled_amount_dec_serde_roundtrip(
+            entity in any_account_state(),
+            delta in any_controlled_amount_dec(),
+        ) {
+            assert_delta_serde_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn stake_registration_serde_roundtrip(
+            entity in prop::option::of(any_account_state()),
+            delta in any_stake_registration(),
+        ) {
+            assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn stake_delegation_serde_roundtrip(
+            entity in any_account_state(),
+            delta in any_stake_delegation(),
+        ) {
+            assert_delta_serde_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn stake_deregistration_serde_roundtrip(
+            entity in any_account_state(),
+            delta in any_stake_deregistration(),
+        ) {
+            assert_delta_serde_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn vote_delegation_serde_roundtrip(
+            entity in any_account_state(),
+            delta in any_vote_delegation(),
+        ) {
+            assert_delta_serde_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn withdrawal_inc_serde_roundtrip(
+            entity in any_account_state(),
+            delta in any_withdrawal_inc(),
+        ) {
+            assert_delta_serde_roundtrip(Some(entity), delta);
         }
     }
 }

--- a/crates/cardano/src/model/testing.rs
+++ b/crates/cardano/src/model/testing.rs
@@ -14,6 +14,7 @@ use pallas::ledger::primitives::{
     Epoch, StakeCredential,
 };
 use proptest::prelude::*;
+use serde::{de::DeserializeOwned, Serialize};
 
 use super::pools::PoolHash;
 
@@ -33,6 +34,42 @@ where
     assert_eq!(
         state, original,
         "delta apply/undo is not reversible: undo did not restore original state"
+    );
+}
+
+/// Asserts that the WAL serialize/deserialize round-trip preserves apply→undo
+/// reversibility.
+///
+/// The lifecycle in `core/sync.rs::run_lifecycle` writes `commit_wal` *before*
+/// `commit_state`, then `apply_entities` mutates each delta in-place to capture
+/// `prev_*` undo state — but those mutations only land on the in-memory copy.
+/// The WAL row itself is encoded **after** apply runs (post-fix), so the
+/// deserialized form must still admit a valid undo.
+///
+/// This helper exercises that contract: serialize the *post-apply* delta,
+/// deserialize it, and assert that calling `undo` on the deserialized instance
+/// restores the original entity. Catches regressions where a delta forgets to
+/// mark a `prev_*` field as `serde`-serialized, or relies on transient state
+/// that doesn't survive the wire format.
+pub fn assert_delta_serde_roundtrip<T, D>(entity: Option<T>, mut delta: D)
+where
+    T: Clone + PartialEq + core::fmt::Debug,
+    D: EntityDelta<Entity = T> + Serialize + DeserializeOwned,
+{
+    let original = entity.clone();
+    let mut state = entity;
+
+    delta.apply(&mut state);
+
+    // Bincode is the WAL's encoding (see crates/redb3/src/wal/mod.rs).
+    let bytes = bincode::serialize(&delta).expect("serialize delta");
+    let restored: D = bincode::deserialize(&bytes).expect("deserialize delta");
+
+    restored.undo(&mut state);
+
+    assert_eq!(
+        state, original,
+        "delta serde-then-undo is not reversible: deserialized undo did not restore original state",
     );
 }
 

--- a/crates/cardano/src/roll/batch.rs
+++ b/crates/cardano/src/roll/batch.rs
@@ -85,6 +85,7 @@ pub struct WorkBatch {
 
     // internal checks
     is_sorted: bool,
+    applied: bool,
 }
 
 impl WorkBatch {
@@ -190,6 +191,10 @@ impl WorkBatch {
         D: Domain<Chain = CardanoLogic, EntityDelta = CardanoDelta>,
     {
         debug_assert!(self.is_sorted);
+        debug_assert!(
+            self.applied,
+            "commit_wal must run after apply_entities so deltas carry prev_* undo state"
+        );
 
         let mut entries = Vec::new();
 
@@ -262,6 +267,8 @@ impl WorkBatch {
                 }
             }
         }
+
+        self.applied = true;
 
         Ok(())
     }

--- a/crates/cardano/src/roll/work_unit.rs
+++ b/crates/cardano/src/roll/work_unit.rs
@@ -64,20 +64,27 @@ where
             &mut self.batch,
         )?;
 
+        // Load entities here so `compute` can apply deltas before WAL serialization;
+        // this is what populates each delta's `prev_*` undo state in time for
+        // `commit_wal` to capture it on the wire.
+        self.batch.load_entities(domain)?;
+
         debug!("roll batch loaded and deltas computed");
         Ok(())
     }
 
     fn compute(&mut self, _shard_index: u32) -> Result<(), DomainError> {
-        // Deltas are computed during load() since they require state access.
+        // Apply deltas to in-memory entities BEFORE the WAL commit. This captures
+        // each delta's `prev_*` undo state on the in-memory delta instances; the
+        // subsequent `commit_wal` then serializes deltas that already carry the
+        // information `delta.undo()` needs during a future rollback.
+        self.batch.sort_by_slot();
+        self.batch.apply_entities()?;
         Ok(())
     }
 
     fn commit_wal(&mut self, domain: &D, _shard_index: u32) -> Result<(), DomainError> {
         debug!("committing roll batch to WAL");
-
-        // Ensure blocks are sorted before WAL commit
-        self.batch.sort_by_slot();
 
         self.batch.commit_wal(domain)?;
 
@@ -85,17 +92,10 @@ where
     }
 
     fn commit_state(&mut self, domain: &D, _shard_index: u32) -> Result<(), DomainError> {
-        debug!("loading entities for roll batch");
-
-        // Load entities that will be modified
-        self.batch.load_entities(domain)?;
-
-        // Apply deltas to entities
-        self.batch.apply_entities()?;
-
         debug!("committing roll batch to state");
 
-        // Commit state changes
+        // Entities are already loaded in `load()` and mutated in `compute()`.
+        // This phase only persists them.
         self.batch.commit_state(domain)?;
 
         info!(

--- a/crates/core/src/sync.rs
+++ b/crates/core/src/sync.rs
@@ -92,7 +92,11 @@ impl<D: Domain> SyncExt for D {
                 crate::state::load_entity_chunk::<Self>(entities.as_slice(), self.state())?;
 
             for (key, entity) in entities.iter_mut() {
-                for delta in log.delta.iter_mut() {
+                // Undo deltas in reverse application order. Each delta's `prev_*`
+                // captures the state immediately before its own apply, so multiple
+                // deltas keyed to the same entity must be reversed last-first to
+                // correctly walk back through the apply chain.
+                for delta in log.delta.iter_mut().rev() {
                     if delta.key() == *key {
                         delta.undo(entity);
                     }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use dolos_core::{
-    BootstrapExt, ChainLogic, ChainPoint, Domain, IndexStore, StateStore, StateWriter, WalStore,
-    WorkUnit,
+    sync::SyncExt as _, BootstrapExt, ChainLogic, ChainPoint, Domain, IndexStore, StateStore,
+    StateWriter, WalStore, WorkUnit,
 };
 use dolos_testing::{
     synthetic::{build_synthetic_blocks, SyntheticBlockConfig},
@@ -111,6 +111,69 @@ fn test_catchup_recovers_archive_and_indexes() {
         slot.is_some(),
         "tx hash {} should be found in index after catch-up",
         tx_hash_hex
+    );
+}
+
+/// Regression: rolling back through WAL entries that came out of the full sync
+/// lifecycle must not panic.
+///
+/// Before the lifecycle reshuffle, `RollWorkUnit::commit_wal` ran *before*
+/// `apply_entities`, so each WAL row's deltas had `prev_*` undo state still set
+/// to `None`. When the chainsync handshake (or any later peer rollback) hit
+/// `domain.rollback(...)`, the loop in `core/sync.rs::rollback` deserialized
+/// those deltas and called `undo()` on them, panicking with
+/// `panicked at … "apply captured stake"` on the first non-trivial delta
+/// (typically `ControlledAmountInc`).
+///
+/// This test feeds blocks through the *full* sync lifecycle (every phase,
+/// including `commit_archive` and `commit_indexes`) and then rolls back to a
+/// prior point. With the lifecycle correctly ordered, the WAL rows carry their
+/// `prev_*` data, undo executes cleanly, and the cursor lands on the rollback
+/// target.
+#[test]
+fn test_rollback_after_full_sync_lifecycle() {
+    let cfg = SyntheticBlockConfig::default();
+    let (blocks, _vectors, cardano_config) = build_synthetic_blocks(cfg);
+    assert!(
+        blocks.len() >= 2,
+        "synthetic config must produce at least 2 blocks for the rollback target to differ from the tip",
+    );
+
+    let genesis = Arc::new(dolos_cardano::include::devnet::load());
+    let domain = ToyDomain::new_with_genesis_and_config(genesis, cardano_config, None, None);
+
+    // Capture the point we'll roll back to before any blocks have been applied
+    // past it. Must be a fully-defined ChainPoint (slot + hash), since
+    // domain.rollback compares with `point == *to` and a Specific(slot, hash)
+    // entry from the WAL won't match a Slot(slot)-only target.
+    let rollback_target = {
+        let block = pallas::ledger::traverse::MultiEraBlock::decode(&blocks[0]).unwrap();
+        ChainPoint::Specific(block.slot(), block.hash())
+    };
+
+    // Feed every block through the live sync lifecycle. `roll_forward` uses
+    // `run_lifecycle` with `include_wal=true`, so this exercises the same path
+    // as the live sync pipeline.
+    for block in &blocks {
+        domain.roll_forward(block.clone()).unwrap();
+    }
+
+    let tip_before_rollback = domain.state().read_cursor().unwrap();
+    assert_ne!(
+        tip_before_rollback.as_ref(),
+        Some(&rollback_target),
+        "tip should be past the rollback target",
+    );
+
+    // Roll back. Without the fix, this panics inside delta.undo() because the
+    // WAL-deserialized deltas have prev_*=None.
+    domain.rollback(&rollback_target).unwrap();
+
+    let cursor_after = domain.state().read_cursor().unwrap();
+    assert_eq!(
+        cursor_after.as_ref(),
+        Some(&rollback_target),
+        "state cursor should be at the rollback target after rollback",
     );
 }
 


### PR DESCRIPTION
## Summary

The roll work-unit lifecycle wrote the WAL before `apply_entities` ran, so every on-disk delta carried `prev_*: None`. When `core/sync.rs::rollback` later deserialized those rows and called `delta.undo()`, the first non-trivial delta (typically `ControlledAmountInc`) panicked with:

```
panicked at crates/cardano/src/model/accounts.rs:329:47: apply captured stake
```

This affected anyone who bootstrapped from a snapshot, started syncing, and then hit any peer-driven rollback past blocks dolos had already roll-forwarded since startup.

The ordering itself is pre-existing (set when work units were formalized in #842), but the panic was **latent until #971** replaced no-op `undo` stubs with real `expect("apply captured ...")` calls. The proptest harness in #971 only round-trips deltas in memory, so it never exercised the WAL serde path.

## What changed

- **`RollWorkUnit` lifecycle reshuffle** (`crates/cardano/src/roll/work_unit.rs`): `load_entities` moved into `load`, `apply_entities` moved into `compute`. `commit_wal` now serializes deltas that already carry `prev_*` undo state. `commit_state` becomes thin (just persist).
- **Invariant guard** (`crates/cardano/src/roll/batch.rs`): new `applied: bool` flag on `WorkBatch`, set by `apply_entities`, asserted by `commit_wal` via `debug_assert!`. A future re-ordering trips locally rather than in production rollback.
- **Reverse undo order** (`crates/core/src/sync.rs`): the inner loop in `rollback` iterated deltas forward when undoing. Multiple deltas keyed to the same entity must be reversed last-first to walk back through the apply chain correctly. Was masked while `prev_*` was `None`; load-bearing once it's populated.
- **New proptest helper** (`crates/cardano/src/model/testing.rs`): `assert_delta_serde_roundtrip` serializes the post-apply delta with bincode (the WAL's encoding), deserializes, and asserts `undo` restores the original entity.
- **Serde-roundtrip proptests** for `ControlledAmountInc`, `ControlledAmountDec`, `StakeRegistration`, `StakeDelegation`, `StakeDeregistration`, `VoteDelegation`, `WithdrawalInc`.
- **Integration test** (`tests/bootstrap.rs::test_rollback_after_full_sync_lifecycle`): feeds blocks through the full sync lifecycle and rolls back. On the un-fixed code it dies with the exact panic from the bug report; with the fix it passes cleanly.

## Verification

- The integration test reproduces the user's exact panic when run against the un-fixed lifecycle (`crates/cardano/src/model/accounts.rs:329:47: apply captured stake`).
- With the fix, full workspace test suite passes — 0 failures across all crates plus integration tests, including 117 cardano lib tests.

## Out of scope (flagged for follow-up)

- Boundary work units (`Ewrap`, `Estart`, `Rupd`) don't write deltas to the WAL today (they inherit the default no-op `commit_wal`), so rollbacks across an epoch boundary still don't undo the boundary deltas. Separate gap.
- State catch-up from WAL after a crash between `commit_wal` and `commit_state` — same recovery window as before this fix; current recovery relies on the peer re-sending the block.

## Test plan

- [x] `cargo test --test bootstrap` — passes (3/3, including the new regression)
- [x] `cargo test -p dolos-cardano --lib` — passes (117/117, including the new serde-roundtrip proptests)
- [x] `cargo test --workspace` — passes, 0 failures
- [x] Confirm the new integration test fails with the exact production panic when applied against an un-fixed `RollWorkUnit`
- [ ] Smoke-test on a live snapshot bootstrap + sync (recommended before merge — the unit/integration coverage validates the lifecycle but exercising a real chainsync rollback against a peer is the final gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback consistency by ensuring deltas are undone in the correct order during state recovery.

* **Tests**
  * Added comprehensive serialization roundtrip validation tests.
  * Added integration test for rollback recovery after full sync lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->