### PR TITLE
feat(u5c): serve v1alpha and v1beta gRPC side-by-side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "byteview"
@@ -1308,7 +1308,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "paste",
  "protoc-wkt",
  "rayon",
@@ -1355,7 +1355,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint",
  "num-rational",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "paste",
  "proptest",
  "rayon",
@@ -1376,7 +1376,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "opentelemetry",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "proptest",
  "rayon",
  "regex",
@@ -1398,7 +1398,7 @@ dependencies = [
  "dolos-core",
  "dolos-testing",
  "fjall",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
@@ -1427,7 +1427,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "rayon",
  "reqwest 0.12.22",
  "serde",
@@ -1451,7 +1451,7 @@ dependencies = [
  "dolos-testing",
  "hex",
  "http-body-util",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "serde",
  "serde_json",
  "tokio",
@@ -1471,7 +1471,7 @@ dependencies = [
  "futures-util",
  "hex",
  "itertools 0.14.0",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "redb",
  "redb-extras",
  "serde",
@@ -1498,7 +1498,7 @@ dependencies = [
  "futures-util",
  "hex",
  "itertools 0.14.0",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "rand 0.9.1",
  "tokio",
  "tokio-stream",
@@ -1518,7 +1518,7 @@ dependencies = [
  "jsonrpsee",
  "opentelemetry",
  "opentelemetry_sdk",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "rand 0.9.1",
  "serde",
  "serde_json",
@@ -3338,15 +3338,32 @@ checksum = "c593225da7e45c57d209c8315805533ca597c0975ceeaf9c53ca96315c52bbb6"
 dependencies = [
  "pallas-addresses 1.0.0-alpha.4",
  "pallas-codec 1.0.0-alpha.4",
- "pallas-configs",
+ "pallas-configs 1.0.0-alpha.4",
  "pallas-crypto 1.0.0-alpha.4",
- "pallas-hardano",
  "pallas-network 1.0.0-alpha.4",
  "pallas-primitives 1.0.0-alpha.4",
  "pallas-traverse 1.0.0-alpha.4",
- "pallas-txbuilder",
- "pallas-utxorpc",
- "pallas-validate",
+ "pallas-txbuilder 1.0.0-alpha.4",
+ "pallas-utxorpc 1.0.0-alpha.4",
+ "pallas-validate 1.0.0-alpha.4",
+]
+
+[[package]]
+name = "pallas"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-configs 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-hardano",
+ "pallas-network 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
+ "pallas-traverse 1.0.0-alpha.6",
+ "pallas-txbuilder 1.0.0-alpha.6",
+ "pallas-utxorpc 1.0.0-alpha.6",
+ "pallas-validate 1.0.0-alpha.6",
 ]
 
 [[package]]
@@ -3382,6 +3399,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-addresses"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "base58",
+ "bech32 0.9.1",
+ "crc",
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pallas-codec"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,6 +3438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-codec"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "hex",
+ "minicbor 0.26.4",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pallas-configs"
 version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3459,21 @@ dependencies = [
  "pallas-addresses 1.0.0-alpha.4",
  "pallas-crypto 1.0.0-alpha.4",
  "pallas-primitives 1.0.0-alpha.4",
+ "serde",
+ "serde_json",
+ "serde_with 3.16.0",
+]
+
+[[package]]
+name = "pallas-configs"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "base64 0.22.1",
+ "num-rational",
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
  "serde",
  "serde_json",
  "serde_with 3.16.0",
@@ -3451,18 +3509,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-crypto"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.6",
+ "rand_core 0.9.3",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pallas-hardano"
-version = "1.0.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fe7b454c3b3e175b0cd7deade25a2298972370ed2b06f63ea7ea4ec7fe62ca"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
 dependencies = [
  "binary-layout",
  "hex",
- "pallas-addresses 1.0.0-alpha.4",
- "pallas-codec 1.0.0-alpha.4",
- "pallas-crypto 1.0.0-alpha.4",
- "pallas-network 1.0.0-alpha.4",
- "pallas-traverse 1.0.0-alpha.4",
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-network 1.0.0-alpha.6",
+ "pallas-traverse 1.0.0-alpha.6",
  "serde",
  "serde_json",
  "serde_with 3.16.0",
@@ -3508,6 +3578,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-network"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "byteorder",
+ "hex",
+ "itertools 0.13.0",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "rand 0.8.5",
+ "socket2 0.5.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "pallas-primitives"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3619,18 @@ dependencies = [
  "hex",
  "pallas-codec 1.0.0-alpha.4",
  "pallas-crypto 1.0.0-alpha.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pallas-primitives"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "hex",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
  "serde",
  "serde_json",
 ]
@@ -3571,6 +3670,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-traverse"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "hex",
+ "itertools 0.13.0",
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
+ "paste",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pallas-txbuilder"
 version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +3697,22 @@ dependencies = [
  "pallas-crypto 1.0.0-alpha.4",
  "pallas-primitives 1.0.0-alpha.4",
  "pallas-traverse 1.0.0-alpha.4",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-txbuilder"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "hex",
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
+ "pallas-traverse 1.0.0-alpha.6",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3615,9 +3746,23 @@ dependencies = [
  "pallas-crypto 1.0.0-alpha.4",
  "pallas-primitives 1.0.0-alpha.4",
  "pallas-traverse 1.0.0-alpha.4",
- "pallas-validate",
+ "pallas-validate 1.0.0-alpha.4",
  "prost-types 0.13.5",
  "utxorpc-spec 0.18.1",
+]
+
+[[package]]
+name = "pallas-utxorpc"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
+ "pallas-traverse 1.0.0-alpha.6",
+ "pallas-validate 1.0.0-alpha.6",
+ "prost-types 0.13.5",
+ "utxorpc-spec 0.19.0",
 ]
 
 [[package]]
@@ -3634,6 +3779,24 @@ dependencies = [
  "pallas-crypto 1.0.0-alpha.4",
  "pallas-primitives 1.0.0-alpha.4",
  "pallas-traverse 1.0.0-alpha.4",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "pallas-validate"
+version = "1.0.0-alpha.6"
+source = "git+https://github.com/txpipe/pallas.git?rev=0da71c2#0da71c2d477147a8c1ed4edb87aaa93faf96ebee"
+dependencies = [
+ "chrono",
+ "hex",
+ "itertools 0.14.0",
+ "pallas-addresses 1.0.0-alpha.6",
+ "pallas-codec 1.0.0-alpha.6",
+ "pallas-crypto 1.0.0-alpha.6",
+ "pallas-primitives 1.0.0-alpha.6",
+ "pallas-traverse 1.0.0-alpha.6",
  "pallas-uplc",
  "serde",
  "thiserror 1.0.69",
@@ -5860,7 +6023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd80f6082e524c6cca2f86ae9b9e7c652e3b0fd1f50a7e5a727ab8a27d43701"
 dependencies = [
  "hex",
- "pallas",
+ "pallas 1.0.0-alpha.4",
  "serde",
  "thiserror 2.0.12",
  "trait-variant",
@@ -6104,6 +6267,22 @@ name = "utxorpc-spec"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e59de89d0dfd8e594377b53a8f67a10de01bb63b15b169248760188fa06fb92a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "pbjson",
+ "pbjson-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "utxorpc-spec"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c5b06a64d715d79a25bebafacd4c24bfed6fd1e9725fab03e02fb67db08663"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6621,7 +6800,7 @@ dependencies = [
  "dolos-cardano",
  "dolos-core",
  "hex",
- "pallas",
+ "pallas 1.0.0-alpha.6",
  "postgres",
  "postgres-native-tls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tracing-subscriber = "0.3.17"
 tracing-log = "0.2"
 miette = { version = "7.6.0", features = ["fancy"] }
 async-trait = "0.1.81"
-bytes = "1.9.0"
+bytes = "1.11"
 async-stream = "0.3.5"
 protoc-wkt = "1.0.0"
 indicatif = "0.17.8"
@@ -199,8 +199,8 @@ readme = "README.md"
 authors = ["TxPipe <hello@txpipe.io>"]
 
 [workspace.dependencies]
-# pallas = { git = "https://github.com/txpipe/pallas.git", rev = "4986428", features = ["hardano", "phase2"] }
-pallas = { version = "1.0.0-alpha.4", features = ["hardano", "phase2", "unstable"] }
+# pallas = { version = "1.0.0-alpha.4", features = ["hardano", "phase2", "unstable"] }
+pallas = { git = "https://github.com/txpipe/pallas.git", rev = "0da71c2", features = ["hardano", "phase2", "unstable"] }
 # pallas = { path = "../pallas/pallas", features = ["hardano", "phase2"] }
 
 thiserror = "2.0.12"

--- a/src/serve/grpc/mod.rs
+++ b/src/serve/grpc/mod.rs
@@ -1,5 +1,5 @@
 use dolos_core::config::GrpcConfig;
-use pallas::interop::utxorpc::{spec as u5c, LedgerContext};
+use pallas::interop::utxorpc::LedgerContext;
 use tonic::transport::{Certificate, Server, ServerTlsConfig};
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -8,11 +8,9 @@ use crate::prelude::*;
 
 mod convert;
 mod masking;
-mod query;
 mod stream;
-mod submit;
-mod sync;
-mod watch;
+mod v1alpha;
+mod v1beta;
 
 #[derive(Clone)]
 pub struct ContextAdapter<T: dolos_core::StateStore>(T);
@@ -29,27 +27,46 @@ where
     async fn run(cfg: Self::Config, domain: D, cancel: C) -> Result<(), ServeError> {
         let addr = cfg.listen_address.parse().unwrap();
 
-        let sync_service = sync::SyncServiceImpl::new(domain.clone(), cancel.clone());
-        let sync_service = u5c::sync::sync_service_server::SyncServiceServer::new(sync_service);
+        let sync_v1alpha = v1alpha::spec::sync::sync_service_server::SyncServiceServer::new(
+            v1alpha::sync::SyncServiceImpl::new(domain.clone(), cancel.clone()),
+        );
+        let sync_v1beta = v1beta::spec::sync::sync_service_server::SyncServiceServer::new(
+            v1beta::sync::SyncServiceImpl::new(domain.clone(), cancel.clone()),
+        );
 
-        let query_service = query::QueryServiceImpl::new(domain.clone());
-        let query_service =
-            u5c::query::query_service_server::QueryServiceServer::new(query_service);
+        let query_v1alpha = v1alpha::spec::query::query_service_server::QueryServiceServer::new(
+            v1alpha::query::QueryServiceImpl::new(domain.clone()),
+        );
+        let query_v1beta = v1beta::spec::query::query_service_server::QueryServiceServer::new(
+            v1beta::query::QueryServiceImpl::new(domain.clone()),
+        );
 
-        let watch_service = watch::WatchServiceImpl::new(domain.clone(), cancel.clone());
-        let watch_service =
-            u5c::watch::watch_service_server::WatchServiceServer::new(watch_service);
+        let watch_v1alpha = v1alpha::spec::watch::watch_service_server::WatchServiceServer::new(
+            v1alpha::watch::WatchServiceImpl::new(domain.clone(), cancel.clone()),
+        );
+        let watch_v1beta = v1beta::spec::watch::watch_service_server::WatchServiceServer::new(
+            v1beta::watch::WatchServiceImpl::new(domain.clone(), cancel.clone()),
+        );
 
-        let submit_service = submit::SubmitServiceImpl::new(domain.clone());
-        let submit_service =
-            u5c::submit::submit_service_server::SubmitServiceServer::new(submit_service);
+        let submit_v1alpha =
+            v1alpha::spec::submit::submit_service_server::SubmitServiceServer::new(
+                v1alpha::submit::SubmitServiceImpl::new(domain.clone()),
+            );
+        let submit_v1beta = v1beta::spec::submit::submit_service_server::SubmitServiceServer::new(
+            v1beta::submit::SubmitServiceImpl::new(domain.clone()),
+        );
 
         let reflection = tonic_reflection::server::Builder::configure()
-            .register_encoded_file_descriptor_set(u5c::cardano::FILE_DESCRIPTOR_SET)
-            .register_encoded_file_descriptor_set(u5c::sync::FILE_DESCRIPTOR_SET)
-            .register_encoded_file_descriptor_set(u5c::query::FILE_DESCRIPTOR_SET)
-            .register_encoded_file_descriptor_set(u5c::submit::FILE_DESCRIPTOR_SET)
-            .register_encoded_file_descriptor_set(u5c::watch::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1alpha::spec::cardano::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1alpha::spec::sync::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1alpha::spec::query::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1alpha::spec::submit::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1alpha::spec::watch::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1beta::spec::cardano::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1beta::spec::sync::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1beta::spec::query::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1beta::spec::submit::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(v1beta::spec::watch::FILE_DESCRIPTOR_SET)
             .register_encoded_file_descriptor_set(protoc_wkt::google::protobuf::FILE_DESCRIPTOR_SET)
             .build_v1()
             .unwrap();
@@ -78,10 +95,14 @@ where
 
         // to allow GrpcWeb we must enable http1
         server
-            .add_service(tonic_web::enable(sync_service))
-            .add_service(tonic_web::enable(query_service))
-            .add_service(tonic_web::enable(submit_service))
-            .add_service(tonic_web::enable(watch_service))
+            .add_service(tonic_web::enable(sync_v1alpha))
+            .add_service(tonic_web::enable(sync_v1beta))
+            .add_service(tonic_web::enable(query_v1alpha))
+            .add_service(tonic_web::enable(query_v1beta))
+            .add_service(tonic_web::enable(submit_v1alpha))
+            .add_service(tonic_web::enable(submit_v1beta))
+            .add_service(tonic_web::enable(watch_v1alpha))
+            .add_service(tonic_web::enable(watch_v1beta))
             .add_service(reflection)
             .serve_with_shutdown(addr, cancel.cancelled())
             .await

--- a/src/serve/grpc/v1alpha/mod.rs
+++ b/src/serve/grpc/v1alpha/mod.rs
@@ -1,0 +1,6 @@
+pub mod query;
+pub mod submit;
+pub mod sync;
+pub mod watch;
+
+pub(super) use pallas::interop::utxorpc::v1alpha::spec;

--- a/src/serve/grpc/v1alpha/query.rs
+++ b/src/serve/grpc/v1alpha/query.rs
@@ -1,13 +1,14 @@
 use dolos_cardano::indexes::CardanoIndexExt;
 use itertools::Itertools as _;
-use pallas::interop::utxorpc::{self as interop, spec::query::any_utxo_pattern::UtxoPattern};
-use pallas::interop::utxorpc::{spec as u5c, LedgerContext};
+use pallas::interop::utxorpc::v1alpha::spec::query::any_utxo_pattern::UtxoPattern;
+use pallas::interop::utxorpc::v1alpha::{self as interop, spec as u5c};
+use pallas::interop::utxorpc::LedgerContext;
 use pallas::ledger::traverse::{MultiEraBlock, MultiEraOutput};
 use std::collections::HashSet;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
-use super::masking::apply_mask;
+use crate::serve::grpc::masking::apply_mask;
 use crate::prelude::*;
 use dolos_cardano::indexes::AsyncCardanoQueryExt;
 
@@ -199,7 +200,7 @@ impl IntoSet for u5c::query::AnyUtxoPattern {
 }
 
 fn from_u5c_txoref(txo: u5c::query::TxoRef) -> Result<TxoRef, Status> {
-    let hash = super::convert::bytes_to_hash32(&txo.hash)?;
+    let hash = crate::serve::grpc::convert::bytes_to_hash32(&txo.hash)?;
     Ok(TxoRef(hash, txo.index))
 }
 
@@ -288,12 +289,14 @@ fn map_cost_models(
         plutus_v1: plutus_v1.clone(),
         plutus_v2: plutus_v2.clone(),
         plutus_v3: plutus_v3.clone(),
+        plutus_v4: None,
     };
 
     let cost_model_map = u5c::cardano::CostModelMap {
         plutus_v1,
         plutus_v2,
         plutus_v3,
+        plutus_v4: None,
     };
 
     (
@@ -1053,7 +1056,7 @@ mod tests {
     use std::sync::Arc;
 
     use dolos_testing::toy_domain::ToyDomain;
-    use pallas::interop::utxorpc::spec::query::query_service_server::QueryService;
+    use pallas::interop::utxorpc::v1alpha::spec::query::query_service_server::QueryService;
 
     use super::*;
 

--- a/src/serve/grpc/v1alpha/submit.rs
+++ b/src/serve/grpc/v1alpha/submit.rs
@@ -1,0 +1,220 @@
+use any_chain_eval::Chain;
+use dolos_core::SubmitExt;
+use futures_core::Stream;
+use futures_util::{StreamExt as _, TryStreamExt as _};
+use pallas::crypto::hash::Hash;
+use pallas::interop::utxorpc::v1alpha::spec::cardano::ExUnits;
+use pallas::interop::utxorpc::v1alpha::spec::submit::{WaitForTxResponse, *};
+use pallas::interop::utxorpc::v1alpha::spec as u5c;
+use pallas::interop::utxorpc::LedgerContext;
+use std::collections::HashSet;
+use std::pin::Pin;
+use tonic::{Request, Response, Status};
+use tracing::info;
+
+use crate::prelude::*;
+
+pub struct SubmitServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    domain: D,
+}
+
+impl<D> SubmitServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    pub fn new(domain: D) -> Self {
+        Self { domain }
+    }
+}
+
+fn tx_stage_to_u5c(stage: MempoolTxStage) -> i32 {
+    match stage {
+        MempoolTxStage::Pending => Stage::Mempool as i32,
+        MempoolTxStage::Propagated => Stage::Network as i32,
+        MempoolTxStage::Acknowledged => Stage::Acknowledged as i32,
+        MempoolTxStage::Confirmed => Stage::Confirmed as i32,
+        _ => Stage::Unspecified as i32,
+    }
+}
+
+fn event_to_watch_mempool_response(event: MempoolEvent) -> WatchMempoolResponse {
+    WatchMempoolResponse {
+        tx: TxInMempool {
+            r#ref: event.tx.hash.to_vec().into(),
+            native_bytes: event.tx.payload.cbor().to_vec().into(),
+            stage: tx_stage_to_u5c(event.tx.stage.clone()),
+            parsed_state: None, // TODO
+        }
+        .into(),
+    }
+}
+
+fn event_to_wait_for_tx_response(event: MempoolEvent) -> WaitForTxResponse {
+    WaitForTxResponse {
+        stage: tx_stage_to_u5c(event.tx.stage.clone()),
+        r#ref: event.tx.hash.to_vec().into(),
+    }
+}
+
+fn tx_eval_to_u5c(eval: Result<MempoolTx, DomainError>) -> u5c::cardano::TxEval {
+    match eval {
+        Ok(tx) => u5c::cardano::TxEval {
+            ex_units: tx.report.iter().flatten().try_fold(
+                u5c::cardano::ExUnits::default(),
+                |acc, eval| {
+                    Some(ExUnits {
+                        steps: acc.steps + eval.units.steps,
+                        memory: acc.memory + eval.units.mem,
+                    })
+                },
+            ),
+            redeemers: tx
+                .report
+                .iter()
+                .flatten()
+                .map(|x| u5c::cardano::Redeemer {
+                    purpose: x.tag as i32,
+                    index: x.index,
+                    ex_units: Some(u5c::cardano::ExUnits {
+                        steps: x.units.steps,
+                        memory: x.units.mem,
+                    }),
+                    ..Default::default()
+                })
+                .collect(),
+            fee: None,      // TODO
+            traces: vec![], // TODO
+            ..Default::default()
+        },
+        Err(e) => u5c::cardano::TxEval {
+            errors: vec![u5c::cardano::EvalError {
+                msg: format!("{e:#?}"),
+            }],
+            ..Default::default()
+        },
+    }
+}
+
+#[async_trait::async_trait]
+impl<D> submit_service_server::SubmitService for SubmitServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    type WaitForTxStream =
+        Pin<Box<dyn Stream<Item = Result<WaitForTxResponse, tonic::Status>> + Send + 'static>>;
+
+    type WatchMempoolStream =
+        Pin<Box<dyn Stream<Item = Result<WatchMempoolResponse, tonic::Status>> + Send + 'static>>;
+
+    async fn submit_tx(
+        &self,
+        request: Request<SubmitTxRequest>,
+    ) -> Result<Response<SubmitTxResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc submit tx request: {:?}", message);
+
+        let chain = self.domain.read_chain();
+
+        let tx = message
+            .tx
+            .ok_or_else(|| Status::invalid_argument("missing tx"))?;
+        let tx_bytes = match tx.r#type {
+            Some(any_chain_tx::Type::Raw(bytes)) => bytes,
+            _ => return Err(Status::invalid_argument("missing or unsupported tx type")),
+        };
+
+        let hash = self
+            .domain
+            .receive_tx("grpc", &chain, tx_bytes.as_ref())
+            .map_err(|e| Status::invalid_argument(format!("could not process tx: {e}")))?;
+
+        Ok(Response::new(SubmitTxResponse {
+            r#ref: hash.to_vec().into(),
+        }))
+    }
+
+    async fn wait_for_tx(
+        &self,
+        request: Request<WaitForTxRequest>,
+    ) -> Result<Response<Self::WaitForTxStream>, Status> {
+        let subjects: HashSet<_> = request
+            .into_inner()
+            .r#ref
+            .into_iter()
+            .map(|x| Hash::from(x.as_ref()))
+            .collect();
+
+        let initial_stages: Vec<_> = subjects
+            .iter()
+            .map(|x| {
+                Result::<_, Status>::Ok(WaitForTxResponse {
+                    stage: tx_stage_to_u5c(self.domain.mempool().check_status(x).stage),
+                    r#ref: x.to_vec().into(),
+                })
+            })
+            .collect();
+
+        let updates = self.domain.mempool().subscribe();
+
+        let updates = UpdateFilter::<D::Mempool>::new(updates, subjects)
+            .map(|x| Ok(event_to_wait_for_tx_response(x)))
+            .boxed();
+
+        let stream = tokio_stream::iter(initial_stages).chain(updates).boxed();
+
+        Ok(Response::new(stream))
+    }
+
+    async fn read_mempool(
+        &self,
+        _request: tonic::Request<ReadMempoolRequest>,
+    ) -> Result<tonic::Response<ReadMempoolResponse>, tonic::Status> {
+        Err(Status::unimplemented("read_mempool is not yet available"))
+    }
+
+    async fn watch_mempool(
+        &self,
+        _request: tonic::Request<WatchMempoolRequest>,
+    ) -> Result<tonic::Response<Self::WatchMempoolStream>, tonic::Status> {
+        let updates = self.domain.mempool().subscribe();
+
+        let stream = updates
+            .map_ok(event_to_watch_mempool_response)
+            .map_err(|e| Status::internal(e.to_string()))
+            .boxed();
+
+        Ok(Response::new(stream))
+    }
+
+    async fn eval_tx(
+        &self,
+        request: tonic::Request<EvalTxRequest>,
+    ) -> Result<tonic::Response<EvalTxResponse>, tonic::Status> {
+        let tx = request
+            .into_inner()
+            .tx
+            .ok_or_else(|| Status::invalid_argument("missing tx"))?;
+
+        let tx_raw = match tx.r#type {
+            Some(any_chain_tx::Type::Raw(bytes)) => bytes.to_vec(),
+            _ => return Err(Status::invalid_argument("missing or unsupported tx type")),
+        };
+
+        let chain = self.domain.read_chain();
+
+        let result = self.domain.validate_tx(&chain, &tx_raw);
+        let result = tx_eval_to_u5c(result);
+
+        let report = AnyChainEval {
+            chain: Some(Chain::Cardano(result)),
+        };
+
+        Ok(Response::new(EvalTxResponse {
+            report: Some(report),
+        }))
+    }
+}

--- a/src/serve/grpc/v1alpha/sync.rs
+++ b/src/serve/grpc/v1alpha/sync.rs
@@ -1,10 +1,10 @@
 use futures_core::Stream;
 use futures_util::StreamExt;
 use itertools::Itertools;
-use pallas::interop::utxorpc as interop;
-use pallas::interop::utxorpc::spec::sync::BlockRef;
+use pallas::interop::utxorpc::v1alpha as interop;
+use pallas::interop::utxorpc::v1alpha::spec::sync::BlockRef;
+use pallas::interop::utxorpc::v1alpha::{spec as u5c, Mapper};
 use pallas::interop::utxorpc::LedgerContext;
-use pallas::interop::utxorpc::{spec as u5c, Mapper};
 use std::pin::Pin;
 use tonic::{Request, Response, Status};
 
@@ -15,14 +15,9 @@ const MAX_DUMP_HISTORY_ITEMS: u32 = 100;
 fn u5c_to_chain_point(block_ref: u5c::sync::BlockRef) -> Result<ChainPoint, Status> {
     Ok(ChainPoint::Specific(
         block_ref.slot,
-        super::convert::bytes_to_hash32(&block_ref.hash)?,
+        crate::serve::grpc::convert::bytes_to_hash32(&block_ref.hash)?,
     ))
 }
-
-// fn raw_to_anychain2(raw: &[u8]) -> AnyChainBlock {
-//     let block = any_chain_block::Chain::Raw(Bytes::copy_from_slice(raw));
-//     AnyChainBlock { chain: Some(block) }
-// }
 
 fn raw_to_anychain<C: LedgerContext>(
     mapper: &Mapper<C>,
@@ -221,13 +216,7 @@ where
             .map(u5c_to_chain_point)
             .try_collect()?;
 
-        // let (stream, point) = super::stream::ChainStream::<D>::start(
-        //     self.domain.wal().clone(),
-        //     self.domain.archive().clone(),
-        //     &intersect,
-        // );
-
-        let stream = super::stream::ChainStream::start::<D, _>(
+        let stream = crate::serve::grpc::stream::ChainStream::start::<D, _>(
             self.domain.clone(),
             intersect.clone(),
             self.cancel.clone(),
@@ -263,7 +252,7 @@ where
 #[cfg(test)]
 mod tests {
     use dolos_testing::toy_domain::ToyDomain;
-    use pallas::interop::utxorpc::spec::sync::sync_service_server::SyncService as _;
+    use pallas::interop::utxorpc::v1alpha::spec::sync::sync_service_server::SyncService as _;
 
     use super::*;
 

--- a/src/serve/grpc/v1alpha/watch.rs
+++ b/src/serve/grpc/v1alpha/watch.rs
@@ -1,15 +1,15 @@
 use futures_core::Stream;
 use futures_util::StreamExt;
-use pallas::interop::utxorpc::spec as u5c;
-use pallas::interop::utxorpc::{self as interop, LedgerContext};
+use pallas::interop::utxorpc::v1alpha::{self as interop, spec as u5c};
+use pallas::interop::utxorpc::LedgerContext;
 use pallas::{
-    interop::utxorpc::spec::watch::any_chain_tx_pattern::Chain,
+    interop::utxorpc::v1alpha::spec::watch::any_chain_tx_pattern::Chain,
     ledger::{addresses::Address, traverse::MultiEraBlock},
 };
 use std::pin::Pin;
 use tonic::{Request, Response, Status};
 
-use super::stream::ChainStream;
+use crate::serve::grpc::stream::ChainStream;
 use crate::prelude::*;
 
 fn outputs_match_address(

--- a/src/serve/grpc/v1beta/mod.rs
+++ b/src/serve/grpc/v1beta/mod.rs
@@ -1,0 +1,6 @@
+pub mod query;
+pub mod submit;
+pub mod sync;
+pub mod watch;
+
+pub(super) use pallas::interop::utxorpc::v1beta::spec;

--- a/src/serve/grpc/v1beta/query.rs
+++ b/src/serve/grpc/v1beta/query.rs
@@ -1,0 +1,1282 @@
+use dolos_cardano::indexes::CardanoIndexExt;
+use itertools::Itertools as _;
+use pallas::interop::utxorpc::v1beta::spec::query::any_utxo_pattern::UtxoPattern;
+use pallas::interop::utxorpc::v1beta::{self as interop, spec as u5c};
+use pallas::interop::utxorpc::LedgerContext;
+use pallas::ledger::traverse::{MultiEraBlock, MultiEraOutput};
+use std::collections::HashSet;
+use tonic::{Request, Response, Status};
+use tracing::{info, warn};
+
+use crate::serve::grpc::masking::apply_mask;
+use crate::prelude::*;
+use dolos_cardano::indexes::AsyncCardanoQueryExt;
+
+pub fn point_to_u5c<T: LedgerContext>(_ledger: &T, point: &ChainPoint) -> u5c::query::ChainPoint {
+    u5c::query::ChainPoint {
+        slot: point.slot(),
+        hash: point.hash().map(|h| h.to_vec()).unwrap_or_default().into(),
+        ..Default::default()
+    }
+}
+
+pub struct QueryServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    domain: D,
+    mapper: interop::Mapper<D>,
+}
+
+impl<D> QueryServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    pub fn new(domain: D) -> Self {
+        let mapper = interop::Mapper::new(domain.clone());
+
+        Self { domain, mapper }
+    }
+}
+
+fn into_status(err: impl std::error::Error) -> Status {
+    Status::internal(err.to_string())
+}
+
+trait IntoSet {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status>;
+}
+
+fn intersect<S: CardanoIndexExt>(
+    indexes: &S,
+    a: impl IntoSet,
+    b: impl IntoSet,
+) -> Result<HashSet<TxoRef>, Status> {
+    let a = a.into_set(indexes)?;
+    let b = b.into_set(indexes)?;
+
+    Ok(a.intersection(&b).cloned().collect())
+}
+
+struct ByAddressQuery(bytes::Bytes);
+
+impl ByAddressQuery {
+    fn maybe_from(data: bytes::Bytes) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self(data))
+    }
+}
+
+impl IntoSet for ByAddressQuery {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        indexes.utxos_by_address(&self.0).map_err(into_status)
+    }
+}
+
+struct ByPaymentQuery(bytes::Bytes);
+
+impl ByPaymentQuery {
+    fn maybe_from(data: bytes::Bytes) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self(data))
+    }
+}
+
+impl IntoSet for ByPaymentQuery {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        indexes.utxos_by_payment(&self.0).map_err(into_status)
+    }
+}
+
+struct ByDelegationQuery(bytes::Bytes);
+
+impl ByDelegationQuery {
+    fn maybe_from(data: bytes::Bytes) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self(data))
+    }
+}
+
+impl IntoSet for ByDelegationQuery {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        indexes.utxos_by_stake(&self.0).map_err(into_status)
+    }
+}
+
+impl IntoSet for u5c::cardano::AddressPattern {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        let exact = ByAddressQuery::maybe_from(self.exact_address);
+        let payment = ByPaymentQuery::maybe_from(self.payment_part);
+        let delegation = ByDelegationQuery::maybe_from(self.delegation_part);
+
+        match (exact, payment, delegation) {
+            (Some(x), None, None) => x.into_set(indexes),
+            (None, Some(x), None) => x.into_set(indexes),
+            (None, None, Some(x)) => x.into_set(indexes),
+            (None, Some(a), Some(b)) => intersect(indexes, a, b),
+            (None, None, None) => Ok(HashSet::default()),
+            _ => Err(Status::invalid_argument("conflicting address criteria")),
+        }
+    }
+}
+
+struct ByPolicyQuery(bytes::Bytes);
+
+impl ByPolicyQuery {
+    fn maybe_from(data: bytes::Bytes) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self(data))
+    }
+}
+
+impl IntoSet for ByPolicyQuery {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        indexes.utxos_by_policy(&self.0).map_err(into_status)
+    }
+}
+
+struct ByAssetQuery(bytes::Bytes);
+
+impl ByAssetQuery {
+    fn maybe_from(data: bytes::Bytes) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self(data))
+    }
+}
+
+impl IntoSet for ByAssetQuery {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        indexes.utxos_by_asset(&self.0).map_err(into_status)
+    }
+}
+
+impl IntoSet for u5c::cardano::AssetPattern {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        let by_policy = ByPolicyQuery::maybe_from(self.policy_id);
+        let by_asset = ByAssetQuery::maybe_from(self.asset_name);
+
+        match (by_policy, by_asset) {
+            (Some(x), None) => x.into_set(indexes),
+            (None, Some(x)) => x.into_set(indexes),
+            (None, None) => Ok(HashSet::default()),
+            _ => Err(Status::invalid_argument("conflicting asset criteria")),
+        }
+    }
+}
+
+impl IntoSet for u5c::cardano::TxOutputPattern {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        match (self.address, self.asset) {
+            (None, Some(x)) => x.into_set(indexes),
+            (Some(x), None) => x.into_set(indexes),
+            (Some(a), Some(b)) => intersect(indexes, a, b),
+            (None, None) => Ok(HashSet::default()),
+        }
+    }
+}
+
+impl IntoSet for u5c::query::AnyUtxoPattern {
+    fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
+        match self.utxo_pattern {
+            Some(UtxoPattern::Cardano(x)) => x.into_set(indexes),
+            _ => Ok(HashSet::new()),
+        }
+    }
+}
+
+fn from_u5c_txoref(txo: u5c::query::TxoRef) -> Result<TxoRef, Status> {
+    let hash = crate::serve::grpc::convert::bytes_to_hash32(&txo.hash)?;
+    Ok(TxoRef(hash, txo.index))
+}
+
+fn u64_to_bigint(value: u64) -> Option<u5c::cardano::BigInt> {
+    if value <= i64::MAX as u64 {
+        Some(u5c::cardano::BigInt {
+            big_int: Some(u5c::cardano::big_int::BigInt::Int(value as i64)),
+        })
+    } else {
+        Some(u5c::cardano::BigInt {
+            big_int: Some(u5c::cardano::big_int::BigInt::BigUInt(
+                value.to_be_bytes().to_vec().into(),
+            )),
+        })
+    }
+}
+
+fn rational_to_u5c(numerator: u64, denominator: u64) -> u5c::cardano::RationalNumber {
+    u5c::cardano::RationalNumber {
+        numerator: numerator as i32,
+        denominator: denominator as u32,
+    }
+}
+
+fn float_to_u5c_rational(value: f32) -> u5c::cardano::RationalNumber {
+    let value = dolos_cardano::utils::float_to_rational(value);
+    rational_to_u5c(value.numerator, value.denominator)
+}
+
+fn map_execution_prices(
+    value: &pallas::interop::hardano::configs::alonzo::ExecutionPrices,
+) -> u5c::cardano::ExPrices {
+    let value: pallas::ledger::primitives::alonzo::ExUnitPrices = value.clone().into();
+
+    u5c::cardano::ExPrices {
+        steps: Some(rational_to_u5c(
+            value.step_price.numerator,
+            value.step_price.denominator,
+        )),
+        memory: Some(rational_to_u5c(
+            value.mem_price.numerator,
+            value.mem_price.denominator,
+        )),
+    }
+}
+
+fn map_execution_units(
+    value: &pallas::interop::hardano::configs::alonzo::ExUnits,
+) -> u5c::cardano::ExUnits {
+    u5c::cardano::ExUnits {
+        steps: value.ex_units_steps,
+        memory: value.ex_units_mem,
+    }
+}
+
+fn map_cost_models(
+    genesis: &Genesis,
+) -> (
+    Option<u5c::cardano::CostModels>,
+    Option<u5c::cardano::CostModelMap>,
+) {
+    use pallas::interop::hardano::configs::alonzo::Language;
+
+    let plutus_v1 = genesis
+        .alonzo
+        .cost_models
+        .get(&Language::PlutusV1)
+        .cloned()
+        .map(Vec::<i64>::from)
+        .map(|values| u5c::cardano::CostModel { values });
+
+    let plutus_v2 = genesis
+        .alonzo
+        .cost_models
+        .get(&Language::PlutusV2)
+        .cloned()
+        .map(Vec::<i64>::from)
+        .map(|values| u5c::cardano::CostModel { values });
+
+    let plutus_v3 =
+        (!genesis.conway.plutus_v3_cost_model.is_empty()).then(|| u5c::cardano::CostModel {
+            values: genesis.conway.plutus_v3_cost_model.clone(),
+        });
+
+    let cost_models = u5c::cardano::CostModels {
+        plutus_v1: plutus_v1.clone(),
+        plutus_v2: plutus_v2.clone(),
+        plutus_v3: plutus_v3.clone(),
+        plutus_v4: None,
+    };
+
+    let cost_model_map = u5c::cardano::CostModelMap {
+        plutus_v1,
+        plutus_v2,
+        plutus_v3,
+        plutus_v4: None,
+    };
+
+    (
+        Some(cost_models)
+            .filter(|x| x.plutus_v1.is_some() || x.plutus_v2.is_some() || x.plutus_v3.is_some()),
+        Some(cost_model_map)
+            .filter(|x| x.plutus_v1.is_some() || x.plutus_v2.is_some() || x.plutus_v3.is_some()),
+    )
+}
+
+fn map_genesis_protocol_params(genesis: &Genesis) -> u5c::cardano::PParams {
+    let shelley = &genesis.shelley.protocol_params;
+    let (cost_models, _) = map_cost_models(genesis);
+
+    u5c::cardano::PParams {
+        max_tx_size: shelley.max_tx_size.into(),
+        min_fee_coefficient: u64_to_bigint(shelley.min_fee_a.into()),
+        min_fee_constant: u64_to_bigint(shelley.min_fee_b.into()),
+        max_block_body_size: shelley.max_block_body_size.into(),
+        max_block_header_size: shelley.max_block_header_size.into(),
+        stake_key_deposit: u64_to_bigint(shelley.key_deposit),
+        pool_deposit: u64_to_bigint(shelley.pool_deposit),
+        pool_retirement_epoch_bound: shelley.e_max,
+        desired_number_of_pools: shelley.n_opt.into(),
+        pool_influence: Some(rational_to_u5c(
+            shelley.a0.numerator,
+            shelley.a0.denominator,
+        )),
+        monetary_expansion: Some(rational_to_u5c(
+            shelley.rho.numerator,
+            shelley.rho.denominator,
+        )),
+        treasury_expansion: Some(rational_to_u5c(
+            shelley.tau.numerator,
+            shelley.tau.denominator,
+        )),
+        min_pool_cost: u64_to_bigint(shelley.min_pool_cost),
+        protocol_version: Some(u5c::cardano::ProtocolVersion {
+            major: shelley.protocol_version.major as u32,
+            minor: shelley.protocol_version.minor as u32,
+        }),
+        max_value_size: genesis.alonzo.max_value_size.into(),
+        collateral_percentage: genesis.alonzo.collateral_percentage.into(),
+        max_collateral_inputs: genesis.alonzo.max_collateral_inputs.into(),
+        cost_models,
+        prices: Some(map_execution_prices(&genesis.alonzo.execution_prices)),
+        max_execution_units_per_transaction: Some(map_execution_units(
+            &genesis.alonzo.max_tx_ex_units,
+        )),
+        max_execution_units_per_block: Some(map_execution_units(
+            &genesis.alonzo.max_block_ex_units,
+        )),
+        min_fee_script_ref_cost_per_byte: Some(rational_to_u5c(
+            genesis.conway.min_fee_ref_script_cost_per_byte,
+            1,
+        )),
+        pool_voting_thresholds: Some(u5c::cardano::VotingThresholds {
+            thresholds: vec![
+                float_to_u5c_rational(genesis.conway.pool_voting_thresholds.motion_no_confidence),
+                float_to_u5c_rational(genesis.conway.pool_voting_thresholds.committee_normal),
+                float_to_u5c_rational(
+                    genesis
+                        .conway
+                        .pool_voting_thresholds
+                        .committee_no_confidence,
+                ),
+                float_to_u5c_rational(genesis.conway.pool_voting_thresholds.hard_fork_initiation),
+                float_to_u5c_rational(genesis.conway.pool_voting_thresholds.pp_security_group),
+            ],
+        }),
+        drep_voting_thresholds: Some(u5c::cardano::VotingThresholds {
+            thresholds: vec![
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.motion_no_confidence),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.committee_normal),
+                float_to_u5c_rational(
+                    genesis
+                        .conway
+                        .d_rep_voting_thresholds
+                        .committee_no_confidence,
+                ),
+                float_to_u5c_rational(
+                    genesis
+                        .conway
+                        .d_rep_voting_thresholds
+                        .update_to_constitution,
+                ),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.hard_fork_initiation),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.pp_network_group),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.pp_economic_group),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.pp_technical_group),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.pp_gov_group),
+                float_to_u5c_rational(genesis.conway.d_rep_voting_thresholds.treasury_withdrawal),
+            ],
+        }),
+        min_committee_size: genesis.conway.committee_min_size as u32,
+        committee_term_limit: genesis.conway.committee_max_term_length.into(),
+        governance_action_validity_period: genesis.conway.gov_action_lifetime.into(),
+        governance_action_deposit: u64_to_bigint(genesis.conway.gov_action_deposit),
+        drep_deposit: u64_to_bigint(genesis.conway.d_rep_deposit),
+        drep_inactivity_period: genesis.conway.d_rep_activity.into(),
+        ..Default::default()
+    }
+}
+
+fn caip2_from_genesis(genesis: &Genesis) -> Result<String, Status> {
+    match genesis.shelley.network_magic {
+        Some(764824073) => Ok("cardano:mainnet".into()),
+        Some(1) => Ok("cardano:preprod".into()),
+        Some(2) => Ok("cardano:preview".into()),
+        Some(x) => Ok(format!("cardano:{x}")),
+        None => Err(Status::internal("missing Cardano network magic")),
+    }
+}
+
+fn map_cardano_genesis(genesis: &Genesis) -> Result<u5c::cardano::Genesis, Status> {
+    let (_, cost_model_map) = map_cost_models(genesis);
+    let constitution_anchor_hash = hex::decode(&genesis.conway.constitution.anchor.data_hash)
+        .map_err(|e| Status::internal(format!("invalid constitution anchor hash: {e}")))?;
+    let constitution_hash = genesis
+        .conway
+        .constitution
+        .script
+        .as_deref()
+        .map(hex::decode)
+        .transpose()
+        .map_err(|e| Status::internal(format!("invalid constitution script hash: {e}")))?
+        .unwrap_or_default();
+
+    Ok(u5c::cardano::Genesis {
+        avvm_distr: genesis.byron.avvm_distr.clone(),
+        block_version_data: Some(u5c::cardano::BlockVersionData {
+            script_version: genesis.byron.block_version_data.script_version.into(),
+            slot_duration: genesis.byron.block_version_data.slot_duration.to_string(),
+            max_block_size: genesis.byron.block_version_data.max_block_size.to_string(),
+            max_header_size: genesis.byron.block_version_data.max_header_size.to_string(),
+            max_tx_size: genesis.byron.block_version_data.max_tx_size.to_string(),
+            max_proposal_size: genesis
+                .byron
+                .block_version_data
+                .max_proposal_size
+                .to_string(),
+            mpc_thd: genesis.byron.block_version_data.mpc_thd.to_string(),
+            heavy_del_thd: genesis.byron.block_version_data.heavy_del_thd.to_string(),
+            update_vote_thd: genesis.byron.block_version_data.update_vote_thd.to_string(),
+            update_proposal_thd: genesis
+                .byron
+                .block_version_data
+                .update_proposal_thd
+                .to_string(),
+            update_implicit: genesis.byron.block_version_data.update_implicit.to_string(),
+            softfork_rule: Some(u5c::cardano::SoftforkRule {
+                init_thd: genesis
+                    .byron
+                    .block_version_data
+                    .softfork_rule
+                    .init_thd
+                    .to_string(),
+                min_thd: genesis
+                    .byron
+                    .block_version_data
+                    .softfork_rule
+                    .min_thd
+                    .to_string(),
+                thd_decrement: genesis
+                    .byron
+                    .block_version_data
+                    .softfork_rule
+                    .thd_decrement
+                    .to_string(),
+            }),
+            tx_fee_policy: Some(u5c::cardano::TxFeePolicy {
+                multiplier: genesis
+                    .byron
+                    .block_version_data
+                    .tx_fee_policy
+                    .multiplier
+                    .to_string(),
+                summand: genesis
+                    .byron
+                    .block_version_data
+                    .tx_fee_policy
+                    .summand
+                    .to_string(),
+            }),
+            unlock_stake_epoch: genesis
+                .byron
+                .block_version_data
+                .unlock_stake_epoch
+                .to_string(),
+        }),
+        fts_seed: genesis.byron.fts_seed.clone().unwrap_or_default(),
+        protocol_consts: Some(u5c::cardano::ProtocolConsts {
+            k: genesis.byron.protocol_consts.k as u32,
+            protocol_magic: genesis.byron.protocol_consts.protocol_magic,
+            vss_max_ttl: genesis
+                .byron
+                .protocol_consts
+                .vss_max_ttl
+                .unwrap_or_default(),
+            vss_min_ttl: genesis
+                .byron
+                .protocol_consts
+                .vss_min_ttl
+                .unwrap_or_default(),
+        }),
+        start_time: genesis.byron.start_time,
+        boot_stakeholders: genesis
+            .byron
+            .boot_stakeholders
+            .iter()
+            .map(|(k, v)| (k.clone(), (*v).into()))
+            .collect(),
+        heavy_delegation: genesis
+            .byron
+            .heavy_delegation
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    u5c::cardano::HeavyDelegation {
+                        cert: v.cert.clone(),
+                        delegate_pk: v.delegate_pk.clone(),
+                        issuer_pk: v.issuer_pk.clone(),
+                        omega: 0,
+                    },
+                )
+            })
+            .collect(),
+        non_avvm_balances: genesis.byron.non_avvm_balances.clone(),
+        vss_certs: genesis
+            .byron
+            .vss_certs
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    u5c::cardano::VssCert {
+                        expiry_epoch: v.expiry_epoch,
+                        signature: v.signature,
+                        signing_key: v.signing_key,
+                        vss_key: v.vss_key,
+                    },
+                )
+            })
+            .collect(),
+        active_slots_coeff: genesis
+            .shelley
+            .active_slots_coeff
+            .map(float_to_u5c_rational),
+        epoch_length: genesis.shelley.epoch_length.unwrap_or_default(),
+        gen_delegs: genesis
+            .shelley
+            .gen_delegs
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    u5c::cardano::GenDelegs {
+                        delegate: v.delegate.unwrap_or_default(),
+                        vrf: v.vrf.unwrap_or_default(),
+                    },
+                )
+            })
+            .collect(),
+        initial_funds: genesis
+            .shelley
+            .initial_funds
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    u64_to_bigint(v).expect("u64 genesis funds must map to bigint"),
+                )
+            })
+            .collect(),
+        max_kes_evolutions: genesis.shelley.max_kes_evolutions.unwrap_or_default(),
+        max_lovelace_supply: genesis.shelley.max_lovelace_supply.and_then(u64_to_bigint),
+        network_id: genesis.shelley.network_id.clone().unwrap_or_default(),
+        network_magic: genesis.shelley.network_magic.unwrap_or_default(),
+        protocol_params: Some(map_genesis_protocol_params(genesis)),
+        security_param: genesis.shelley.security_param.unwrap_or_default(),
+        slot_length: genesis.shelley.slot_length.unwrap_or_default(),
+        slots_per_kes_period: genesis.shelley.slots_per_kes_period.unwrap_or_default(),
+        system_start: genesis.shelley.system_start.clone().unwrap_or_default(),
+        update_quorum: genesis.shelley.update_quorum.unwrap_or_default(),
+        lovelace_per_utxo_word: u64_to_bigint(genesis.alonzo.lovelace_per_utxo_word),
+        execution_prices: Some(map_execution_prices(&genesis.alonzo.execution_prices)),
+        max_tx_ex_units: Some(map_execution_units(&genesis.alonzo.max_tx_ex_units)),
+        max_block_ex_units: Some(map_execution_units(&genesis.alonzo.max_block_ex_units)),
+        max_value_size: genesis.alonzo.max_value_size,
+        collateral_percentage: genesis.alonzo.collateral_percentage,
+        max_collateral_inputs: genesis.alonzo.max_collateral_inputs,
+        cost_models: cost_model_map,
+        committee: Some(u5c::cardano::Committee {
+            members: genesis.conway.committee.members.clone(),
+            threshold: Some(rational_to_u5c(
+                genesis.conway.committee.threshold.numerator,
+                genesis.conway.committee.threshold.denominator,
+            )),
+        }),
+        constitution: Some(u5c::cardano::Constitution {
+            anchor: Some(u5c::cardano::Anchor {
+                url: genesis.conway.constitution.anchor.url.clone(),
+                content_hash: constitution_anchor_hash.into(),
+            }),
+            hash: constitution_hash.into(),
+        }),
+        committee_min_size: genesis.conway.committee_min_size,
+        committee_max_term_length: genesis.conway.committee_max_term_length.into(),
+        gov_action_lifetime: genesis.conway.gov_action_lifetime.into(),
+        gov_action_deposit: u64_to_bigint(genesis.conway.gov_action_deposit),
+        drep_deposit: u64_to_bigint(genesis.conway.d_rep_deposit),
+        drep_activity: genesis.conway.d_rep_activity.into(),
+        min_fee_ref_script_cost_per_byte: Some(rational_to_u5c(
+            genesis.conway.min_fee_ref_script_cost_per_byte,
+            1,
+        )),
+        drep_voting_thresholds: Some(u5c::cardano::DRepVotingThresholds {
+            motion_no_confidence: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.motion_no_confidence,
+            )),
+            committee_normal: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.committee_normal,
+            )),
+            committee_no_confidence: Some(float_to_u5c_rational(
+                genesis
+                    .conway
+                    .d_rep_voting_thresholds
+                    .committee_no_confidence,
+            )),
+            update_to_constitution: Some(float_to_u5c_rational(
+                genesis
+                    .conway
+                    .d_rep_voting_thresholds
+                    .update_to_constitution,
+            )),
+            hard_fork_initiation: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.hard_fork_initiation,
+            )),
+            pp_network_group: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.pp_network_group,
+            )),
+            pp_economic_group: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.pp_economic_group,
+            )),
+            pp_technical_group: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.pp_technical_group,
+            )),
+            pp_gov_group: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.pp_gov_group,
+            )),
+            treasury_withdrawal: Some(float_to_u5c_rational(
+                genesis.conway.d_rep_voting_thresholds.treasury_withdrawal,
+            )),
+        }),
+        pool_voting_thresholds: Some(u5c::cardano::PoolVotingThresholds {
+            motion_no_confidence: Some(float_to_u5c_rational(
+                genesis.conway.pool_voting_thresholds.motion_no_confidence,
+            )),
+            committee_normal: Some(float_to_u5c_rational(
+                genesis.conway.pool_voting_thresholds.committee_normal,
+            )),
+            committee_no_confidence: Some(float_to_u5c_rational(
+                genesis
+                    .conway
+                    .pool_voting_thresholds
+                    .committee_no_confidence,
+            )),
+            hard_fork_initiation: Some(float_to_u5c_rational(
+                genesis.conway.pool_voting_thresholds.hard_fork_initiation,
+            )),
+            pp_security_group: Some(float_to_u5c_rational(
+                genesis.conway.pool_voting_thresholds.pp_security_group,
+            )),
+        }),
+    })
+}
+
+fn map_era_boundary(boundary: &dolos_cardano::EraBoundary) -> u5c::cardano::EraBoundary {
+    u5c::cardano::EraBoundary {
+        time: boundary.timestamp.saturating_mul(1000),
+        slot: boundary.slot,
+        epoch: boundary.epoch,
+    }
+}
+
+fn protocol_to_era_name(protocol: u16) -> &'static str {
+    match protocol {
+        0..=1 => "byron",
+        2 => "shelley",
+        3 => "allegra",
+        4 => "mary",
+        5..=6 => "alonzo",
+        7..=8 => "babbage",
+        9..=10 => "conway",
+        _ => "unknown",
+    }
+}
+
+fn map_era_summary(
+    era: &dolos_cardano::EraSummary,
+    active_protocol: u16,
+    active_params: &u5c::cardano::PParams,
+) -> u5c::cardano::EraSummary {
+    u5c::cardano::EraSummary {
+        name: protocol_to_era_name(era.protocol).into(),
+        start: Some(map_era_boundary(&era.start)),
+        end: era.end.as_ref().map(map_era_boundary),
+        protocol_params: (era.protocol == active_protocol).then(|| active_params.clone()),
+    }
+}
+
+async fn into_u5c_utxo<S: Domain + LedgerContext>(
+    txo: &TxoRef,
+    body: &EraCbor,
+    mapper: &interop::Mapper<S>,
+    domain: &S,
+) -> Result<u5c::query::AnyUtxoData, Box<dyn std::error::Error>> {
+    use pallas::ledger::primitives::conway::DatumOption;
+
+    let query = dolos_core::AsyncQueryFacade::new(domain.clone());
+
+    let parsed_output = MultiEraOutput::try_from(body)?;
+    let mut parsed = mapper.map_tx_output(&parsed_output, None);
+
+    // If the output has a datum hash, try to fetch the datum value from storage
+    if let Some(DatumOption::Hash(datum_hash)) = parsed_output.datum() {
+        match query.get_datum(&datum_hash).await {
+            Ok(Some(datum_bytes)) => {
+                // Decode the datum and update the parsed output
+                match pallas::codec::minicbor::decode::<
+                    pallas::ledger::primitives::conway::PlutusData,
+                >(&datum_bytes)
+                {
+                    Ok(plutus_data) => {
+                        // Update the datum field with both hash and payload
+                        parsed.datum = Some(u5c::cardano::Datum {
+                            hash: datum_hash.to_vec().into(),
+                            payload: Some(mapper.map_plutus_datum(&plutus_data)),
+                            original_cbor: Some(datum_bytes.into()),
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            datum_hash = hex::encode(datum_hash),
+                            error = %e,
+                            "Failed to decode datum value from storage"
+                        );
+                    }
+                }
+            }
+            Ok(None) => {
+                warn!(
+                    datum_hash = hex::encode(datum_hash),
+                    txo_ref = format!("{}#{}", hex::encode(txo.0), txo.1),
+                    "Datum value not found in storage for UTXO with datum hash"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    datum_hash = hex::encode(datum_hash),
+                    error = %e,
+                    "Error querying datum storage"
+                );
+            }
+        }
+    }
+
+    Ok(u5c::query::AnyUtxoData {
+        txo_ref: Some(u5c::query::TxoRef {
+            hash: txo.0.to_vec().into(),
+            index: txo.1,
+        }),
+        native_bytes: body.1.clone().into(),
+        parsed_state: Some(u5c::query::any_utxo_data::ParsedState::Cardano(parsed)),
+        block_ref: None,
+    })
+}
+
+#[async_trait::async_trait]
+impl<D> u5c::query::query_service_server::QueryService for QueryServiceImpl<D>
+where
+    D: Domain + LedgerContext,
+{
+    async fn read_params(
+        &self,
+        request: Request<u5c::query::ReadParamsRequest>,
+    ) -> Result<Response<u5c::query::ReadParamsResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - read_params");
+
+        let tip = self
+            .domain
+            .state()
+            .read_cursor()
+            .map_err(into_status)?
+            .ok_or(Status::internal("Failed to find ledger tip"))?;
+
+        let pparams = dolos_cardano::load_effective_pparams::<D>(self.domain.state())
+            .map_err(|_| Status::internal("Failed to load current pparams"))?;
+
+        let pparams = dolos_cardano::utils::pparams_to_pallas(&pparams);
+
+        let mut response = u5c::query::ReadParamsResponse {
+            values: Some(u5c::query::AnyChainParams {
+                params: u5c::query::any_chain_params::Params::Cardano(
+                    self.mapper.map_pparams(pparams),
+                )
+                .into(),
+            }),
+            ledger_tip: Some(point_to_u5c(&self.domain, &tip)),
+        };
+
+        if let Some(mask) = message.field_mask {
+            response = apply_mask(response, mask.paths)
+                .map_err(|_| Status::internal("Failed to apply field mask"))?
+        }
+
+        Ok(Response::new(response))
+    }
+
+    async fn read_data(
+        &self,
+        request: Request<u5c::query::ReadDataRequest>,
+    ) -> Result<Response<u5c::query::ReadDataResponse>, Status> {
+        let _message = request.into_inner();
+
+        info!("received new grpc query - read_data");
+
+        todo!()
+    }
+
+    async fn read_utxos(
+        &self,
+        request: Request<u5c::query::ReadUtxosRequest>,
+    ) -> Result<Response<u5c::query::ReadUtxosResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - read_utxos");
+
+        let keys: Vec<_> = message
+            .keys
+            .into_iter()
+            .map(from_u5c_txoref)
+            .try_collect()?;
+
+        let utxos = StateStore::get_utxos(self.domain.state(), keys)
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let mut items = Vec::new();
+        for (k, v) in utxos.iter() {
+            items.push(
+                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?,
+            );
+        }
+
+        let cursor = self
+            .domain
+            .state()
+            .read_cursor()
+            .map_err(|e| Status::internal(e.to_string()))?
+            .as_ref()
+            .map(|p| point_to_u5c(&self.domain, p));
+
+        Ok(Response::new(u5c::query::ReadUtxosResponse {
+            items,
+            ledger_tip: cursor,
+        }))
+    }
+
+    async fn search_utxos(
+        &self,
+        request: Request<u5c::query::SearchUtxosRequest>,
+    ) -> Result<Response<u5c::query::SearchUtxosResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - search_utxos");
+
+        let set = match message.predicate {
+            Some(x) => match x.r#match {
+                Some(x) => x.into_set(self.domain.indexes())?,
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "only 'match' predicate is supported by Dolos",
+                    ));
+                }
+            },
+            _ => {
+                return Err(Status::invalid_argument(
+                    "criteria too broad, narrow it down",
+                ));
+            }
+        };
+
+        let utxos = StateStore::get_utxos(self.domain.state(), set.into_iter().collect_vec())
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let mut items = Vec::new();
+        for (k, v) in utxos.iter() {
+            items.push(
+                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?,
+            );
+        }
+
+        let cursor = self
+            .domain
+            .state()
+            .read_cursor()
+            .map_err(|e| Status::internal(e.to_string()))?
+            .as_ref()
+            .map(|p| point_to_u5c(&self.domain, p));
+
+        Ok(Response::new(u5c::query::SearchUtxosResponse {
+            items,
+            ledger_tip: cursor,
+            next_token: String::default(),
+        }))
+    }
+
+    async fn read_tx(
+        &self,
+        request: Request<u5c::query::ReadTxRequest>,
+    ) -> Result<Response<u5c::query::ReadTxResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - read_tx");
+
+        let tx_hash = message.hash;
+
+        let query = dolos_core::AsyncQueryFacade::new(self.domain.clone());
+        let (block_bytes, tx_index) = query
+            .block_by_tx_hash(tx_hash.to_vec())
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?
+            .ok_or_else(|| Status::not_found("tx hash not found"))?;
+
+        let block = MultiEraBlock::decode(&block_bytes)
+            .map_err(|e| Status::internal(format!("failed to decode block: {e}")))?;
+
+        let tx = block
+            .txs()
+            .get(tx_index)
+            .cloned()
+            .ok_or_else(|| Status::not_found("tx hash not found"))?;
+
+        let native_bytes = tx.encode().into();
+
+        let cursor = self
+            .domain
+            .state()
+            .read_cursor()
+            .map_err(|e| Status::internal(e.to_string()))?
+            .as_ref()
+            .map(|p| point_to_u5c(&self.domain, p));
+
+        let mut response = u5c::query::ReadTxResponse {
+            tx: Some(u5c::query::AnyChainTx {
+                native_bytes,
+                block_ref: Some(u5c::query::ChainPoint {
+                    slot: block.slot(),
+                    hash: block.hash().to_vec().into(),
+                    height: block.header().number(),
+                    timestamp: self.domain.get_slot_timestamp(block.slot()).unwrap_or(0),
+                }),
+                chain: Some(u5c::query::any_chain_tx::Chain::Cardano(
+                    self.mapper.map_tx(&tx),
+                )),
+            }),
+            ledger_tip: cursor,
+        };
+
+        if let Some(mask) = message.field_mask {
+            response = apply_mask(response, mask.paths)
+                .map_err(|e| Status::internal(format!("failed to apply field mask: {e}")))?;
+        }
+
+        Ok(Response::new(response))
+    }
+
+    async fn read_genesis(
+        &self,
+        request: Request<u5c::query::ReadGenesisRequest>,
+    ) -> Result<Response<u5c::query::ReadGenesisResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - read_genesis");
+
+        let genesis = self.domain.genesis();
+
+        let mut response = u5c::query::ReadGenesisResponse {
+            genesis: genesis.shelley_hash.to_vec().into(),
+            caip2: caip2_from_genesis(&genesis)?,
+            config: Some(u5c::query::read_genesis_response::Config::Cardano(
+                map_cardano_genesis(&genesis)?,
+            )),
+        };
+
+        if let Some(mask) = message.field_mask {
+            response = apply_mask(response, mask.paths)
+                .map_err(|e| Status::internal(format!("failed to apply field mask: {e}")))?;
+        }
+
+        Ok(Response::new(response))
+    }
+
+    async fn read_era_summary(
+        &self,
+        request: Request<u5c::query::ReadEraSummaryRequest>,
+    ) -> Result<Response<u5c::query::ReadEraSummaryResponse>, Status> {
+        let message = request.into_inner();
+
+        info!("received new grpc query - read_era_summary");
+
+        let chain_summary = dolos_cardano::load_era_summary::<D>(self.domain.state())
+            .map_err(|e| Status::internal(format!("failed to load era summary: {e}")))?;
+
+        let active_pparams = dolos_cardano::load_effective_pparams::<D>(self.domain.state())
+            .map_err(|e| Status::internal(format!("failed to load current pparams: {e}")))?;
+        let active_protocol = active_pparams.protocol_major_or_default();
+        let active_params = self
+            .mapper
+            .map_pparams(dolos_cardano::utils::pparams_to_pallas(&active_pparams));
+
+        let summaries = chain_summary
+            .iter_all()
+            .map(|era| map_era_summary(era, active_protocol, &active_params))
+            .collect();
+
+        let mut response = u5c::query::ReadEraSummaryResponse {
+            summary: Some(u5c::query::read_era_summary_response::Summary::Cardano(
+                u5c::cardano::EraSummaries { summaries },
+            )),
+        };
+
+        if let Some(mask) = message.field_mask {
+            response = apply_mask(response, mask.paths)
+                .map_err(|e| Status::internal(format!("failed to apply field mask: {e}")))?;
+        }
+
+        Ok(Response::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dolos_testing::toy_domain::ToyDomain;
+    use pallas::interop::utxorpc::v1beta::spec::query::query_service_server::QueryService;
+
+    use super::*;
+
+    #[test]
+    fn maps_known_networks_to_caip2() {
+        let mainnet = dolos_cardano::include::mainnet::load();
+        let preprod = dolos_cardano::include::preprod::load();
+        let preview = dolos_cardano::include::preview::load();
+
+        assert_eq!(caip2_from_genesis(&mainnet).unwrap(), "cardano:mainnet");
+        assert_eq!(caip2_from_genesis(&preprod).unwrap(), "cardano:preprod");
+        assert_eq!(caip2_from_genesis(&preview).unwrap(), "cardano:preview");
+    }
+
+    #[test]
+    fn falls_back_to_network_magic_for_unknown_caip2() {
+        let mut genesis = dolos_cardano::include::preview::load();
+        genesis.shelley.network_magic = Some(42);
+
+        assert_eq!(caip2_from_genesis(&genesis).unwrap(), "cardano:42");
+    }
+
+    #[test]
+    fn maps_representative_genesis_fields() {
+        let genesis = dolos_cardano::include::preview::load();
+        let mapped = map_cardano_genesis(&genesis).unwrap();
+        let expected_anchor_hash =
+            hex::decode(&genesis.conway.constitution.anchor.data_hash).unwrap();
+        let expected_constitution_hash = hex::decode(
+            genesis
+                .conway
+                .constitution
+                .script
+                .as_deref()
+                .expect("preview genesis includes a constitution script"),
+        )
+        .unwrap();
+
+        assert_eq!(mapped.network_magic, 2);
+        assert_eq!(mapped.epoch_length, genesis.shelley.epoch_length.unwrap());
+        assert_eq!(mapped.slot_length, genesis.shelley.slot_length.unwrap());
+        assert_eq!(mapped.system_start, genesis.shelley.system_start.unwrap());
+        assert!(mapped.protocol_params.is_some());
+        assert!(mapped.execution_prices.is_some());
+        assert!(mapped.cost_models.is_some());
+
+        let constitution = mapped.constitution.expect("missing constitution");
+        let anchor = constitution.anchor.expect("missing constitution anchor");
+
+        assert_eq!(
+            anchor.content_hash.as_ref(),
+            expected_anchor_hash.as_slice()
+        );
+        assert_eq!(
+            constitution.hash.as_ref(),
+            expected_constitution_hash.as_slice()
+        );
+        assert_ne!(anchor.content_hash.as_ref(), constitution.hash.as_ref());
+    }
+
+    #[tokio::test]
+    async fn read_genesis_applies_field_mask() {
+        let domain = ToyDomain::new_with_genesis(
+            Arc::new(dolos_cardano::include::preview::load()),
+            None,
+            None,
+        );
+        let service = QueryServiceImpl::new(domain);
+        let mut request = u5c::query::ReadGenesisRequest {
+            field_mask: Some(Default::default()),
+        };
+        request.field_mask.as_mut().unwrap().paths = vec!["caip2".into()];
+
+        let response = QueryService::read_genesis(&service, Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.caip2, "cardano:preview");
+        assert!(response.genesis.is_empty());
+        assert!(response.config.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_genesis_returns_hash_and_config() {
+        let genesis = Arc::new(dolos_cardano::include::preprod::load());
+        let expected_hash = genesis.shelley_hash.to_vec();
+        let domain = ToyDomain::new_with_genesis(genesis, None, None);
+        let service = QueryServiceImpl::new(domain);
+
+        let response = QueryService::read_genesis(
+            &service,
+            Request::new(u5c::query::ReadGenesisRequest { field_mask: None }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert_eq!(response.genesis.as_ref(), expected_hash.as_slice());
+        assert_eq!(response.caip2, "cardano:preprod");
+
+        match response.config {
+            Some(u5c::query::read_genesis_response::Config::Cardano(cardano)) => {
+                assert_eq!(cardano.network_magic, 1);
+                assert!(cardano.protocol_params.unwrap().max_value_size > 0);
+            }
+            _ => panic!("missing cardano genesis config"),
+        }
+    }
+
+    #[test]
+    fn maps_protocols_to_era_names() {
+        assert_eq!(protocol_to_era_name(0), "byron");
+        assert_eq!(protocol_to_era_name(2), "shelley");
+        assert_eq!(protocol_to_era_name(3), "allegra");
+        assert_eq!(protocol_to_era_name(4), "mary");
+        assert_eq!(protocol_to_era_name(6), "alonzo");
+        assert_eq!(protocol_to_era_name(8), "babbage");
+        assert_eq!(protocol_to_era_name(10), "conway");
+        assert_eq!(protocol_to_era_name(42), "unknown");
+    }
+
+    #[tokio::test]
+    async fn read_era_summary_returns_active_era_params_only() {
+        let domain = ToyDomain::new_with_genesis(
+            Arc::new(dolos_cardano::include::preview::load()),
+            None,
+            None,
+        );
+        let service = QueryServiceImpl::new(domain);
+
+        let response = QueryService::read_era_summary(
+            &service,
+            Request::new(u5c::query::ReadEraSummaryRequest { field_mask: None }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        let summaries = match response.summary {
+            Some(u5c::query::read_era_summary_response::Summary::Cardano(cardano)) => {
+                cardano.summaries
+            }
+            _ => panic!("missing cardano era summaries"),
+        };
+
+        assert!(!summaries.is_empty());
+
+        let active_with_params = summaries
+            .iter()
+            .filter(|x| x.protocol_params.is_some())
+            .count();
+        assert_eq!(active_with_params, 1);
+
+        let active = summaries
+            .iter()
+            .find(|x| x.protocol_params.is_some())
+            .expect("expected active era with protocol params");
+
+        assert_eq!(active.name, "alonzo");
+        assert!(active.start.is_some());
+    }
+
+    #[tokio::test]
+    async fn read_era_summary_returns_boundary_time_in_milliseconds() {
+        let domain = ToyDomain::new_with_genesis(
+            Arc::new(dolos_cardano::include::preview::load()),
+            None,
+            None,
+        );
+        let service = QueryServiceImpl::new(domain);
+
+        let response = QueryService::read_era_summary(
+            &service,
+            Request::new(u5c::query::ReadEraSummaryRequest { field_mask: None }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        let summaries = match response.summary {
+            Some(u5c::query::read_era_summary_response::Summary::Cardano(cardano)) => {
+                cardano.summaries
+            }
+            _ => panic!("missing cardano era summaries"),
+        };
+
+        let first = summaries
+            .first()
+            .expect("expected at least one era summary");
+        let start = first.start.as_ref().expect("expected era start");
+
+        assert_eq!(start.slot, 0);
+        assert_eq!(start.time % 1000, 0);
+        assert!(start.time >= 1_666_656_000_000);
+    }
+
+    #[tokio::test]
+    async fn read_era_summary_applies_field_mask() {
+        let domain = ToyDomain::new_with_genesis(
+            Arc::new(dolos_cardano::include::preview::load()),
+            None,
+            None,
+        );
+        let service = QueryServiceImpl::new(domain);
+        let mut request = u5c::query::ReadEraSummaryRequest {
+            field_mask: Some(Default::default()),
+        };
+        request.field_mask.as_mut().unwrap().paths = vec!["cardano.summaries".into()];
+
+        let response = QueryService::read_era_summary(&service, Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        match response.summary {
+            Some(u5c::query::read_era_summary_response::Summary::Cardano(cardano)) => {
+                assert!(!cardano.summaries.is_empty());
+            }
+            _ => panic!("missing cardano era summaries"),
+        }
+    }
+}

--- a/src/serve/grpc/v1beta/submit.rs
+++ b/src/serve/grpc/v1beta/submit.rs
@@ -3,10 +3,10 @@ use dolos_core::SubmitExt;
 use futures_core::Stream;
 use futures_util::{StreamExt as _, TryStreamExt as _};
 use pallas::crypto::hash::Hash;
-use pallas::interop::utxorpc as u5c;
-use pallas::interop::utxorpc::spec::cardano::ExUnits;
-use pallas::interop::utxorpc::spec::submit::{WaitForTxResponse, *};
-use pallas::interop::utxorpc::{self as interop, LedgerContext};
+use pallas::interop::utxorpc::v1beta::spec::cardano::ExUnits;
+use pallas::interop::utxorpc::v1beta::spec::submit::{WaitForTxResponse, *};
+use pallas::interop::utxorpc::v1beta::spec as u5c;
+use pallas::interop::utxorpc::LedgerContext;
 use std::collections::HashSet;
 use std::pin::Pin;
 use tonic::{Request, Response, Status};
@@ -19,7 +19,6 @@ where
     D: Domain + LedgerContext,
 {
     domain: D,
-    _mapper: interop::Mapper<D>,
 }
 
 impl<D> SubmitServiceImpl<D>
@@ -27,9 +26,7 @@ where
     D: Domain + LedgerContext,
 {
     pub fn new(domain: D) -> Self {
-        let _mapper = interop::Mapper::new(domain.clone());
-
-        Self { domain, _mapper }
+        Self { domain }
     }
 }
 
@@ -62,11 +59,11 @@ fn event_to_wait_for_tx_response(event: MempoolEvent) -> WaitForTxResponse {
     }
 }
 
-fn tx_eval_to_u5c(eval: Result<MempoolTx, DomainError>) -> u5c::spec::cardano::TxEval {
+fn tx_eval_to_u5c(eval: Result<MempoolTx, DomainError>) -> u5c::cardano::TxEval {
     match eval {
-        Ok(tx) => u5c::spec::cardano::TxEval {
+        Ok(tx) => u5c::cardano::TxEval {
             ex_units: tx.report.iter().flatten().try_fold(
-                u5c::spec::cardano::ExUnits::default(),
+                u5c::cardano::ExUnits::default(),
                 |acc, eval| {
                     Some(ExUnits {
                         steps: acc.steps + eval.units.steps,
@@ -78,10 +75,10 @@ fn tx_eval_to_u5c(eval: Result<MempoolTx, DomainError>) -> u5c::spec::cardano::T
                 .report
                 .iter()
                 .flatten()
-                .map(|x| u5c::spec::cardano::Redeemer {
+                .map(|x| u5c::cardano::Redeemer {
                     purpose: x.tag as i32,
                     index: x.index,
-                    ex_units: Some(u5c::spec::cardano::ExUnits {
+                    ex_units: Some(u5c::cardano::ExUnits {
                         steps: x.units.steps,
                         memory: x.units.mem,
                     }),
@@ -92,8 +89,8 @@ fn tx_eval_to_u5c(eval: Result<MempoolTx, DomainError>) -> u5c::spec::cardano::T
             traces: vec![], // TODO
             ..Default::default()
         },
-        Err(e) => u5c::spec::cardano::TxEval {
-            errors: vec![u5c::spec::cardano::EvalError {
+        Err(e) => u5c::cardano::TxEval {
+            errors: vec![u5c::cardano::EvalError {
                 msg: format!("{e:#?}"),
             }],
             ..Default::default()

--- a/src/serve/grpc/v1beta/sync.rs
+++ b/src/serve/grpc/v1beta/sync.rs
@@ -1,0 +1,329 @@
+use futures_core::Stream;
+use futures_util::StreamExt;
+use itertools::Itertools;
+use pallas::interop::utxorpc::v1beta as interop;
+use pallas::interop::utxorpc::v1beta::spec::sync::BlockRef;
+use pallas::interop::utxorpc::v1beta::{spec as u5c, Mapper};
+use pallas::interop::utxorpc::LedgerContext;
+use std::pin::Pin;
+use tonic::{Request, Response, Status};
+
+use crate::prelude::*;
+
+const MAX_DUMP_HISTORY_ITEMS: u32 = 100;
+
+fn u5c_to_chain_point(block_ref: u5c::sync::BlockRef) -> Result<ChainPoint, Status> {
+    Ok(ChainPoint::Specific(
+        block_ref.slot,
+        crate::serve::grpc::convert::bytes_to_hash32(&block_ref.hash)?,
+    ))
+}
+
+fn raw_to_anychain<C: LedgerContext>(
+    mapper: &Mapper<C>,
+    body: &BlockBody,
+) -> u5c::sync::AnyChainBlock {
+    let block = mapper.map_block_cbor(body);
+
+    u5c::sync::AnyChainBlock {
+        native_bytes: body.to_vec().into(),
+        chain: u5c::sync::any_chain_block::Chain::Cardano(block).into(),
+    }
+}
+
+fn raw_to_blockref<C: LedgerContext>(
+    mapper: &Mapper<C>,
+    body: &BlockBody,
+) -> Option<u5c::sync::BlockRef> {
+    let block = mapper.map_block_cbor(body);
+    let header = block.header?;
+
+    Some(u5c::sync::BlockRef {
+        slot: header.slot,
+        hash: header.hash,
+        height: header.height,
+        timestamp: block.timestamp,
+    })
+}
+
+fn point_to_blockref(point: &ChainPoint, timestamp: u64) -> u5c::sync::BlockRef {
+    BlockRef {
+        hash: point.hash().map(|h| h.to_vec()).unwrap_or_default().into(),
+        slot: point.slot(),
+        timestamp,
+        ..Default::default()
+    }
+}
+
+fn tip_event_to_response<C: LedgerContext>(
+    mapper: &Mapper<C>,
+    event: &TipEvent,
+) -> u5c::sync::FollowTipResponse {
+    match event {
+        TipEvent::Apply(_, block) => {
+            let block_ref = raw_to_blockref(mapper, block);
+            u5c::sync::FollowTipResponse {
+                action: Some(u5c::sync::follow_tip_response::Action::Apply(
+                    raw_to_anychain(mapper, block),
+                )),
+                tip: block_ref,
+            }
+        }
+        TipEvent::Undo(_, block) => u5c::sync::FollowTipResponse {
+            action: Some(u5c::sync::follow_tip_response::Action::Undo(
+                raw_to_anychain(mapper, block),
+            )),
+            tip: None, // TODO: we don't have easy access to the new tip here
+        },
+        TipEvent::Mark(x) => u5c::sync::FollowTipResponse {
+            action: Some(u5c::sync::follow_tip_response::Action::Reset(
+                point_to_blockref(x, 0), // TODO: we don't have the timestamp here
+            )),
+            tip: Some(point_to_blockref(x, 0)),
+        },
+    }
+}
+
+pub struct SyncServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    domain: D,
+    mapper: interop::Mapper<D>,
+    cancel: C,
+}
+
+impl<D, C> SyncServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    pub fn new(domain: D, cancel: C) -> Self {
+        let mapper = Mapper::new(domain.clone());
+
+        Self {
+            domain,
+            mapper,
+            cancel,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<D, C> u5c::sync::sync_service_server::SyncService for SyncServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    type FollowTipStream =
+        Pin<Box<dyn Stream<Item = Result<u5c::sync::FollowTipResponse, Status>> + Send + 'static>>;
+
+    async fn fetch_block(
+        &self,
+        request: Request<u5c::sync::FetchBlockRequest>,
+    ) -> Result<Response<u5c::sync::FetchBlockResponse>, Status> {
+        let message = request.into_inner();
+
+        let query = dolos_core::AsyncQueryFacade::new(self.domain.clone());
+
+        let mut out = Vec::new();
+        for br in message.r#ref.iter() {
+            let mut body: Option<BlockBody> = None;
+
+            if !br.hash.is_empty() {
+                body = query
+                    .block_by_hash(br.hash.to_vec())
+                    .await
+                    .map_err(|_| Status::internal("Failed to query chain service."))?;
+            }
+
+            if body.is_none() && br.height != 0 {
+                body = query
+                    .block_by_number(br.height)
+                    .await
+                    .map_err(|_| Status::internal("Failed to query chain service."))?;
+            }
+
+            if body.is_none() && br.slot != 0 {
+                body = query
+                    .block_by_slot(br.slot)
+                    .await
+                    .map_err(|_| Status::internal("Failed to query chain service."))?;
+            }
+
+            let Some(body) = body else {
+                return Err(Status::not_found(format!("Failed to find block: {br:?}")));
+            };
+
+            out.push(raw_to_anychain(&self.mapper, &body));
+        }
+
+        let response = u5c::sync::FetchBlockResponse { block: out };
+
+        Ok(Response::new(response))
+    }
+
+    async fn dump_history(
+        &self,
+        request: Request<u5c::sync::DumpHistoryRequest>,
+    ) -> Result<Response<u5c::sync::DumpHistoryResponse>, Status> {
+        let msg = request.into_inner();
+
+        let from = msg.start_token.map(|x| x.slot);
+
+        if msg.max_items > MAX_DUMP_HISTORY_ITEMS {
+            return Err(Status::invalid_argument(format!(
+                "max_items must be less than or equal to {MAX_DUMP_HISTORY_ITEMS}"
+            )));
+        }
+
+        let len = msg.max_items as usize;
+
+        let mut range = self
+            .domain
+            .archive()
+            .get_range(from, None)
+            .map_err(|_| Status::internal("cant query archive"))?;
+
+        let items = range
+            .by_ref()
+            .take(len)
+            .map(|(_, body)| raw_to_anychain(&self.mapper, &body))
+            .collect();
+
+        let next_token = range
+            .next()
+            .and_then(|(_, body)| raw_to_blockref(&self.mapper, &body));
+
+        let response = u5c::sync::DumpHistoryResponse {
+            block: items,
+            next_token,
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn follow_tip(
+        &self,
+        request: Request<u5c::sync::FollowTipRequest>,
+    ) -> Result<Response<Self::FollowTipStream>, tonic::Status> {
+        let request = request.into_inner();
+
+        let intersect: Vec<_> = request
+            .intersect
+            .into_iter()
+            .map(u5c_to_chain_point)
+            .try_collect()?;
+
+        let stream = crate::serve::grpc::stream::ChainStream::start::<D, _>(
+            self.domain.clone(),
+            intersect.clone(),
+            self.cancel.clone(),
+        );
+
+        let mapper = self.mapper.clone();
+
+        let stream = stream.map(move |log| Ok(tip_event_to_response(&mapper, &log)));
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn read_tip(
+        &self,
+        _request: tonic::Request<u5c::sync::ReadTipRequest>,
+    ) -> std::result::Result<tonic::Response<u5c::sync::ReadTipResponse>, tonic::Status> {
+        let (point, _) = self
+            .domain
+            .wal()
+            .find_tip()
+            .map_err(|e| Status::internal(format!("Unable to read WAL: {e:?}")))?
+            .ok_or(Status::internal("chain has no data."))?;
+
+        let timestamp = self.domain.get_slot_timestamp(point.slot()).unwrap_or(0);
+        let response = u5c::sync::ReadTipResponse {
+            tip: Some(point_to_blockref(&point, timestamp)),
+        };
+
+        Ok(Response::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_testing::toy_domain::ToyDomain;
+    use pallas::interop::utxorpc::v1beta::spec::sync::sync_service_server::SyncService as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_dump_history_pagination() {
+        let domain = ToyDomain::new(None, None);
+        let cancel = CancelTokenImpl::default();
+
+        let batch = (0..34)
+            .map(|i| dolos_testing::blocks::make_conway_block(i).1)
+            .collect_vec();
+
+        use dolos_core::ImportExt;
+        domain.import_blocks(batch).unwrap();
+
+        let service = SyncServiceImpl::new(domain, cancel);
+
+        let mut start_token = None;
+
+        for _ in 0..3 {
+            let request = u5c::sync::DumpHistoryRequest {
+                start_token,
+                max_items: 10,
+                field_mask: None,
+            };
+
+            let response = service
+                .dump_history(Request::new(request))
+                .await
+                .unwrap()
+                .into_inner();
+
+            assert_eq!(response.block.len(), 10);
+
+            start_token = response.next_token;
+        }
+
+        let request = u5c::sync::DumpHistoryRequest {
+            start_token,
+            max_items: 10,
+            field_mask: None,
+        };
+
+        let response = service
+            .dump_history(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.block.len(), 4);
+        assert_eq!(response.next_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_dump_history_max_items() {
+        let domain = ToyDomain::new(None, None);
+        let cancel = CancelTokenImpl::default();
+
+        let service = SyncServiceImpl::new(domain, cancel);
+
+        let request = u5c::sync::DumpHistoryRequest {
+            start_token: None,
+            max_items: MAX_DUMP_HISTORY_ITEMS + 1,
+            field_mask: None,
+        };
+
+        let response = service
+            .dump_history(Request::new(request))
+            .await
+            .unwrap_err();
+
+        assert_eq!(response.code(), tonic::Code::InvalidArgument);
+    }
+}

--- a/src/serve/grpc/v1beta/watch.rs
+++ b/src/serve/grpc/v1beta/watch.rs
@@ -1,0 +1,291 @@
+use futures_core::Stream;
+use futures_util::StreamExt;
+use pallas::interop::utxorpc::v1beta::{self as interop, spec as u5c};
+use pallas::interop::utxorpc::LedgerContext;
+use pallas::{
+    interop::utxorpc::v1beta::spec::watch::any_chain_tx_pattern::Chain,
+    ledger::{addresses::Address, traverse::MultiEraBlock},
+};
+use std::pin::Pin;
+use tonic::{Request, Response, Status};
+
+use crate::serve::grpc::stream::ChainStream;
+use crate::prelude::*;
+
+fn outputs_match_address(
+    pattern: &u5c::cardano::AddressPattern,
+    outputs: &[u5c::cardano::TxOutput],
+) -> bool {
+    let exact_matches = pattern.exact_address.is_empty()
+        || outputs.iter().any(|o| o.address == pattern.exact_address);
+
+    let delegation_matches = pattern.delegation_part.is_empty()
+        || outputs.iter().any(|o| {
+            let addr = Address::from_bytes(&o.address).unwrap();
+            match addr {
+                Address::Shelley(s) => s.delegation().to_vec().eq(&pattern.delegation_part),
+                _ => false,
+            }
+        });
+    let payment_matches = pattern.payment_part.is_empty()
+        || outputs.iter().any(|o| {
+            let addr = Address::from_bytes(&o.address).unwrap();
+            match addr {
+                Address::Shelley(s) => s.payment().to_vec().eq(&pattern.payment_part),
+                _ => false,
+            }
+        });
+
+    exact_matches && delegation_matches && payment_matches
+}
+
+fn outputs_match_asset(
+    asset_pattern: &u5c::cardano::AssetPattern,
+    outputs: &[u5c::cardano::TxOutput],
+) -> bool {
+    outputs
+        .iter()
+        .any(|o| matches_asset(asset_pattern, &o.assets))
+}
+
+fn matches_asset(
+    asset_pattern: &u5c::cardano::AssetPattern,
+    assets: &[u5c::cardano::Multiasset],
+) -> bool {
+    assets.iter().any(|ma| {
+        if !asset_pattern.policy_id.is_empty() && asset_pattern.policy_id.ne(&ma.policy_id) {
+            return false;
+        }
+        if asset_pattern.asset_name.is_empty() {
+            return true;
+        }
+        ma.assets
+            .iter()
+            .any(|ma| asset_pattern.asset_name.eq(&ma.name))
+    })
+}
+
+fn matches_output(
+    pattern: &u5c::cardano::TxOutputPattern,
+    outputs: &[u5c::cardano::TxOutput],
+) -> bool {
+    let address_match = pattern
+        .address
+        .as_ref()
+        .is_none_or(|addr_pattern| outputs_match_address(addr_pattern, outputs));
+
+    let asset_match = pattern
+        .asset
+        .as_ref()
+        .is_none_or(|asset_pattern| outputs_match_asset(asset_pattern, outputs));
+
+    address_match && asset_match
+}
+
+fn matches_cardano_pattern(tx_pattern: &u5c::cardano::TxPattern, tx: &u5c::cardano::Tx) -> bool {
+    let has_address_match = tx_pattern.has_address.as_ref().is_none_or(|addr_pattern| {
+        let outputs: Vec<_> = tx.outputs.to_vec();
+        let inputs: Vec<_> = tx
+            .inputs
+            .iter()
+            .filter_map(|x| x.as_output.as_ref().cloned())
+            .collect();
+
+        outputs_match_address(addr_pattern, &inputs)
+            || outputs_match_address(addr_pattern, &outputs)
+    });
+
+    let consumes_match = tx_pattern.consumes.as_ref().is_none_or(|out_pattern| {
+        let inputs: Vec<_> = tx
+            .inputs
+            .iter()
+            .filter_map(|x| x.as_output.as_ref().cloned())
+            .collect();
+        matches_output(out_pattern, &inputs)
+    });
+
+    let mints_asset_match = tx_pattern
+        .mints_asset
+        .as_ref()
+        .is_none_or(|asset_pattern| matches_asset(asset_pattern, &tx.mint));
+
+    let moves_asset_match = tx_pattern.moves_asset.as_ref().is_none_or(|asset_pattern| {
+        let inputs: Vec<_> = tx
+            .inputs
+            .iter()
+            .filter_map(|x| x.as_output.as_ref().cloned())
+            .collect();
+        outputs_match_asset(asset_pattern, &inputs)
+            || outputs_match_asset(asset_pattern, &tx.outputs)
+    });
+
+    let produces_match = tx_pattern
+        .produces
+        .as_ref()
+        .is_none_or(|out_pattern| matches_output(out_pattern, &tx.outputs));
+
+    has_address_match && consumes_match && mints_asset_match && moves_asset_match && produces_match
+}
+
+fn matches_chain(chain: &Chain, tx: &u5c::cardano::Tx) -> bool {
+    match chain {
+        Chain::Cardano(tx_pattern) => matches_cardano_pattern(tx_pattern, tx),
+    }
+}
+
+fn apply_predicate(predicate: &u5c::watch::TxPredicate, tx: &u5c::cardano::Tx) -> bool {
+    let tx_matches = predicate
+        .r#match
+        .as_ref()
+        .and_then(|pattern| pattern.chain.as_ref())
+        .is_none_or(|chain| matches_chain(chain, tx));
+
+    let not_clause = predicate.not.iter().any(|p| apply_predicate(p, tx));
+
+    let and_clause = predicate.all_of.iter().all(|p| apply_predicate(p, tx));
+
+    let or_clause =
+        predicate.any_of.is_empty() || predicate.any_of.iter().any(|p| apply_predicate(p, tx));
+
+    tx_matches && !not_clause && and_clause && or_clause
+}
+
+fn block_to_txs<C: LedgerContext>(
+    block: &RawBlock,
+    mapper: &interop::Mapper<C>,
+    request: &u5c::watch::WatchTxRequest,
+) -> Vec<u5c::watch::AnyChainTx> {
+    let bytes = block;
+    let block = MultiEraBlock::decode(block).unwrap();
+    let txs = block.txs();
+
+    txs.iter()
+        .map(|x: &pallas::ledger::traverse::MultiEraTx<'_>| mapper.map_tx(x))
+        .filter(|tx| {
+            request
+                .predicate
+                .as_ref()
+                .is_none_or(|predicate| apply_predicate(predicate, tx))
+        })
+        .map(|x| u5c::watch::AnyChainTx {
+            chain: Some(u5c::watch::any_chain_tx::Chain::Cardano(x)),
+            block: Some(u5c::watch::AnyChainBlock {
+                native_bytes: bytes.to_vec().into(),
+                chain: Some(u5c::watch::any_chain_block::Chain::Cardano(
+                    mapper.map_block(&block),
+                )),
+            }),
+        })
+        .collect()
+}
+
+fn raw_to_blockref<C: LedgerContext>(
+    mapper: &interop::Mapper<C>,
+    raw: &[u8],
+) -> Option<u5c::watch::BlockRef> {
+    let block = mapper.map_block_cbor(raw);
+    let header = block.header?;
+
+    Some(u5c::watch::BlockRef {
+        slot: header.slot,
+        hash: header.hash,
+        height: header.height,
+    })
+}
+
+fn roll_to_watch_response<C: LedgerContext>(
+    mapper: &interop::Mapper<C>,
+    log: &TipEvent,
+    request: &u5c::watch::WatchTxRequest,
+) -> impl Stream<Item = u5c::watch::WatchTxResponse> {
+    let txs: Vec<_> = match log {
+        TipEvent::Apply(_, block) => {
+            let txs = block_to_txs(block, mapper, request);
+            if txs.is_empty() {
+                let block_ref = raw_to_blockref(mapper, block);
+                if let Some(r) = block_ref {
+                    vec![u5c::watch::WatchTxResponse {
+                        action: Some(u5c::watch::watch_tx_response::Action::Idle(r)),
+                    }]
+                } else {
+                    vec![]
+                }
+            } else {
+                txs.into_iter()
+                    .map(u5c::watch::watch_tx_response::Action::Apply)
+                    .map(|x| u5c::watch::WatchTxResponse { action: Some(x) })
+                    .collect()
+            }
+        }
+        TipEvent::Undo(_, block) => block_to_txs(block, mapper, request)
+            .into_iter()
+            .map(u5c::watch::watch_tx_response::Action::Undo)
+            .map(|x| u5c::watch::WatchTxResponse { action: Some(x) })
+            .collect(),
+        // TODO: shouldn't we have a u5c event for origin?
+        TipEvent::Mark(..) => vec![],
+    };
+
+    tokio_stream::iter(txs)
+}
+
+pub struct WatchServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    domain: D,
+    mapper: interop::Mapper<D>,
+    cancel: C,
+}
+
+impl<D, C> WatchServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    pub fn new(domain: D, cancel: C) -> Self {
+        let mapper = interop::Mapper::new(domain.clone());
+
+        Self {
+            domain,
+            mapper,
+            cancel,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<D, C> u5c::watch::watch_service_server::WatchService for WatchServiceImpl<D, C>
+where
+    D: Domain + LedgerContext,
+    C: CancelToken,
+{
+    type WatchTxStream = Pin<
+        Box<dyn Stream<Item = Result<u5c::watch::WatchTxResponse, tonic::Status>> + Send + 'static>,
+    >;
+
+    async fn watch_tx(
+        &self,
+        request: Request<u5c::watch::WatchTxRequest>,
+    ) -> Result<Response<Self::WatchTxStream>, Status> {
+        let inner_req = request.into_inner();
+
+        let intersect = inner_req
+            .intersect
+            .iter()
+            .map(|x| ChainPoint::Specific(x.slot, x.hash.to_vec().as_slice().into()))
+            .collect::<Vec<ChainPoint>>();
+
+        let stream =
+            ChainStream::start::<D, _>(self.domain.clone(), intersect, self.cancel.clone());
+
+        let mapper = self.mapper.clone();
+
+        let stream = stream
+            .flat_map(move |log| roll_to_watch_response(&mapper, &log, &inner_req))
+            .map(Ok);
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+}


### PR DESCRIPTION
## Summary

- Register UTxORPC **v1alpha** and **v1beta** services on the same gRPC listener. Clients pick which proto package they call (`utxorpc.v1alpha.*` vs `utxorpc.v1beta.*`); on the wire these are entirely separate services so v1alpha bytes stay byte-identical.
- Bumps `pallas` to git rev `0da71c2` to pull in the v1beta proto package and `v1beta::Mapper` from `pallas-utxorpc`.

## Layout

```
src/serve/grpc/
├── mod.rs              # registers 8 server impls + 10 file descriptor sets
├── convert.rs          # unchanged, version-agnostic
├── masking.rs          # unchanged, version-agnostic
├── stream.rs           # unchanged, version-agnostic
├── v1alpha/{query,sync,watch,submit}.rs  # moved from src/serve/grpc/
└── v1beta/{query,sync,watch,submit}.rs   # new, mostly identical to v1alpha
```

The only semantic divergence between the two trees is in `read_utxos`: v1beta's `Datum.original_cbor` is `Option<Bytes>` instead of `Bytes`, so the datum-attach path wraps with `Some(...)`. Everything else is import-path swaps — this is a deliberate design choice over macro-driven dedup; if drift becomes a problem we can revisit.

Drive-by cleanups: dropped the unused `_mapper` field from `SubmitServiceImpl` (both versions) and removed two stale commented-out code blocks in `sync.rs`.

## Test plan

- [x] `cargo build --features grpc` — clean
- [x] `cargo build` (default features) — clean
- [x] `cargo clippy --lib --features grpc` — clean
- [x] `cargo test --lib --features grpc serve::grpc` — 24/24 pass (mirrored test sets across both versions)
- [ ] Smoke test against a running dolos instance:
  - `grpcurl -plaintext localhost:50051 list` shows both `utxorpc.v1alpha.*` and `utxorpc.v1beta.*` packages
  - `grpcurl ... utxorpc.v1alpha.query.QueryService/ReadParams` and the v1beta equivalent both return expected pparams
  - `utxorpc.v1beta.sync.SyncService/FollowTip` streams blocks with v1beta-only fields populated (`votes`, `bootstrap_witnesses`, `original_cbor`)
- [ ] Wire-format regression: capture a v1alpha `FetchBlock` response on `main` and on this branch — bytes should match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive gRPC v1beta API support with Query, Submit, Sync, and Watch services alongside v1alpha
  * Servers now support both API versions simultaneously for improved client compatibility

* **Dependencies**
  * Upgraded bytes dependency from 1.9.0 to 1.11
  * Updated pallas dependency to latest development version with unstable features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->