### PR TITLE
fix(grpc): populate block_ref in AnyUtxoData via block_by_tx_hash

### DIFF
--- a/crates/core/src/async_query.rs
+++ b/crates/core/src/async_query.rs
@@ -5,9 +5,22 @@ use tokio::sync::Semaphore;
 use pallas::ledger::traverse::MultiEraBlock;
 
 use crate::{
-    archive::ArchiveStore, indexes::IndexStore, ArchiveError, BlockBody, BlockSlot, ChainError,
-    ChainPoint, Domain, DomainError, EraCbor, IndexError, TagDimension, TxOrder,
+    archive::ArchiveStore, indexes::IndexStore, ArchiveError, BlockBody, BlockHash, BlockHeight,
+    BlockSlot, ChainError, ChainPoint, Domain, DomainError, EraCbor, IndexError, TagDimension,
+    TxOrder,
 };
+
+/// Lightweight block metadata for a transaction, extracted via a single decode.
+///
+/// Returned by `block_meta_by_tx_hash`. Callers that need the full block body
+/// should use `block_by_tx_hash` instead.
+#[derive(Debug, Clone)]
+pub struct BlockRefMeta {
+    pub slot: BlockSlot,
+    pub hash: BlockHash,
+    pub height: BlockHeight,
+    pub tx_index: TxOrder,
+}
 
 #[derive(Debug, Clone)]
 pub struct AsyncQueryOptions {
@@ -132,6 +145,42 @@ where
         }
 
         Ok(None)
