### PR TITLE
docs: document issue label structure in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Please follow these basic guidelines when filling a feature request:
 Issues are organized with a few small label families:
 
 - **Type** — the kind of work: `bug`, `enhancement`, `documentation`, `question`.
-- **`area:*`** — the affected subsystem, mirroring our commit scopes: `area:cardano`, `area:minibf`, `area:trp`, `area:utxorpc`, `area:cli`, `area:sync`, `area:storage`, `area:ogmios`, `area:bootstrap`, `area:observability`, `area:testing`.
+- **`area:*`** — the affected subsystem, mirroring our commit scopes: `area:cardano`, `area:minibf`, `area:trp`, `area:utxorpc`, `area:cli`, `area:sync`, `area:storage`, `area:bootstrap`, `area:observability`, `area:testing`.
 - **Status** — triage state: `needs-triage` (not yet reviewed), `needs-info` (waiting on the reporter), `blocked`, `duplicate`, `invalid`, `wontfix`.
 - **Contributor** — good entry points: `good first issue`, `help wanted`, `agent-friendly` (well-scoped for an AI coding agent), `githoney-bounty` (has an associated Githoney bounty).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,17 @@ Please follow these basic guidelines when filling a feature request:
 - Create a new github issue
 - Provide a description of your use case (how would you use the new feature)
 
+## Issue Labels
+
+Issues are organized with a few small label families:
+
+- **Type** — the kind of work: `bug`, `enhancement`, `documentation`, `question`.
+- **`area:*`** — the affected subsystem, mirroring our commit scopes: `area:cardano`, `area:minibf`, `area:trp`, `area:utxorpc`, `area:cli`, `area:sync`, `area:storage`, `area:ogmios`, `area:bootstrap`, `area:observability`, `area:testing`.
+- **Status** — triage state: `needs-triage` (not yet reviewed), `needs-info` (waiting on the reporter), `blocked`, `duplicate`, `invalid`, `wontfix`.
+- **Contributor** — good entry points: `good first issue`, `help wanted`, `agent-friendly` (well-scoped for an AI coding agent), `githoney-bounty` (has an associated Githoney bounty).
+
+Maintainers apply labels during triage, so you don't need to label your own issues. New here? Start by filtering for `good first issue` and `help wanted`.
+
 ## Pull Requests
 
 All PRs are welcome, but please take into account these requirements for your contribution to be considered by the maintainers:


### PR DESCRIPTION
## Summary

Adds an **Issue Labels** section to `.github/CONTRIBUTING.md` documenting the label taxonomy now in use, so contributors understand how issues are organized.

The section covers four label families:
- **Type** — `bug`, `enhancement`, `documentation`, `question`
- **`area:*`** — subsystem labels mirroring our commit scopes (`area:cardano`, `area:minibf`, `area:trp`, `area:utxorpc`, `area:cli`, `area:sync`, `area:storage`, `area:ogmios`, `area:bootstrap`, `area:observability`, `area:testing`)
- **Status** — `needs-triage`, `needs-info`, `blocked`, `duplicate`, `invalid`, `wontfix`
- **Contributor** — `good first issue`, `help wanted`, `agent-friendly`, `githoney-bounty`

It also notes that maintainers apply labels at triage and points newcomers to the entry-point labels.

Docs-only change; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Issue Labels” section to the contribution guide.
  * Clarified how issues are categorized using label families for work type, area, triage status, and contributor starting points.
  * Included guidance that maintainers apply labels during triage, including how to filter for “good first issue” and “help wanted.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->