### PR TITLE
[codex] Fix driver error monitoring

### DIFF
--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -1,12 +1,14 @@
 use dolos_core::config::{ChainConfig, GenesisConfig, LoggingConfig, RootConfig, TelemetryConfig};
 use dolos_core::BootstrapExt;
+use futures_util::{stream::FuturesUnordered, StreamExt};
 use miette::{Context as _, IntoDiagnostic};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
 use std::sync::Arc;
 use std::{fs, path::PathBuf, time::Duration};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::{filter::Targets, prelude::*};
 
 use dolos::adapters::DomainAdapter;
@@ -297,6 +299,27 @@ pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationTo
     pipeline.teardown();
 }
 
+pub async fn monitor_drivers(
+    mut drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>>,
+    exit: CancellationToken,
+) {
+    while let Some(result) = drivers.next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                error!("driver error: {}", e);
+                warn!("cancelling remaining drivers");
+                exit.cancel();
+            }
+            Err(e) => {
+                error!("driver task failed: {}", e);
+                warn!("cancelling remaining drivers");
+                exit.cancel();
+            }
+        }
+    }
+}
+
 pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
     let root = &config.storage.path;
 
@@ -313,4 +336,40 @@ pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
         info!("Path is not a directory, ignoring.");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream::FuturesUnordered;
+    use std::io;
+    use tokio::task::JoinHandle;
+
+    #[tokio::test]
+    async fn monitor_drivers_observes_later_failures_before_waiting_for_earlier_drivers() {
+        let exit = CancellationToken::new();
+        let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
+
+        let exit_for_slow_driver = exit.clone();
+        drivers.push(tokio::spawn(async move {
+            exit_for_slow_driver.cancelled().await;
+            Ok(())
+        }));
+
+        drivers.push(tokio::spawn(async {
+            Err(ServeError::BindError(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "socket already exists",
+            )))
+        }));
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            monitor_drivers(drivers, exit.clone()),
+        )
+        .await
+        .expect("driver monitor should observe the bind failure promptly");
+
+        assert!(exit.is_cancelled());
+    }
 }

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -4,13 +4,15 @@ use dolos_core::config::{
 };
 use dolos_core::BootstrapExt;
 use dolos_snapshot::registry::Auth;
+use futures_util::{stream::FuturesUnordered, StreamExt};
 use miette::{Context as _, IntoDiagnostic};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
 use std::sync::Arc;
 use std::{fs, path::PathBuf, time::Duration};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::{filter::Targets, prelude::*};
 
 use dolos::adapters::DomainAdapter;
@@ -389,6 +391,27 @@ pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationTo
     pipeline.teardown();
 }
 
+pub async fn monitor_drivers(
+    mut drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>>,
+    exit: CancellationToken,
+) {
+    while let Some(result) = drivers.next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                error!("driver error: {}", e);
+                warn!("cancelling remaining drivers");
+                exit.cancel();
+            }
+            Err(e) => {
+                error!("driver task failed: {}", e);
+                warn!("cancelling remaining drivers");
+                exit.cancel();
+            }
+        }
+    }
+}
+
 pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
     let root = &config.storage.path;
 
@@ -410,6 +433,9 @@ pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
 #[cfg(test)]
 mod tests {
     use dolos_core::config::StelaeRegistryConfig;
+    use futures_util::stream::FuturesUnordered;
+    use std::io;
+    use tokio::task::JoinHandle;
 
     use super::*;
     use crate::init::OFFICIAL_REGISTRY_PASSWORD;
@@ -584,5 +610,33 @@ mod tests {
             },
             "the DOLOS_ prefix no longer reaches [stelae.registry]",
         );
+    }
+
+    #[tokio::test]
+    async fn monitor_drivers_observes_later_failures_before_waiting_for_earlier_drivers() {
+        let exit = CancellationToken::new();
+        let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
+
+        let exit_for_slow_driver = exit.clone();
+        drivers.push(tokio::spawn(async move {
+            exit_for_slow_driver.cancelled().await;
+            Ok(())
+        }));
+
+        drivers.push(tokio::spawn(async {
+            Err(ServeError::BindError(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "socket already exists",
+            )))
+        }));
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            monitor_drivers(drivers, exit.clone()),
+        )
+        .await
+        .expect("driver monitor should observe the bind failure promptly");
+
+        assert!(exit.is_cancelled());
     }
 }

--- a/src/bin/dolos/daemon.rs
+++ b/src/bin/dolos/daemon.rs
@@ -1,7 +1,7 @@
 use dolos_core::config::RootConfig;
 use futures_util::stream::FuturesUnordered;
 use miette::{Context, IntoDiagnostic};
-use tracing::{error, warn};
+use tracing::warn;
 
 #[derive(Debug, clap::Args)]
 pub struct Args {}
@@ -47,14 +47,7 @@ pub async fn run(config: RootConfig, _args: &Args) -> miette::Result<()> {
         exit.clone(),
     );
 
-    for result in drivers {
-        if let Err(e) = result.await.unwrap() {
-            error!("driver error: {}", e);
-
-            warn!("cancelling remaining drivers");
-            exit.cancel();
-        }
-    }
+    crate::common::monitor_drivers(drivers, exit.clone()).await;
 
     sync.await.unwrap();
 

--- a/src/bin/dolos/serve.rs
+++ b/src/bin/dolos/serve.rs
@@ -1,7 +1,6 @@
 use dolos_core::config::RootConfig;
 use futures_util::stream::FuturesUnordered;
 use log::warn;
-use tracing::error;
 
 #[derive(Debug, clap::Args)]
 pub struct Args {}
@@ -25,14 +24,7 @@ pub async fn run(config: RootConfig, _args: &Args) -> miette::Result<()> {
         exit.clone(),
     );
 
-    for result in drivers {
-        if let Err(e) = result.await.unwrap() {
-            error!("driver error: {}", e);
-
-            warn!("cancelling remaining drivers");
-            exit.cancel();
-        }
-    }
+    crate::common::monitor_drivers(drivers, exit.clone()).await;
 
     warn!("shutdown complete");
 


### PR DESCRIPTION
## Summary

- add a shared driver monitor that polls driver tasks by completion order
- use it from both `serve` and `daemon` so driver failures are observed promptly
- add a regression test for a later failing driver sitting behind an earlier long-running driver

## Root cause

`serve` and `daemon` collected driver join handles in a `FuturesUnordered`, but then awaited each join handle from the collection iterator. That made failures depend on insertion order rather than completion order. If an earlier driver kept running and a later Ouroboros Unix socket driver failed to bind, the bind error could remain unread until shutdown.

Fixes #293.

## Bounty note

I linked Githoney bounty `64` from #293 with `/githoney link-bounty --bountyId 64`. The issue bot comment shows a `2025-01-26` deadline, so please confirm whether it is still claimable.

## Verification

- `cargo test monitor_drivers_observes_later_failures_before_waiting_for_earlier_drivers --no-default-features`
- `cargo test --no-default-features`
- `git diff --check`

I also tried `cargo fmt --check`, but this checkout has pre-existing rustfmt drift outside this PR on stable rustfmt, so I left those unrelated files untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver failure detection so errors trigger prompt shutdown without waiting for unrelated tasks to complete.
  * Continued monitoring remaining drivers after a failure to ensure additional errors are detected and reported.

* **Refactor**
  * Unified driver monitoring and error handling across service configurations, providing more consistent shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->