### PR TITLE
fix(bootstrap): keep snapshot progress bar live during ranged download

### DIFF
--- a/src/bin/dolos/bootstrap/ranged.rs
+++ b/src/bin/dolos/bootstrap/ranged.rs
@@ -182,8 +182,8 @@ impl Drop for RangedReader {
 }
 
 /// Download a single byte range `[start, end]` into `path`, retrying transient
-/// failures. Progress is advanced by the chunk length only on success, so a
-/// retried chunk is never double-counted.
+/// failures. Progress advances as bytes arrive; a failed attempt rolls its
+/// bytes back before retrying, so a retried chunk is never double-counted.
 fn download_chunk(
     client: &Client,
     url: &str,
@@ -196,11 +196,8 @@ fn download_chunk(
     let mut attempt = 0;
 
     loop {
-        match try_download_chunk(client, url, &range, path) {
-            Ok(()) => {
-                progress.inc(end - start + 1);
-                return Ok(());
-            }
+        match try_download_chunk(client, url, &range, path, progress) {
+            Ok(()) => return Ok(()),
             Err(e) => {
                 // Clean up any partial file before retrying.
                 let _ = std::fs::remove_file(path);
@@ -220,7 +217,13 @@ fn download_chunk(
     }
 }
 
-fn try_download_chunk(client: &Client, url: &str, range: &str, path: &Path) -> io::Result<()> {
+fn try_download_chunk(
+    client: &Client,
+    url: &str,
+    range: &str,
+    path: &Path,
+    progress: &ProgressBar,
+) -> io::Result<()> {
     let mut response = client
         .get(url)
         .header(RANGE, range)
@@ -231,16 +234,30 @@ fn try_download_chunk(client: &Client, url: &str, range: &str, path: &Path) -> i
     let mut file = File::create(path)?;
     let mut buf = vec![0u8; 256 * 1024];
 
-    loop {
-        let n = response.read(&mut buf).map_err(io::Error::other)?;
-        if n == 0 {
-            break;
+    // Advance the bar as bytes arrive so it animates continuously rather than
+    // jumping once per completed chunk. `written` tracks this attempt so a
+    // failed attempt can be rolled back before a retry re-downloads the range,
+    // keeping the bar from over-counting past the total.
+    let mut written = 0u64;
+    let result = (|| -> io::Result<()> {
+        loop {
+            let n = response.read(&mut buf).map_err(io::Error::other)?;
+            if n == 0 {
+                break;
+            }
+            file.write_all(&buf[..n])?;
+            progress.inc(n as u64);
+            written += n as u64;
         }
-        file.write_all(&buf[..n])?;
+        file.flush()?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        progress.set_position(progress.position().saturating_sub(written));
     }
 
-    file.flush()?;
-    Ok(())
+    result
 }
 
 /// Spawn the background downloader and return a reader over the staged chunks.

--- a/src/bin/dolos/bootstrap/snapshot.rs
+++ b/src/bin/dolos/bootstrap/snapshot.rs
@@ -142,6 +142,10 @@ fn fetch_snapshot_ranged(
 
     let progress = feedback.bytes_progress_bar();
     progress.set_length(total_size);
+    // Keep the bar redrawing even while the downloader is blocked on
+    // backpressure (waiting for the extractor to free a window slot), so it
+    // never looks frozen during a legitimate pause.
+    progress.enable_steady_tick(std::time::Duration::from_millis(120));
 
     let reader = ranged::ranged_reader(
         client.clone(),


### PR DESCRIPTION
## Problem

Follow-up to #1025 (ranged ring-buffer snapshot download). During a bootstrap the progress bar **looked frozen** even though the download was clearly progressing.

## Root cause

In the ranged downloader, progress was advanced **once per completed 64 MiB chunk**. So the bar sat motionless for seconds at a time while a chunk downloaded, then jumped — the opposite of the old single-stream path, which incremented on every small read and therefore looked smooth.

## Fix

- **Increment per read** (256 KiB granularity) as bytes arrive within each chunk, instead of once per finished chunk.
- **Roll back a failed attempt's bytes** before retrying, so a retried chunk re-downloads its range without the bar over-counting past the total.
- **Enable a steady tick (120 ms)** so the bar keeps redrawing even while the downloader is legitimately paused on window backpressure (waiting for the extractor to free a slot).

## Verification

- `cargo build` + `cargo clippy` clean.
- Live-endpoint e2e test (`ranged_matches_direct_fetch`, `--ignored`) passes, including its `progress.position() == total` assertion — confirming per-read increments sum exactly to the total with no double-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Download progress bars now continuously update in real-time as data streams during ranged requests, replacing batch updates after completion.
* Progress displays remain responsive during snapshot downloads, preventing the UI from appearing frozen during system backpressure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->