### PR TITLE
ci: add cargo-deny advisories gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
+  deny:
+    name: cargo deny (advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # Fails the build on any RustSec advisory affecting the locked
+      # dependency tree. Config lives in deny.toml (advisories only). The
+      # action installs cargo-deny and caches the advisory database.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,36 @@
+# cargo-deny configuration — https://embarkstudios.github.io/cargo-deny/
+#
+# Scoped to RustSec security advisories. CI runs `cargo deny check advisories`,
+# so the licenses/bans/sources sections are intentionally omitted for now; add
+# them in a follow-up if we want to gate those too.
+
+[advisories]
+version = 2
+
+# The gate blocks on active vulnerabilities and unsound advisories (both are
+# hard errors in cargo-deny v2 and cannot be reached in a released Dolos
+# without a fix). The two softer RustSec categories are downgraded so the
+# pipeline stays focused on exploitable issues:
+#
+#   yanked = "warn"        A yanked crate is a maintenance signal, not an
+#                          exploit. Some of ours (fjall, lsm-tree) are yanked
+#                          upstream storage-engine releases we can't trivially
+#                          move off, so blocking on yanked would make CI brittle
+#                          to upstream yanks. Still surfaced in the logs.
+#
+#   unmaintained = "none"  Unmaintained crates (e.g. bincode 1, paste) are an
+#                          informational signal, not a vulnerability, and we
+#                          depend on several deliberately. Tightening this to
+#                          "workspace" is a reasonable follow-up initiative.
+yanked = "warn"
+unmaintained = "none"
+
+# Advisory IDs to consciously accept. Keep this empty by default. Only add an
+# entry (with a one-line reason and, ideally, a tracking issue) for a
+# vulnerability/unsound advisory that is genuinely unreachable in Dolos and
+# cannot be resolved by a bump — e.g. a vulnerable crate pulled in only by dev
+# tooling or behind a disabled feature. Every entry is a standing risk
+# acceptance, so justify it.
+ignore = [
+    # "RUSTSEC-0000-0000", # reason — <issue link>
+]


### PR DESCRIPTION
## Summary

Adds a `deny` job to CI that runs `cargo deny check advisories`, making dependency-vulnerability scanning a **standing gate** rather than relying solely on GitHub Dependabot.

PR 3 of 3, closing out the security-advisory cleanup:
- #1057 — dependency bumps (**merged**)
- #1058 — opentelemetry `0.30 → 0.32`
- **this PR** — the CI gate

## Why (RustSec ≠ GitHub Advisory DB)

While wiring this up, cargo-deny (RustSec) and Dependabot (GitHub Advisory DB) turned out to report **different** sets:
- cargo-deny flagged a **`crossbeam-epoch` vulnerability** (`RUSTSEC-2025-0055`) and an **`anyhow` unsound** advisory that Dependabot never surfaced — both now fixed in #1057.
- Conversely Dependabot flagged openssl/quinn/opentelemetry that cargo-deny considers unreachable/not-applicable.

A standing cargo-deny gate closes the RustSec side of that gap for the shipped tree.

## Policy (`deny.toml`, advisories-only)

| Category | Action | Rationale |
|---|---|---|
| vulnerabilities + unsound | **block** | hard errors; can't ship without a fix |
| yanked | **warn** | `fjall`/`lsm-tree` are yanked upstream releases we can't trivially move off; blocking would make CI brittle to upstream yanks (still visible in logs) |
| unmaintained | **off** | informational, not exploitable (`bincode` 1, `paste`, …); can be tightened to `"workspace"` as a follow-up |

licenses/bans/sources sections are intentionally omitted for now.

## Verification

Verified against current main with cargo-deny 0.19.9:

```
$ cargo deny check advisories
warning[yanked]: detected yanked crate ... fjall
warning[yanked]: detected yanked crate ... lsm-tree
advisories ok
```

Passes clean — only the two non-blocking yanked warnings. (The CI job uses `EmbarkStudios/cargo-deny-action@v2`, which installs cargo-deny and caches the advisory DB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency security checks to the build process.
  * CI now fails when known Rust security advisories are detected, helping keep releases safer.
  * Added security policy settings for advisory handling, including default warning behavior for yanked packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->