### PR TITLE
test: harden housekeeping/pruning test coverage

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -694,17 +694,18 @@ pub trait Domain: Send + Sync + Clone + 'static {
         let mut rounds = 0;
 
         loop {
+            // Check the budget before running so `Some(0)` is a genuine no-op.
+            if let Some(max) = max_rounds {
+                if rounds >= max {
+                    break;
+                }
+            }
+
             let done = self.housekeeping()?;
             rounds += 1;
 
             if done {
                 break;
-            }
-
-            if let Some(max) = max_rounds {
-                if rounds >= max {
-                    break;
-                }
             }
         }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -685,6 +685,31 @@ pub trait Domain: Send + Sync + Clone + 'static {
 
         Ok(archive_pruned && wal_pruned)
     }
+
+    /// Runs [`Self::housekeeping`] repeatedly until it reports no remaining
+    /// backlog (each call prunes at most `MAX_PRUNE_SLOTS_PER_HOUSEKEEPING`).
+    /// `max_rounds` is an upper bound, not a fixed count: a converged run stops
+    /// early. Returns the number of rounds executed.
+    fn drain_housekeeping(&self, max_rounds: Option<u64>) -> Result<u64, DomainError> {
+        let mut rounds = 0;
+
+        loop {
+            let done = self.housekeeping()?;
+            rounds += 1;
+
+            if done {
+                break;
+            }
+
+            if let Some(max) = max_rounds {
+                if rounds >= max {
+                    break;
+                }
+            }
+        }
+
+        Ok(rounds)
+    }
 }
 
 #[trait_variant::make(Send)]

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -189,7 +189,8 @@ fn test_prune_history() {
     // Prune: keep max 500_000 slots of history.
     // Tip is 864_100, so prune before 864_100 - 500_000 = 364_100.
     // Slots 100 and 200 should be pruned.
-    store.prune_history(500_000, None).unwrap();
+    let done = store.prune_history(500_000, None).unwrap();
+    assert!(done, "unbatched prune must finish in one call");
 
     assert_eq!(store.get_block_by_slot(&100).unwrap(), None);
     assert_eq!(store.get_block_by_slot(&200).unwrap(), None);
@@ -201,6 +202,72 @@ fn test_prune_history() {
         store.get_block_by_slot(&864_100).unwrap(),
         Some(fake_block(864_100))
     );
+}
+
+/// Slots currently held by the archive, ascending.
+fn stored_slots(store: &ArchiveStore) -> Vec<BlockSlot> {
+    store
+        .get_range(None, None)
+        .unwrap()
+        .map(|(s, _)| s)
+        .collect()
+}
+
+#[test]
+fn test_prune_history_no_excess_is_noop() {
+    let store = test_store();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    // History (300 - 100 = 200) is within the 1000-slot window: nothing to prune.
+    let done = store.prune_history(1_000, Some(10)).unwrap();
+    assert!(done, "no-excess prune must report done");
+    assert_eq!(stored_slots(&store), vec![100, 200, 300], "nothing removed");
+}
+
+#[test]
+fn test_prune_history_batched_converges() {
+    let store = test_store();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [0, 100, 200, 300, 400, 500] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let max_slots = 100;
+    let max_prune = 150;
+
+    // First round: excess (500 - 0 - 100 = 400) exceeds the batch, so more work remains.
+    let done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+    assert!(!done, "large backlog should not finish in one batch");
+    let after_first = stored_slots(&store);
+    assert_eq!(after_first.first(), Some(&200), "batch must advance the start");
+    assert_eq!(
+        store.get_tip().unwrap().map(|(s, _)| s),
+        Some(500),
+        "tip preserved across batches"
+    );
+
+    // Loop to completion, bounded to detect non-convergence.
+    let mut done = false;
+    let mut rounds = 1;
+    while !done {
+        done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+        rounds += 1;
+        assert!(rounds < 100, "batched pruning did not converge");
+    }
+
+    // Converges to exactly the protected window: 500 - 400 = 100 = max_slots.
+    assert_eq!(stored_slots(&store), vec![400, 500], "only the window remains");
 }
 
 #[test]

--- a/crates/testing/src/toy_domain.rs
+++ b/crates/testing/src/toy_domain.rs
@@ -237,6 +237,13 @@ impl ToyDomain {
 
         domain
     }
