### PR TITLE
chore: Snapshots on R2

### DIFF
--- a/src/bin/dolos/bootstrap/snapshot.rs
+++ b/src/bin/dolos/bootstrap/snapshot.rs
@@ -50,7 +50,7 @@ impl Args {
 }
 
 const DEFAULT_URL_TEMPLATE: &str =
-    "https://dolos-snapshots.s3-accelerate.amazonaws.com/${VERSION}/${NETWORK}/${VARIANT}/${POINT}.tar.gz";
+    "https://dolos-snapshots.txpipe.cloud/${VERSION}/${NETWORK}/${VARIANT}/${POINT}.tar.gz";
 
 fn define_snapshot_url(config: &RootConfig, args: &Args) -> Option<String> {
     if config.upstream.is_emulator() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default snapshot download endpoint configuration. The fallback download host has been changed to a new endpoint when no custom download URL is specified, while maintaining the same path structure for snapshot retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->