### PR TITLE
feat(grpc): configurable HTTP/2 transport tuning

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -688,6 +688,27 @@ pub struct GrpcConfig {
     pub tls_client_ca_root: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     permissive_cors: Option<bool>,
+
+    // --- HTTP/2 transport tuning ---
+    /// Enable hyper's adaptive (BDP-based) flow-control windowing. Defaults to
+    /// `true`. When enabled, the explicit `http2_initial_*_window_size` values
+    /// are ignored by hyper (adaptive sizing takes precedence).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http2_adaptive_window: Option<bool>,
+    /// Initial HTTP/2 stream-level flow-control window, in bytes. Ignored when
+    /// `http2_adaptive_window` is on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http2_initial_stream_window_size: Option<u32>,
+    /// Initial HTTP/2 connection-level flow-control window, in bytes. Ignored
+    /// when `http2_adaptive_window` is on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http2_initial_connection_window_size: Option<u32>,
+    /// Maximum HTTP/2 frame size, in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http2_max_frame_size: Option<u32>,
+    /// Maximum number of concurrent HTTP/2 streams per connection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http2_max_concurrent_streams: Option<u32>,
 }
 
 impl GrpcConfig {
@@ -696,6 +717,11 @@ impl GrpcConfig {
             listen_address,
             tls_client_ca_root,
             permissive_cors: None,
+            http2_adaptive_window: None,
+            http2_initial_stream_window_size: None,
+            http2_initial_connection_window_size: None,
+            http2_max_frame_size: None,
+            http2_max_concurrent_streams: None,
         }
     }
 
@@ -706,6 +732,11 @@ impl GrpcConfig {
 
     pub fn permissive_cors(&self) -> bool {
         self.permissive_cors.unwrap_or(true)
+    }
+
+    /// Whether adaptive HTTP/2 windowing should be used. Defaults to `true`.
+    pub fn http2_adaptive_window(&self) -> bool {
+        self.http2_adaptive_window.unwrap_or(true)
     }
 }
 

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -264,15 +264,27 @@ The `submit` section controls how Dolos submits transactions to the network. Thi
 
 The `serve.grpc` section controls the options for the gRPC endpoint that can be used by clients.
 
-| property           | type    | example             |
-| ------------------ | ------- | ------------------- |
-| listen_address     | string  | "[::]:50051"        |
-| tls_client_ca_root | string  | "./ca.pem"          |
-| permissive_cors    | boolean | true (default)      |
+| property                             | type    | example        |
+| ------------------------------------ | ------- | -------------- |
+| listen_address                       | string  | "[::]:50051"   |
+| tls_client_ca_root                   | string  | "./ca.pem"     |
+| permissive_cors                      | boolean | true (default) |
+| http2_adaptive_window                | boolean | true (default) |
+| http2_initial_stream_window_size     | integer | 8388608        |
+| http2_initial_connection_window_size | integer | 16777216       |
+| http2_max_frame_size                 | integer | 16384          |
+| http2_max_concurrent_streams         | integer | 256            |
 
 - `listen_address`: the local address (`IP:PORT`) to listen for incoming gRPC connections (`[::]` represents any IP address).
 - `tls_client_ca_root`: optional path to a CA root file for client TLS authentication.
 - `permissive_cors`: allow cross-origin requests from any origin (defaults to `true`).
+- `http2_adaptive_window`: enable hyper's adaptive (BDP-based) HTTP/2 flow-control windowing, auto-sizing the stream/connection windows to the link instead of pinning them at the 64 KiB default. Defaults to `true`. When enabled, `http2_initial_stream_window_size` and `http2_initial_connection_window_size` are ignored (the two modes are mutually exclusive in hyper).
+- `http2_initial_stream_window_size`: explicit initial stream-level flow-control window in bytes. Only takes effect when `http2_adaptive_window` is set to `false`.
+- `http2_initial_connection_window_size`: explicit initial connection-level flow-control window in bytes. Only takes effect when `http2_adaptive_window` is set to `false`.
+- `http2_max_frame_size`: maximum HTTP/2 frame size in bytes.
+- `http2_max_concurrent_streams`: maximum number of concurrent HTTP/2 streams per connection.
+
+Note: HTTP/2 flow control is hop-by-hop and the receiver advertises the window that gates the sender. For server-streaming RPCs dolos is the sender, so these server-side windows govern downloads only when a client connects to dolos directly; behind a proxy the proxy's advertised window applies instead.
 
 ## `serve.minibf` section
 

--- a/src/serve/grpc/mod.rs
+++ b/src/serve/grpc/mod.rs
@@ -2,7 +2,7 @@ use dolos_core::config::GrpcConfig;
 use pallas::interop::utxorpc::LedgerContext;
 use tonic::transport::{Certificate, Server, ServerTlsConfig};
 use tower_http::cors::CorsLayer;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::prelude::*;
 
