### PR TITLE
feat(cardano): stage van Rossem (v11) prep and update preview proposals

### DIFF
--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -243,6 +243,8 @@ pub fn migrate_pparams_version(
         (8, 9) => into_conway(current, &genesis.conway),
         // One intra-era hard-fork in conway at protocol version 10
         (9, 10) => intra_era_hardfork(current, to),
+        // Van Rossem: intra-era hard-fork to protocol version 11
+        (10, 11) => intra_era_hardfork(current, to),
         (from, to) => {
             unimplemented!("don't know how to bump from version {from} to {to}",)
         }
@@ -284,5 +286,25 @@ pub fn protocol_constants(version: u16, genesis: &Genesis) -> ProtocolConstants 
             epoch_length: genesis.shelley.epoch_length.unwrap_or_default() as u64,
             slot_length: genesis.shelley.slot_length.unwrap_or_default() as u64,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::load_genesis;
+
+    #[test]
+    fn force_pparams_to_van_rossem() {
+        let path = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("test_data")
+            .join("mainnet")
+            .join("genesis");
+
+        let genesis = load_genesis(&path);
+        let initial = from_byron_genesis(&genesis.byron);
+        let result = force_pparams_version(&initial, &genesis, 0, 11).unwrap();
+
+        assert_eq!(result.protocol_major(), Some(11));
     }
 }

--- a/crates/cardano/src/hacks.rs
+++ b/crates/cardano/src/hacks.rs
@@ -243,6 +243,19 @@ pub mod proposals {
                 "f046a88280e6c5b18dd057027964860f6b0b7918f4532d50455ad257a14a70ed#0" => {
                     Canceled(1096)
                 }
+                // ParameterChange proposals superseded by 014c32e5...#0 enacted at 1270
+                "4ac138ad9ffc3021bb6168d042d86becb595ec25db02ae0f142fbc23d10c08da#0" => {
+                    Canceled(1270)
+                }
+                "4ac138ad9ffc3021bb6168d042d86becb595ec25db02ae0f142fbc23d10c08da#1" => {
+                    Canceled(1270)
+                }
+                "2585fa3772a1866ae8e79bc4f19cf094c7815f4e7963e363078c8f573bd6268a#0" => {
+                    Canceled(1270)
+                }
+                "4c885796072684fe8d0cccf1cec57972d63434b75b285754db8e5140c4ff30c7#0" => {
+                    Canceled(1270)
+                }
                 // v7→v8 hard fork proposals (epoch 20, 2-epoch lag: effect at 22)
                 "cbc14ec74b2a20d6c4cc307e73b5a2465eb6cd68df64704f7bc844dac6018500#0" => {
                     Ratified(21)


### PR DESCRIPTION
## Summary

- **Stage van Rossem (protocol v11) migration arm.** Adds `(10, 11) => intra_era_hardfork(current, to)` to `migrate_pparams_version` in `crates/cardano/src/forks.rs` so a v10→v11 boundary no longer panics in `force_pparams_version`. Van Rossem is an intra-Conway-era hardfork (no new pparams, certs, gov actions, or CBOR shape), so `intra_era_hardfork` is the correct helper. Ledger-side support is gated on upstream pallas issues [#752](https://github.com/txpipe/pallas/issues/752), [#753](https://github.com/txpipe/pallas/issues/753), [#754](https://github.com/txpipe/pallas/issues/754), [#755](https://github.com/txpipe/pallas/issues/755).
- **Update preview proposal outcomes.** Adds four `Canceled(1270)` entries in `crates/cardano/src/hacks.rs` for `ParameterChange` proposals on preview that were superseded by `014c32e5...#0` enacted at epoch 1270. Without these, those proposals fall through to `Unknown` and expire via `max_epoch` instead of being correctly canceled at 1270, mismatching DBSync timing.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p dolos-cardano` (118/118 passing, includes new `forks::tests::force_pparams_to_van_rossem` regression guard)
- [ ] End-to-end preview replay past v11 — gated on the upstream pallas readiness, not unblockable in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for protocol version 11, including automatic parameter migration and configuration updates from protocol version 10, enabling seamless network upgrades

* **Bug Fixes**
  * Enhanced proposal outcome classification to accurately identify and mark specific proposals as canceled, improving proposal status visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->