### PR TITLE
chore: link high-stakes TODOs to tracking issues

### DIFF
--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -162,7 +162,7 @@ impl BoundaryWork {
                 // refund schedule. With this order, the refund clones the live
                 // values with rewards already applied.
                 // TODO: move retires to ESTART (after the snapshot has been taken)
-                // and drop this ordering hack.
+                // and drop this ordering hack. (#1037)
                 visitor_rewards.visit_account(self, &account_id, &account)?;
                 visitor_drops.visit_account(self, &account_id, &account)?;
             }

--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -244,7 +244,7 @@ pub fn migrate_pparams_version(
         // Van Rossem: intra-era hard-fork to protocol version 11
         (10, 11) => intra_era_hardfork(current, to),
         (from, to) => {
-            unimplemented!("don't know how to bump from version {from} to {to}",)
+            unimplemented!("don't know how to bump from version {from} to {to} (#1033)",)
         }
     }
 }

--- a/crates/cardano/src/genesis/staking.rs
+++ b/crates/cardano/src/genesis/staking.rs
@@ -48,7 +48,7 @@ fn parse_pool(dto: &ConfigPool) -> PoolState {
             reward_account: parse_reward_account(&dto.reward_account),
             vrf_keyhash: dto.vrf.parse().unwrap(),
 
-            // TODO: finish parsing the initial pool set
+            // TODO: finish parsing the initial pool set (#1038)
             pool_owners: vec![],
             relays: vec![],
             pool_metadata: None,

--- a/crates/cardano/src/pots.rs
+++ b/crates/cardano/src/pots.rs
@@ -635,5 +635,5 @@ mod tests {
     }
 
     // TODO: add property based testing that ensures that the pots are
-    // consistent
+    // consistent (#1039)
 }

