### PR TITLE
fix(cardano): make compute_delta pub(crate) to satisfy private_interfaces

### DIFF
--- a/crates/cardano/src/roll/mod.rs
+++ b/crates/cardano/src/roll/mod.rs
@@ -534,7 +534,7 @@ impl<'a> DeltaBuilder<'a> {
 }
 
 #[instrument(name = "roll", skip_all)]
-pub fn compute_delta<D: Domain>(
+pub(crate) fn compute_delta<D: Domain>(
     genesis: Arc<Genesis>,
     cache: &Cache,
     state: &D::State,


### PR DESCRIPTION
## Summary

One-word visibility fix for a latent clippy failure. `crates/cardano/src/roll/mod.rs` declared:

```rust
pub fn compute_delta<D: Domain>(genesis: Arc<Genesis>, cache: &Cache, ...)
```

but `Cache` is `pub(crate)` (`lib.rs:283`), so a public signature exposes a crate-private type — the `private_interfaces` warn-by-default **rustc** lint. CI runs `cargo clippy --all-targets --all-features -- -D warnings`, which turns it into a hard error:

```
error: type `Cache` is more private than the item `roll::compute_delta`
error: could not compile `dolos-cardano` (lib) due to 1 previous error
```

Fix: narrow the fn to `pub(crate)`. It has **no external callers** (only `roll/work_unit.rs`, inside the crate) and `Cache` is never used cross-crate, so this satisfies the lint without leaking the internal `Cache` type into the public API.

## Why it wasn't already red on main

The lint is a warning on main today, but the `cargo clippy` job's `Swatinem/rust-cache` served a warm `dolos-cardano` result and skipped re-linting it. Any PR that busts that cache — e.g. #1058's dependency bump — forces a recompile, re-runs the lint, and fails CI. So this is a pre-existing latent failure that will recur; fixing it on main unblocks those PRs (#1058 clears clippy on rebase).

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` (full workspace, forced `dolos-cardano` recompile via `cargo clean -p`) — passes clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)