+    }
+
+    /// Look up the block containing a given transaction hash and return only
+    /// chain-point metadata, decoding the block once inside the blocking task.
+    ///
+    /// Prefer this over `block_by_tx_hash` when only the chain point is needed —
+    /// it avoids a second `MultiEraBlock::decode` in the caller.
+    pub async fn block_meta_by_tx_hash(
+        &self,
+        tx_hash: Vec<u8>,
+    ) -> Result<Option<BlockRefMeta>, DomainError> {
+        self.run_blocking(move |domain| {
+            let Some(slot) = domain.indexes().slot_by_tx_hash(&tx_hash)? else {
+                return Ok(None);
+            };
+            let Some(raw) = domain.archive().get_block_by_slot(&slot)? else {
+                return Ok(None);
+            };
+            let block = MultiEraBlock::decode(raw.as_slice())
+                .map_err(|e| DomainError::ChainError(ChainError::DecodingError(e)))?;
+            let Some((tx_index, _)) = block
+                .txs()
+                .iter()
+                .enumerate()
+                .find(|(_, tx)| tx.hash().as_slice() == tx_hash.as_slice())
+            else {
+                return Ok(None);
+            };
+            Ok(Some(BlockRefMeta {
+                slot: block.slot(),
+                hash: block.hash(),
+                height: block.number(),
+                tx_index,
+            }))
+        })
+        .await
     }
 
     pub async fn tx_cbor(&self, tx_hash: Vec<u8>) -> Result<Option<EraCbor>, DomainError> {

--- a/src/serve/grpc/block_refs.rs
+++ b/src/serve/grpc/block_refs.rs
@@ -1,0 +1,97 @@
+//! Shared helpers for resolving `block_ref` metadata for UTxOs returned by
+//! `read_utxos` / `search_utxos` across the v1alpha and v1beta query services.
+//!
+//! Loads era summary once per request and deduplicates `block_meta_by_tx_hash`
+//! lookups by source transaction — UTxOs sharing a producing tx pay a single
+//! decode rather than one per item.
+
+use std::collections::HashMap;
+
+use dolos_core::{
+    async_query::{AsyncQueryFacade, BlockRefMeta},
+    BlockHeight, BlockSlot, Domain, TxHash, TxoRef,
+};
+use tonic::Status;
+use tracing::debug;
+
+/// Chain-agnostic block reference data assembled from a single
+/// `block_meta_by_tx_hash` lookup plus the request-scoped era summary.
+#[derive(Clone, Debug)]
+pub struct BlockRefData {
+    pub slot: BlockSlot,
+    pub hash: [u8; 32],
+    pub height: BlockHeight,
+    pub timestamp: u64,
+}
+
+/// Fetch a `BlockRefData` for every UTxO in `txo_refs`, deduplicating by
+/// source transaction so each unique tx incurs at most one storage round-trip
+/// and one block decode. The returned map is keyed by `TxHash`; entries are
+/// absent for transactions that are not in the archive (e.g. genesis UTxOs,
+/// custom UTxOs, or transactions ahead of the current indexer cursor).
+///
+/// Storage errors surface as `Status::internal`. Block-decode errors for
+/// archive entries that did exist degrade to a `debug!` log and a missing map
+/// entry — these indicate node-internal corruption that callers cannot fix.
+pub async fn fetch_block_refs<D>(
+    domain: &D,
+    txo_refs: impl IntoIterator<Item = &TxoRef>,
+) -> Result<HashMap<TxHash, BlockRefData>, Status>
+where
+    D: Domain + pallas::interop::utxorpc::LedgerContext,
+{
+    let unique_hashes: Vec<TxHash> = txo_refs
+        .into_iter()
+        .map(|r| r.0)
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if unique_hashes.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let chain_summary = dolos_cardano::eras::load_era_summary::<D>(domain.state())
+        .map_err(|e| Status::internal(format!("failed to load era summary: {e}")))?;
+
+    let query = AsyncQueryFacade::new(domain.clone());
+    let mut out = HashMap::with_capacity(unique_hashes.len());
+
+    for tx_hash in unique_hashes {
+        match query.block_meta_by_tx_hash(tx_hash.to_vec()).await {
+            Ok(Some(BlockRefMeta {
+                slot, hash, height, ..
+            })) => {
+                out.insert(
+                    tx_hash,
+                    BlockRefData {
+                        slot,
+                        hash: *hash,
+                        height,
+                        timestamp: chain_summary.slot_time(slot),
+                    },
+                );
+            }
+            Ok(None) => {
+                // tx not in archive (yet) — leave missing; caller emits None.
+            }
+            Err(e) => {
+                if matches!(e, dolos_core::DomainError::ChainError(_)) {
+                    debug!(
+                        tx_hash = %hex::encode(tx_hash),
+                        error = %e,
+                        "failed to decode block while resolving UTxO block_ref",
+                    );
+                    continue;
+                }
+                return Err(Status::internal(format!(
+                    "block_meta_by_tx_hash lookup failed for tx {}: {}",
+                    hex::encode(tx_hash),
+                    e,
+                )));
+            }
+        }
+    }
+
+    Ok(out)
+}

--- a/src/serve/grpc/mod.rs
+++ b/src/serve/grpc/mod.rs
@@ -6,6 +6,7 @@ use tracing::info;
 
 use crate::prelude::*;
 
+pub(crate) mod block_refs;
 mod convert;
 mod masking;
 mod stream;
@@ -48,10 +49,9 @@ where
             v1beta::watch::WatchServiceImpl::new(domain.clone(), cancel.clone()),
         );
 
-        let submit_v1alpha =
-            v1alpha::spec::submit::submit_service_server::SubmitServiceServer::new(
-                v1alpha::submit::SubmitServiceImpl::new(domain.clone()),
-            );
+        let submit_v1alpha = v1alpha::spec::submit::submit_service_server::SubmitServiceServer::new(
+            v1alpha::submit::SubmitServiceImpl::new(domain.clone()),
+        );
         let submit_v1beta = v1beta::spec::submit::submit_service_server::SubmitServiceServer::new(
             v1beta::submit::SubmitServiceImpl::new(domain.clone()),
         );

--- a/src/serve/grpc/v1alpha/query.rs
+++ b/src/serve/grpc/v1alpha/query.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
-use crate::serve::grpc::masking::apply_mask;
 use crate::prelude::*;
