### PR TITLE
fix: recover from unclean shutdown using PID-based lockfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base64.workspace = true
 bech32.workspace = true
 bincode.workspace = true
 chrono.workspace = true
+libc = "0.2"
 futures-core.workspace = true
 futures-util.workspace = true
 hex.workspace = true

--- a/src/serve/o7s_unix/mod.rs
+++ b/src/serve/o7s_unix/mod.rs
@@ -128,8 +128,14 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
                     .map_err(|e| ServeError::Internal(e.into()))?;
             } else {
                 return Err(ServeError::Internal(
-                    format!("socket {} is in use by PID {}", cfg.service.listen_path.display(), 
-                        std::fs::read_to_string(&lock_path).unwrap_or_default().trim()).into(),
+                    format!(
+                        "socket {} is in use by PID {}",
+                        cfg.service.listen_path.display(),
+                        std::fs::read_to_string(&lock_path)
+                            .unwrap_or_default()
+                            .trim()
+                    )
+                    .into(),
                 ));
             }
         }

--- a/src/serve/o7s_unix/mod.rs
+++ b/src/serve/o7s_unix/mod.rs
@@ -129,7 +129,7 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
             } else {
                 return Err(ServeError::Internal(
                     format!("socket {} is in use by PID {}", cfg.service.listen_path.display(), 
-                        std::fs::read_to_string(&lock_path).unwrap_or_default().trim().to_string()).into(),
+                        std::fs::read_to_string(&lock_path).unwrap_or_default().trim()).into(),
                 ));
             }
         }

--- a/src/serve/o7s_unix/mod.rs
+++ b/src/serve/o7s_unix/mod.rs
@@ -6,6 +6,22 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::prelude::*;
 
+/// Check if a process with the given PID is still running
+fn is_process_running(pid: u32) -> bool {
+    // Send signal 0 to check if a process exists without affecting it.
+    // Returns true if the process is running, false if it doesn't exist
+    // or we lack permission (which means something else owns the pid).
+    #[cfg(unix)]
+    {
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
 mod chainsync;
 mod statequery;
 mod utils;
@@ -95,11 +111,31 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
     #[instrument(skip_all)]
     async fn run(cfg: Self::Config, domain: D, cancel: C) -> Result<(), ServeError> {
         // preventive removal of socket file in case of unclean shutdown
+        // check if a stale PID lockfile exists and the process is dead before removing
+        let lock_path = cfg.service.listen_path.with_extension("pid");
         if std::fs::metadata(&cfg.service.listen_path).is_ok() {
-            debug!("preventive removal of socket file");
-            std::fs::remove_file(&cfg.service.listen_path)
-                .map_err(|e| ServeError::Internal(e.into()))?;
+            let stale = match std::fs::read_to_string(&lock_path) {
+                Ok(pid_str) => {
+                    let pid: u32 = pid_str.trim().parse().unwrap_or(0);
+                    pid == 0 || !is_process_running(pid)
+                }
+                Err(_) => true, // no lockfile = stale, safe to remove
+            };
+            if stale {
+                debug!("preventive removal of stale socket file");
+                let _ = std::fs::remove_file(&lock_path);
+                std::fs::remove_file(&cfg.service.listen_path)
+                    .map_err(|e| ServeError::Internal(e.into()))?;
+            } else {
+                return Err(ServeError::Internal(
+                    format!("socket {} is in use by PID {}", cfg.service.listen_path.display(), 
+                        std::fs::read_to_string(&lock_path).unwrap_or_default().trim().to_string()).into(),
+                ));
+            }
         }
+        // write our PID to the lockfile
+        std::fs::write(&lock_path, std::process::id().to_string())
+            .map_err(|e| ServeError::Internal(e.into()))?;
 
         let mut tasks = TaskTracker::new();
 
@@ -119,6 +155,8 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
                 return Err(ServeError::Internal(error.into()));
             }
         }
+        // clean up PID lockfile
+        let _ = std::fs::remove_file(cfg.service.listen_path.with_extension("pid"));
 
         // notify the tracker that we're done receiving new tasks. Without this explicit
         // close, the wait will block forever.


### PR DESCRIPTION
Fixes #293

When dolos is killed with `kill -9`, the Unix socket file remains on disk, preventing restart with `Address already in use (os error 48)`.

This implements the lockfile approach suggested in the issue:

1. **On startup**: Write a `.pid` file alongside the socket containing the current process ID
2. **On startup (stale socket detected)**: Read the PID from the lockfile and check if the process is still running using `kill(pid, 0)` (signal 0 = no-op, just checks existence)
3. **If process is dead**: Safely remove the stale socket and proceed
4. **If process is alive**: Return a clear error: `socket X is in use by PID Y`
5. **On graceful shutdown**: Clean up both the socket and the PID lockfile

The existing code already tried to remove stale sockets, but it had no way to know if another dolos instance was legitimately using the socket. The PID lockfile solves this.

Changes:
- `src/serve/o7s_unix/mod.rs`: Added `is_process_running()` helper, PID lockfile logic on startup, lockfile cleanup on shutdown
- `Cargo.toml`: Added `libc = "0.2"` dependency (already transitively included via `nix`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup validation by checking a previously recorded PID and confirming whether the process is still running before reusing an existing socket.
  * Prevents accidental socket reuse by detecting stale or invalid PID lockfile state and refusing startup when the socket is actively in use.
  * Added PID lockfile handling to automatically clear stale/invalid lockfiles and perform best-effort removal of the PID lockfile during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->