### PR TITLE
feat(cardano): add newly-enacted governance proposal mappings

### DIFF
--- a/crates/cardano/src/hacks.rs
+++ b/crates/cardano/src/hacks.rs
@@ -321,6 +321,14 @@ pub mod proposals {
                 "17e78f5e08ba112509729d81f28005caa161878238df3cfc4af983abdc96f9f3#0" => {
                     Canceled(252)
                 }
+                // Parameter Change enacted at epoch 289
+                "3e1b4d548e3cb10944aa42168c9e0e6c43636e96d0db7fa630645e713c722451#0" => {
+                    Ratified(288)
+                }
+                // Hard Fork Initiation enacted at epoch 294
+                "79fb4bac13dfc272a53357309f70bc8c60f1950137b24585b850147251ff2554#0" => {
+                    Ratified(293)
+                }
                 _ => match protocol {
                     0..=8 => RatifiedCurrentEpoch,
                     _ => Unknown,
@@ -667,6 +675,34 @@ pub mod proposals {
                 // Treasury Withdrawal (6,900,000 ADA)
                 "f35285db3c4e085ad331843b3007737952b8a322bb3216311edc37fdf44ad3da#0" => {
                     Ratified(624)
+                }
+
+                // Treasury Withdrawals batch enacted at epoch 634 (6 outputs)
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#0" => {
+                    Ratified(633)
+                }
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#1" => {
+                    Ratified(633)
+                }
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#2" => {
+                    Ratified(633)
+                }
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#3" => {
+                    Ratified(633)
+                }
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#5" => {
+                    Ratified(633)
+                }
+                "73e171a4c0730b4b59ecae271ab89f12a9d56360b02920e1f95107dbdc1d6762#6" => {
+                    Ratified(633)
+                }
+                // Treasury Withdrawal (3,303,750 ADA) enacted at epoch 635
+                "3f0ff0d848cab1036621f92732fef5ea1cb6466305889777ee95496933dfd1e4#0" => {
+                    Ratified(634)
+                }
+                // Treasury Withdrawal (4,600,000 ADA) enacted at epoch 635
+                "4206ae0bc11ba74f9eb86cd561ba684e44f0f9dfe12bc8f23911422a7e0a75f3#0" => {
+                    Ratified(634)
                 }
 
                 _ => match protocol {


### PR DESCRIPTION
## Summary

Ran the `update-proposals` skill to reconcile the hardcoded Conway governance proposal outcomes in `crates/cardano/src/hacks.rs` against DBSync across all three networks. Dolos doesn't implement DRep voting, so these outcomes are hardcoded; missing entries cause wrong deposit refund timing and missed treasury withdrawals, leading to pot mismatches as epoch tests advance.

## Changes

**Mainnet:**
| Proposal | Type | Outcome |
|----------|------|---------|
| `73e171a4…#0,1,2,3,5,6` | TreasuryWithdrawals (enacted 634) | `Ratified(633)` |
| `3f0ff0d8…#0` | TreasuryWithdrawals 3,303,750 ₳ (enacted 635) | `Ratified(634)` |
| `4206ae0b…#0` | TreasuryWithdrawals 4,600,000 ₳ (enacted 635) | `Ratified(634)` |

**Preprod:**
| Proposal | Type | Outcome |
|----------|------|---------|
| `3e1b4d54…#0` | ParameterChange (enacted 289) | `Ratified(288)` |
| `79fb4bac…#0` | HardForkInitiation (enacted 294) | `Ratified(293)` |

**Preview:** no changes — all enacted proposals already mapped.

Formula used: `Ratified(enacted_epoch - 1)`.

## Dropped/expired check

All early-dropped `ParameterChange` proposals needing `Canceled` entries were already present. Remaining dropped/expired proposals are either `InfoAction` (no on-chain effect) or natural expiry (`dropped = expired + 1`), so `Unknown`/`max_epoch` is correct — no entries needed.

## Verification

`cargo check -p dolos-cardano` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for additional governance proposals on preprod and mainnet networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->