### PR TITLE
fix(cardano): short-circuit ewrap replay between boundary phases

### DIFF
--- a/crates/cardano/src/ewrap/work_unit.rs
+++ b/crates/cardano/src/ewrap/work_unit.rs
@@ -40,10 +40,10 @@ pub struct EwrapWorkUnit {
     /// account-mutation deltas are non-idempotent on replay).
     ///
     /// When `initialize()` detects the boundary was closed in a prior
-    /// run (`ewrap_progress.committed == total`), `start_shard` is set
-    /// to `total_shards` so the runtime's shard loop runs zero
-    /// iterations. `is_replay_noop()` reads back this signal to make
-    /// `finalize()` a no-op — see that method for the full rationale.
+    /// run (`ewrap_progress.committed == total`), this lands at
+    /// `total_shards` so the runtime's shard loop runs zero iterations.
+    /// `is_complete()` reads back this signal to make `finalize()` a
+    /// no-op — see that method for the full rationale.
     start_shard: u32,
 
     /// During the per-shard loop, holds the in-flight shard's
@@ -68,24 +68,30 @@ impl EwrapWorkUnit {
         self.boundary.as_ref()
     }
 
-    /// True when this work unit represents a replay of a boundary whose
-    /// EWRAP already closed in a prior run — i.e. `initialize()` saw
-    /// `ewrap_progress.committed == total` and set
-    /// `start_shard = total_shards` to skip the shard loop. In that
-    /// case `finalize()` must also no-op so we don't re-emit
-    /// `EpochWrapUpV3` over already-committed state; the next boundary
-    /// trigger will fall through to ESTART, which resumes from
+    /// True when this work unit's shard plan has nothing left to run —
+    /// i.e. the persisted `ewrap_progress` shows `committed == total`,
+    /// meaning EWRAP for this boundary closed in a prior run. The
+    /// boundary is being re-triggered because the cursor only advances
+    /// at ESTART finalize (`estart::commit::commit_finalize`), so a
+    /// crash between EWRAP and ESTART finalize leaves the cursor behind
+    /// the boundary block and the next live block re-emits both work
+    /// units. Both `initialize()` (to log + skip the assignment of
+    /// shard work) and `finalize()` (to skip re-emitting `EpochWrapUpV3`
+    /// over already-committed state) consult this predicate; the work
+    /// buffer then flips to ESTART, which resumes from
     /// `estart_progress.committed` via the existing per-shard path.
     ///
     /// Derived rather than stored: `start_shard >= total_shards` is a
-    /// state we only enter via the `initialize()` short-circuit, since
-    /// neither field changes after `initialize()` returns.
+    /// state we only enter when `initialize()` reads
+    /// `ewrap_progress.committed == ewrap_progress.total` and assigns
+    /// `start_shard = committed`. Neither field changes after
+    /// `initialize()` returns.
     ///
     /// Precondition: `initialize()` has been called. A freshly
     /// `new()`-constructed unit has both fields at 0 and would
     /// spuriously report `true`; in practice the runtime always calls
     /// `initialize()` before any phase that reads this predicate.
-    fn is_replay_noop(&self) -> bool {
+    fn is_complete(&self) -> bool {
         self.start_shard >= self.total_shards
     }
 }
@@ -119,33 +125,23 @@ where
         let epoch = load_epoch::<D>(domain.state())?;
         let progress = epoch.ewrap_progress.as_ref();
         self.total_shards = progress.map(|p| p.total).unwrap_or(ACCOUNT_SHARDS);
-
-        // `committed == total` means EWRAP for this boundary already
-        // closed in a prior run (per `EpochWrapUpV3` semantics — the
-        // field stays populated after EWRAP finalize and is cleared
-        // only by `EpochTransitionV2` at ESTART finalize). The current
-        // boundary trigger is a replay caused by the cursor not having
-        // advanced past the boundary block (cursor only moves at ESTART
-        // finalize, in `estart::commit::commit_finalize`). Short-circuit:
-        // run zero shards, no-op finalize. The work buffer will then
-        // emit ESTART, which resumes from `estart_progress.committed`.
-        if let Some(p) = progress {
-            if p.committed == p.total {
-                // Set start_shard == total_shards so the runtime's shard
-                // loop runs zero iterations; `is_replay_noop()` reads
-                // back this signal to make `finalize()` skip too.
-                self.start_shard = p.total;
-                tracing::info!(
-                    slot = self.slot,
-                    committed = p.committed,
-                    total = p.total,
-                    "ewrap already completed in prior run; short-circuiting on replay"
-                );
-                return Ok(());
-            }
-        }
-
         self.start_shard = progress.map(|p| p.committed).unwrap_or(0);
+
+        // When `is_complete()` holds, `committed == total` from a prior
+        // run that closed EWRAP but didn't reach ESTART finalize (per
+        // `EpochWrapUpV3` semantics — the field stays populated after
+        // EWRAP finalize and is cleared only by `EpochTransitionV2`).
+        // The runtime's shard loop will run zero iterations and
+        // `finalize()` will short-circuit on the same predicate.
+        if self.is_complete() {
+            tracing::info!(
+                slot = self.slot,
+                committed = self.start_shard,
+                total = self.total_shards,
+                "ewrap already completed in prior run; short-circuiting on replay"
+            );
+            return Ok(());
+        }
 
         debug!(
             slot = self.slot,
@@ -208,7 +204,7 @@ where
     }
 
     fn finalize(&mut self, domain: &D) -> Result<(), DomainError> {
-        if self.is_replay_noop() {
+        if self.is_complete() {
             debug!(
                 slot = self.slot,
                 "ewrap finalize skipped (boundary already closed in prior run)"

--- a/crates/cardano/src/ewrap/work_unit.rs
+++ b/crates/cardano/src/ewrap/work_unit.rs
@@ -38,6 +38,12 @@ pub struct EwrapWorkUnit {
     /// from `EpochState.ewrap_progress.committed` so a restart after a
     /// mid-boundary crash skips already-committed shards (the per-shard
     /// account-mutation deltas are non-idempotent on replay).
+    ///
+    /// When `initialize()` detects the boundary was closed in a prior
+    /// run (`ewrap_progress.committed == total`), `start_shard` is set
+    /// to `total_shards` so the runtime's shard loop runs zero
+    /// iterations. `is_replay_noop()` reads back this signal to make
+    /// `finalize()` a no-op — see that method for the full rationale.
     start_shard: u32,
 
     /// During the per-shard loop, holds the in-flight shard's
@@ -60,6 +66,22 @@ impl EwrapWorkUnit {
 
     pub fn boundary(&self) -> Option<&BoundaryWork> {
         self.boundary.as_ref()
+    }
+
+    /// True when this work unit represents a replay of a boundary whose
+    /// EWRAP already closed in a prior run — i.e. `initialize()` saw
+    /// `ewrap_progress.committed == total` and set
+    /// `start_shard = total_shards` to skip the shard loop. In that
+    /// case `finalize()` must also no-op so we don't re-emit
+    /// `EpochWrapUpV3` over already-committed state; the next boundary
+    /// trigger will fall through to ESTART, which resumes from
+    /// `estart_progress.committed` via the existing per-shard path.
+    ///
+    /// Derived rather than stored: `start_shard >= total_shards` is a
+    /// state we only enter via the `initialize()` short-circuit, since
+    /// neither field changes after `initialize()` returns.
+    fn is_replay_noop(&self) -> bool {
+        self.start_shard >= self.total_shards
     }
 }
 
@@ -92,6 +114,32 @@ where
         let epoch = load_epoch::<D>(domain.state())?;
         let progress = epoch.ewrap_progress.as_ref();
         self.total_shards = progress.map(|p| p.total).unwrap_or(ACCOUNT_SHARDS);
+
+        // `committed == total` means EWRAP for this boundary already
+        // closed in a prior run (per `EpochWrapUpV3` semantics — the
+        // field stays populated after EWRAP finalize and is cleared
+        // only by `EpochTransitionV2` at ESTART finalize). The current
+        // boundary trigger is a replay caused by the cursor not having
+        // advanced past the boundary block (cursor only moves at ESTART
+        // finalize, in `estart::commit::commit_finalize`). Short-circuit:
+        // run zero shards, no-op finalize. The work buffer will then
+        // emit ESTART, which resumes from `estart_progress.committed`.
+        if let Some(p) = progress {
+            if p.committed == p.total {
+                // Set start_shard == total_shards so the runtime's shard
+                // loop runs zero iterations; `is_replay_noop()` reads
+                // back this signal to make `finalize()` skip too.
+                self.start_shard = p.total;
+                tracing::info!(
+                    slot = self.slot,
+                    committed = p.committed,
+                    total = p.total,
+                    "ewrap already completed in prior run; short-circuiting on replay"
+                );
+                return Ok(());
+            }
+        }
+
         self.start_shard = progress.map(|p| p.committed).unwrap_or(0);
 
         debug!(
@@ -155,6 +203,14 @@ where
     }
 
     fn finalize(&mut self, domain: &D) -> Result<(), DomainError> {
+        if self.is_replay_noop() {
+            debug!(
+                slot = self.slot,
+                "ewrap finalize skipped (boundary already closed in prior run)"
+            );
+            return Ok(());
+        }
+
         debug!(slot = self.slot, "loading ewrap context");
 
         let mut boundary = BoundaryWork::load_finalize::<D>(domain.state(), self.genesis.clone())?;

--- a/crates/cardano/src/ewrap/work_unit.rs
+++ b/crates/cardano/src/ewrap/work_unit.rs
@@ -80,6 +80,11 @@ impl EwrapWorkUnit {
     /// Derived rather than stored: `start_shard >= total_shards` is a
     /// state we only enter via the `initialize()` short-circuit, since
     /// neither field changes after `initialize()` returns.
+    ///
+    /// Precondition: `initialize()` has been called. A freshly
+    /// `new()`-constructed unit has both fields at 0 and would
+    /// spuriously report `true`; in practice the runtime always calls
+    /// `initialize()` before any phase that reads this predicate.
     fn is_replay_noop(&self) -> bool {
         self.start_shard >= self.total_shards
     }

--- a/crates/cardano/src/ewrap/wrapup.rs
+++ b/crates/cardano/src/ewrap/wrapup.rs
@@ -1,4 +1,4 @@
-use crate::{AccountState, CardanoDelta, EndStats, EpochWrapUpV2, PoolHash, PoolState, PoolWrapUp};
+use crate::{AccountState, CardanoDelta, EndStats, EpochWrapUpV3, PoolHash, PoolState, PoolWrapUp};
 use dolos_core::ChainError;
 
 #[derive(Default)]
@@ -138,15 +138,20 @@ impl super::BoundaryVisitor for BoundaryVisitor {
         // Assemble the final `EndStats` from the prepare-time fields plus the
         // shard-populated accumulators (already in `ending_state.end`), and
         // emit `EpochWrapUp` to close the epoch boundary. Apply will
-        // overwrite `entity.end` with these stats, rotate the rolling/pparams
-        // snapshots forward, and clear `ewrap_progress`.
+        // overwrite `entity.end` with these stats and rotate the
+        // rolling/pparams snapshots forward. `ewrap_progress` is left
+        // at `Some(total, total)` from the last `EWrapProgress` shard
+        // so the EwrapWorkUnit can short-circuit a replay if a crash
+        // lands between EWRAP finalize and ESTART finalize;
+        // `EpochTransitionV2` (run at ESTART finalize) is the single
+        // writer that clears the field.
         let final_stats = define_end_stats(ctx);
 
         // Stash the final stats on `ending_state.end` so the post-commit
         // archive write in `commit_ewrap` reflects the finalised state.
         ctx.ending_state.end = Some(final_stats.clone());
 
-        ctx.deltas.add_for_entity(EpochWrapUpV2::new(final_stats));
+        ctx.deltas.add_for_entity(EpochWrapUpV3::new(final_stats));
 
         Ok(())
     }

--- a/crates/cardano/src/lib.rs
+++ b/crates/cardano/src/lib.rs
@@ -399,11 +399,12 @@ impl dolos_core::ChainLogic for CardanoLogic {
                         epoch = epoch.number,
                         committed = progress.committed,
                         total_shards = progress.total,
-                        "found EpochState.ewrap_progress.committed == total at \
-                         startup — Ewrap (closing phase) was not committed \
-                         before crash. The next boundary attempt will re-run \
-                         Ewraps and Ewrap; idempotency should keep the \
-                         result correct."
+                        "found EpochState.ewrap_progress.committed == total \
+                         at startup — EWRAP for this boundary closed in a \
+                         prior run but ESTART finalize did not commit before \
+                         crash. The next boundary trigger will short-circuit \
+                         the EwrapWorkUnit (no replay) and resume the ESTART \
+                         pipeline from estart_progress.committed."
                     );
                 }
             }

--- a/crates/cardano/src/model/accounts.rs
+++ b/crates/cardano/src/model/accounts.rs
@@ -709,6 +709,17 @@ impl dolos_core::EntityDelta for PoolDelegatorRetire {
         self.prev_pool = Some(entity.pool.clone());
         self.prev_retired_pool = entity.retired_pool;
 
+        // TODO: read via `entity.pool.snapshot_at(self.epoch)` (the same
+        // accessor the visitor uses in `ewrap::drops::BoundaryVisitor`)
+        // instead of `live()`, and guard the `schedule` call below on
+        // `entity.pool.epoch() == Some(self.epoch)` with skip-on-mismatch.
+        // The visitor reads the snapshot at `current_epoch`; once the
+        // entity has been rotated past that epoch, `live()` and
+        // `snapshot_at(epoch)` disagree, and the `unreachable!` below
+        // fires (see the EWRAP-replay crash recovery analysis). The
+        // `ewrap_progress` short-circuit removes the known way to hit
+        // this divergence, but the underlying invariant — visitor and
+        // delta agree on which slot to read — is still fragile.
         let prev_pool_live = entity.pool.live().cloned();
 
         // apply changes
@@ -763,7 +774,11 @@ impl dolos_core::EntityDelta for DRepDelegatorDrop {
         // save undo info
         self.prev_drep = Some(entity.drep.clone());
 
-        // apply changes
+        // TODO: guard the `schedule` call on `entity.drep.epoch() == Some(self.epoch)`
+        // with skip-on-mismatch, mirroring the planned hardening in
+        // `PoolDelegatorRetire::apply`. `schedule` writes to `next` regardless
+        // of the entity's current epoch; if the entity has been rotated past
+        // `self.epoch`, this scheduling lands on the wrong boundary.
         entity
             .drep
             .schedule(self.epoch, Some(DRepDelegation::NotDelegated));

--- a/crates/cardano/src/model/epochs.rs
+++ b/crates/cardano/src/model/epochs.rs
@@ -675,13 +675,18 @@ impl dolos_core::EntityDelta for EpochWrapUp {
     }
 }
 
-/// V2 of `EpochWrapUp` — adds `prev_ewrap_progress` undo state for the
-/// new sharded ewrap pipeline. Constructed by all post-cutover commit paths;
-/// the legacy `EpochWrapUp` is kept solely for replay of older WAL rows.
-/// Carries the fully populated `EndStats` (prepare-time fields from the
-/// wrap-up visitor + reward accumulators from the preceding `Ewrap` runs).
-/// Apply overwrites `entity.end` with these final stats, rotates the
-/// rolling and pparams snapshots forward, and clears `ewrap_progress`.
+/// Superseded by `EpochWrapUpV3`. Kept for WAL replay of rows emitted
+/// by the V2-era binary (variant index 40 in `CardanoDelta`). New
+/// commit paths must construct `EpochWrapUpV3` instead.
+///
+/// V2's `apply` cleared `EpochState.ewrap_progress` to `None` at EWRAP
+/// finalize. V3 leaves the field at `Some(total, total)` so that the
+/// "EWRAP done, ESTART pending finalize" window is unambiguously
+/// distinguishable from "no boundary in flight" — required by the
+/// EwrapWorkUnit replay short-circuit. V2 is preserved verbatim so
+/// historical rows replay/undo identically to how the original
+/// binary applied them.
+#[deprecated(note = "kept for WAL replay; emit `EpochWrapUpV3` instead")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EpochWrapUpV2 {
     pub(crate) stats: EndStats,
@@ -693,6 +698,7 @@ pub struct EpochWrapUpV2 {
     pub(crate) prev_ewrap_progress: Option<ShardProgress>,
 }
 
+#[allow(deprecated)]
 impl EpochWrapUpV2 {
     pub fn new(stats: EndStats) -> Self {
         Self {
@@ -705,6 +711,7 @@ impl EpochWrapUpV2 {
     }
 }
 
+#[allow(deprecated)]
 impl dolos_core::EntityDelta for EpochWrapUpV2 {
     type Entity = EpochState;
 
@@ -732,6 +739,66 @@ impl dolos_core::EntityDelta for EpochWrapUpV2 {
         entity.pparams = self.prev_pparams.clone().expect("apply captured pparams");
         entity.end = self.prev_end.clone();
         entity.ewrap_progress = self.prev_ewrap_progress.clone();
+    }
+}
+
+/// V3 of `EpochWrapUp` — drops the `prev_ewrap_progress` undo field
+/// because `apply` no longer mutates `EpochState.ewrap_progress`. After
+/// V3 commits, `ewrap_progress` is left at `Some(total, total)` from the
+/// last `EWrapProgress` shard delta and serves as the unambiguous
+/// "EWRAP done, ESTART pending finalize" marker. `EpochTransitionV2`
+/// (run at ESTART finalize) is the only remaining writer that clears
+/// the field; that single-writer invariant is what lets a crash
+/// between EWRAP finalize and ESTART finalize be recovered cleanly:
+/// the next boundary trigger sees `committed == total` and short-
+/// circuits the EwrapWorkUnit instead of replaying it over partially-
+/// rotated state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpochWrapUpV3 {
+    pub(crate) stats: EndStats,
+
+    // undo
+    pub(crate) prev_rolling: Option<EpochValue<RollingStats>>,
+    pub(crate) prev_pparams: Option<EpochValue<PParamsSet>>,
+    pub(crate) prev_end: Option<EndStats>,
+    // No prev_ewrap_progress — apply does not mutate ewrap_progress.
+}
+
+impl EpochWrapUpV3 {
+    pub fn new(stats: EndStats) -> Self {
+        Self {
+            stats,
+            prev_rolling: None,
+            prev_pparams: None,
+            prev_end: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for EpochWrapUpV3 {
+    type Entity = EpochState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((EpochState::NS, CURRENT_EPOCH_KEY))
+    }
+
+    fn apply(&mut self, entity: &mut Option<Self::Entity>) {
+        let entity = entity.as_mut().expect("existing epoch");
+
+        self.prev_rolling = Some(entity.rolling.clone());
+        self.prev_pparams = Some(entity.pparams.clone());
+        self.prev_end = entity.end.clone();
+
+        entity.rolling.scheduled_or_default();
+        entity.pparams.scheduled_or_default();
+        entity.end = Some(self.stats.clone());
+    }
+
+    fn undo(&self, entity: &mut Option<Self::Entity>) {
+        let entity = entity.as_mut().expect("existing epoch");
+        entity.rolling = self.prev_rolling.clone().expect("apply captured rolling");
+        entity.pparams = self.prev_pparams.clone().expect("apply captured pparams");
+        entity.end = self.prev_end.clone();
     }
 }
 
@@ -1501,11 +1568,25 @@ mod prop_tests {
         }
     }
 
+    #[allow(deprecated)]
+    fn make_epoch_wrap_up_v2(stats: EndStats) -> EpochWrapUpV2 {
+        EpochWrapUpV2::new(stats)
+    }
+
     prop_compose! {
+        #[allow(deprecated)]
         fn any_epoch_wrap_up_v2()(
             stats in any_end_stats(),
         ) -> EpochWrapUpV2 {
-            EpochWrapUpV2::new(stats)
+            make_epoch_wrap_up_v2(stats)
+        }
+    }
+
+    prop_compose! {
+        fn any_epoch_wrap_up_v3()(
+            stats in any_end_stats(),
+        ) -> EpochWrapUpV3 {
+            EpochWrapUpV3::new(stats)
         }
     }
 
@@ -1669,9 +1750,18 @@ mod prop_tests {
         }
 
         #[test]
+        #[allow(deprecated)]
         fn epoch_wrap_up_v2_roundtrip(
             entity in any_epoch_state(),
             delta in any_epoch_wrap_up_v2(),
+        ) {
+            assert_delta_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn epoch_wrap_up_v3_roundtrip(
+            entity in any_epoch_state(),
+            delta in any_epoch_wrap_up_v3(),
         ) {
             assert_delta_roundtrip(Some(entity), delta);
         }

--- a/crates/cardano/src/model/epochs.rs
+++ b/crates/cardano/src/model/epochs.rs
@@ -675,8 +675,16 @@ impl dolos_core::EntityDelta for EpochWrapUp {
     }
 }
 
+// TODO(wal-compat): legacy variant kept for backward-compatible WAL decoding.
+// Remove this struct, its `EntityDelta` impl, the `EpochWrapUpV2` variant of
+// `CardanoDelta` (along with its `delta_from!` in `legacy_delta_from` and the
+// match arms in `key`/`apply`/`undo`), and the `epoch_wrap_up_v2_roundtrip`
+// proptest once the WAL backfill window has rolled past the V3 cutover — at
+// that point no on-disk WAL row will reference variant index 42 carrying
+// `prev_ewrap_progress`. A reasonable trigger is "no production node has WAL
+// rows older than the V3 cutover".
 /// Superseded by `EpochWrapUpV3`. Kept for WAL replay of rows emitted
-/// by the V2-era binary (variant index 40 in `CardanoDelta`). New
+/// by the V2-era binary (variant index 42 in `CardanoDelta`). New
 /// commit paths must construct `EpochWrapUpV3` instead.
 ///
 /// V2's `apply` cleared `EpochState.ewrap_progress` to `None` at EWRAP

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -229,6 +229,7 @@ pub enum CardanoDelta {
     RupdProgress(Box<RupdProgress>),
     EpochWrapUpV2(Box<EpochWrapUpV2>),
     EpochTransitionV2(Box<EpochTransitionV2>),
+    EpochWrapUpV3(Box<EpochWrapUpV3>),
 }
 
 impl CardanoDelta {
@@ -295,6 +296,7 @@ mod legacy_delta_from {
     use super::*;
     delta_from!(EpochTransition);
     delta_from!(EpochWrapUp);
+    delta_from!(EpochWrapUpV2);
 }
 delta_from!(DRepDelegatorDrop);
 delta_from!(PoolDelegatorRetire);
@@ -311,8 +313,8 @@ delta_from!(DequeueReward);
 delta_from!(EWrapProgress);
 delta_from!(EStartProgress);
 delta_from!(RupdProgress);
-delta_from!(EpochWrapUpV2);
 delta_from!(EpochTransitionV2);
+delta_from!(EpochWrapUpV3);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -352,6 +354,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::RupdProgress(x) => x.key(),
             Self::EpochWrapUpV2(x) => x.key(),
             Self::EpochTransitionV2(x) => x.key(),
+            Self::EpochWrapUpV3(x) => x.key(),
             Self::PoolDelegatorRetire(x) => x.key(),
             Self::DRepDelegatorDrop(x) => x.key(),
             Self::PoolWrapUp(x) => x.key(),
@@ -401,6 +404,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::RupdProgress(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::EpochWrapUpV2(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::EpochTransitionV2(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::EpochWrapUpV3(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::DRepDelegatorDrop(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolDelegatorRetire(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolWrapUp(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -450,6 +454,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::RupdProgress(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::EpochWrapUpV2(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::EpochTransitionV2(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::EpochWrapUpV3(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::DRepDelegatorDrop(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolDelegatorRetire(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolWrapUp(x) => Self::downcast_undo(x.as_ref(), entity),


### PR DESCRIPTION
## Summary
- Add `EpochWrapUpV3` that leaves `EpochState.ewrap_progress` populated after EWRAP finalize. With this change, `Some(committed=total, total)` unambiguously means "EWRAP done, ESTART pending finalize" — `EpochTransitionV2` (run at ESTART finalize) is the single remaining writer that clears the field.
- Make `EwrapWorkUnit::initialize` short-circuit when `committed == total`: set `start_shard = total_shards` to skip the shard loop, and `finalize` reads back `is_replay_noop()` to skip too. The next boundary trigger falls through to ESTART, which resumes from `estart_progress.committed` via the existing per-shard path.
- Deprecate `EpochWrapUpV2` (kept verbatim for WAL replay of historical rows), append the V3 variant to `CardanoDelta`, update the misleading startup warning text, and leave follow-up TODOs at `PoolDelegatorRetire::apply` / `DRepDelegatorDrop::apply` for the deeper hardening.

## Why
A mainnet operator's Dolos crashed mid-boundary at epoch 628→629 with `estart_progress = Some(committed=31, total=32)`. EWRAP for epoch 628 had completed, ESTART had committed 31 of 32 shards, then the process died before shard 31 / finalize. On restart the cursor was still at the last block of epoch 628 (the cursor only advances at ESTART finalize), so the next live block re-triggered the boundary and re-emitted EWRAP for a boundary whose EWRAP visitors then ran over partially-rotated accounts. `PoolDelegatorRetire::apply` hit `unreachable!("account delegated to pool")` because the visitor read the snapshot at `current_epoch` (returned `mark = Pool(P)`) while the delta's apply read `live` (returned `NotDelegated` from a scheduled deregistration). 

Root cause of the *replay*: `EpochState` had no flag distinguishing "EWRAP not started for this boundary" from "EWRAP done." Both presented as `ewrap_progress = None`. The fix gives that distinction a representation in state and teaches `EwrapWorkUnit` to recognize it.

## Out of scope
- True crash recovery for partial ESTART (`true shard resume` TODO at `lib.rs:443`) — the existing per-shard resume path is sufficient once EWRAP no longer replays.
- Hardening the `unreachable!` itself. Captured as TODO comments at the panic site and the symmetric `DRepDelegatorDrop::apply`. Direction recorded there: read via `snapshot_at(self.epoch)` (matches the visitor's accessor) and guard the `schedule` write on `entity.epoch() == Some(self.epoch)`.

## Caveats
- `EpochWrapUpV2` is retained `#[deprecated]` for WAL replay of pre-cutover rows. New commit paths only emit V3.
- External tooling that interprets `Some(_)` on `ewrap_progress` as "EWRAP in flight" must be updated to check `committed < total` instead — between EWRAP and ESTART finalize on every boundary, the field is now `Some(total, total)` rather than `None`.
- This fix only closes the "EWRAP done, ESTART pending finalize" recovery hole. A crash *during* EWRAP shards (`committed < total`) still relies on the existing per-shard idempotency claims.

## Test plan
- [x] `cargo build --workspace` — clean (no warnings).
- [x] `cargo test --workspace --lib` — 498 tests pass, 0 failed. Includes the new `epoch_wrap_up_v3_roundtrip` proptest and the existing V1/V2 roundtrips (WAL-replay compatibility preserved).
- [x] `cargo test -p dolos-cardano work::tests` — boundary-emission tests still pass; the fix lives at the work-unit layer, the WorkBuffer is unchanged.
- [ ] **Operator validation**: against a copy of the broken DB from the original incident, confirm the patched binary logs `ewrap already completed in prior run; short-circuiting on replay`, ESTART resumes from shard 31, finalize runs, and no `unreachable!` panic.
- [ ] **Integration regression** (suggested follow-up): a test that forces `ewrap_progress = Some(T, T)` + `estart_progress = Some(T-1, T)` and asserts clean recovery end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added epoch boundary completion detection to skip redundant finalization operations during system recovery.

* **Bug Fixes**
  * Improved crash recovery handling for epoch transitions.
  * Added safeguards for potential boundary/epoch mismatches in delegation operations.

* **Chores**
  * Updated epoch finalization mechanism with improved state persistence across system restarts.
  * Deprecated legacy epoch wrap-up implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->