### PR TITLE
chore: bump pallas to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,18 +3470,18 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "pallas"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67de60814616eed4524f6d837de2c20a15f8561b1eb47a44bbcba7664ce06af9"
+checksum = "846ff0e3269c223e6ed6202eca1dc98399bc85f7db9be4e4574fab778cfa981b"
 dependencies = [
- "pallas-addresses 1.0.0",
- "pallas-codec 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-codec 1.1.1",
  "pallas-configs",
- "pallas-crypto 1.0.0",
+ "pallas-crypto 1.1.1",
  "pallas-hardano",
- "pallas-network 1.0.0",
- "pallas-primitives 1.0.0",
- "pallas-traverse 1.0.0",
+ "pallas-network 1.1.1",
+ "pallas-primitives 1.1.1",
+ "pallas-traverse 1.1.1",
  "pallas-txbuilder",
  "pallas-utxorpc",
  "pallas-validate",
@@ -3505,17 +3505,17 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a454bf65522d3114aeedbc6e44a0f5a00d384b15c8cd45a16be61d925979602f"
+checksum = "4d10fe64a9b5b4b72d1e9ed3a802a6d87a204385a48bdca0136f7fb9ff8be73f"
 dependencies = [
  "base58",
  "bech32 0.11.1",
  "crc",
  "cryptoxide 0.4.4",
  "hex",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
  "thiserror 2.0.18",
 ]
 
@@ -3533,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243ff83c13d40b3b089dbfe102372484c530da0a917aa60cfce80793aad9d0e8"
+checksum = "84f558ab7f9d4057aba59a3c8f18dcc06876d803dabced52c431b4ae5b137b2a"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -3545,15 +3545,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-configs"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918b8474886a2d8a47ef9fb4809075a693e746af44eaba7625c7c407a6719c6e"
+checksum = "9413d9d84c67434857c08ec2d92c96452671c68fb1921c0c1999a7a699587186"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
- "pallas-addresses 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-primitives 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-primitives 1.1.1",
  "serde",
  "serde_json",
  "serde_with 3.16.0",
@@ -3576,13 +3576,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fb8dcda11769c8f665c398b217efbef46493d449ed503134d39011bdd81e44"
+checksum = "5abe09448466b168f50eb0beaae4e38a16e49bdfe6b2fba5748ea17a025b15b1"
 dependencies = [
  "cryptoxide 0.4.4",
  "hex",
- "pallas-codec 1.0.0",
+ "pallas-codec 1.1.1",
  "rand_core 0.10.1",
  "serde",
  "thiserror 2.0.18",
@@ -3590,17 +3590,17 @@ dependencies = [
 
 [[package]]
 name = "pallas-hardano"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcddd4284dc749b431b4e416753c1d2b6605613b9dea2c76477255dfdbc2c2e1"
+checksum = "adf818b49428697b0d0d5e680fecffa94020b141460dc6ebfe45295b43c8a6b1"
 dependencies = [
  "binary-layout",
  "hex",
- "pallas-addresses 1.0.0",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-network 1.0.0",
- "pallas-traverse 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-network 1.1.1",
+ "pallas-traverse 1.1.1",
  "serde",
  "serde_json",
  "serde_with 3.16.0",
@@ -3629,15 +3629,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977b79ac140dfaa8d8fb887ec741957961b6e877a9b5ea72b42bacadeae6428d"
+checksum = "4854a1aacddb0021d35469a961e494cb6d2bd2d6de82c6ee4ca2768861cf16cb"
 dependencies = [
  "byteorder",
  "hex",
  "itertools 0.14.0",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
  "rand 0.10.1",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3663,13 +3663,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100ae20c24335361a2ca50722726ce8d26f6b1a5014e2851acbed6428c9975c0"
+checksum = "35c2b627b97f708bbb0252834e300d56b1ccea9c982c0e4189d1a414c1b53c18"
 dependencies = [
  "hex",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
  "serde",
  "serde_json",
 ]
@@ -3693,16 +3693,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bc516b69c6023952fc76e6bc5d4a68a2ab41b1ad555e6b002d9c6654fc4cf7"
+checksum = "ba24ccce6561ab01d910aa8a89abf7f949f4009c0e36771e763f09d3efba1eed"
 dependencies = [
  "hex",
  "itertools 0.14.0",
- "pallas-addresses 1.0.0",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-primitives 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-primitives 1.1.1",
  "paste",
  "serde",
  "thiserror 2.0.18",
@@ -3710,16 +3710,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-txbuilder"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70249fa4fc477d6f53153cf3e2a34e703e43d1b592f787907ad19ee04e0233c"
+checksum = "24573093e2c342a63cda545ef799c51248a9ccb07061a9de0f2126b694830697"
 dependencies = [
  "hex",
- "pallas-addresses 1.0.0",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-primitives 1.0.0",
- "pallas-traverse 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-primitives 1.1.1",
+ "pallas-traverse 1.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3727,14 +3727,14 @@ dependencies = [
 
 [[package]]
 name = "pallas-utxorpc"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b7e243b3e4f4d652b6e4b1cf33a1eb6630d329e958623af642c5de636a788e"
+checksum = "bb8a5432ea38e559378d5872d012c5cf34df95e0ed7e5a224aa2645ce57f9675"
 dependencies = [
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-primitives 1.0.0",
- "pallas-traverse 1.0.0",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-primitives 1.1.1",
+ "pallas-traverse 1.1.1",
  "pallas-validate",
  "prost-types 0.13.5",
  "utxorpc-spec 0.19.0",
@@ -3742,19 +3742,19 @@ dependencies = [
 
 [[package]]
 name = "pallas-validate"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efd1ec0b05f7691012740c4ce6edc0c65399011eef05bb774e58b80b216481c"
+checksum = "dfaac47eb61c648c32cb98bd9fc74414bd173ee57b17c59412242731d0365964"
 dependencies = [
  "amaru-uplc",
  "chrono",
  "hex",
  "itertools 0.14.0",
- "pallas-addresses 1.0.0",
- "pallas-codec 1.0.0",
- "pallas-crypto 1.0.0",
- "pallas-primitives 1.0.0",
- "pallas-traverse 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-codec 1.1.1",
+ "pallas-crypto 1.1.1",
+ "pallas-primitives 1.1.1",
+ "pallas-traverse 1.1.1",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -5958,8 +5958,8 @@ dependencies = [
  "cryptoxide 0.4.4",
  "ed25519-bip32",
  "hex",
- "pallas-addresses 1.0.0",
- "pallas-crypto 1.0.0",
+ "pallas-addresses 1.1.1",
+ "pallas-crypto 1.1.1",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ readme = "README.md"
 authors = ["TxPipe <hello@txpipe.io>"]
 
 [workspace.dependencies]
-pallas = { version = "1.0.0", features = ["hardano", "phase2", "unstable"] }
+pallas = { version = "1.1.1", features = ["hardano", "phase2", "unstable"] }
 # pallas = { git = "https://github.com/txpipe/pallas.git", rev = "a7b5a86", features = ["hardano", "phase2", "unstable"] }
 # pallas = { path = "../pallas/pallas", features = ["hardano", "phase2", "unstable"] }
 


### PR DESCRIPTION
Bumps the `pallas` workspace dependency from `1.0.0` to `1.1.1` (latest).

- Updated `version` in `Cargo.toml` workspace dependencies
- Refreshed `Cargo.lock` (all `pallas-*` sub-crates moved to 1.1.1)
- `cargo check --workspace` compiles cleanly; no source changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pallas dependency to version 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->