### PR TITLE
chore(cardano): update governance proposals status

### DIFF
--- a/crates/cardano/src/hacks.rs
+++ b/crates/cardano/src/hacks.rs
@@ -337,6 +337,10 @@ pub mod proposals {
                 "79fb4bac13dfc272a53357309f70bc8c60f1950137b24585b850147251ff2554#0" => {
                     Ratified(293)
                 }
+                // Parameter Change enacted at epoch 296
+                "4aa45fe4266c114201733bbc641164b4d3eac51081afeee12ddc92235b58f45c#0" => {
+                    Ratified(295)
+                }
                 _ => match protocol {
                     0..=8 => RatifiedCurrentEpoch,
                     _ => Unknown,
@@ -556,6 +560,14 @@ pub mod proposals {
                     Ratified(536)
                 }
 
+                // Hard Fork to Protocol Version 11 — submitted epoch 637, all three
+                // governance bodies voting yes with zero no votes. Anticipated
+                // ratification at epoch 641, enactment at epoch 642.
+                // Uncomment when ratification is confirmed on-chain.
+                // "fdd468da5cc4ac8431dcd7e2b3211666c73bc229f85879469f67f1d9d51d344d#0" => {
+                //     Ratified(641)
+                // }
+
                 // Plutus V3 Cost Model Parameter Changes Prior to Chang#2
                 "b2a591ac219ce6dcca5847e0248015209c7cb0436aa6bd6863d0c1f152a60bc5#0" => {
                     Ratified(525)
@@ -719,6 +731,18 @@ pub mod proposals {
                 // Parameter Change enacted at epoch 638
                 "c82f3834898e4d70d3605fa0d92ffe31345701075b107a54309c1525f9581f62#0" => {
                     Ratified(637)
+                }
+                // Treasury Withdrawal enacted at epoch 639
+                "c05eed09c8706453c97c88d403c4ff43b7786a552fe8711aa07d3e6529ffd8ba#0" => {
+                    Ratified(638)
+                }
+                // Treasury Withdrawal enacted at epoch 640
+                "aaa6d9ccb72639c77db46b73bec2eaff9e5fcdfa04909cf1a0f7855a4d31485a#0" => {
+                    Ratified(639)
+                }
+                // Treasury Withdrawal enacted at epoch 641
+                "17e43ffe4b2e0df1787d54f21ac66643c74abb131a326272fceecbdbbdd0d3fc#0" => {
+                    Ratified(640)
                 }
 
                 _ => match protocol {


### PR DESCRIPTION
## Summary

Queried DBSync for all three networks (mainnet, preprod, preview) and cross-referenced every enacted governance proposal against the hardcoded outcomes in `crates/cardano/src/hacks.rs`.

## Changes

### 4 missing enacted proposals added

| Network | Proposal | Type | Enacted | Entry |
|---|---|---|---|---|
| preprod | `4aa45fe4...#0` | ParameterChange | 296 | `Ratified(295)` |
| mainnet | `c05eed09...#0` | TreasuryWithdrawals | 639 | `Ratified(638)` |
| mainnet | `aaa6d9cc...#0` | TreasuryWithdrawals | 640 | `Ratified(639)` |
| mainnet | `17e43ffe...#0` | TreasuryWithdrawals | 641 | `Ratified(640)` |

### 1 commented-out pending HardForkInitiation entry

Mainnet proposal `fdd468da...#0` targets protocol version 11.0. All three governance bodies are voting yes with zero no votes (3 CC, 169 DReps, 356 SPOs). The proposal was submitted at epoch 637 and expires after epoch 644. Anticipated ratification at epoch 641 with enactment at epoch 642. The entry is commented out — uncomment when ratification is confirmed on-chain.

### Verification

- No incorrect `Ratified` epochs found in existing entries
- Preview was fully up to date
- All dropped/expired proposals either have existing `Canceled` entries or correctly fall through to `Unknown` (natural expiry via `max_epoch`)

```
cargo check -p dolos-cardano ✓
cargo clippy -p dolos-cardano ✓
cargo test --test epoch_pots --release ✓
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for additional governance/proposal history entries on Preprod and Mainnet.
  * Improved recognition of several treasury withdrawal outcomes and one parameter change event.
  * Added reference notes for an upcoming mainnet protocol upgrade timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->