### PR TITLE
fix(cardano): inject Plutus POSIXTime in milliseconds for mempool validation

### DIFF
--- a/crates/cardano/src/eras.rs
+++ b/crates/cardano/src/eras.rs
@@ -50,6 +50,12 @@ impl EraSummary {
 
 pub type Timestamp = u64;
 
+/// Milliseconds per second.
+///
+/// [`ChainSummary`] stores time in seconds; Plutus `POSIXTime` is in
+/// milliseconds. Used when crossing that boundary.
+const MS_PER_SECOND: u64 = 1000;
+
 #[derive(Debug, Default, Clone)]
 pub struct ChainSummary {
     past: Vec<EraSummary>,
@@ -72,6 +78,27 @@ impl ChainSummary {
     pub fn slot_time(&self, slot: u64) -> Timestamp {
         let era = self.era_for_slot(slot);
         era.slot_time(slot)
+    }
+
+    /// Build a Plutus [`SlotConfig`] from the edge era.
+    ///
+    /// [`ChainSummary`] keeps `slot_length` and `timestamp` in **seconds**
+    /// (the Ouroboros era-summary convention), but a Plutus `ScriptContext`
+    /// expects `POSIXTime` in **milliseconds**. Pallas' `SlotConfig` does no
+    /// scaling of its own (`zero_time + (slot - zero_slot) * slot_length`), so
+    /// both fields must already be in milliseconds. Convert here, at the seam
+    /// between dolos' seconds-world and pallas' ms-world, so no call site has
+    /// to remember the unit mismatch.
+    pub fn to_pallas_slot_config(
+        &self,
+    ) -> pallas::ledger::validate::phase2::script_context::SlotConfig {
+        let edge = self.edge();
+
+        pallas::ledger::validate::phase2::script_context::SlotConfig {
+            slot_length: edge.slot_length * MS_PER_SECOND,
+            zero_slot: edge.start.slot,
+            zero_time: edge.start.timestamp * MS_PER_SECOND,
+        }
     }
 
     pub fn append_era(&mut self, protocol: u16, era: EraSummary) {
@@ -251,5 +278,37 @@ pub fn load_active_era<D: Domain>(
             Err(_) => Err(ChainError::EraNotFound),
         },
         None => Err(ChainError::EraNotFound),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_config_is_in_milliseconds() {
+        // Mainnet Shelley edge era: time in seconds, slot length of 1 second.
+        let mut summary = ChainSummary::default();
+        summary.append_era(
+            2,
+            EraSummary {
+                start: EraBoundary {
+                    epoch: 208,
+                    slot: 4_492_800,
+                    timestamp: 1_596_059_091,
+                },
+                end: None,
+                epoch_length: 432_000,
+                slot_length: 1,
+                protocol: 2,
+            },
+        );
+
+        let sc = summary.to_pallas_slot_config();
+
+        // POSIXTime must be milliseconds; this matches pallas' mainnet default.
+        assert_eq!(sc.slot_length, 1_000);
+        assert_eq!(sc.zero_slot, 4_492_800);
+        assert_eq!(sc.zero_time, 1_596_059_091_000);
     }
 }

--- a/crates/cardano/src/validate.rs
+++ b/crates/cardano/src/validate.rs
@@ -108,11 +108,9 @@ pub fn evaluate_tx<D: Domain>(
 
     let pparams = crate::utils::pparams_to_pallas(&pparams);
 
-    let slot_config = pallas::ledger::validate::phase2::script_context::SlotConfig {
-        slot_length: pparams.slot_length(),
-        zero_slot: eras.edge().start.slot,
-        zero_time: eras.edge().start.timestamp,
-    };
+    // `eras` keeps slot_length/timestamp in seconds; the Plutus ScriptContext
+    // needs POSIXTime in milliseconds. The conversion lives in the helper.
+    let slot_config = eras.to_pallas_slot_config();
 
     let input_refs = tx.requires().iter().map(From::from).collect();
 


### PR DESCRIPTION
## Summary

Phase-2 script-context evaluation in the mempool (`evaluate_tx` in `crates/cardano/src/validate.rs`) built pallas' `SlotConfig` directly from `ChainSummary` values, which are stored in **seconds** (the Ouroboros era-summary convention). Pallas' `SlotConfig` expects **milliseconds** and does no scaling of its own:

```rust
// pallas-validate/src/phase2/script_context.rs
let ms_after_begin = (slot - sc.zero_slot) * sc.slot_length;
sc.zero_time + ms_after_begin   // units == input units, no *1000
```

As a result the `POSIXTime` exposed in `txInfoValidRange` was **1000× too small**. Any Plutus script that inspects the validity range (deadlines, time-locks) would mis-validate transactions in the mempool.

## Root cause

`ChainSummary`/`EraSummary` keep `slot_length` and `timestamp` in seconds (`forks.rs` divides slot duration by 1000; `start.timestamp` comes from `chrono::DateTime::timestamp()`, Unix seconds). Every other consumer already converts at the boundary — e.g. the gRPC era-summary path does `boundary.timestamp.saturating_mul(1000)` (`src/serve/grpc/*/query.rs:702`). The mempool validation path was the one site that fed seconds straight into pallas' ms-based `SlotConfig`.

## Fix

The mismatch is an impedance boundary between two libraries with different unit conventions (dolos = seconds, pallas Plutus = milliseconds). Pallas is correct as-is — its contract matches upstream `cardano-ledger`'s `SlotConfig` — so the conversion belongs on the dolos side, at the seam.

- Add `ChainSummary::to_pallas_slot_config()`, which converts both `slot_length` and `zero_time` from seconds to milliseconds in one named place, so no future call site has to remember the unit mismatch.
- Use it from `evaluate_tx`.

## Testing

- New unit test `slot_config_is_in_milliseconds` using mainnet Shelley values — the expected output (`slot_length: 1000`, `zero_slot: 4492800`, `zero_time: 1596059091000`) exactly matches pallas' documented mainnet `SlotConfig::default()`.
- `cargo clippy -p dolos-cardano` clean; `cargo build --bin dolos` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal slot configuration handling by consolidating time conversion logic for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->