### PR TITLE
fix: improve search of utxo by full asset & fail on missing policy id

### DIFF
--- a/src/serve/grpc/v1alpha/query.rs
+++ b/src/serve/grpc/v1alpha/query.rs
@@ -167,14 +167,20 @@ impl IntoSet for ByAssetQuery {
 
 impl IntoSet for u5c::cardano::AssetPattern {
     fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
-        let by_policy = ByPolicyQuery::maybe_from(self.policy_id);
-        let by_asset = ByAssetQuery::maybe_from(self.asset_name);
+        let by_policy = ByPolicyQuery::maybe_from(self.policy_id.clone());
+        let by_asset = ByAssetQuery::maybe_from(self.asset_name.clone());
 
         match (by_policy, by_asset) {
+            (Some(_), Some(_)) => {
+                let mut subject = self.policy_id.to_vec();
+                subject.extend_from_slice(&self.asset_name);
+                ByAssetQuery(bytes::Bytes::from(subject)).into_set(indexes)
+            }
             (Some(x), None) => x.into_set(indexes),
-            (None, Some(x)) => x.into_set(indexes),
+            (None, Some(_)) => Err(Status::invalid_argument(
+                "asset name query requires a policy_id",
+            )),
             (None, None) => Ok(HashSet::default()),
-            _ => Err(Status::invalid_argument("conflicting asset criteria")),
         }
     }
 }

--- a/src/serve/grpc/v1beta/query.rs
+++ b/src/serve/grpc/v1beta/query.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
-use crate::serve::grpc::masking::apply_mask;
 use crate::prelude::*;
+use crate::serve::grpc::masking::apply_mask;
 use dolos_cardano::indexes::AsyncCardanoQueryExt;
 
 pub fn point_to_u5c<T: LedgerContext>(_ledger: &T, point: &ChainPoint) -> u5c::query::ChainPoint {
@@ -167,14 +167,20 @@ impl IntoSet for ByAssetQuery {
 
 impl IntoSet for u5c::cardano::AssetPattern {
     fn into_set<S: CardanoIndexExt>(self, indexes: &S) -> Result<HashSet<TxoRef>, Status> {
-        let by_policy = ByPolicyQuery::maybe_from(self.policy_id);
-        let by_asset = ByAssetQuery::maybe_from(self.asset_name);
+        let by_policy = ByPolicyQuery::maybe_from(self.policy_id.clone());
+        let by_asset = ByAssetQuery::maybe_from(self.asset_name.clone());
 
         match (by_policy, by_asset) {
+            (Some(_), Some(_)) => {
+                let mut subject = self.policy_id.to_vec();
+                subject.extend_from_slice(&self.asset_name);
+                ByAssetQuery(bytes::Bytes::from(subject)).into_set(indexes)
+            }
             (Some(x), None) => x.into_set(indexes),
-            (None, Some(x)) => x.into_set(indexes),
+            (None, Some(_)) => Err(Status::invalid_argument(
+                "asset name query requires a policy_id",
+            )),
             (None, None) => Ok(HashSet::default()),
-            _ => Err(Status::invalid_argument("conflicting asset criteria")),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated asset query validation to require both policy ID and asset name when querying by asset. Asset name-only queries now return an error; policy-only queries are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->