### PR TITLE
fix(cardano): fail loud on lagging pool snapshots and unfinished epoch boundaries

### DIFF
--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -184,6 +184,23 @@ impl super::WorkContext {
     ) -> Result<(), ChainError> {
         debug!("committing estart finalize changes");
 
+        // Finalize advances the epoch and rotates every pool in one commit, so
+        // it must run exactly once and only after all shards committed. Require
+        // `committed == total` and that the epoch has not advanced, turning a
+        // would-be double-rotation into a loud error. (Guards finalize only,
+        // not per-shard replay — see the "true shard resume" TODO.)
+        let ended = self.ended_state();
+        let progress = ended.estart_progress.as_ref();
+        let all_shards_committed = progress.is_some_and(|p| p.committed == p.total);
+        if !all_shards_committed {
+            return Err(dolos_core::BrokenInvariant::EpochBoundaryIncomplete {
+                epoch: ended.number,
+                committed: progress.map(|p| p.committed),
+                total: progress.map(|p| p.total),
+            }
+            .into());
+        }
+
         // Collect era transition data first (only 1-2 entities, not a memory concern)
         let era_transition = self.collect_era_transition(state)?;
 

--- a/crates/cardano/src/estart/work_unit.rs
+++ b/crates/cardano/src/estart/work_unit.rs
@@ -15,7 +15,8 @@
 //!
 //! `AccountTransition` is not natively idempotent (re-applying double-rolls
 //! the EpochValue snapshot), so true mid-shard resume requires additional
-//! work — same TODO posture as `EwrapWorkUnit`.
+//! work — same TODO posture as `EwrapWorkUnit`. `finalize` is separately
+//! guarded to run exactly once (see `commit_finalize`).
 
 use std::sync::Arc;
 

--- a/crates/cardano/src/lib.rs
+++ b/crates/cardano/src/lib.rs
@@ -357,105 +357,51 @@ impl dolos_core::ChainLogic for CardanoLogic {
             None => WorkBuffer::Empty,
         };
 
-        // Crash-recovery check: if the previous process crashed mid-boundary,
-        // `EpochState.ewrap_progress` will be `Some(p)` with `p.committed`
-        // equal to the next Ewrap that should have run, and `p.total` the
-        // boundary's shard count captured at the first commit. Detect and
-        // warn — full resume requires re-fetching the boundary block from
-        // upstream, which is tracked separately. The persisted `total` is
-        // used for the in-flight boundary even if `crate::shard::ACCOUNT_SHARDS`
-        // changed across versions, to avoid breaking the in-progress pipeline.
+        // Crash-recovery diagnostics for a boundary interrupted by a prior
+        // crash. The two progress fields are NOT mutually exclusive: under
+        // `EpochWrapUpV3`, `ewrap_progress` is left at `Some(total, total)`
+        // once the close phase finishes and is only cleared by
+        // `EpochTransition` at ESTART finalize — so mid-open both fields are
+        // set and both checks can fire. These only warn; resume itself is not
+        // yet fully idempotent.
+        // TODO: implement true shard resume (#1018).
         if let Ok(epoch) = load_epoch::<D>(state) {
-            if let Some(progress) = epoch.ewrap_progress.as_ref() {
-                let configured = crate::shard::ACCOUNT_SHARDS;
-                if progress.total != configured {
+            let configured = crate::shard::ACCOUNT_SHARDS;
+            let warn_resume = |phase: &'static str, p: &ShardProgress| {
+                if p.total != configured {
                     tracing::warn!(
+                        phase,
                         epoch = epoch.number,
-                        stored_total = progress.total,
+                        stored_total = p.total,
                         configured_total = configured,
-                        "in-flight boundary uses {} shards but ACCOUNT_SHARDS = {}; \
-                         the in-flight boundary will continue with {} (the persisted total) \
-                         and the new value takes effect on the next boundary",
-                        progress.total,
-                        configured,
-                        progress.total,
+                        "CARDANO-003: in-flight boundary shard count differs from configured; \
+                         continuing with the persisted total"
                     );
                 }
-                if progress.committed < progress.total {
+                if p.committed < p.total {
                     tracing::warn!(
+                        phase,
                         epoch = epoch.number,
-                        next_shard = progress.committed,
-                        total_shards = progress.total,
-                        "crash detected mid-boundary: ewrap_progress is set. \
-                         On the next block that triggers the boundary, dolos will \
-                         resume the Ewrap pipeline; correctness depends on shard \
-                         idempotency (state deletes are no-ops if already applied; \
-                         EWrapProgress guards on shard_index). Operators should \
-                         monitor the subsequent boundary for inconsistency. \
-                         TODO: implement true shard resume."
+                        next_shard = p.committed,
+                        total_shards = p.total,
+                        "CARDANO-004: crash detected mid-boundary; resuming on the next boundary trigger"
                     );
                 } else {
                     tracing::warn!(
+                        phase,
                         epoch = epoch.number,
-                        committed = progress.committed,
-                        total_shards = progress.total,
-                        "found EpochState.ewrap_progress.committed == total \
-                         at startup — EWRAP for this boundary closed in a \
-                         prior run but ESTART finalize did not commit before \
-                         crash. The next boundary trigger will short-circuit \
-                         the EwrapWorkUnit (no replay) and resume the ESTART \
-                         pipeline from estart_progress.committed."
+                        committed = p.committed,
+                        total_shards = p.total,
+                        "CARDANO-005: boundary half-closed at startup; resuming the remaining phase"
                     );
                 }
-            }
+            };
 
-            // Same crash-recovery check for the EStart-shard half of the
-            // boundary. Only one of the two progress fields can be set at
-            // any time — Ewrap clears `ewrap_progress` before any
-            // EStart-shard runs, and `EpochTransition` clears
-            // `estart_progress` when the new epoch opens.
-            if let Some(progress) = epoch.estart_progress.as_ref() {
-                let configured = crate::shard::ACCOUNT_SHARDS;
-                if progress.total != configured {
-                    tracing::warn!(
-                        epoch = epoch.number,
-                        stored_total = progress.total,
-                        configured_total = configured,
-                        "in-flight estart-shard boundary uses {} shards but \
-                         ACCOUNT_SHARDS = {}; the in-flight boundary will \
-                         continue with {} (the persisted total) and the new \
-                         value takes effect on the next boundary",
-                        progress.total,
-                        configured,
-                        progress.total,
-                    );
-                }
-                if progress.committed < progress.total {
-                    tracing::warn!(
-                        epoch = epoch.number,
-                        next_shard = progress.committed,
-                        total_shards = progress.total,
-                        "crash detected mid-boundary: estart_progress is set. \
-                         On the next block that triggers the boundary, dolos will \
-                         resume the EStart-shard pipeline; correctness depends on \
-                         shard idempotency (EStartProgress guards on \
-                         shard_index, but AccountTransition is not natively \
-                         idempotent). Operators should monitor the subsequent \
-                         boundary for inconsistency. TODO: implement true shard \
-                         resume."
-                    );
-                } else {
-                    tracing::warn!(
-                        epoch = epoch.number,
-                        committed = progress.committed,
-                        total_shards = progress.total,
-                        "found EpochState.estart_progress.committed == total \
-                         at startup — Estart finalize was not committed before \
-                         crash. The next boundary attempt will re-run \
-                         EStart-shards and finalize; idempotency should keep the \
-                         result correct."
-                    );
-                }
+            if let Some(p) = epoch.ewrap_progress.as_ref() {
+                warn_resume("ewrap", p);
+            }
+            if let Some(p) = epoch.estart_progress.as_ref() {
+                warn_resume("estart", p);
             }
         }
 

--- a/crates/cardano/src/model/pools.rs
+++ b/crates/cardano/src/model/pools.rs
@@ -319,6 +319,12 @@ impl dolos_core::EntityDelta for PoolRegistration {
 pub struct MintedBlocksInc {
     pub(crate) operator: Hash<28>,
     pub(crate) count: u32,
+
+    /// Block epoch, used by `apply` to assert snapshot alignment. Transient
+    /// (`#[serde(skip)]`): WAL deltas are only ever undone, never re-applied,
+    /// so the `0` it decodes to off the WAL is never read.
+    #[serde(skip)]
+    pub(crate) epoch: Epoch,
 }
 
 impl dolos_core::EntityDelta for MintedBlocksInc {
@@ -330,6 +336,18 @@ impl dolos_core::EntityDelta for MintedBlocksInc {
 
     fn apply(&mut self, entity: &mut Option<PoolState>) {
         if let Some(entity) = entity {
+            // `live` is positional: minting into a snapshot that lags this
+            // epoch folds the blocks into a mislabeled slot and corrupts
+            // `blocks_minted`. ESTART keeps every pool aligned, so a mismatch
+            // is a broken invariant — fail loud rather than corrupt.
+            assert!(
+                entity.snapshot.is_at_epoch(self.epoch),
+                "CARDANO-001: pool {} snapshot at epoch {:?} lags block epoch {}",
+                hex::encode(self.operator),
+                entity.snapshot.epoch(),
+                self.epoch,
+            );
+
             entity.blocks_minted_total += self.count;
             let live = entity.snapshot.unwrap_live_mut();
             live.blocks_minted += self.count;
@@ -499,15 +517,6 @@ mod prop_tests {
     }
 
     prop_compose! {
-        fn any_minted_blocks_inc()(
-            operator in root::any_hash_28(),
-            count in 1u32..100u32,
-        ) -> MintedBlocksInc {
-            MintedBlocksInc { operator, count }
-        }
-    }
-
-    prop_compose! {
         fn any_pool_deregistration()(
             operator in root::any_hash_28(),
             epoch in root::any_epoch(),
@@ -547,10 +556,13 @@ mod prop_tests {
 
         #[test]
         fn minted_blocks_inc_roundtrip(
-            entity in prop::option::of(any_pool_state()),
-            delta in any_minted_blocks_inc(),
+            pool in any_pool_state(),
+            count in 1u32..100u32,
         ) {
-            assert_delta_roundtrip(entity, delta);
+            // `apply` asserts alignment, so the delta carries the pool's epoch.
+            let epoch = pool.snapshot.epoch().expect("any_pool_state fills a concrete epoch");
+            let delta = MintedBlocksInc { operator: pool.operator, count, epoch };
+            assert_delta_roundtrip(Some(pool), delta);
         }
 
         #[test]
@@ -576,5 +588,41 @@ mod prop_tests {
         ) {
             assert_delta_roundtrip(Some(entity), delta);
         }
+    }
+
+    /// A snapshot lagging the block's epoch must panic, not silently corrupt
+    /// `blocks_minted`.
+    #[test]
+    #[should_panic(expected = "CARDANO-001")]
+    fn minting_into_lagging_pool_panics() {
+        use dolos_core::EntityDelta as _;
+
+        let operator = Hash::<28>::from([1u8; 28]);
+        let snapshot = PoolSnapshot {
+            is_retired: false,
+            blocks_minted: 0,
+            is_new: false,
+            params: PoolParams {
+                vrf_keyhash: Hash::from([0u8; 32]),
+                pledge: 0,
+                cost: 0,
+                margin: RationalNumber { numerator: 0, denominator: 1 },
+                reward_account: vec![],
+                pool_owners: vec![],
+                relays: vec![],
+                pool_metadata: None,
+            },
+        };
+        let pool = PoolState {
+            operator,
+            snapshot: EpochValue::with_live(5, snapshot),
+            blocks_minted_total: 0,
+            register_slot: 0,
+            retiring_epoch: None,
+            deposit: 0,
+        };
+
+        // Block epoch 6 runs ahead of the pool's epoch-5 snapshot.
+        MintedBlocksInc { operator, count: 1, epoch: 6 }.apply(&mut Some(pool));
     }
 }

--- a/crates/cardano/src/roll/pools.rs
+++ b/crates/cardano/src/roll/pools.rs
@@ -32,7 +32,11 @@ impl BlockVisitor for PoolStateVisitor {
 
         if let Some(key) = block.header().issuer_vkey() {
             let operator: Hash<28> = Hasher::<224>::hash(key);
-            deltas.add_for_entity(MintedBlocksInc { operator, count: 1 });
+            deltas.add_for_entity(MintedBlocksInc {
+                operator,
+                count: 1,
+                epoch,
+            });
         }
 
         Ok(())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -250,8 +250,12 @@ pub enum BrokenInvariant {
     #[error("missing pool {}", hex::encode(.0))]
     MissingPool(Vec<u8>),
 
-    #[error("epoch boundary incomplete")]
-    EpochBoundaryIncomplete,
+    #[error("CARDANO-002: epoch boundary {epoch} incomplete (estart shards {committed:?}/{total:?})")]
+    EpochBoundaryIncomplete {
+        epoch: Epoch,
+        committed: Option<u32>,
+        total: Option<u32>,
+    },
 }
 
 pub type UtxoMap = HashMap<TxoRef, Arc<EraCbor>>;
@@ -441,10 +445,7 @@ pub enum ChainError {
     #[error("epoch value version not found for epoch {0}")]
     EpochValueVersionNotFound(Epoch),
 
-    #[error(
-        "pool snapshot lagging: pool {pool} at epoch {pool_epoch:?}, expected current epoch \
-         {current_epoch} (stake/performance snapshot unavailable for reward calculation)"
-    )]
+    #[error("CARDANO-001: pool {pool} snapshot at epoch {pool_epoch:?}, expected {current_epoch}")]
     PoolSnapshotLagging {
         pool: String,
         pool_epoch: Option<Epoch>,

--- a/docs/content/operations/index.mdx
+++ b/docs/content/operations/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Operations
+sidebar:
+  hidden: true
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Guidance for running and operating a Dolos instance: how it runs, how to read its logs and traces, how to tune performance, and how to act on error codes.
+
+<CardGrid>
+  <LinkCard title="Operation Modes" href="./operations/modes" />
+  <LinkCard title="Logging" href="./operations/logging" />
+  <LinkCard title="Tracing" href="./operations/tracing" />
+  <LinkCard title="Performance" href="./operations/performance" />
+  <LinkCard title="Troubleshooting" href="./operations/troubleshooting" />
+</CardGrid>

--- a/docs/content/operations/troubleshooting.mdx
+++ b/docs/content/operations/troubleshooting.mdx
@@ -1,0 +1,67 @@
+---
+title: Troubleshooting
+sidebar:
+  order: 5
+---
+
+Dolos tags certain operational failures with a stable error code (e.g. `CARDANO-001`). When you see one in the logs, look it up here for what it means and how to act.
+
+Codes are grouped by subsystem: `CARDANO-*` covers ledger / epoch-boundary state. Severity is `error` (the node stops) unless noted as a warning.
+
+Crash-recovery warnings (`CARDANO-003/004/005`) carry a `phase` field of `ewrap` (epoch close) or `estart` (epoch open) indicating which half of the boundary they refer to.
+
+## CARDANO-001 — pool snapshot lagging
+
+```
+CARDANO-001: pool <hash> snapshot at epoch <e>, expected <current>
+```
+
+**Meaning.** A pool's stake/performance snapshot is at an older epoch than the rest of the ledger. Each pool's snapshot window is rotated forward on every epoch boundary; this one was left behind, so the data needed for reward calculation (its `go`/`mark` slots) is missing or misaligned.
+
+**When you see it.** Either at block processing (a block mints into the lagging pool) or at the reward update (RUPD) for the epoch.
+
+**Likely cause.** Inconsistent state persisted by an abnormal shutdown during an epoch boundary — the boundary resume path is not yet fully idempotent. It does not occur during healthy, uninterrupted operation.
+
+**What to do.** The node cannot compute correct rewards from this state, so it stops rather than emit wrong data. Re-bootstrap the node from a trusted snapshot. Capture the full log line (the pool hash and both epochs) when reporting the issue.
+
+## CARDANO-002 — epoch boundary incomplete
+
+```
+CARDANO-002: epoch boundary <e> incomplete (estart shards <committed>/<total>)
+```
+
+**Meaning.** The epoch-opening (ESTART) finalize step was asked to run before all of its sharded work had committed, or after the epoch had already advanced. Finalize must run exactly once per boundary; this guard refuses to run it on an inconsistent boundary rather than double-apply the transition.
+
+**Likely cause.** An abnormal shutdown mid-boundary followed by a resume that did not replay every shard. As with `CARDANO-001`, this points at the not-yet-idempotent boundary resume path.
+
+**What to do.** Restart the node; the boundary is re-driven from its last consistent point. If the error persists across restarts, the on-disk state is inconsistent — re-bootstrap from a trusted snapshot and report the log line (epoch and shard counts).
+
+## CARDANO-003 — boundary shard count changed (warning)
+
+```
+CARDANO-003: in-flight boundary shard count differs from configured; continuing with the persisted total
+```
+
+**Meaning.** A boundary was in flight when the node was last stopped, and the build's shard count has since changed. The in-flight boundary finishes with the count it started with; the new value applies from the next boundary.
+
+**What to do.** Nothing — informational. It only appears once, on the restart that resumes an in-flight boundary.
+
+## CARDANO-004 — crash detected mid-boundary, resuming (warning)
+
+```
+CARDANO-004: crash detected mid-boundary; resuming on the next boundary trigger
+```
+
+**Meaning.** The node stopped while a boundary's sharded work was partway done. On the next block that triggers the boundary, dolos resumes from the last committed shard.
+
+**What to do.** Let it run, then **watch the following boundary**. Resume is not yet fully idempotent (see #1018), so verify the next epoch's data looks consistent. Persisted inconsistency surfaces later as `CARDANO-001` or `CARDANO-002`.
+
+## CARDANO-005 — boundary half-closed at startup, resuming (warning)
+
+```
+CARDANO-005: boundary half-closed at startup; resuming the remaining phase
+```
+
+**Meaning.** One half of a boundary committed before the stop and the other did not (e.g. epoch close finished but epoch open did not). The completed half is not replayed; dolos resumes the remaining phase.
+
+**What to do.** Nothing required; same caveat as `CARDANO-004` — watch the boundary for consistency.


### PR DESCRIPTION
> **Scope note:** this is **hardening / fail-loud**, not recovery. It does **not** implement true shard resume and does **not** repair an already-lagging pool. Root cause (a persisted pool snapshot lagging the epoch) is still unconfirmed — most likely non-idempotent mid-boundary crash resume, flagged by the existing `TODO: implement true shard resume` (restored here) and tracked in #1018.

## Context

Follow-up to #1016, which turned an obscure `unwrap` panic at RUPD into a clear error when a `PoolState` snapshot lags the current epoch. That only *surfaced* the condition. This PR adds two **fail-loud guards** so the same corruption is caught earlier and a half-finished boundary can't silently double-apply.

### What we established
- The healthy boundary path **cannot** produce a lag: ESTART `commit_finalize` advances `EpochState.number` in the **same atomic commit** as every `PoolTransition` + cursor.
- A persisted lag therefore comes from an abnormal crash/resume. The sharding code (#978) already flags this with **`TODO: implement true shard resume`** and the note that **`AccountTransition` is not natively idempotent**. That is the suspected root cause; it is **not fixed here** (see #1018).

## What this PR does (both are guards)

### Piece A — guard the silent-corruption hole
`MintedBlocksInc::apply` accumulates blocks into the pool's positional `live` slot, which only holds this epoch's blocks when the snapshot is aligned. `apply` now **asserts** alignment to the block's epoch before accumulating — a descriptive panic at the origin, consistent with the infallible delta-apply layer's existing invariant `expect`s. The block epoch rides on a transient `#[serde(skip)]` field; WAL deltas are only ever undone, so the WAL format is unchanged.

### Piece B — guard ESTART finalize
`commit_finalize` now asserts every shard committed and the epoch hasn't advanced before rotating pools / advancing the epoch, returning `BrokenInvariant::EpochBoundaryIncomplete` otherwise. A **defensive assertion on the finalize step only** — it does **not** make the per-shard `AccountTransition` replay idempotent (the restored shard-resume TODO stands).

### Error codes + troubleshooting
Both errors are now **codified** with concise messages and documented in a new `docs/content/operations/troubleshooting.mdx`:
- **`CARDANO-001`** — pool snapshot lagging (RUPD path + the `MintedBlocksInc::apply` assert)
- **`CARDANO-002`** — epoch boundary incomplete (ESTART finalize guard)

The verbose explanation/operator guidance moved from the message strings into that page.

## Explicitly NOT in this PR
- **True shard resume** — idempotent mid-boundary resume (the actual fix; #1018).
- **Repair of already-corrupted state** — nodes that already persisted a lag keep failing loud with `CARDANO-001` and need a re-bootstrap.

## Testing
- `cargo clippy --workspace --all-targets` — clean.
- `cargo test -p dolos-cardano --lib` — 122 pass, incl. `minting_into_lagging_pool_panics` (`#[should_panic(expected = "CARDANO-001")]`) and an aligned `minted_blocks_inc_roundtrip`.
- Piece B's positive path is exercised by the boundary-crossing suites (`epoch_pots`, `tests/cardano`) in CI; fixtures are unavailable locally (dangling symlinks, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened epoch-boundary resume to ensure finalize proceeds only when boundary work is fully complete, preventing unwanted era advancement, streaming, archive logging, and cursor updates.
  * Added epoch-aware validation for minted-block deltas to detect pool snapshot lag and reject mismatched-epoch updates with a clear error.
  * Improved epoch-boundary and crash-recovery diagnostics with more precise error reporting, including committed/total details.
* **Documentation**
  * Expanded troubleshooting docs with structured guidance for CARDANO-001 through CARDANO-005.
* **Tests**
  * Updated and extended minted-block delta coverage, including a regression test for epoch-mismatch panics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