+
+    /// Override the sync config so tests can exercise pruning windows
+    /// (`max_rollback` / `max_history`); default leaves both `None`.
+    pub fn with_sync_config(mut self, sync_config: SyncConfig) -> Self {
+        self.sync_config = sync_config;
+        self
+    }
 }
 
 pub struct TipSubscription {

--- a/src/bin/dolos/data/housekeeping.rs
+++ b/src/bin/dolos/data/housekeeping.rs
@@ -18,22 +18,11 @@ pub async fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
     let domain = setup_domain(config)?;
 
-    let mut done = false;
-    let mut rounds = 0;
-
-    while !done {
-        tracing::info!(round = rounds, max =? args.max_rounds, "starting housekeeping round");
-        done = match domain.housekeeping() {
-            Ok(done) => done,
-            Err(err) => {
-                tracing::error!(err =? err, "running housekeeping");
-                bail!("got error while running housekeeping");
-            }
-        };
-        rounds += 1;
-
-        if let Some(max) = args.max_rounds {
-            done = rounds >= max;
+    match domain.drain_housekeeping(args.max_rounds) {
+        Ok(rounds) => tracing::info!(rounds, "housekeeping complete"),
+        Err(err) => {
+            tracing::error!(err =? err, "running housekeeping");
+            bail!("got error while running housekeeping");
         }
     }
 

--- a/tests/housekeeping.rs
+++ b/tests/housekeeping.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the housekeeping (WAL/archive pruning) stack.
+//!
+//! Covers the layers above the store-level `prune_history` unit tests:
+//! `Domain::housekeeping` orchestration (which stores it prunes and how it
+//! combines their `done` flags), the `drain_housekeeping` batching loop, and
+//! that store errors propagate instead of being swallowed — the failure mode
+//! that let the WAL slot-range endianness bug (PR #1045) grow a WAL to ~15×
+//! its budget undetected.
+
+use std::sync::Arc;
+
+use dolos_core::{
+    config::SyncConfig, ArchiveWriter, ChainPoint, Domain, LogEntry, LogValue, WalStore,
+};
+use dolos_cardano::CardanoDelta;
+use dolos_testing::{
+    faults::{FaultyToyDomain, TestFault},
+    toy_domain::ToyDomain,
+};
+
+/// `SyncConfig` with only the pruning windows set (other fields default).
+fn sync_config(max_rollback: Option<u64>, max_history: Option<u64>) -> SyncConfig {
+    let mut cfg = SyncConfig::default();
+    cfg.max_rollback = max_rollback;
+    cfg.max_history = max_history;
+    cfg
+}
+
+/// WAL entry at `slot` with a nonzero hash, so it survives `remove_before` at
+/// its own slot (the zero-hash cutoff bound compares strictly below it).
+fn wal_entry(slot: u64) -> LogEntry<CardanoDelta> {
+    let mut hash = [1u8; 32];
+    hash[0..8].copy_from_slice(&slot.to_be_bytes());
+    (ChainPoint::Specific(slot, hash.into()), LogValue::origin())
+}
+
+fn seed_wal(domain: &ToyDomain, slots: std::ops::Range<u64>) {
+    let entries: Vec<_> = slots.map(wal_entry).collect();
+    domain.wal().append_entries(&entries).unwrap();
+}
+
+fn wal_start(domain: &impl Domain) -> Option<u64> {
+    domain.wal().find_start().unwrap().map(|(p, _)| p.slot())
+}
+
+fn wal_tip(domain: &impl Domain) -> Option<u64> {
+    domain.wal().find_tip().unwrap().map(|(p, _)| p.slot())
+}
+
+fn seed_archive(domain: &ToyDomain, slots: std::ops::Range<u64>) {
+    let writer = domain.archive().start_writer().unwrap();
+    for slot in slots {
+        let point = ChainPoint::Specific(slot, [0u8; 32].into());
+        let block = Arc::new(format!("block-{slot}").into_bytes());
+        writer.apply(&point, &block).unwrap();
+    }
+    writer.commit().unwrap();
+}
+
+/// Block slots currently indexed by the archive, ascending.
+fn archive_slots(domain: &ToyDomain) -> Vec<u64> {
+    domain
+        .archive()
+        .get_range(None, None)
+        .unwrap()
+        .map(|(s, _)| s)
+        .collect()
+}
+
+fn archive_tip(domain: &ToyDomain) -> Option<u64> {
+    domain.archive().get_tip().unwrap().map(|(s, _)| s)
+}
+
+/// Both windows configured and within one batch: a single call prunes both
+/// stores to `tip - window` and reports `done`.
+#[test]
+fn housekeeping_prunes_configured_stores() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(100), Some(100)));
+    seed_wal(&domain, 2000..2600); // tip 2599
+    seed_archive(&domain, 2000..2600);
+
+    let done = domain.housekeeping().unwrap();
+    assert!(done, "backlog within one batch must finish");
+
+    assert_eq!(wal_tip(&domain), Some(2599), "wal tip preserved");
+    assert_eq!(wal_start(&domain), Some(2499), "wal pruned to tip - max_rollback");
+
+    assert_eq!(archive_tip(&domain), Some(2599), "archive tip preserved");
+    let archived = archive_slots(&domain);
+    assert_eq!(archived.first(), Some(&2499), "archive pruned to tip - max_history");
+    assert_eq!(archived.last(), Some(&2599));
+}
+
+/// `housekeeping` returns the `&&` of the two stores' `done`: with a WAL
+/// backlog beyond one batch it reports `false` until the loop drains it.
+#[test]
+fn housekeeping_returns_false_until_converged() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(1000), None));
+    seed_wal(&domain, 1..15_000); // tip 14_999, excess ~14k > one 10k batch
+
+    assert!(!domain.housekeeping().unwrap(), "backlog exceeds one batch");
+
+    let mut rounds = 1;
+    while !domain.housekeeping().unwrap() {
+        rounds += 1;
+        assert!(rounds < 100, "housekeeping did not converge");
+    }
+
+    assert_eq!(wal_tip(&domain), Some(14_999), "tip preserved");
+    assert_eq!(wal_start(&domain), Some(13_999), "converges to tip - max_rollback");
+}
+
+/// Unconfigured windows (`None`) leave a store untouched, and `housekeeping`
+/// still reports `done`.
+#[test]
+fn housekeeping_skips_unconfigured_stores() {
+    let domain = ToyDomain::new(None, None); // default sync_config: both None
+    seed_wal(&domain, 2000..2100);
+    seed_archive(&domain, 2000..2100);
+
+    let wal_before = (wal_start(&domain), wal_tip(&domain));
+    let archive_before = archive_slots(&domain);
+
+    assert!(domain.housekeeping().unwrap(), "nothing to prune → done");
+
+    assert_eq!((wal_start(&domain), wal_tip(&domain)), wal_before, "wal untouched");
+    assert_eq!(archive_slots(&domain), archive_before, "archive untouched");
+}
+
+/// Only the configured store is pruned; the other is left alone.
+#[test]
+fn housekeeping_only_prunes_configured_store() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(100), None));
+    seed_wal(&domain, 2000..2600); // tip 2599
+    seed_archive(&domain, 2000..2600);
+
+    let archive_before = archive_slots(&domain);
+
+    assert!(domain.housekeeping().unwrap());
+
+    assert_eq!(wal_start(&domain), Some(2499), "wal pruned to window");
+    assert_eq!(archive_slots(&domain), archive_before, "archive untouched (max_history None)");
+}
+
+/// A WAL store error surfaces out of `housekeeping` instead of being swallowed.
+#[test]
+fn housekeeping_propagates_wal_error() {
+    let inner = ToyDomain::new(None, None).with_sync_config(sync_config(Some(100), None));
+    let domain = FaultyToyDomain::new(inner, TestFault::WalStoreError);
+
+    assert!(domain.housekeeping().is_err(), "wal store error must surface");
+}
+
+/// An archive store error surfaces out of `housekeeping`.
+#[test]
+fn housekeeping_propagates_archive_error() {
+    let inner = ToyDomain::new(None, None).with_sync_config(sync_config(None, Some(100)));
+    let domain = FaultyToyDomain::new(inner, TestFault::ArchiveStoreError);
+
+    assert!(domain.housekeeping().is_err(), "archive store error must surface");
+}
+
+/// `drain_housekeeping(None)` loops until the backlog is fully drained.
+#[test]
+fn drain_housekeeping_converges() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(1000), None));
+    seed_wal(&domain, 1..30_001); // tip 30_000, needs multiple 10k batches
+
+    let rounds = domain.drain_housekeeping(None).unwrap();
+
+    assert!(rounds > 1, "multi-batch backlog must take multiple rounds");
+    assert_eq!(wal_tip(&domain), Some(30_000), "tip preserved");
+    assert_eq!(wal_start(&domain), Some(29_000), "drained to tip - max_rollback");
+}
+
+/// `max_rounds` caps the loop: it stops after the budget with backlog left.
+#[test]
+fn drain_housekeeping_caps_at_max_rounds() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(1000), None));
+    seed_wal(&domain, 1..30_001); // tip 30_000
+
+    let rounds = domain.drain_housekeeping(Some(1)).unwrap();
+
+    assert_eq!(rounds, 1, "stops after the round budget");
+    assert_eq!(wal_tip(&domain), Some(30_000), "tip preserved");
+    assert!(
+        wal_start(&domain).unwrap() < 29_000,
+        "backlog remains: not yet drained to the window"
+    );
+}
+
+/// `max_rounds` is an upper bound, not a fixed count: a converged run exits
+/// early rather than spinning the remaining rounds.
+#[test]
+fn drain_housekeeping_stops_when_done() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(100), None));
+    seed_wal(&domain, 1..600); // small backlog, converges in one round
+
+    let rounds = domain.drain_housekeeping(Some(10)).unwrap();
+
+    assert_eq!(rounds, 1, "converged run stops early, not at max_rounds");
+}