@@ -12,6 +12,43 @@ mod masking;
 mod stream;
 mod v1alpha;
 mod v1beta;
+
+/// Applies the HTTP/2 transport tuning from [`GrpcConfig`] to the tonic server
+/// builder.
+///
+/// Adaptive windowing (BDP-based) is on by default and, when enabled, makes the
+/// explicit window sizes moot — hyper auto-sizes the stream/connection windows
+/// to the link. The two modes are mutually exclusive in hyper, so we warn if
+/// both are set rather than silently dropping the fixed sizes.
+fn apply_http2_tuning(mut server: Server, cfg: &GrpcConfig) -> Server {
+    if let Some(f) = cfg.http2_max_frame_size {
+        server = server.max_frame_size(Some(f));
+    }
+    if let Some(s) = cfg.http2_max_concurrent_streams {
+        server = server.max_concurrent_streams(Some(s));
+    }
+
+    if cfg.http2_adaptive_window() {
+        if cfg.http2_initial_stream_window_size.is_some()
+            || cfg.http2_initial_connection_window_size.is_some()
+        {
+            warn!(
+                "grpc: http2_adaptive_window is enabled, so http2_initial_stream_window_size \
+                 and http2_initial_connection_window_size are ignored"
+            );
+        }
+        return server.http2_adaptive_window(Some(true));
+    }
+
+    if let Some(w) = cfg.http2_initial_stream_window_size {
+        server = server.initial_stream_window_size(Some(w));
+    }
+    if let Some(w) = cfg.http2_initial_connection_window_size {
+        server = server.initial_connection_window_size(Some(w));
+    }
+
+    server
+}
 
 #[derive(Clone)]
 pub struct ContextAdapter<T: dolos_core::StateStore>(T);
@@ -77,7 +114,9 @@ where
             CorsLayer::new()
         };
 
-        let mut server = Server::builder().accept_http1(true).layer(cors_layer);
+        let builder = apply_http2_tuning(Server::builder().accept_http1(true), &cfg);
+
+        let mut server = builder.layer(cors_layer);
 
         if let Some(pem) = &cfg.tls_client_ca_root {
             let pem = std::env::current_dir().unwrap().join(pem);


### PR DESCRIPTION
## Summary

Exposes the gRPC server's HTTP/2 transport settings through `GrpcConfig` so operators can tune flow-control windows and stream limits from `dolos.toml`. Previously the tonic transport was built with no HTTP/2 tuning, inheriting hyper/`h2` defaults — a 64 KiB per-stream flow-control window with adaptive (BDP) windowing off — and none of it was reachable through config.

Closes #1010.

## Changes

- **`crates/core/src/config.rs`** — Add five optional HTTP/2 fields to `GrpcConfig`, all backwards-compatible (`#[serde(default, skip_serializing_if = "Option::is_none")]`, existing configs parse unchanged):
  - `http2_adaptive_window` (default: `true`)
  - `http2_initial_stream_window_size`
  - `http2_initial_connection_window_size`
  - `http2_max_frame_size`
  - `http2_max_concurrent_streams`
- **`src/serve/grpc/mod.rs`** — Plumb the fields into `Server::builder()` via a dedicated `apply_http2_tuning` helper (return-early on the adaptive branch).
- **`docs/content/configuration/schema.mdx`** — Document the new fields in the `serve.grpc` reference.

## Example

```toml
[serve.grpc]
listen_address = "[::]:50051"
http2_adaptive_window = true
# or pin explicit windows instead (requires http2_adaptive_window = false):
# http2_initial_stream_window_size     = 8388608   # 8 MiB
# http2_initial_connection_window_size = 16777216  # 16 MiB
```

## Notes / reviewer call-outs

- **Behavior change:** `http2_adaptive_window` defaults to **on**, so windows now auto-size to the BDP instead of being pinned at 64 KiB for *every* deployment, not just opt-in ones. This is the best-practice default but it is a runtime change — flagging it explicitly.
- **Mutual exclusivity:** adaptive windowing and explicit fixed window sizes are mutually exclusive in hyper. Rather than silently dropping the fixed sizes, setting both logs a warning.
- **Scope — this is not the fix for the proxied ~1 MB/s download symptom.** HTTP/2 flow control is hop-by-hop and receiver-advertised; for server-streaming dolos is the *sender*, so these server-side windows govern downloads only when a client connects to dolos directly. Behind the demeter proxy, the proxy already advertises 8 MiB to dolos and the cap lives on the client↔proxy hop (client-side). What this PR delivers: removes dolos as a future/edge bottleneck for direct higher-latency links, enables adaptive windowing as a sane default, tunes the inbound/submit direction, and gives operators a config lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable HTTP/2 transport tuning options including adaptive windowing, initial stream/connection window sizes, maximum frame size, and concurrent stream limits.

* **Documentation**
  * Enhanced gRPC configuration documentation with new HTTP/2 parameters and flow-control behavior guidance for server-streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->