+use crate::serve::grpc::masking::apply_mask;
 use dolos_cardano::indexes::AsyncCardanoQueryExt;
 
 pub fn point_to_u5c<T: LedgerContext>(_ledger: &T, point: &ChainPoint) -> u5c::query::ChainPoint {
@@ -777,6 +777,36 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
         }
     }
 
+    // TODO: batch and dedupe per-page — UTxOs sharing a source tx currently re-decode the
+    // same block once each. Acceptable for typical query sizes; revisit if pages get large.
+    let block_ref = match query.block_by_tx_hash(txo.0.to_vec()).await {
+        Ok(Some((block_bytes, _tx_index))) => match MultiEraBlock::decode(&block_bytes) {
+            Ok(block) => Some(u5c::query::ChainPoint {
+                slot: block.slot(),
+                hash: block.hash().to_vec().into(),
+                height: block.header().number(),
+                timestamp: domain.get_slot_timestamp(block.slot()).unwrap_or(0),
+            }),
+            Err(e) => {
+                warn!(
+                    tx_hash = hex::encode(txo.0),
+                    error = %e,
+                    "Failed to decode block for UTxO block_ref lookup"
+                );
+                None
+            }
+        },
+        Ok(None) => None,
+        Err(e) => {
+            warn!(
+                tx_hash = hex::encode(txo.0),
+                error = %e,
+                "block_by_tx_hash lookup failed for UTxO"
+            );
+            None
+        }
+    };
+
     Ok(u5c::query::AnyUtxoData {
         txo_ref: Some(u5c::query::TxoRef {
             hash: txo.0.to_vec().into(),
@@ -784,7 +814,7 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
         }),
         native_bytes: body.1.clone().into(),
         parsed_state: Some(u5c::query::any_utxo_data::ParsedState::Cardano(parsed)),
-        block_ref: None,
+        block_ref,
     })
 }
 

--- a/src/serve/grpc/v1alpha/query.rs
+++ b/src/serve/grpc/v1alpha/query.rs
@@ -9,8 +9,18 @@ use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
 use crate::prelude::*;
+use crate::serve::grpc::block_refs::BlockRefData;
 use crate::serve::grpc::masking::apply_mask;
 use dolos_cardano::indexes::AsyncCardanoQueryExt;
+
+fn to_chain_point(data: &BlockRefData) -> u5c::query::ChainPoint {
+    u5c::query::ChainPoint {
+        slot: data.slot,
+        hash: data.hash.to_vec().into(),
+        height: data.height,
+        timestamp: data.timestamp,
+    }
+}
 
 pub fn point_to_u5c<T: LedgerContext>(_ledger: &T, point: &ChainPoint) -> u5c::query::ChainPoint {
     u5c::query::ChainPoint {
@@ -726,6 +736,7 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
     body: &EraCbor,
     mapper: &interop::Mapper<S>,
     domain: &S,
+    block_ref: Option<u5c::query::ChainPoint>,
 ) -> Result<u5c::query::AnyUtxoData, Box<dyn std::error::Error>> {
     use pallas::ledger::primitives::conway::DatumOption;
 
@@ -776,36 +787,6 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
             }
         }
     }
