### PR TITLE
fix(minibf): source address-utxo tx_hash from TxoRef, not archive block_data

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -481,11 +481,10 @@ impl<'a> IntoModel<AddressUtxoContentInner> for UtxoOutputModelBuilder<'a> {
     fn into_model(self) -> Result<AddressUtxoContentInner, StatusCode> {
         let out = AddressUtxoContentInner {
             address: self.output.address().into_model()?,
-            tx_hash: self
-                .block_data
-                .as_ref()
-                .map(|data| data.tx_hash.to_string())
-                .unwrap_or_default(),
+            // source the tx_hash from the UTxO's own TxoRef (always present),
+            // not the archive block_data lookup which is None for blocks older
+            // than `max_history` and would yield an empty hash.
+            tx_hash: self.txo_ref.0.to_string(),
             block: self
                 .block_data
                 .as_ref()


### PR DESCRIPTION
`GET /addresses/{address}/utxos` returns an empty `tx_hash` for any UTxO whose source block has aged out of the archive: the handler derives `tx_hash` from a `block_data` archive lookup, and on a miss (`block_data == None`, governed by `max_history`) `.unwrap_or_default()` yields `""`. With the default `max_history = 10000` this hits any UTxO older than the window; a Blockfrost client then rejects the 0-length hash.

Fix: source `tx_hash` from the UTxO's own `TxoRef` (always present) instead of the archive lookup — identical value when the block is archived, correct value when it isn't.

Repro: set a small `[sync] max_history`, sync, query an address holding a UTxO created before the window → `"tx_hash": ""`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of transaction hash derivation for UTXO outputs by using the transaction reference directly, reducing dependency on external block data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->