### PR TITLE
feat(bootstrap): migrate mithril client to v2 Cardano Database format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,17 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +199,29 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -371,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "az"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "backtrace"
@@ -462,6 +474,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bip39"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,7 +501,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -513,9 +545,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -554,19 +586,28 @@ checksum = "c8e57d94ea05f950ea73ff557aecaa2c11ef6efd3bcca98e64efd35415bd687d"
 dependencies = [
  "serde",
  "serde_json",
- "serde_with 3.16.0",
+ "serde_with 3.21.0",
 ]
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -607,10 +648,11 @@ checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -745,10 +787,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -992,7 +1053,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1005,7 +1066,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1139,12 +1200,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1163,11 +1224,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1188,11 +1248,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1365,7 +1425,7 @@ dependencies = [
  "axum 0.8.4",
  "base64 0.22.1",
  "bech32 0.11.1",
- "bincode",
+ "bincode 1.3.3",
  "bytes",
  "chrono",
  "clap",
@@ -1406,7 +1466,7 @@ dependencies = [
  "protoc-wkt",
  "rayon",
  "redb-extras",
- "reqwest 0.12.22",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "stats_alloc",
@@ -1438,7 +1498,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bech32 0.11.1",
- "bincode",
+ "bincode 1.3.3",
  "chrono",
  "crc",
  "dolos-core",
@@ -1474,7 +1534,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_with 3.16.0",
+ "serde_with 3.21.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -1487,7 +1547,7 @@ dependencies = [
 name = "dolos-fjall"
 version = "1.4.0"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "dolos-core",
  "dolos-testing",
  "fjall",
@@ -1522,7 +1582,7 @@ dependencies = [
  "num-traits",
  "pallas",
  "rayon",
- "reqwest 0.12.22",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1557,7 +1617,7 @@ dependencies = [
 name = "dolos-redb3"
 version = "1.4.0"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "dolos-core",
  "dolos-testing",
  "futures-core",
@@ -1602,7 +1662,7 @@ name = "dolos-trp"
 version = "1.4.0"
 dependencies = [
  "base64 0.22.1",
- "bincode",
+ "bincode 1.3.3",
  "dolos-cardano",
  "dolos-core",
  "dolos-testing",
@@ -1624,6 +1684,12 @@ dependencies = [
  "tx3-resolver",
  "tx3-sdk",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1653,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1736,6 +1802,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1756,10 +1825,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed"
-version = "1.29.0"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
 dependencies = [
  "az",
  "bytemuck",
@@ -1782,7 +1857,7 @@ dependencies = [
  "byteorder-lite",
  "byteview",
  "dashmap",
- "flume 0.12.0",
+ "flume",
  "log",
  "lsm-tree",
  "lz4_flex",
@@ -1792,24 +1867,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
 ]
 
 [[package]]
@@ -1818,6 +1881,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
  "spin",
 ]
 
@@ -1858,10 +1924,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1874,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1884,15 +1956,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1901,15 +1973,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1918,21 +1990,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1942,7 +2014,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1995,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2027,11 +2098,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2582,7 +2655,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "crossterm 0.29.0",
  "dyn-clone",
  "fuzzy-matcher",
@@ -2606,17 +2679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -2681,6 +2743,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,11 +2803,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2802,9 +2914,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -2812,7 +2924,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -2973,7 +3085,6 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
 dependencies = [
- "half",
  "minicbor-derive 0.15.3",
 ]
 
@@ -3022,18 +3133,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mithril-aggregator-client"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19d38369e71418fb9ab7e1e4cb01123b0e821ef081900a6cb77e16be7ad6831"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "mithril-common",
+ "reqwest 0.13.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "mithril-aggregator-discovery"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b525f1cd6a4b8affed3525795fd4635d249eb08a52a3fce2182fb0fe678e24"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "mithril-aggregator-client",
+ "mithril-common",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -3048,22 +3195,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "mithril-client"
-version = "0.12.2"
+name = "mithril-cardano-node-internal-database"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee06cf25db2bc6bcff892893adf5809e663ef4d8326cf022c22b6c1a2be2efac"
+checksum = "ccef807bf3f7846d3c6a1009c62594bc40958ce7f1eef648d6861f4ef1104aee"
 dependencies = [
  "anyhow",
- "async-recursion",
+ "async-trait",
+ "digest 0.10.7",
+ "hex",
+ "mithril-common",
+ "serde",
+ "serde_json",
+ "sha2",
+ "slog",
+ "thiserror 2.0.18",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "mithril-client"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7babd1c95fe7eb73eafb35bd12ed2efdf84601f1e2e633728f7ac0565a04ae"
+dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "flate2",
- "flume 0.11.1",
+ "flume",
  "futures",
- "getrandom 0.2.15",
+ "getrandom 0.4.2",
+ "mithril-aggregator-client",
+ "mithril-aggregator-discovery",
+ "mithril-cardano-node-internal-database",
  "mithril-common",
- "reqwest 0.12.22",
- "semver",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "slog",
@@ -3077,13 +3246,14 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.27"
+version = "0.6.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3377e855390a51c95ec1d093bd5f760e0a0b9cf9ae022584fb158636aa2108c1"
+checksum = "0399524c347d2e59663fb1251e72bb81affa69264a1deefb1c468f11660bf688"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.11.1",
+ "bincode 2.0.1",
  "blake2 0.10.6",
  "chrono",
  "ciborium",
@@ -3096,11 +3266,6 @@ dependencies = [
  "mithril-build-script",
  "mithril-stm",
  "nom 8.0.0",
- "pallas-addresses 0.32.0",
- "pallas-codec 0.32.0",
- "pallas-network 0.32.0",
- "pallas-primitives 0.32.0",
- "pallas-traverse 0.32.0",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
@@ -3108,7 +3273,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "serde_with 3.16.0",
+ "serde_with 3.21.0",
  "sha2",
  "slog",
  "strum",
@@ -3121,19 +3286,24 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.42"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9767e5d1c23e2ecc1410047a40aaeb1c60674aad2d97588c3bc59c82ba355f49"
+checksum = "e5a4e1b17f29e9976fd92082a1671418eab2bcb7e85825294c6fc486ce20efa9"
 dependencies = [
+ "anyhow",
  "blake2 0.10.6",
  "blst",
+ "ciborium",
  "digest 0.10.7",
+ "hex",
  "num-bigint",
+ "num-integer",
  "num-rational",
  "num-traits",
  "rand_core 0.6.4",
  "rayon",
  "serde",
+ "subtle",
  "thiserror 2.0.18",
 ]
 
@@ -3148,15 +3318,6 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.15",
-]
 
 [[package]]
 name = "native-tls"
@@ -3181,7 +3342,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3212,7 +3373,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3346,7 +3507,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3472,33 +3633,17 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "846ff0e3269c223e6ed6202eca1dc98399bc85f7db9be4e4574fab778cfa981b"
 dependencies = [
- "pallas-addresses 1.1.1",
- "pallas-codec 1.1.1",
+ "pallas-addresses",
+ "pallas-codec",
  "pallas-configs",
- "pallas-crypto 1.1.1",
+ "pallas-crypto",
  "pallas-hardano",
- "pallas-network 1.1.1",
- "pallas-primitives 1.1.1",
- "pallas-traverse 1.1.1",
+ "pallas-network",
+ "pallas-primitives",
+ "pallas-traverse",
  "pallas-txbuilder",
  "pallas-utxorpc",
  "pallas-validate",
-]
-
-[[package]]
-name = "pallas-addresses"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bd039d7f1618d12ff348dd03eebe38c5d2a010325750e5341526c419b0f8e0"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "crc",
- "cryptoxide 0.4.4",
- "hex",
- "pallas-codec 0.32.0",
- "pallas-crypto 0.32.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3512,21 +3657,9 @@ dependencies = [
  "crc",
  "cryptoxide 0.4.4",
  "hex",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
+ "pallas-codec",
+ "pallas-crypto",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "pallas-codec"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
-dependencies = [
- "hex",
- "minicbor 0.25.1",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3549,27 +3682,12 @@ checksum = "9413d9d84c67434857c08ec2d92c96452671c68fb1921c0c1999a7a699587186"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
- "pallas-addresses 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-primitives 1.1.1",
+ "pallas-addresses",
+ "pallas-crypto",
+ "pallas-primitives",
  "serde",
  "serde_json",
- "serde_with 3.16.0",
-]
-
-[[package]]
-name = "pallas-crypto"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
-dependencies = [
- "cryptoxide 0.4.4",
- "hex",
- "pallas-codec 0.32.0",
- "rand_core 0.6.4",
- "serde",
- "thiserror 1.0.69",
- "zeroize",
+ "serde_with 3.21.0",
 ]
 
 [[package]]
@@ -3580,7 +3698,7 @@ checksum = "5abe09448466b168f50eb0beaae4e38a16e49bdfe6b2fba5748ea17a025b15b1"
 dependencies = [
  "cryptoxide 0.4.4",
  "hex",
- "pallas-codec 1.1.1",
+ "pallas-codec",
  "rand_core 0.10.1",
  "serde",
  "thiserror 2.0.18",
@@ -3594,34 +3712,16 @@ checksum = "adf818b49428697b0d0d5e680fecffa94020b141460dc6ebfe45295b43c8a6b1"
 dependencies = [
  "binary-layout",
  "hex",
- "pallas-addresses 1.1.1",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-network 1.1.1",
- "pallas-traverse 1.1.1",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-network",
+ "pallas-traverse",
  "serde",
  "serde_json",
- "serde_with 3.16.0",
+ "serde_with 3.21.0",
  "tap",
  "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "pallas-network"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e44dd876dc70cbbfc865bb9143131f57edab2c45e873d915732b81982ddb67"
-dependencies = [
- "byteorder",
- "hex",
- "itertools 0.13.0",
- "pallas-codec 0.32.0",
- "pallas-crypto 0.32.0",
- "rand 0.8.6",
- "socket2 0.5.9",
- "thiserror 1.0.69",
- "tokio",
  "tracing",
 ]
 
@@ -3634,8 +3734,8 @@ dependencies = [
  "byteorder",
  "hex",
  "itertools 0.14.0",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
+ "pallas-codec",
+ "pallas-crypto",
  "rand 0.10.1",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3645,48 +3745,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "hex",
- "log",
- "pallas-codec 0.32.0",
- "pallas-crypto 0.32.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "pallas-primitives"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c2b627b97f708bbb0252834e300d56b1ccea9c982c0e4189d1a414c1b53c18"
 dependencies = [
  "hex",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
+ "pallas-codec",
+ "pallas-crypto",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "pallas-traverse"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
-dependencies = [
- "hex",
- "itertools 0.13.0",
- "pallas-addresses 0.32.0",
- "pallas-codec 0.32.0",
- "pallas-crypto 0.32.0",
- "pallas-primitives 0.32.0",
- "paste",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3697,10 +3764,10 @@ checksum = "ba24ccce6561ab01d910aa8a89abf7f949f4009c0e36771e763f09d3efba1eed"
 dependencies = [
  "hex",
  "itertools 0.14.0",
- "pallas-addresses 1.1.1",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-primitives 1.1.1",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
  "paste",
  "serde",
  "thiserror 2.0.18",
@@ -3713,11 +3780,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24573093e2c342a63cda545ef799c51248a9ccb07061a9de0f2126b694830697"
 dependencies = [
  "hex",
- "pallas-addresses 1.1.1",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-primitives 1.1.1",
- "pallas-traverse 1.1.1",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
+ "pallas-traverse",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3729,10 +3796,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb8a5432ea38e559378d5872d012c5cf34df95e0ed7e5a224aa2645ce57f9675"
 dependencies = [
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-primitives 1.1.1",
- "pallas-traverse 1.1.1",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
+ "pallas-traverse",
  "pallas-validate",
  "prost-types 0.13.5",
  "utxorpc-spec 0.19.0",
@@ -3748,11 +3815,11 @@ dependencies = [
  "chrono",
  "hex",
  "itertools 0.14.0",
- "pallas-addresses 1.1.1",
- "pallas-codec 1.1.1",
- "pallas-crypto 1.1.1",
- "pallas-primitives 1.1.1",
- "pallas-traverse 1.1.1",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
+ "pallas-traverse",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -3892,12 +3959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,7 +4077,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "lazy_static",
  "num-traits",
  "rand 0.9.3",
@@ -4201,6 +4262,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
@@ -4315,7 +4377,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4344,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4389,7 +4451,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4398,7 +4460,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4475,9 +4537,49 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.2",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4500,9 +4602,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
@@ -4515,38 +4617,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.1",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower 0.5.2",
- "tower-http 0.6.8",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -4557,7 +4627,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4606,7 +4676,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4619,7 +4689,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -4628,10 +4698,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4650,7 +4721,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4673,11 +4744,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4781,7 +4880,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4790,11 +4889,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -4803,9 +4902,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4819,9 +4918,9 @@ checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4835,11 +4934,12 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4864,15 +4964,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4933,11 +5033,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4946,7 +5047,7 @@ dependencies = [
  "schemars 1.1.0",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.16.0",
+ "serde_with_macros 3.21.0",
  "time",
 ]
 
@@ -4964,11 +5065,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5011,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5031,9 +5132,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -5047,9 +5148,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -5073,6 +5174,28 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5200,23 +5323,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -5290,7 +5412,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5474,22 +5596,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.3",
  "tokio-macros",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5504,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5838,7 +5957,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -5854,7 +5973,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -6026,9 +6145,9 @@ dependencies = [
  "cryptoxide 0.4.4",
  "ed25519-bip32",
  "hex",
- "pallas-addresses 1.1.1",
- "pallas-crypto 1.1.1",
- "reqwest 0.12.22",
+ "pallas-addresses",
+ "pallas-crypto",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6062,9 +6181,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typetag"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f22b40dd7bfe8c14230cf9702081366421890435b2d625fa92b4acc4c3de6f"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -6075,9 +6194,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6160,6 +6279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6235,11 +6360,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6304,6 +6429,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -6377,48 +6508,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6426,22 +6541,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -6470,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6487,7 +6602,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
  "semver",
@@ -6495,9 +6610,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6511,6 +6626,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6781,7 +6905,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6822,7 +6946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
  "indexmap 2.9.0",
  "log",
  "serde",
@@ -7021,6 +7145,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,29 +201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,15 +762,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -1467,6 +1435,7 @@ dependencies = [
  "rayon",
  "redb-extras",
  "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "stats_alloc",
@@ -1684,12 +1653,6 @@ dependencies = [
  "tx3-resolver",
  "tx3-sdk",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1922,12 +1885,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -4262,7 +4219,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
@@ -4599,7 +4555,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4702,7 +4657,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4776,7 +4730,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ tonic-reflection = { version = "0.12.3", optional = true }
 http = "1.3.1"
 hyper = "1.5"
 
-mithril-client = { version = "0.12.2", optional = true, default-features = false, features = [
+mithril-client = { version = "0.14.5", optional = true, default-features = false, features = [
     "fs",
     "num-integer-backend",
     "rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,19 @@ tonic-reflection = { version = "0.12.3", optional = true }
 http = "1.3.1"
 hyper = "1.5"
 
+# `rustls-no-provider` avoids reqwest 0.13's hard-wired aws-lc-rs crypto
+# provider (a large C dependency requiring cmake). The direct rustls dep below
+# guarantees ring is compiled in as the provider instead.
 mithril-client = { version = "0.14.5", optional = true, default-features = false, features = [
     "fs",
     "num-integer-backend",
-    "rustls-tls",
-    "rustls-tls-webpki-roots",
+    "rustls-no-provider",
+] }
+rustls = { version = "0.23", optional = true, default-features = false, features = [
+    "ring",
+    "logging",
+    "std",
+    "tls12",
 ] }
 
 [dev-dependencies]
@@ -145,7 +153,7 @@ path = "tests/bootstrap.rs"
 
 [features]
 strict = ["dolos-cardano/strict"]
-mithril = ["mithril-client"]
+mithril = ["mithril-client", "rustls"]
 utils = ["comfy-table", "inquire", "toml"]
 debug = ["console-subscriber", "tokio/tracing"]
 

--- a/adrs/004_oci_snapshots.md
+++ b/adrs/004_oci_snapshots.md
@@ -122,6 +122,9 @@ State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_sch
   "epoch": 550,
   "compression": {"algo": "zstd", "level": 9},
   "stateShards": 16,
+  "history": [
+    {"epoch": 549, "descriptorDigest": "sha256:…"},
+    {"epoch": 548, "descriptorDigest": "sha256:…"} ],
   "layers": [
     {"kind": "blocks", "epoch": 0, "startSlot": 0, "endSlot": 21599,
      "diffId": "sha256:…", "records": 21600, "uncompressedSize": 43210000},
@@ -129,6 +132,8 @@ State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_sch
 ```
 
 `diffId` = sha256 of the uncompressed CBOR sequence. Determinism and signing are defined only over this document's sha256. Signatures are Ed25519 over the descriptor digest, pushed as OCI referrer artifacts (`application/vnd.dolos.snapshot.signature.v1`, cosign-compatible envelope where convenient). Restore verifies registry blob digests (transport integrity) and diffIds (canonical identity).
+
+`history` embeds the digest of every previously published descriptor, so the latest signed descriptor transitively attests the entire publication history (~80 bytes per epoch, ~50 KB after 600 epochs — negligible for a config blob). This makes attestation outlive blob retention: a snapshot whose blobs have long been garbage-collected can still be verified by anyone holding a copy, because the copy carries its own descriptor (the OCI config blob) — check that descriptor's digest against the `history` of the latest signed descriptor, then the layers against its diffIds. No external trusted storage of attestations is required.
 
 Note: a side-effect of anchoring identity on uncompressed content digests is that snapshots can be mirrored over any content-addressed transport (e.g. IPFS) — or re-compressed with a different algorithm — and still verify against the same signed descriptor. This is a property of the format, not a requirement of the protocol; the OCI registry remains the canonical distribution channel.
 
@@ -165,7 +170,7 @@ trusted_keys = ["ed25519:…"]  # mirrors mithril genesis_key style
 4. Determinism job: an independent runner that synced by any means runs `dolos snapshot digest` and alerts on descriptor mismatch.
 5. Matching verifiers sign and push referrer signatures; clients enforce k-of-n.
 
-Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged state blobs are reclaimed by registry GC; epoch blobs remain referenced by later manifests.
+Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged state blobs are reclaimed by registry GC; epoch blobs remain referenced by later manifests. Trust evidence for reclaimed snapshots survives in the descriptor `history` of every later publish.
 
 ### Restore pipeline
 

--- a/adrs/004_oci_snapshots.md
+++ b/adrs/004_oci_snapshots.md
@@ -130,6 +130,8 @@ State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_sch
 
 `diffId` = sha256 of the uncompressed CBOR sequence. Determinism and signing are defined only over this document's sha256. Signatures are Ed25519 over the descriptor digest, pushed as OCI referrer artifacts (`application/vnd.dolos.snapshot.signature.v1`, cosign-compatible envelope where convenient). Restore verifies registry blob digests (transport integrity) and diffIds (canonical identity).
 
+Note: a side-effect of anchoring identity on uncompressed content digests is that snapshots can be mirrored over any content-addressed transport (e.g. IPFS) — or re-compressed with a different algorithm — and still verify against the same signed descriptor. This is a property of the format, not a requirement of the protocol; the OCI registry remains the canonical distribution channel.
+
 ### Code layout
 
 New crate `crates/snapshot` (`dolos-snapshot`): `spec.rs` (descriptor, canonical JSON), `frame.rs` (deterministic CBOR-seq primitives), `layers/{blocks,indexes,logs,state}.rs`, `export.rs` / `restore.rs` (generic over `dolos_core::Domain`), `digest.rs` (streaming sha256+zstd), `oci.rs` (feature `oci`, built on the `oci-client` crate). New deps: `zstd`, `serde_jcs`, `oci-client`.
@@ -168,7 +170,7 @@ Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged s
 ### Restore pipeline
 
 1. Resolve tag → manifest → descriptor; verify digest, schema, network magic and signatures.
-2. Plan epoch range from `sync.max_history`; diff against the progress file (`<storage.path>/.snapshot-restore.json`, records descriptor digest + completed layer diffIds) for `--continue`.
+2. Plan epoch range from `sync.max_history`; diff against the progress file (`<storage.path>/.snapshot-restore.json`, records descriptor digest + completed layer diffIds) for `--continue`. Preflight: sum the descriptor `uncompressedSize` of the planned layers and fail early if free space at `storage.path` is insufficient; derive download progress and time-remaining estimates from the manifest's compressed blob sizes.
 3. Open stores; `IndexStore::initialize_schema()`.
 4. Per epoch (checkpointed): fetch + verify `blocks`/`logs` → archive appends, commit; fetch `indexes` → pre-hashed appends, commit.
 5. State tip: fetch the 16 shards (parallelizable) → dispatch per namespace; `set_cursor(descriptor.point)` last so `has_existing_data()` only ever sees complete restores; commit.

--- a/adrs/004_oci_snapshots.md
+++ b/adrs/004_oci_snapshots.md
@@ -122,9 +122,6 @@ State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_sch
   "epoch": 550,
   "compression": {"algo": "zstd", "level": 9},
   "stateShards": 16,
-  "history": [
-    {"epoch": 549, "descriptorDigest": "sha256:…"},
-    {"epoch": 548, "descriptorDigest": "sha256:…"} ],
   "layers": [
     {"kind": "blocks", "epoch": 0, "startSlot": 0, "endSlot": 21599,
      "diffId": "sha256:…", "records": 21600, "uncompressedSize": 43210000},
@@ -132,10 +129,6 @@ State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_sch
 ```
 
 `diffId` = sha256 of the uncompressed CBOR sequence. Determinism and signing are defined only over this document's sha256. Signatures are Ed25519 over the descriptor digest, pushed as OCI referrer artifacts (`application/vnd.dolos.snapshot.signature.v1`, cosign-compatible envelope where convenient). Restore verifies registry blob digests (transport integrity) and diffIds (canonical identity).
-
-`history` embeds the digest of every previously published descriptor, so the latest signed descriptor transitively attests the entire publication history (~80 bytes per epoch, ~50 KB after 600 epochs — negligible for a config blob). This makes attestation outlive blob retention: a snapshot whose blobs have long been garbage-collected can still be verified by anyone holding a copy, because the copy carries its own descriptor (the OCI config blob) — check that descriptor's digest against the `history` of the latest signed descriptor, then the layers against its diffIds. No external trusted storage of attestations is required.
-
-Note: a side-effect of anchoring identity on uncompressed content digests is that snapshots can be mirrored over any content-addressed transport (e.g. IPFS) — or re-compressed with a different algorithm — and still verify against the same signed descriptor. This is a property of the format, not a requirement of the protocol; the OCI registry remains the canonical distribution channel.
 
 ### Code layout
 
@@ -170,12 +163,12 @@ trusted_keys = ["ed25519:…"]  # mirrors mithril genesis_key style
 4. Determinism job: an independent runner that synced by any means runs `dolos snapshot digest` and alerts on descriptor mismatch.
 5. Matching verifiers sign and push referrer signatures; clients enforce k-of-n.
 
-Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged state blobs are reclaimed by registry GC; epoch blobs remain referenced by later manifests. Trust evidence for reclaimed snapshots survives in the descriptor `history` of every later publish.
+Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged state blobs are reclaimed by registry GC; epoch blobs remain referenced by later manifests.
 
 ### Restore pipeline
 
 1. Resolve tag → manifest → descriptor; verify digest, schema, network magic and signatures.
-2. Plan epoch range from `sync.max_history`; diff against the progress file (`<storage.path>/.snapshot-restore.json`, records descriptor digest + completed layer diffIds) for `--continue`. Preflight: sum the descriptor `uncompressedSize` of the planned layers and fail early if free space at `storage.path` is insufficient; derive download progress and time-remaining estimates from the manifest's compressed blob sizes.
+2. Plan epoch range from `sync.max_history`; diff against the progress file (`<storage.path>/.snapshot-restore.json`, records descriptor digest + completed layer diffIds) for `--continue`.
 3. Open stores; `IndexStore::initialize_schema()`.
 4. Per epoch (checkpointed): fetch + verify `blocks`/`logs` → archive appends, commit; fetch `indexes` → pre-hashed appends, commit.
 5. State tip: fetch the 16 shards (parallelizable) → dispatch per namespace; `set_cursor(descriptor.point)` last so `has_existing_data()` only ever sees complete restores; commit.

--- a/docs/content/bootstrap/mithril.mdx
+++ b/docs/content/bootstrap/mithril.mdx
@@ -59,7 +59,7 @@ If you use the `dolos init` command, bootstrap is triggered automatically after 
 </Aside>
 
 <Aside type="note">
-The import step supports resuming from previous runs via the `--continue` flag. The download step also supports resuming: when `--continue` is set, only immutable files not already present in the download directory are fetched.
+The process supports resuming from previous runs (use the global `--continue` flag to allow bootstrap to proceed when Dolos storage already has data). The download step resumes automatically: if immutable files already exist in the download directory, only the missing ones are fetched.
 </Aside>
 
 In addition to the [global bootstrap flags](../bootstrap), the `mithril` subcommand accepts the following flags:
@@ -75,4 +75,4 @@ In addition to the [global bootstrap flags](../bootstrap), the `mithril` subcomm
 | `--download-start <N>` | Start downloading from this immutable file number (inclusive) | none |
 | `--download-end <N>` | Download up to this immutable file number (inclusive) | none |
 
-When `--download-start` and `--download-end` are not specified, the full range of immutable files is downloaded. If immutable files already exist in the download directory, the download resumes from the next missing file.
+When `--download-start` and `--download-end` are not specified, the full range of immutable files is downloaded and verified. If immutable files already exist in the download directory, the download resumes from the highest file present (which is re-fetched in case a previous run left it incomplete); certificate verification still covers the full set of immutable files. When an explicit range is given, verification is scoped to that range.

--- a/docs/content/bootstrap/mithril.mdx
+++ b/docs/content/bootstrap/mithril.mdx
@@ -8,6 +8,8 @@ import { Aside } from '@astrojs/starlight/components';
 
 _Mithril_ is a signature scheme that generates a certificate to convince verifiers that a portion of the stake of a system has signed a message. There's currently a network of Cardano SPOs continuously verifying snapshots of the history of the chain and making them available for consumption by client applications, such as Dolos.
 
+Dolos uses the Mithril **Cardano Database v2** snapshot format, which certifies immutable files via a Merkle tree. This allows Dolos to download and verify individual immutable file chunks incrementally rather than requiring a single monolithic archive. Ancillary files (ledger state) are not downloaded; Dolos rebuilds ledger state from block history.
+
 From _Dolos'_ perspective, the process of bootstrapping with _Mithril_ involves the following steps (which are executed automatically):
 
 1. Downloading a snapshot from a cloud server
@@ -56,8 +58,8 @@ The process will take from several minutes to a few hours depending on the netwo
 If you use the `dolos init` command, bootstrap is triggered automatically after configuration so you don't need to run this manually.
 </Aside>
 
-<Aside type="caution">
-The import step supports resuming from previous runs via the `--continue` flag. However, the download step does not support resuming.
+<Aside type="note">
+The import step supports resuming from previous runs via the `--continue` flag. The download step also supports resuming: when `--continue` is set, only immutable files not already present in the download directory are fetched.
 </Aside>
 
 In addition to the [global bootstrap flags](../bootstrap), the `mithril` subcommand accepts the following flags:
@@ -70,3 +72,7 @@ In addition to the [global bootstrap flags](../bootstrap), the `mithril` subcomm
 | `--retain-snapshot` | Retain downloaded snapshot instead of deleting it | `false` |
 | `--chunk-size <N>` | Number of blocks to process per chunk (more is faster but uses more memory) | `500` |
 | `--start-from <POINT>` | Resume import from a specific chain point | none |
+| `--download-start <N>` | Start downloading from this immutable file number (inclusive) | none |
+| `--download-end <N>` | Download up to this immutable file number (inclusive) | none |
+
+When `--download-start` and `--download-end` are not specified, the full range of immutable files is downloaded. If immutable files already exist in the download directory, the download resumes from the next missing file.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.93"
 components = ["rustfmt", "clippy"]

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -183,30 +183,60 @@ fn highest_existing_immutable(immutable_dir: &Path) -> Option<u64> {
     max
 }
 
-/// Compute the immutable file range to download based on CLI args and existing
-/// files on disk. If immutables already exist locally and no explicit range is
-/// given, resume from the next missing file.
-fn compute_immutable_range(args: &Args, immutable_dir: &Path) -> ImmutableFileRange {
-    if let (Some(start), Some(end)) = (args.download_start, args.download_end) {
-        return ImmutableFileRange::Range(start, end);
+/// Ranges of immutable files to download and to verify.
+struct DownloadPlan {
+    /// Range to download, if any. `None` when files on disk already cover the
+    /// snapshot.
+    download: Option<ImmutableFileRange>,
+    /// Range to verify against the certificate.
+    verify: ImmutableFileRange,
+}
+
+/// Build the explicit range requested via CLI args, if any.
+fn explicit_range(args: &Args) -> Option<ImmutableFileRange> {
+    match (args.download_start, args.download_end) {
+        (Some(start), Some(end)) => Some(ImmutableFileRange::Range(start, end)),
+        (Some(start), None) => Some(ImmutableFileRange::From(start)),
+        (None, Some(end)) => Some(ImmutableFileRange::UpTo(end)),
+        (None, None) => None,
     }
-    if let Some(start) = args.download_start {
-        return ImmutableFileRange::From(start);
-    }
-    if let Some(end) = args.download_end {
-        return ImmutableFileRange::UpTo(end);
+}
+
+/// Compute the download & verification plan based on CLI args, existing files
+/// on disk and the snapshot's last immutable file number.
+///
+/// When an explicit range is given, both download and verification are scoped
+/// to it. Otherwise the full range is verified; if immutables already exist
+/// locally, the download resumes from the highest file present. The highest
+/// file is re-fetched (not skipped) because an interrupted run may have left
+/// it truncated, and it's never verified until this run completes.
+fn plan_download(args: &Args, immutable_dir: &Path, last_immutable: u64) -> DownloadPlan {
+    if let Some(verify) = explicit_range(args) {
+        return DownloadPlan {
+            download: explicit_range(args),
+            verify,
+        };
     }
 
-    if let Some(highest) = highest_existing_immutable(immutable_dir) {
-        info!(
-            highest,
-            "resuming download from immutable file {}",
-            highest + 1
-        );
-        return ImmutableFileRange::From(highest + 1);
-    }
+    let download = match highest_existing_immutable(immutable_dir) {
+        Some(highest) if highest > last_immutable => {
+            info!(
+                highest,
+                last_immutable, "local immutable files already cover the snapshot"
+            );
+            None
+        }
+        Some(highest) => {
+            info!(highest, "resuming download from immutable file {highest}");
+            Some(ImmutableFileRange::From(highest))
+        }
+        None => Some(ImmutableFileRange::Full),
+    };
 
-    ImmutableFileRange::Full
+    DownloadPlan {
+        download,
+        verify: ImmutableFileRange::Full,
+    }
 }
 
 async fn fetch_snapshot(
@@ -247,25 +277,32 @@ async fn fetch_snapshot(
     let target_directory = Path::new(&args.download_dir);
     let immutable_dir = target_directory.join("immutable");
 
-    let immutable_range = compute_immutable_range(args, &immutable_dir);
+    let last_immutable = snapshot.beacon.immutable_file_number;
+    let plan = plan_download(args, &immutable_dir, last_immutable);
 
-    let download_opts = DownloadUnpackOptions {
-        allow_override: true,
-        include_ancillary: false,
-        ..DownloadUnpackOptions::default()
-    };
+    if let Some(immutable_range) = &plan.download {
+        let download_opts = DownloadUnpackOptions {
+            allow_override: true,
+            include_ancillary: false,
+            ..DownloadUnpackOptions::default()
+        };
 
-    db_client
-        .download_unpack(&snapshot, &immutable_range, target_directory, download_opts)
-        .await?;
+        db_client
+            .download_unpack(&snapshot, immutable_range, target_directory, download_opts)
+            .await?;
 
-    let nb_files = immutable_range.length(snapshot.beacon.immutable_file_number);
+        let nb_files = immutable_range.length(last_immutable);
 
-    if let Err(e) = db_client
-        .add_statistics(immutable_range == ImmutableFileRange::Full, false, nb_files)
-        .await
-    {
-        warn!("failed incrementing snapshot download statistics: {:?}", e);
+        if let Err(e) = db_client
+            .add_statistics(
+                *immutable_range == ImmutableFileRange::Full,
+                false,
+                nb_files,
+            )
+            .await
+        {
+            warn!("failed incrementing snapshot download statistics: {:?}", e);
+        }
     }
 
     if !args.skip_validation {
@@ -277,7 +314,7 @@ async fn fetch_snapshot(
             .verify_cardano_database(
                 &certificate,
                 &snapshot,
-                &immutable_range,
+                &plan.verify,
                 false,
                 target_directory,
                 &verified_digests,
@@ -446,4 +483,100 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     info!("bootstrap complete, run `dolos daemon` to start the node");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_with_range(start: Option<u64>, end: Option<u64>) -> Args {
+        Args {
+            download_start: start,
+            download_end: end,
+            ..Default::default()
+        }
+    }
+
+    fn touch_immutables(dir: &Path, numbers: impl IntoIterator<Item = u64>) {
+        for n in numbers {
+            for ext in ["chunk", "primary", "secondary"] {
+                std::fs::write(dir.join(format!("{n:05}.{ext}")), []).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn plan_uses_explicit_range_for_download_and_verify() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let plan = plan_download(&args_with_range(Some(5), Some(8)), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::Range(5, 8)));
+        assert_eq!(plan.verify, ImmutableFileRange::Range(5, 8));
+
+        let plan = plan_download(&args_with_range(Some(5), None), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::From(5)));
+        assert_eq!(plan.verify, ImmutableFileRange::From(5));
+
+        let plan = plan_download(&args_with_range(None, Some(8)), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::UpTo(8)));
+        assert_eq!(plan.verify, ImmutableFileRange::UpTo(8));
+    }
+
+    #[test]
+    fn plan_downloads_and_verifies_full_on_fresh_dir() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let plan = plan_download(&args_with_range(None, None), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::Full));
+        assert_eq!(plan.verify, ImmutableFileRange::Full);
+
+        // a missing dir behaves like a fresh one
+        let plan = plan_download(&args_with_range(None, None), &dir.path().join("nope"), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::Full));
+    }
+
+    #[test]
+    fn plan_resumes_from_highest_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_immutables(dir.path(), 0..=4);
+
+        // the highest file is re-fetched (not skipped): an interrupted run may
+        // have left it truncated
+        let plan = plan_download(&args_with_range(None, None), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::From(4)));
+        assert_eq!(plan.verify, ImmutableFileRange::Full);
+    }
+
+    #[test]
+    fn plan_refetches_boundary_file_when_download_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_immutables(dir.path(), 0..=10);
+
+        // highest == last must not produce an out-of-bounds range (From(11)
+        // would make the mithril client fail with "invalid immutable file
+        // range" when resuming after a crash during import)
+        let plan = plan_download(&args_with_range(None, None), dir.path(), 10);
+        assert_eq!(plan.download, Some(ImmutableFileRange::From(10)));
+        assert_eq!(plan.verify, ImmutableFileRange::Full);
+    }
+
+    #[test]
+    fn plan_skips_download_when_local_files_exceed_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_immutables(dir.path(), 0..=11);
+
+        let plan = plan_download(&args_with_range(None, None), dir.path(), 10);
+        assert_eq!(plan.download, None);
+        assert_eq!(plan.verify, ImmutableFileRange::Full);
+    }
+
+    #[test]
+    fn highest_existing_ignores_non_numeric_files() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_immutables(dir.path(), [0, 3]);
+        std::fs::write(dir.path().join("lock"), []).unwrap();
+        std::fs::write(dir.path().join("clean"), []).unwrap();
+
+        assert_eq!(highest_existing_immutable(dir.path()), Some(3));
+    }
 }

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -2,7 +2,10 @@ use dolos_core::config::{MithrilConfig, RootConfig};
 use dolos_core::ImportExt;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
-use mithril_client::{ClientBuilder, MessageBuilder, MithrilError, MithrilResult};
+use mithril_client::cardano_database_client::{DownloadUnpackOptions, ImmutableFileRange};
+use mithril_client::{
+    AggregatorDiscoveryType, ClientBuilder, MessageBuilder, MithrilError, MithrilResult,
+};
 use std::{path::Path, sync::Arc};
 use tracing::{info, warn};
 
@@ -33,6 +36,14 @@ pub struct Args {
 
     #[arg(long)]
     start_from: Option<ChainPoint>,
+
+    /// Start downloading from this immutable file number (inclusive)
+    #[arg(long)]
+    download_start: Option<u64>,
+
+    /// Download up to this immutable file number (inclusive)
+    #[arg(long)]
+    download_end: Option<u64>,
 }
 
 impl Default for Args {
@@ -44,34 +55,93 @@ impl Default for Args {
             retain_snapshot: Default::default(),
             chunk_size: 500,
             start_from: None,
+            download_start: None,
+            download_end: None,
         }
     }
 }
 
 struct MithrilFeedback {
-    download_pb: indicatif::ProgressBar,
+    aggregate_pb: indicatif::ProgressBar,
     validate_pb: indicatif::ProgressBar,
+}
+
+impl MithrilFeedback {
+    fn new(feedback: &Feedback) -> Self {
+        let multi = feedback.multi_progress();
+
+        let aggregate_pb = multi.add(indicatif::ProgressBar::hidden());
+        aggregate_pb.set_style(
+            indicatif::ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} files {msg}",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+        );
+        aggregate_pb.set_message("downloading immutable files");
+
+        let validate_pb = multi.add(indicatif::ProgressBar::new_spinner());
+        validate_pb.set_style(
+            indicatif::ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] {msg}")
+                .unwrap(),
+        );
+
+        Self {
+            aggregate_pb,
+            validate_pb,
+        }
+    }
 }
 
 #[async_trait::async_trait]
 impl mithril_client::feedback::FeedbackReceiver for MithrilFeedback {
     async fn handle_event(&self, event: mithril_client::feedback::MithrilEvent) {
         match event {
-            mithril_client::feedback::MithrilEvent::SnapshotDownloadStarted { .. } => {
-                self.download_pb.set_message("snapshot download started")
-            }
-            mithril_client::feedback::MithrilEvent::SnapshotDownloadProgress {
-                downloaded_bytes,
-                size,
-                ..
-            } => {
-                self.download_pb.set_length(size);
-                self.download_pb.set_position(downloaded_bytes);
-                self.download_pb.set_message("downloading Mithril snapshot");
-            }
-            mithril_client::feedback::MithrilEvent::SnapshotDownloadCompleted { .. } => {
-                self.download_pb.set_message("snapshot download completed");
-            }
+            mithril_client::feedback::MithrilEvent::CardanoDatabase(db_event) => match db_event {
+                mithril_client::feedback::MithrilEventCardanoDatabase::Started {
+                    total_immutable_files,
+                    ..
+                } => {
+                    self.aggregate_pb
+                        .set_draw_target(indicatif::ProgressDrawTarget::stderr());
+                    self.aggregate_pb.set_length(total_immutable_files);
+                    self.aggregate_pb.set_position(0);
+                }
+                mithril_client::feedback::MithrilEventCardanoDatabase::ImmutableDownloadCompleted {
+                    ..
+                } => {
+                    self.aggregate_pb.inc(1);
+                }
+                mithril_client::feedback::MithrilEventCardanoDatabase::Completed { .. } => {
+                    self.aggregate_pb.finish_with_message("download completed");
+                }
+                mithril_client::feedback::MithrilEventCardanoDatabase::DigestDownloadStarted {
+                    size,
+                    ..
+                } => {
+                    self.validate_pb.set_length(size);
+                    self.validate_pb.set_position(0);
+                    self.validate_pb.set_message("downloading digests");
+                }
+                mithril_client::feedback::MithrilEventCardanoDatabase::DigestDownloadProgress {
+                    downloaded_bytes,
+                    size,
+                    ..
+                } => {
+                    self.validate_pb.set_length(size);
+                    self.validate_pb.set_position(downloaded_bytes);
+                    self.validate_pb.set_message("downloading digests");
+                }
+                mithril_client::feedback::MithrilEventCardanoDatabase::DigestDownloadCompleted {
+                    ..
+                } => {
+                    self.validate_pb
+                        .finish_with_message("digests downloaded");
+                }
+                _ => {
+                    tracing::debug!("unhandled mithril event: {db_event:?}");
+                }
+            },
             mithril_client::feedback::MithrilEvent::CertificateChainValidationStarted {
                 ..
             } => {
@@ -93,10 +163,50 @@ impl mithril_client::feedback::FeedbackReceiver for MithrilFeedback {
                     .set_message("certificate fetched from cache");
             }
             x => {
-                self.validate_pb.set_message(format!("{x:?}"));
+                tracing::debug!("unhandled mithril event: {x:?}");
             }
         }
     }
+}
+
+/// Scan the immutable directory for the highest immutable file number present.
+fn highest_existing_immutable(immutable_dir: &Path) -> Option<u64> {
+    let entries = std::fs::read_dir(immutable_dir).ok()?;
+    let mut max: Option<u64> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(num_str) = name.split('.').next().and_then(|s| s.parse::<u64>().ok()) {
+            max = Some(max.map_or(num_str, |m| m.max(num_str)));
+        }
+    }
+    max
+}
+
+/// Compute the immutable file range to download based on CLI args and existing
+/// files on disk. If immutables already exist locally and no explicit range is
+/// given, resume from the next missing file.
+fn compute_immutable_range(args: &Args, immutable_dir: &Path) -> ImmutableFileRange {
+    if let (Some(start), Some(end)) = (args.download_start, args.download_end) {
+        return ImmutableFileRange::Range(start, end);
+    }
+    if let Some(start) = args.download_start {
+        return ImmutableFileRange::From(start);
+    }
+    if let Some(end) = args.download_end {
+        return ImmutableFileRange::UpTo(end);
+    }
+
+    if let Some(highest) = highest_existing_immutable(immutable_dir) {
+        info!(
+            highest,
+            "resuming download from immutable file {}",
+            highest + 1
+        );
+        return ImmutableFileRange::From(highest + 1);
+    }
+
+    ImmutableFileRange::Full
 }
 
 async fn fetch_snapshot(
@@ -104,26 +214,27 @@ async fn fetch_snapshot(
     config: &MithrilConfig,
     feedback: &Feedback,
 ) -> MithrilResult<()> {
-    let feedback = MithrilFeedback {
-        download_pb: feedback.bytes_progress_bar(),
-        validate_pb: feedback.indeterminate_progress_bar(),
-    };
+    let feedback = MithrilFeedback::new(feedback);
 
-    let client = ClientBuilder::aggregator(&config.aggregator, &config.genesis_key)
+    let client = ClientBuilder::new(AggregatorDiscoveryType::Url(config.aggregator.clone()))
+        .set_genesis_verification_key(mithril_client::GenesisVerificationKey::JsonHex(
+            config.genesis_key.clone(),
+        ))
         .add_feedback_receiver(Arc::new(feedback))
-        .set_ancillary_verification_key(config.ancillary_key.clone())
         .build()?;
 
-    let snapshots = client.cardano_database().list().await?;
+    let db_client = client.cardano_database_v2();
+
+    let snapshots = db_client.list().await?;
 
     let last_digest = snapshots
-        .first()
+        .iter()
+        .max_by_key(|s| s.beacon.immutable_file_number)
         .ok_or(MithrilError::msg("no snapshot available"))?
-        .digest
-        .as_ref();
+        .hash
+        .as_str();
 
-    let snapshot = client
-        .cardano_database()
+    let snapshot = db_client
         .get(last_digest)
         .await?
         .ok_or(MithrilError::msg("no snapshot available"))?;
@@ -134,26 +245,58 @@ async fn fetch_snapshot(
         .await?;
 
     let target_directory = Path::new(&args.download_dir);
+    let immutable_dir = target_directory.join("immutable");
 
-    client
-        .cardano_database()
-        .download_unpack(&snapshot, target_directory)
+    let immutable_range = compute_immutable_range(args, &immutable_dir);
+
+    let download_opts = DownloadUnpackOptions {
+        allow_override: true,
+        include_ancillary: false,
+        ..DownloadUnpackOptions::default()
+    };
+
+    db_client
+        .download_unpack(&snapshot, &immutable_range, target_directory, download_opts)
         .await?;
 
-    if let Err(e) = client.cardano_database().add_statistics(&snapshot).await {
+    let nb_files = immutable_range.length(snapshot.beacon.immutable_file_number);
+
+    if let Err(e) = db_client
+        .add_statistics(immutable_range == ImmutableFileRange::Full, false, nb_files)
+        .await
+    {
         warn!("failed incrementing snapshot download statistics: {:?}", e);
     }
 
     if !args.skip_validation {
+        let verified_digests = db_client
+            .download_and_verify_digests(&certificate, &snapshot)
+            .await?;
+
+        let merkle_proof = db_client
+            .verify_cardano_database(
+                &certificate,
+                &snapshot,
+                &immutable_range,
+                false,
+                target_directory,
+                &verified_digests,
+            )
+            .await
+            .map_err(|e| MithrilError::msg(format!("verification failed: {e:?}")))?;
+
+        let message = MessageBuilder::new()
+            .compute_cardano_database_message(&certificate, &merkle_proof)
+            .await?;
+
+        if !certificate.match_message(&message) {
+            return Err(MithrilError::msg(
+                "mithril certificate does not match the downloaded snapshot",
+            ));
+        }
+    } else {
         warn!("skipping validation, assuming snapshot is already validated");
-        return Ok(());
     }
-
-    let message = MessageBuilder::new()
-        .compute_snapshot_message(&certificate, target_directory)
-        .await?;
-
-    assert!(certificate.match_message(&message));
 
     Ok(())
 }

--- a/src/bin/dolos/feedback.rs
+++ b/src/bin/dolos/feedback.rs
@@ -1,4 +1,5 @@
 pub use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::sync::Arc;
 
 pub struct ProgressReader<R> {
     inner: R,
@@ -20,10 +21,14 @@ impl<R: std::io::Read> std::io::Read for ProgressReader<R> {
 }
 
 pub struct Feedback {
-    multi: MultiProgress,
+    multi: Arc<MultiProgress>,
 }
 
 impl Feedback {
+    pub fn multi_progress(&self) -> Arc<MultiProgress> {
+        self.multi.clone()
+    }
+
     pub fn indeterminate_progress_bar(&self) -> ProgressBar {
         let pb = ProgressBar::new_spinner();
 
@@ -65,7 +70,7 @@ impl Feedback {
 
 impl Default for Feedback {
     fn default() -> Self {
-        let multi = MultiProgress::new();
+        let multi = Arc::new(MultiProgress::new());
 
         Self { multi }
     }


### PR DESCRIPTION
## Summary

Mithril v1 (CardanoImmutableFilesFull) has been decommissioned in client distribution 2617. This PR migrates Dolos to the v2 **CardanoDatabase** format, which certifies immutable files via a Merkle tree and supports incremental download of individual immutable file archives.

### What changed

- **mithril-client bumped from 0.12.2 to 0.14.5** — uses `cardano_database_v2()` API (v1 `cardano_database()` is removed)
- **rust-toolchain bumped from 1.91 to 1.93** — required by `fixed v1.31.0`, a transitive dep of `mithril-common 0.6.67` (the only version compatible with the client's `strum 0.28`)
- **Crypto provider kept on `ring`** — mithril-client uses reqwest 0.13, whose `rustls` feature hard-wires the `aws-lc-rs` provider (a large C dependency needing cmake). We use mithril-client's `rustls-no-provider` feature and add a direct `rustls`/`ring` dep so `ring` stays the sole provider. Keeps `aws-lc-rs`/`aws-lc-sys` (and `cmake`/`dunce`/`fs_extra`) out of the lockfile and avoids duplicating a second TLS crypto stack in the binary.
- **`fetch_snapshot()` rewritten** for the v2 pipeline:
  - `download_and_verify_digests` -> `download_unpack(ImmutableFileRange)` -> `verify_cardano_database` -> `compute_cardano_database_message`
  - Streaming download -> unpack (no tar materialized on disk)
  - Merkle proof verification of an arbitrary subset of immutable files
- **Ancillary files not downloaded** (`include_ancillary: false`) — Dolos rebuilds ledger state from blocks via `import_blocks`
- **New `--download-start`/`--download-end` flags** for explicit immutable file range selection. When given, both download and verification are scoped to that range.
- **Automatic download resume**: when immutables already exist on disk (no explicit range given), resume from the highest file present. The highest file is **re-fetched** rather than skipped (an interrupted run may have left it truncated; `allow_override` is set), and if local files already cover the snapshot the download is skipped entirely. Verification always covers the **full** immutable set on this path, so files fetched by an earlier aborted run are still checked against the certificate. (Resume is disk-driven and independent of the global `--continue` flag.)
- **Fixed inverted `skip_validation` gate** — content hash check now runs by default; skipped only when `--skip-validation` is passed
- **Replaced `assert!`** with proper `Result` error on certificate message mismatch
- **Sort snapshots by `beacon.immutable_file_number`** (replaces blind `snapshots.first()`)
- **Updated feedback receiver** for v2 `CardanoDatabase` event variants
- **Unit tests** for the download/verify range planning (fresh dir, explicit range, resume, completed-download boundary, over-covered local dir)
- **Updated docs** for v2 format, download resume, and new flags

### Disk usage during bootstrap

Each immutable file archive is streamed directly into the unpacker (`reqwest bytes_stream` -> `zstd::Decoder` -> `tar::unpack`) — no `.tar.zst` is ever materialized on disk. Peak disk-in-use is just the unpacked immutable files being written to `download_dir/immutable/` (up to 20 concurrent streams by default). No staging dir, no tar doubling.

### Backward compatibility

- `MithrilConfig.ancillary_key` is kept in config but silently ignored (avoids breaking existing `dolos.toml` files)
- `--retain-snapshot` semantics unchanged (keeps `download_dir/immutable/` + marker files)

### Verification

- `cargo clippy --workspace --all-targets --all-features` — zero warnings
- `cargo build --workspace --all-targets --all-features` — clean build
- `cargo test --workspace` — all pass (pre-existing `strict` feature proptest failures in `dolos-cardano` confirmed unrelated)

### Closes

N/A — proactive migration to stay compatible with the live Mithril network (v1 decommissioned in distribution 2617).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mithril bootstrap now supports downloading a bounded immutable-file range via `--download-start` and `--download-end`.
  * Downloads can resume from the next missing immutable file based on existing local `immutable/` data.
  * Progress reporting now reflects Cardano Database v2 immutable-file and digest downloads.
* **Bug Fixes**
  * Improved snapshot validation now detects certificate mismatches for downloaded snapshots (with optional skipping).
* **Documentation**
  * Updated Mithril bootstrap guidance for Cardano Database v2 and expanded restore planning details, including descriptor history.
* **Chores**
  * Updated the Mithril client dependency and the Rust toolchain version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
