### PR TITLE
fix(minibf): return 404 for valid but non-existent asset in `/assets/{asset}/addresses`

### DIFF
--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -513,9 +513,16 @@ pub async fn by_subject_addresses<D>(
 ) -> Result<Json<Vec<AssetAddressesInner>>, Error>
 where
     D: Domain + Clone + Send + Sync + 'static,
+    Option<AssetState>: From<D::Entity>,
 {
     let pagination = Pagination::try_from(params)?;
     let asset = hex::decode(&subject).map_err(|_| Error::InvalidAsset)?;
+
+    let entity_key = pallas::crypto::hash::Hasher::<256>::hash(asset.as_slice());
+    domain
+        .read_cardano_entity::<AssetState>(entity_key.as_slice())?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
     let utxoset = domain
         .indexes()
         .utxos_by_asset(&asset)
@@ -792,6 +799,46 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
         let asset = app.vectors().asset_unit.as_str();
         let path = format!("/assets/{asset}");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn assets_by_subject_addresses_happy_path() {
+        let app = TestApp::new();
+        let asset = app.vectors().asset_unit.as_str();
+        let path = format!("/assets/{asset}/addresses");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let addresses: Vec<AssetAddressesInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse asset addresses");
+        assert!(!addresses.is_empty());
+    }
+
+    #[tokio::test]
+    async fn assets_by_subject_addresses_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/assets/{}/addresses", invalid_asset());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn assets_by_subject_addresses_not_found() {
+        let app = TestApp::new();
+        let path = format!("/assets/{}/addresses", missing_asset());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn assets_by_subject_addresses_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let asset = app.vectors().asset_unit.as_str();
+        let path = format!("/assets/{asset}/addresses");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 }

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -519,9 +519,9 @@ where
     let asset = hex::decode(&subject).map_err(|_| Error::InvalidAsset)?;
 
     let entity_key = pallas::crypto::hash::Hasher::<256>::hash(asset.as_slice());
-    domain
-        .read_cardano_entity::<AssetState>(entity_key.as_slice())?
-        .ok_or(StatusCode::NOT_FOUND)?;
+    if !domain.cardano_entity_exists::<AssetState>(entity_key.as_slice())? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
 
     let utxoset = domain
         .indexes()


### PR DESCRIPTION
Resolves #1119.

## Context

The `/assets/{asset}/addresses` endpoint scanned the UTxO set for the asset and returned an empty array when no matching UTxOs were found. For a well-formed asset unit that was never minted, this produced `http/200` with `[]` in the body, whereas the Blockfrost API returns `http/404`.

Look up the asset's `AssetState` up front and return `http/404` when it is absent, before scanning the UTxO set. Add route tests covering the happy path, malformed asset (`http/400`), unknown asset (`http/404`), and state-store failure (`http/500`).

This has been tested with `blockfrost-tests`, and the respective test is now passing on Preview:

- https://github.com/blockfrost/blockfrost-tests/blob/594f054ecb5e5a7e68f27abff3d8fe3bab285ea5/src/fixtures/preview/assets/assets-addresses.ts#L28-L35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior of the asset addresses endpoint for valid, missing, and invalid asset inputs.
  * Added an early missing-asset check to return `NOT_FOUND` more reliably.
  * Enhanced responses when the state lookup fails.

* **Tests**
  * Added integration coverage for `/assets/{asset}/addresses`, including happy path, `BAD_REQUEST`, `NOT_FOUND`, and `INTERNAL_SERVER_ERROR`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->