--- a/crates/cardano/src/roll/batch.rs
+++ b/crates/cardano/src/roll/batch.rs
@@ -148,7 +148,7 @@ impl WorkBatch {
     where
         D: Domain<Chain = CardanoLogic>,
     {
-        // TODO: paralelize in chunks
+        // TODO: paralelize in chunks (#1040)
 
         let all_refs: Vec<_> = self
             .blocks
@@ -285,7 +285,7 @@ impl WorkBatch {
         }
 
         // TODO: we treat the UTxO set differently due to tech-debt. We should migrate
-        // this into the entity system.
+        // this into the entity system. (#1042)
         for block in self.blocks.iter() {
             if let Some(utxo_delta) = &block.utxo_delta {
                 writer.apply_utxoset(utxo_delta)?;

--- a/crates/cardano/src/roll/mod.rs
+++ b/crates/cardano/src/roll/mod.rs
@@ -568,7 +568,7 @@ pub fn compute_delta<D: Domain>(
         builder.crawl()?;
 
         // TODO: we treat the UTxO set differently due to tech-debt. We should migrate
-        // this into the entity system.
+        // this into the entity system. (#1042)
         let blockd = block.decoded();
         let blockd = blockd.view();
         let utxos = utxoset::compute_apply_delta(blockd, &batch.utxos_decoded)?;

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -394,7 +394,7 @@ pub trait StateStore: Sized + Send + Sync + Clone {
     //     Ok(EntityValueIterTyped::<E>::new(inner, ns))
     // }
 
-    // TODO: generalize UTxO Set into generic entity system
+    // TODO: generalize UTxO Set into generic entity system (#1042)
 
     fn get_utxos(&self, refs: Vec<TxoRef>) -> Result<UtxoMap, StateError>;
 }

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -314,7 +314,7 @@ impl CoreIndexStore for IndexStore {
     }
 
     fn copy(&self, _target: &Self) -> Result<(), IndexError> {
-        todo!("copy not implemented for fjall index store")
+        todo!("copy not implemented for fjall index store (#1036)")
     }
 
     fn cursor(&self) -> Result<Option<ChainPoint>, IndexError> {

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -321,7 +321,7 @@ impl CoreStateStore for StateStore {
     ) -> Result<Self::EntityValueIter, StateError> {
         // Multimap not supported - panic if called
         unimplemented!(
-            "iter_entity_values is not supported in fjall state store (no multimap support)"
+            "iter_entity_values is not supported in fjall state store (no multimap support) (#1036)"
         )
     }
 

--- a/crates/redb3/src/state/mod.rs
+++ b/crates/redb3/src/state/mod.rs
@@ -137,7 +137,7 @@ impl StateStore {
             table.initialize(&mut wx)?;
         }
 
-        // TODO: refactor into entities model
+        // TODO: refactor into entities model (#1042)
         utxoset::UtxosTable::initialize(&wx)?;
 
         wx.commit()?;

--- a/crates/redb3/src/state/utxoset.rs
+++ b/crates/redb3/src/state/utxoset.rs
@@ -280,7 +280,7 @@ mod tests {
         apply_utxoset!(store, &indexes, [&genesis]);
 
         // TODO: the store is not persisting the cursor unless it's a specific point. We
-        // need to fix this in the next breaking change version.
+        // need to fix this in the next breaking change version. (#1035)
         //assert_eq!(store.cursor().unwrap(), Some(ChainPoint::Origin));
 
         let bobs = get_test_address_utxos(&store, &indexes, TestAddress::Bob);
@@ -329,7 +329,7 @@ mod tests {
         apply_utxoset!(store, &indexes, [&undo]);
 
         // TODO: the store is not persisting the origin cursor, instead it's keeping it
-        // empty. We should fix this in the next breaking change version.
+        // empty. We should fix this in the next breaking change version. (#1035)
         assert_eq!(store.read_cursor().unwrap(), None);
 
         let bobs = get_test_address_utxos(&store, &indexes, TestAddress::Bob);

--- a/src/bin/dolos/data/dump_logs.rs
+++ b/src/bin/dolos/data/dump_logs.rs
@@ -296,7 +296,7 @@ const POOL_HRP: bech32::Hrp = bech32::Hrp::parse_unchecked("pool");
 impl TableRow for StakeLog {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for stakes logs");
+            todo!("dbsync format not supported for stakes logs (#1032)");
         }
         vec![
             //"pool hex",
@@ -314,7 +314,7 @@ impl TableRow for StakeLog {
 
     fn row(&self, key: &LogKey, ctx: &RowContext) -> Vec<String> {
         if matches!(ctx.format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for stakes logs");
+            todo!("dbsync format not supported for stakes logs (#1032)");
         }
         let temporal = TemporalKey::from(key.clone());
         let epoch = u64::from_be_bytes(temporal.as_ref().try_into().unwrap());

--- a/src/bin/dolos/data/dump_state.rs
+++ b/src/bin/dolos/data/dump_state.rs
@@ -54,7 +54,7 @@ fn format_stake_at(account: &AccountState, epoch: Epoch) -> String {
 impl TableRow for AccountState {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for accounts state");
+            todo!("dbsync format not supported for accounts state (#1032)");
         }
         vec![
             "cred",
@@ -72,7 +72,7 @@ impl TableRow for AccountState {
 
     fn row(&self, key: &EntityKey, _network: AddressNetwork, format: OutputFormat) -> Vec<String> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for accounts state");
+            todo!("dbsync format not supported for accounts state (#1032)");
         }
         let epoch = self.stake.epoch().unwrap_or_default();
 
@@ -97,7 +97,7 @@ impl TableRow for AccountState {
 impl TableRow for EpochState {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for epochs state");
+            todo!("dbsync format not supported for epochs state (#1032)");
         }
         vec![
             "number",
@@ -116,7 +116,7 @@ impl TableRow for EpochState {
 
     fn row(&self, _key: &EntityKey, _network: AddressNetwork, format: OutputFormat) -> Vec<String> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for epochs state");
+            todo!("dbsync format not supported for epochs state (#1032)");
         }
         let pparams = self.pparams.live();
 
@@ -205,7 +205,7 @@ impl TableRow for EraSummary {
 impl TableRow for PendingRewardState {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for pending rewards state");
+            todo!("dbsync format not supported for pending rewards state (#1032)");
         }
         vec![
             "stake bech32",
@@ -221,7 +221,7 @@ impl TableRow for PendingRewardState {
 
     fn row(&self, key: &EntityKey, network: AddressNetwork, format: OutputFormat) -> Vec<String> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for pending rewards state");
+            todo!("dbsync format not supported for pending rewards state (#1032)");
         }
         let stake_hex = hex::encode(key.as_ref());
         let stake_bech32 = pallas_extras::stake_credential_to_address(network, &self.credential)
@@ -278,7 +278,7 @@ fn format_pool_epoch(values: &EpochValue<PoolSnapshot>, epoch_delta: u64) -> Str
 impl TableRow for PoolState {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for pools state");
+            todo!("dbsync format not supported for pools state (#1032)");
         }
         vec![
             "key",
@@ -295,7 +295,7 @@ impl TableRow for PoolState {
 
     fn row(&self, key: &EntityKey, _network: AddressNetwork, format: OutputFormat) -> Vec<String> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for pools state");
+            todo!("dbsync format not supported for pools state (#1032)");
         }
         let entity_key = key.clone();
         let pool_hash = entity_key.as_ref()[..28].try_into().unwrap();
@@ -323,7 +323,7 @@ impl TableRow for PoolState {
 impl TableRow for ProposalState {
     fn header(format: OutputFormat) -> Vec<&'static str> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for proposals state");
+            todo!("dbsync format not supported for proposals state (#1032)");
         }
         vec![
             "key",
@@ -340,7 +340,7 @@ impl TableRow for ProposalState {
 
     fn row(&self, key: &EntityKey, _network: AddressNetwork, format: OutputFormat) -> Vec<String> {
         if matches!(format, OutputFormat::Dbsync) {
-            todo!("dbsync format not supported for proposals state");
+            todo!("dbsync format not supported for proposals state (#1032)");
         }
         let action = match &self.action {
             ProposalAction::ParamChange(x) => format!("Params({})", x.len()),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -25,7 +25,7 @@ fn define_gasket_policy(config: &Option<RetryConfig>) -> gasket::runtime::Policy
     };
 
     gasket::runtime::Policy {
-        // TODO: we skip checking timeouts to avoid stalling the pipeline on slow work units. The long-term solution is to scope work units to fit within a particular quota.
+        // TODO: we skip checking timeouts to avoid stalling the pipeline on slow work units. The long-term solution is to scope work units to fit within a particular quota. (#1041)
         tick_timeout: None,
         bootstrap_retry: retries.clone(),
         work_retry: retries.clone(),


### PR DESCRIPTION
Links high-stakes in-code TODO/HACK/`todo!()` markers to newly-filed tracking issues, so the markers and the tracker stay in sync. Surfaced during a backlog-triage pass over the codebase.

Comment/string-only changes (no behavior change); `cargo check --workspace` passes.

## Markers linked

| Issue | Area | Markers |
|---|---|---|
| #1032 | area:cli | dbsync dump-format panics (`dump_state.rs` ×10, `dump_logs.rs` ×2) |
| #1033 | area:cardano | `forks.rs` unknown version-bump panic |
| #1035 | area:storage | redb3 utxoset cursor/origin not persisted (×2) |
| #1036 | area:storage | fjall `copy` + `iter_entity_values` unimplemented |
| #1037 | area:cardano | ewrap move-retires-to-ESTART ordering hack |
| #1038 | area:cardano | genesis initial pool set |
| #1039 | area:testing / area:cardano | pots property-based test |
| #1040 | area:cardano | roll batch parallelize |
| #1041 | area:sync | sync work-unit quota |
| #1042 | area:storage | UTxO-set → generic entity system (×4) |

References use the existing repo convention (trailing `(#NNNN)`); for `todo!()`/`unimplemented!()` the id is embedded in the message string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)