--- a/tests/housekeeping.rs
+++ b/tests/housekeeping.rs
@@ -200,3 +200,16 @@ fn drain_housekeeping_stops_when_done() {
 
     assert_eq!(rounds, 1, "converged run stops early, not at max_rounds");
 }
+
+/// A zero budget is a genuine no-op: no rounds run, nothing is pruned.
+#[test]
+fn drain_housekeeping_zero_rounds_is_noop() {
+    let domain = ToyDomain::new(None, None).with_sync_config(sync_config(Some(100), None));
+    seed_wal(&domain, 2000..2600); // tip 2599, over the window
+
+    let before = (wal_start(&domain), wal_tip(&domain));
+    let rounds = domain.drain_housekeeping(Some(0)).unwrap();
+
+    assert_eq!(rounds, 0, "zero budget runs no rounds");
+    assert_eq!((wal_start(&domain), wal_tip(&domain)), before, "wal untouched");
+}


### PR DESCRIPTION
## Context

The WAL slot-range endianness bug (fixed in #1045) went undetected for a long time because the **housekeeping/pruning stack had almost no test coverage** and failed *silently* — `prune_history` swallowed `SlotNotFound` and logged "skipping", so housekeeping reported success while pruning nothing (a preprod instance grew its WAL to ~15× `max_rollback`). #1045 added WAL-store unit tests; this PR fills the layers above and beside it (`Domain::housekeeping` orchestration, the CLI drain loop, archive `prune_history` gaps, and fault propagation), so a future silent-prune regression fails a test instead of shipping.

## Tests

- **Archive `prune_history`** (`crates/redb3/src/archive/tests.rs`) — added `test_prune_history_no_excess_is_noop` (`excess == 0` path) and `test_prune_history_batched_converges` (batched `done=false → true`, tip + `max_slots` window preserved); strengthened the existing full-prune test to assert `done == true`.
- **New `tests/housekeeping.rs`** (9 tests over `ToyDomain` / `FaultyToyDomain`):
  - orchestration — both stores pruned to `tip - window`, tip preserved;
  - the `archive_done && wal_done` combine — returns `false` until the loop converges;
  - unconfigured (`None`) and one-sided windows leave the untouched store alone;
  - the drain loop — converges, caps at `max_rounds`, and stops early when done;
  - **fault propagation** — a WAL or archive store error surfaces out of `housekeeping()` instead of being swallowed (the failure mode that hid the endianness bug).

## Supporting changes

- `ToyDomain::with_sync_config` builder — `sync_config` was hardcoded to defaults (both windows `None`), so `housekeeping()` pruned nothing and was untestable.
- `Domain::drain_housekeeping(max_rounds)` default method — extracts the `data housekeeping` drain loop so it is driveable against `ToyDomain`; the CLI `run()` is now a thin wrapper.
- **CLI `max_rounds` correction (small behavior change):** the old loop did `done = rounds >= max`, *overwriting* housekeeping's own `done` and forcing exactly-N rounds even after the backlog drained. `max_rounds` is now a true upper bound (early-exit on convergence).

## Verification

- `cargo test --test housekeeping` — 9/9
- `cargo test -p dolos-redb3 archive::` — 21/21 · `wal::` — 11/11 (no regression)
- `cargo test -p dolos-testing`, `cargo build`, `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `drain_housekeeping` to run housekeeping repeatedly until completion or an optional round cap is reached.
  * Added a builder-style method to simplify configuring sync behavior in the toy test domain.
  * Expanded end-to-end integration coverage for WAL and archive pruning orchestration.

* **Bug Fixes**
  * Housekeeping orchestration now uses `drain_housekeeping`, reporting the number of rounds completed.
  * Improved pruning tests to assert completion behavior for batched and no-op cases, including strict error propagation.
  * Added coverage for `drain_housekeeping(Some(0))` as a true no-op.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->