-
-    // TODO: batch and dedupe per-page — UTxOs sharing a source tx currently re-decode the
-    // same block once each. Acceptable for typical query sizes; revisit if pages get large.
-    let block_ref = match query.block_by_tx_hash(txo.0.to_vec()).await {
-        Ok(Some((block_bytes, _tx_index))) => match MultiEraBlock::decode(&block_bytes) {
-            Ok(block) => Some(u5c::query::ChainPoint {
-                slot: block.slot(),
-                hash: block.hash().to_vec().into(),
-                height: block.header().number(),
-                timestamp: domain.get_slot_timestamp(block.slot()).unwrap_or(0),
-            }),
-            Err(e) => {
-                warn!(
-                    tx_hash = hex::encode(txo.0),
-                    error = %e,
-                    "Failed to decode block for UTxO block_ref lookup"
-                );
-                None
-            }
-        },
-        Ok(None) => None,
-        Err(e) => {
-            warn!(
-                tx_hash = hex::encode(txo.0),
-                error = %e,
-                "block_by_tx_hash lookup failed for UTxO"
-            );
-            None
-        }
-    };
 
     Ok(u5c::query::AnyUtxoData {
         txo_ref: Some(u5c::query::TxoRef {
@@ -889,10 +870,14 @@ where
         let utxos = StateStore::get_utxos(self.domain.state(), keys)
             .map_err(|e| Status::internal(e.to_string()))?;
 
+        let block_refs =
+            crate::serve::grpc::block_refs::fetch_block_refs(&self.domain, utxos.keys()).await?;
+
         let mut items = Vec::new();
         for (k, v) in utxos.iter() {
+            let block_ref = block_refs.get(&k.0).map(to_chain_point);
             items.push(
-                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                into_u5c_utxo(k, v, &self.mapper, &self.domain, block_ref)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?,
             );
@@ -939,10 +924,14 @@ where
         let utxos = StateStore::get_utxos(self.domain.state(), set.into_iter().collect_vec())
             .map_err(|e| Status::internal(e.to_string()))?;
 
+        let block_refs =
+            crate::serve::grpc::block_refs::fetch_block_refs(&self.domain, utxos.keys()).await?;
+
         let mut items = Vec::new();
         for (k, v) in utxos.iter() {
+            let block_ref = block_refs.get(&k.0).map(to_chain_point);
             items.push(
-                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                into_u5c_utxo(k, v, &self.mapper, &self.domain, block_ref)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?,
             );

--- a/src/serve/grpc/v1beta/query.rs
+++ b/src/serve/grpc/v1beta/query.rs
@@ -777,6 +777,36 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
         }
     }
 
+    // TODO: batch and dedupe per-page — UTxOs sharing a source tx currently re-decode the
+    // same block once each. Acceptable for typical query sizes; revisit if pages get large.
+    let block_ref = match query.block_by_tx_hash(txo.0.to_vec()).await {
+        Ok(Some((block_bytes, _tx_index))) => match MultiEraBlock::decode(&block_bytes) {
+            Ok(block) => Some(u5c::query::ChainPoint {
+                slot: block.slot(),
+                hash: block.hash().to_vec().into(),
+                height: block.header().number(),
+                timestamp: domain.get_slot_timestamp(block.slot()).unwrap_or(0),
+            }),
+            Err(e) => {
+                warn!(
+                    tx_hash = hex::encode(txo.0),
+                    error = %e,
+                    "Failed to decode block for UTxO block_ref lookup"
+                );
+                None
+            }
+        },
+        Ok(None) => None,
+        Err(e) => {
+            warn!(
+                tx_hash = hex::encode(txo.0),
+                error = %e,
+                "block_by_tx_hash lookup failed for UTxO"
+            );
+            None
+        }
+    };
+
     Ok(u5c::query::AnyUtxoData {
         txo_ref: Some(u5c::query::TxoRef {
             hash: txo.0.to_vec().into(),
@@ -784,7 +814,7 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
         }),
         native_bytes: body.1.clone().into(),
         parsed_state: Some(u5c::query::any_utxo_data::ParsedState::Cardano(parsed)),
-        block_ref: None,
+        block_ref,
     })
 }
 

--- a/src/serve/grpc/v1beta/query.rs
+++ b/src/serve/grpc/v1beta/query.rs
@@ -9,8 +9,18 @@ use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
 use crate::prelude::*;
+use crate::serve::grpc::block_refs::BlockRefData;
 use crate::serve::grpc::masking::apply_mask;
 use dolos_cardano::indexes::AsyncCardanoQueryExt;
+
+fn to_chain_point(data: &BlockRefData) -> u5c::query::ChainPoint {
+    u5c::query::ChainPoint {
+        slot: data.slot,
+        hash: data.hash.to_vec().into(),
+        height: data.height,
+        timestamp: data.timestamp,
+    }
+}
 
 pub fn point_to_u5c<T: LedgerContext>(_ledger: &T, point: &ChainPoint) -> u5c::query::ChainPoint {
     u5c::query::ChainPoint {
@@ -726,6 +736,7 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
     body: &EraCbor,
     mapper: &interop::Mapper<S>,
     domain: &S,
+    block_ref: Option<u5c::query::ChainPoint>,
 ) -> Result<u5c::query::AnyUtxoData, Box<dyn std::error::Error>> {
     use pallas::ledger::primitives::conway::DatumOption;
 
@@ -776,36 +787,6 @@ async fn into_u5c_utxo<S: Domain + LedgerContext>(
             }
         }
     }
-
-    // TODO: batch and dedupe per-page — UTxOs sharing a source tx currently re-decode the
-    // same block once each. Acceptable for typical query sizes; revisit if pages get large.
-    let block_ref = match query.block_by_tx_hash(txo.0.to_vec()).await {
-        Ok(Some((block_bytes, _tx_index))) => match MultiEraBlock::decode(&block_bytes) {
-            Ok(block) => Some(u5c::query::ChainPoint {
-                slot: block.slot(),
-                hash: block.hash().to_vec().into(),
-                height: block.header().number(),
-                timestamp: domain.get_slot_timestamp(block.slot()).unwrap_or(0),
-            }),
-            Err(e) => {
-                warn!(
-                    tx_hash = hex::encode(txo.0),
-                    error = %e,
-                    "Failed to decode block for UTxO block_ref lookup"
-                );
-                None
-            }
-        },
-        Ok(None) => None,
-        Err(e) => {
-            warn!(
-                tx_hash = hex::encode(txo.0),
-                error = %e,
-                "block_by_tx_hash lookup failed for UTxO"
-            );
-            None
-        }
-    };
 
     Ok(u5c::query::AnyUtxoData {
         txo_ref: Some(u5c::query::TxoRef {
@@ -889,10 +870,14 @@ where
         let utxos = StateStore::get_utxos(self.domain.state(), keys)
             .map_err(|e| Status::internal(e.to_string()))?;
 
+        let block_refs =
+            crate::serve::grpc::block_refs::fetch_block_refs(&self.domain, utxos.keys()).await?;
+
         let mut items = Vec::new();
         for (k, v) in utxos.iter() {
+            let block_ref = block_refs.get(&k.0).map(to_chain_point);
             items.push(
-                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                into_u5c_utxo(k, v, &self.mapper, &self.domain, block_ref)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?,
             );
@@ -939,10 +924,14 @@ where
         let utxos = StateStore::get_utxos(self.domain.state(), set.into_iter().collect_vec())
             .map_err(|e| Status::internal(e.to_string()))?;
 
+        let block_refs =
+            crate::serve::grpc::block_refs::fetch_block_refs(&self.domain, utxos.keys()).await?;
+
         let mut items = Vec::new();
         for (k, v) in utxos.iter() {
+            let block_ref = block_refs.get(&k.0).map(to_chain_point);
             items.push(
-                into_u5c_utxo(k, v, &self.mapper, &self.domain)
+                into_u5c_utxo(k, v, &self.mapper, &self.domain, block_ref)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?,
             );


### PR DESCRIPTION
## What

`into_u5c_utxo` (in both `src/serve/grpc/v1alpha/query.rs` and `src/serve/grpc/v1beta/query.rs`) now populates `AnyUtxoData.block_ref` instead of returning `None`. Every UTxO returned by `read_utxos` and `search_utxos` will now carry the block (slot/hash/height/timestamp) that produced it.

## Why

The `block_ref` field was added to `AnyUtxoData` as part of the u5c 0.18.1 upgrade in #813 (commit `2b6de0bc`), but it landed as a placeholder — `block_ref: None` — and the reverse lookup was never wired up. Consumers querying UTxOs through `read_utxos` / `search_utxos` therefore lose all block-level metadata for those UTxOs.

A downstream library ([`pogun-chainfollower`](https://github.com/input-output-hk/pogun-chainfollower/pull/212)) shipped a `filter_map` tourniquet to silently drop these items so the rest of the pipeline doesn't fall over. Populating the field at the source makes that workaround unnecessary.

## How

Mirror the pattern already used by `read_tx` (a few functions down in the same file): call `AsyncQueryFacade::block_by_tx_hash(txo.0.to_vec())`, decode the block with `MultiEraBlock::decode`, and build a `ChainPoint { slot, hash, height, timestamp }`. The reverse lookup is backed by the existing `slot_by_tx_hash` index — no new indexing is needed; it is already implemented across both storage backends (`dolos-redb3`, `dolos-fjall`).

Lookup failures (tx not in archive, decode error, query error) `warn!` with the tx hash and fall back to `block_ref: None`. This mirrors the existing posture in `into_u5c_utxo` for datum-decode errors — graceful degradation rather than failing the whole call.

Applied to both `v1alpha` and `v1beta` (near-identical files).

## Performance tradeoff (please weigh in)

`into_u5c_utxo` is invoked once per UTxO. With this patch, a `search_utxos` page of N UTxOs costs N reverse-lookups + N full `MultiEraBlock::decode` calls. When the UTxOs cluster on M < N source txs (typical — multi-output txs), N − M of those decodes are redundant.

This PR takes the **Tier 1** path: per-UTxO lookup, with a `TODO` comment near the new code marking the spot for future batching. Correctness over performance, acceptable cost for typical query sizes.

**Tier 2** (deferred): refactor `read_utxos` / `search_utxos` to gather unique tx hashes from the page first, batch-fetch a `HashMap<TxHash, ChainPoint>`, and thread it into `into_u5c_utxo` via a signature change. Bigger diff, better cost profile.

Happy to land Tier 2 inline before merge if reviewers prefer it, or to track it as a follow-up issue — deferring to maintainer judgment.

## Tests

No existing test harness exercises `read_utxos` / `search_utxos` against fixture blocks — the in-file test module only covers genesis/era-summary RPCs against the in-memory `ToyDomain`, which doesn't have meaningful archive integration for `block_by_tx_hash` to return `Some`. I didn't want to invent a heavy fixture/seeded-chain scaffolding without first asking whether maintainers want one. **Please advise**:

- comfortable merging on review-only and tracking a test in a follow-up?
- or would you like a test (and is there a preferred harness pattern — e2e under `tests/` against a seeded snapshot, or a unit test with a richer mock domain)?

## Quality gates (locally, against `a5dc18f`)

- `cargo fmt --check` — the two touched files are clean. (Pre-existing fmt diffs in unrelated files exist on `main` because `rustfmt.toml` enables `wrap_comments = true`, which only applies on nightly. Untouched.)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo build --workspace --all-targets --all-features` — clean.
- `cargo test --workspace --all-targets` — 540 passed, 0 failed (matches CI shape — `ci.yml` does not pass `--all-features`).
  - Note: `cargo test --workspace --all-features` shows 14 pre-existing failures in `dolos-cardano` proptests (`model::accounts::prop_tests::*`, `model::epochs::prop_tests::*`, `model::pools::prop_tests::pool_registration_roundtrip`, etc.). I verified these fail on bare `main@a5dc18f` without my changes, so they're unrelated to this PR.

## Scope

- Both `v1alpha` and `v1beta` updated.
- No proto changes (`block_ref: Option<ChainPoint>` already exists on `AnyUtxoData`).
- No new storage indexes.
- No unrelated refactors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UTXO query responses now include block reference metadata (slot, block hash, block height, transaction index) for returned UTXOs.
  * The system prefetches and deduplicates block lookups to reduce redundant work when resolving UTXO origins.
* **Bug Fixes**
  * Missing or malformed block data is handled gracefully with warnings; queries continue when some block refs are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/dolos/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->