### PR TITLE
fix(testing): use Waker::noop() to satisfy clippy::manual_noop_waker

### DIFF
--- a/crates/testing/src/streams.rs
+++ b/crates/testing/src/streams.rs
@@ -1,19 +1,12 @@
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 
 use futures_core::Stream;
 
-struct NoopWake;
-
-impl Wake for NoopWake {
-    fn wake(self: Arc<Self>) {}
-}
-
 /// Build a no-op waker for synchronously driving streams in tests.
 pub fn noop_waker() -> Waker {
-    Arc::new(NoopWake).into()
+    Waker::noop().clone()
 }
 
 /// A generic stream backed by a scripted sequence of poll results.


### PR DESCRIPTION
## Summary
- Replaces the manual `Wake` impl for `NoopWake` in `crates/testing/src/streams.rs` with `Waker::noop().clone()`, fixing the `clippy::manual_noop_waker` lint that's currently failing CI on main.

## Test plan
- [x] `cargo clippy -p dolos-testing --all-targets --all-features -- -D warnings` passes locally
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal testing utilities with no impact to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/dolos/pull/1004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->