### PR TITLE
fix(grpc): convert ChainPoint/BlockRef timestamp from seconds to ms

### DIFF
--- a/src/serve/grpc/block_refs.rs
+++ b/src/serve/grpc/block_refs.rs
@@ -68,7 +68,7 @@ where
                         slot,
                         hash: *hash,
                         height,
-                        timestamp: chain_summary.slot_time(slot),
+                        timestamp: chain_summary.slot_time(slot) * 1000,
                     },
                 );
             }

--- a/src/serve/grpc/v1alpha/query.rs
+++ b/src/serve/grpc/v1alpha/query.rs
@@ -995,7 +995,11 @@ where
                     slot: block.slot(),
                     hash: block.hash().to_vec().into(),
                     height: block.header().number(),
-                    timestamp: self.domain.get_slot_timestamp(block.slot()).unwrap_or(0),
+                    timestamp: self
+                        .domain
+                        .get_slot_timestamp(block.slot())
+                        .map(|s| s * 1000)
+                        .unwrap_or(0),
                 }),
                 chain: Some(u5c::query::any_chain_tx::Chain::Cardano(
                     self.mapper.map_tx(&tx),

--- a/src/serve/grpc/v1alpha/sync.rs
+++ b/src/serve/grpc/v1alpha/sync.rs
@@ -274,7 +274,11 @@ where
             .map_err(|e| Status::internal(format!("Unable to read WAL: {e:?}")))?
             .ok_or(Status::internal("chain has no data."))?;
 
-        let timestamp = self.domain.get_slot_timestamp(point.slot()).unwrap_or(0);
+        let timestamp = self
+            .domain
+            .get_slot_timestamp(point.slot())
+            .map(|s| s * 1000)
+            .unwrap_or(0);
         let response = u5c::sync::ReadTipResponse {
             tip: Some(point_to_blockref(&point, timestamp)),
         };

--- a/src/serve/grpc/v1beta/query.rs
+++ b/src/serve/grpc/v1beta/query.rs
@@ -995,7 +995,11 @@ where
                     slot: block.slot(),
                     hash: block.hash().to_vec().into(),
                     height: block.header().number(),
-                    timestamp: self.domain.get_slot_timestamp(block.slot()).unwrap_or(0),
+                    timestamp: self
+                        .domain
+                        .get_slot_timestamp(block.slot())
+                        .map(|s| s * 1000)
+                        .unwrap_or(0),
                 }),
                 chain: Some(u5c::query::any_chain_tx::Chain::Cardano(
                     self.mapper.map_tx(&tx),

--- a/src/serve/grpc/v1beta/sync.rs
+++ b/src/serve/grpc/v1beta/sync.rs
@@ -274,7 +274,11 @@ where
             .map_err(|e| Status::internal(format!("Unable to read WAL: {e:?}")))?
             .ok_or(Status::internal("chain has no data."))?;
 
-        let timestamp = self.domain.get_slot_timestamp(point.slot()).unwrap_or(0);
+        let timestamp = self
+            .domain
+            .get_slot_timestamp(point.slot())
+            .map(|s| s * 1000)
+            .unwrap_or(0);
         let response = u5c::sync::ReadTipResponse {
             tip: Some(point_to_blockref(&point, timestamp)),
         };


### PR DESCRIPTION
While integrating PR #1000 downstream into a Cardano application that consumes utxo-rpc through `pogun-chainfollower`, we noticed the new `block_ref` field on `SearchUtxos`/`ReadUtxos` came back populated but with a 10-digit timestamp — a UNIX seconds value, not the milliseconds the utxorpc proto declares. Tracing it further, the same unit mismatch exists in four pre-existing sites in Dolos's gRPC layer (`ReadTip`, `ReadTx`, both on v1alpha and v1beta), all the way through `EraSummary::slot_time` and the pallas `LedgerContext` adapter.
## What the proto says

`utxorpc/spec` declares the timestamp field as milliseconds in four places, consistently:

- `proto/utxorpc/v1alpha/query/query.proto` — `ChainPoint.timestamp` (`// Block ms timestamp`)
- `proto/utxorpc/v1beta/query/query.proto` — `ChainPoint.timestamp` (same)
- `proto/utxorpc/v1alpha/sync/sync.proto` — `BlockRef.timestamp` (same)
- `proto/utxorpc/v1beta/sync/sync.proto` — `BlockRef.timestamp` (same)

## What Dolos actually writes

The root is `EraSummary::slot_time` (`crates/cardano/src/eras.rs:23`) which returns seconds. Three confirming signals in-tree:

1. `crates/cardano/src/eras.rs:38` — the sibling helper names its arithmetic `let second_delta = slot_delta * self.slot_length;`.
2. `crates/cardano/src/forks.rs:81` — Byron's ms-typed `slot_duration` is divided by 1000 before being stored as `slot_length`.
3. `crates/cardano/src/forks.rs:106` — Shelley `system_start` is stored as `chrono::DateTime::timestamp() as u64`, which is unix seconds.

That seconds value flows directly into proto fields documented as ms at five sites:

| RPC | Site | Status before this PR |
|---|---|---|
| `QueryService.ReadTx` (v1alpha) | `src/serve/grpc/v1alpha/query.rs:998` | pre-existing on `main` |
| `QueryService.ReadTx` (v1beta) | `src/serve/grpc/v1beta/query.rs:998` | pre-existing on `main` |
| `SyncService.ReadTip` (v1alpha) | `src/serve/grpc/v1alpha/sync.rs:277` | pre-existing on `main` |
| `SyncService.ReadTip` (v1beta) | `src/serve/grpc/v1beta/sync.rs:277` | pre-existing on `main` |
| `QueryService.SearchUtxos` & `ReadUtxos` (via `block_ref`) | `src/serve/grpc/block_refs.rs:71` | introduced in #1000 |

The first four route through `LedgerContext::get_slot_timestamp` (pallas trait, doc'd as seconds — correctly implemented by Dolos's adapter at `src/adapters/mod.rs:208`). The fifth bypasses the trait and calls `chain_summary.slot_time(slot)` directly because PR #1000 hoists the era summary per request — also correct in isolation, but seconds.

## The fix

Convert at the boundary. Each gRPC site that writes into a `// Block ms timestamp` proto field multiplies the seconds-typed source value by 1000. Five surgical edits, total diff +21/−5.

The pallas `LedgerContext::get_slot_timestamp` trait is **not** changed — its contract is seconds and Dolos correctly implements it. The conversion belongs at the proto write boundary, not at the trait. The internal `EraSummary::slot_time` is also unchanged for the same reason.

## Verification — built and probed a preprod snapshot

`dolos bootstrap snapshot --variant full` on preprod, `dolos daemon`, then `grpcurl` against each endpoint. Before this PR (PR #1000 alone), all five RPCs returned 10-digit timestamp values that decode to the correct date when read as seconds and to January 1970 when read as ms. After this PR, every endpoint returns the same value × 1000 — 13 digits, decoding correctly as ms:

| RPC | Before | After |
|---|---|---|
| `ReadTip` (v1alpha + v1beta) | `1777953075` (≈ 1970-01-21 as ms) | `1777979745000` (2026-05-05 09:55:45 UTC) |
| `ReadTx` (v1alpha + v1beta) | `1777567069` | `1777567069000` (2026-04-30 16:37:49 UTC) |
| `ReadUtxos` (v1alpha + v1beta) | `1777567069` | `1777567069000` (2026-04-30 16:37:49 UTC) |
| `SearchUtxos` (v1alpha + v1beta) | `1777575127` | `1777575127000` (2026-04-30 18:52:07 UTC) |

Slot math sanity check: preprod's byron `startTime + byron_slots × 20s + shelley_slots × 1s = slot_time(slot)` lines up to the second for every value above. The conversion isn't reinterpreting anything — it's just promoting units.

## Stacking

Based on `fix/u5c-block-ref-populate`. The diff against `main` will include PR #1000's changes plus this PR's five-site fix; the diff against `fix/u5c-block-ref-populate` is just the five edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized block reference metadata handling to improve consistency across gRPC query services.

* **Improvements**
  * Standardized timestamp formatting to milliseconds across all API endpoints for consistent time representation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/dolos/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->