### PR TITLE
feat(trp): populate reference script expression in TRP UTxO mapping

### DIFF
--- a/crates/trp/src/mapping.rs
+++ b/crates/trp/src/mapping.rs
@@ -4,7 +4,7 @@ use tx3_resolver::{Expression, StructExpr};
 
 use dolos_core::{EraCbor, TxoRef};
 use pallas::{
-    codec::utils::KeyValuePairs,
+    codec::{minicbor, utils::KeyValuePairs},
     ledger::{
         primitives::{conway::DatumOption, BigInt, Constr, PlutusData},
         traverse::{Era, MultiEraAsset, MultiEraOutput, MultiEraPolicyAssets, MultiEraValue},
@@ -132,11 +132,22 @@ pub fn into_tx3_utxo(
         _ => None,
     };
 
+    // Carry the full tagged `ScriptRef` CBOR (the `[tag, body]` array) so the
+    // compiler can read the reference script's Plutus language directly from
+    // its tag. We must NOT store only the inner script body, which would drop
+    // the language tag.
+    let script = parsed
+        .script_ref()
+        .map(|script_ref| minicbor::to_vec(&script_ref))
+        .transpose()
+        .map_err(|e| tx3_resolver::Error::StoreError(e.to_string()))?
+        .map(Expression::Bytes);
+
     Ok(tx3_resolver::Utxo {
         r#ref,
         address,
         datum,
         assets,
-        script: None,
+        script,
     })
 }


### PR DESCRIPTION
## Problem

`into_tx3_utxo` (`crates/trp/src/mapping.rs`) hardcoded `script: None`, so reference scripts attached to resolved UTxOs never reached the tx3 compiler. Without it, the compiler cannot determine the Plutus language of a reference script and falls back to a default.

## Fix

The raw UTxO CBOR (`EraCbor`) already carries the reference script, and `into_tx3_utxo` already decodes it into a `MultiEraOutput`. Map `parsed.script_ref()` into `utxo.script` as `Expression::Bytes`, mirroring the existing `map_datum` path. No data-store interface change is needed.

The **full tagged `ScriptRef` CBOR** (`[tag, body]`) is preserved so the consumer can read the script's Plutus language directly from the tag. We deliberately do **not** store only the inner script body (as some hash-lookup paths do, e.g. `crates/cardano/src/indexes/query.rs`), which would drop the language tag.

## Context

This is the provider-side half of a fix for reference-script Plutus-version handling in the tx3 compiler (companion PR: `tx3-lang/tx3#331`). Once published, the tx3-cardano compiler reads the language from the tag this mapping now supplies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction UTXOs now properly include script information in their data representation, improving data completeness for transaction processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/dolos/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->