### PR TITLE
chore(trp): bump tx3-cardano and tx3-resolver to 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,18 +4679,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4711,18 +4699,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -4832,17 +4808,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5949,9 +5914,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tx3-cardano"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85887868dcd17f73a22da5743a1cefd1964f2d1770e1c353eff0a9a8c7c1c639"
+checksum = "4236a96b6aca1c023ade08376b9dea9896febe75f45db1415c3d40c213a2b93d"
 dependencies = [
  "hex",
  "pallas",
@@ -5964,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-resolver"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222d1d0c56d7f88c8acb6e9cd0552cc08f92fb90fbb3d3b39b3892f77fc51a2e"
+checksum = "94e3cb94cde957acd65413e379de9e7b9fa4707aac5906577b1b0a157ea3e6b3"
 dependencies = [
  "approx",
  "base64 0.22.1",
@@ -5983,9 +5948,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-sdk"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ebe5c071e568628c648d73f56301fda978ec3c1c1b1a8be179225a6bf7cb36"
+checksum = "16120896b5d73621383f4980b3047769de90aea90fe26f500152d61d2287ddaa"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5996,7 +5961,6 @@ dependencies = [
  "pallas-addresses 1.0.0",
  "pallas-crypto 1.0.0",
  "reqwest",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6006,9 +5970,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e332c5ab744e8f17d54dfa4b6e3e177d5055141a1f37625303d4613277a72"
+checksum = "4bd8b43d04c3d116e901407cf4c6fa4949938f8904dddf7088cb97efcacd8bb2"
 dependencies = [
  "ciborium",
  "hex",

--- a/crates/trp/Cargo.toml
+++ b/crates/trp/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee = { version = "0.24.9", features = ["server"] }
 opentelemetry = "0.30.0"
 opentelemetry_sdk = "0.30.0"
 
-tx3-cardano = "0.21.0"
-tx3-resolver = "0.21.0"
+tx3-cardano = "0.22.0"
+tx3-resolver = "0.22.0"
 
 # tx3-cardano = { path = "../../../../tx3-lang/tx3/crates/tx3-cardano" }
 # tx3-resolver = { path = "../../../../tx3-lang/tx3/crates/tx3-resolver" }
@@ -38,6 +38,6 @@ tx3-resolver = "0.21.0"
 dolos-testing = { path = "../testing" }
 rand = "0.9.1"
 
-tx3-sdk = "0.12.0"
+tx3-sdk = "0.13.0"
 # tx3-sdk = { path = "../../../../rust-sdk" }
 # tx3-sdk = { git = "https://github.com/tx3-lang/rust-sdk.git" }


### PR DESCRIPTION
Bumps the tx3 dependencies in `dolos-trp` to the latest published `0.22.0` line:

- `tx3-cardano` 0.21.0 → 0.22.0
- `tx3-resolver` 0.21.0 → 0.22.0
- `tx3-sdk` (dev-dep) 0.12.0 → 0.13.0
- `tx3-tir` 0.17.0 → 0.18.0 (transitive, via lockfile)

### Why
Dolos was one minor version behind the latest published tx3 crates. This keeps the embedded TRP resolver current with upstream.

### Scope / note
This is a routine version bump with **no behavioral change**. In particular it does **not** add complex/record `invoke` argument support — `tx3-resolver::interop::from_json` in 0.22.0 still only coerces `Int/Bool/Bytes/Address/UtxoRef/Undefined` and rejects record/`List`/`Map`/`Tuple`/`Custom` targets. That remains a separate upstream change.

### Verification
- `cargo build -p dolos-trp` — clean, no breaking-change fallout from 0.21→0.22 / tir 0.17→0.18.
- `cargo test -p dolos-trp` — all 10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to newer versions to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->