### PR TITLE
chore(trp): bump tx3-cardano and tx3-resolver to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
  "blst",
  "bumpalo",
  "chumsky",
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "divan",
  "hamming",
  "hex",
@@ -459,6 +459,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1046,6 +1059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
+name = "cryptoxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "facfae029ec4373769eb4bd936bcf537de1052abaee9f246e667c9443be6aa95"
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1641,15 @@ dependencies = [
  "pkcs8",
  "serde",
  "signature",
+]
+
+[[package]]
+name = "ed25519-bip32"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bf77cf581d1a8c5f73c45e6d31aa45cfcb94438310f2f628b07e4727949115"
+dependencies = [
+ "cryptoxide 0.5.1",
 ]
 
 [[package]]
@@ -3468,7 +3496,7 @@ dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "hex",
  "pallas-codec 0.32.0",
  "pallas-crypto 0.32.0",
@@ -3484,7 +3512,7 @@ dependencies = [
  "base58",
  "bech32 0.11.1",
  "crc",
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "hex",
  "pallas-codec 1.0.0",
  "pallas-crypto 1.0.0",
@@ -3537,7 +3565,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
 dependencies = [
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "hex",
  "pallas-codec 0.32.0",
  "rand_core 0.6.4",
@@ -3552,7 +3580,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9fb8dcda11769c8f665c398b217efbef46493d449ed503134d39011bdd81e44"
 dependencies = [
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "hex",
  "pallas-codec 1.0.0",
  "rand_core 0.10.1",
@@ -5930,7 +5958,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "trait-variant",
- "tx3-tir 0.17.0",
+ "tx3-tir",
  "utxorpc",
 ]
 
@@ -5949,39 +5977,31 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "trait-variant",
- "tx3-tir 0.17.0",
+ "tx3-tir",
  "uuid",
 ]
 
 [[package]]
 name = "tx3-sdk"
-version = "0.8.0"
-source = "git+https://github.com/tx3-lang/rust-sdk.git#d6cbdcb81c4aed40cb6974a0148662afd4f451d5"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ebe5c071e568628c648d73f56301fda978ec3c1c1b1a8be179225a6bf7cb36"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
+ "bip39",
+ "cryptoxide 0.4.4",
+ "ed25519-bip32",
  "hex",
+ "pallas-addresses 1.0.0",
+ "pallas-crypto 1.0.0",
  "reqwest",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tx3-tir 0.13.0",
+ "tokio",
  "uuid",
-]
-
-[[package]]
-name = "tx3-tir"
-version = "0.13.0"
-source = "git+https://github.com/tx3-lang/tx3.git#b70f6433bd8cc51d4e9bd78aec856c00d3599ce6"
-dependencies = [
- "base64 0.22.1",
- "bech32 0.11.1",
- "ciborium",
- "hex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5921,9 +5921,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tx3-cardano"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9edb0d0a9eea83b2cd17381722234b5557eae91cffa285ec2e0beaeec19921"
+checksum = "85887868dcd17f73a22da5743a1cefd1964f2d1770e1c353eff0a9a8c7c1c639"
 dependencies = [
  "hex",
  "pallas",
@@ -5936,9 +5936,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-resolver"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a459806519fde9420ea1a1c0b72de89903bb3fde658ff549255ae21428869d8b"
+checksum = "222d1d0c56d7f88c8acb6e9cd0552cc08f92fb90fbb3d3b39b3892f77fc51a2e"
 dependencies = [
  "approx",
  "base64 0.22.1",

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee = { version = "0.24.9", features = ["server"] }
 opentelemetry = "0.30.0"
 opentelemetry_sdk = "0.30.0"
 
-tx3-cardano = "0.19.0"
-tx3-resolver = "0.19.0"
+tx3-cardano = "0.21.0"
+tx3-resolver = "0.21.0"
 
 # tx3-cardano = { path = "../../../../tx3-lang/tx3/crates/tx3-cardano" }
 # tx3-resolver = { path = "../../../../tx3-lang/tx3/crates/tx3-resolver" }

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -38,6 +38,6 @@ tx3-resolver = "0.21.0"
 dolos-testing = { path = "../testing" }
 rand = "0.9.1"
 
-# tx3-sdk = "0.13.0"
+tx3-sdk = "0.12.0"
 # tx3-sdk = { path = "../../../../rust-sdk" }
-tx3-sdk = { git = "https://github.com/tx3-lang/rust-sdk.git" }
+# tx3-sdk = { git = "https://github.com/tx3-lang/rust-sdk.git" }


### PR DESCRIPTION
## Summary

Brings dolos's TRP backend in line with the current Tx3 toolchain release ahead of pinning dolos into the Tx3 toolchain beta channel:

- `tx3-cardano` and `tx3-resolver`: `0.19.0` → `0.21.0` (latest published, matching tx3 v0.21.0)
- `tx3-sdk` dev-dependency: switched from the `rust-sdk` git source (resolved to tx3-sdk 0.8.0, which pulled in an old `tx3-tir 0.13.0`) to the published `tx3-sdk 0.12.0`, which no longer depends on `tx3-tir`. This drops the duplicate `tx3-tir` from the lockfile.

## Testing

- `cargo build -p dolos-trp` ✅
- `cargo test -p dolos-trp` ✅ (10 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer compatible releases to keep the build ecosystem current.
  * Switched a development helper dependency from a repository-based source to the official package registry for more stable dev installs and consistent CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->