### PR TITLE
fix(cardano): update Conway governance proposal mappings

### DIFF
--- a/crates/cardano/src/hacks.rs
+++ b/crates/cardano/src/hacks.rs
@@ -341,6 +341,10 @@ pub mod proposals {
                 "4aa45fe4266c114201733bbc641164b4d3eac51081afeee12ddc92235b58f45c#0" => {
                     Ratified(295)
                 }
+                // Parameter Change superseded at epoch 296
+                "7b8b1d6c22fc2ff8f1a1526a8027ad9df025dc9a7013b81ef51fb869bcc1af44#0" => {
+                    Canceled(296)
+                }
                 _ => match protocol {
                     0..=8 => RatifiedCurrentEpoch,
                     _ => Unknown,
@@ -561,12 +565,11 @@ pub mod proposals {
                 }
 
                 // Hard Fork to Protocol Version 11 — submitted epoch 637, all three
-                // governance bodies voting yes with zero no votes. Anticipated
-                // ratification at epoch 641, enactment at epoch 642.
-                // Uncomment when ratification is confirmed on-chain.
-                // "fdd468da5cc4ac8431dcd7e2b3211666c73bc229f85879469f67f1d9d51d344d#0" => {
-                //     Ratified(641)
-                // }
+                // governance bodies voting yes with zero no votes. Ratified at
+                // epoch 643, enactment at epoch 644.
+                "fdd468da5cc4ac8431dcd7e2b3211666c73bc229f85879469f67f1d9d51d344d#0" => {
+                    Ratified(643)
+                }
 
                 // Plutus V3 Cost Model Parameter Changes Prior to Chang#2
                 "b2a591ac219ce6dcca5847e0248015209c7cb0436aa6bd6863d0c1f152a60bc5#0" => {
@@ -743,6 +746,14 @@ pub mod proposals {
                 // Treasury Withdrawal enacted at epoch 641
                 "17e43ffe4b2e0df1787d54f21ac66643c74abb131a326272fceecbdbbdd0d3fc#0" => {
                     Ratified(640)
+                }
+                // Parameter Change enacted at epoch 643
+                "c75bb221606687aa858ec89c7a15c88e9c17054f2e045ae31ecc8a9687cd206e#0" => {
+                    Ratified(642)
+                }
+                // Treasury Withdrawal enacted at epoch 643
+                "4f6e5df9a6e14bd49e406e2bbb0d108b3be2be64b9569b930053a0c1eebe0d47#0" => {
+                    Ratified(642)
                 }
 
                 _ => match protocol {

--- a/skills/update-proposals/SKILL.md
+++ b/skills/update-proposals/SKILL.md
@@ -31,6 +31,7 @@ SELECT
     encode(tx.hash, 'hex') || '#' || gap.index::text AS proposal_id,
     gap.type::text AS proposal_type,
     b.epoch_no AS submitted_epoch,
+    gap.ratified_epoch,
     gap.enacted_epoch,
     gap.dropped_epoch,
     gap.expired_epoch
@@ -43,6 +44,7 @@ ORDER BY b.epoch_no, gap.index;
 **Key columns:**
 - `proposal_id`: The `txhash#index` format used in hacks.rs match arms
 - `type`: `TreasuryWithdrawals`, `NewConstitution`, `NewCommittee`, `ParameterChange`, `HardForkInitiation`, `InfoAction`
+- `ratified_epoch`: Non-null if the proposal was ratified (enactment follows at the next epoch). Use this when `enacted_epoch` is still NULL — the proposal is ratified but enactment hasn't happened yet at the current DBSync tip.
 - `enacted_epoch`: Non-null if the proposal was enacted on-chain
 - `dropped_epoch`: Non-null if the proposal was dropped (superseded by another)
 - `expired_epoch`: Non-null if the proposal expired without ratification
@@ -54,25 +56,26 @@ SELECT
     encode(tx.hash, 'hex') || '#' || gap.index::text AS proposal_id,
     gap.type::text AS proposal_type,
     b.epoch_no AS submitted_epoch,
+    gap.ratified_epoch,
     gap.enacted_epoch,
-    (gap.enacted_epoch - 1)::text AS expected_ratified
+    COALESCE(gap.ratified_epoch, gap.enacted_epoch - 1)::text AS expected_ratified
 FROM gov_action_proposal gap
 JOIN tx ON tx.id = gap.tx_id
 JOIN block b ON b.id = tx.block_id
-WHERE gap.enacted_epoch IS NOT NULL
-ORDER BY gap.enacted_epoch, gap.index;
+WHERE gap.enacted_epoch IS NOT NULL OR gap.ratified_epoch IS NOT NULL
+ORDER BY COALESCE(gap.enacted_epoch, gap.ratified_epoch), gap.index;
 ```
 
-The formula is: **`Ratified(enacted_epoch - 1)`**. Ratification happens one epoch before enactment in Conway governance.
+The formula is: **`Ratified(enacted_epoch - 1)`**, or equivalently `Ratified(ratified_epoch)`. Ratification happens one epoch before enactment in Conway governance. Include proposals where `ratified_epoch` is non-null but `enacted_epoch` is still NULL — these are ratified but awaiting enactment at the current tip, and still need `Ratified` entries in hacks.rs.
 
 ## Step 4: Cross-reference against hacks.rs
 
 Read `crates/cardano/src/hacks.rs` and find the network's `outcome()` function (e.g., `pub mod mainnet`). Compare every enacted proposal from Step 3 against existing match arms.
 
 **Check for:**
-1. **Missing entries**: Enacted proposals not in hacks.rs. These return `Unknown`, never get enacted, and eventually expire -- causing wrong deposit refund timing and missed treasury withdrawals.
-2. **Wrong Ratified epoch**: Existing entries where the `Ratified(N)` doesn't match `enacted_epoch - 1`.
-3. **Still-pending proposals**: Proposals with no `enacted_epoch`, `dropped_epoch`, or `expired_epoch` yet. These correctly return `Unknown` and will need entries added later when resolved.
+1. **Missing entries**: Enacted or ratified proposals not in hacks.rs. These return `Unknown`, never get enacted, and eventually expire -- causing wrong deposit refund timing and missed treasury withdrawals.
+2. **Wrong Ratified epoch**: Existing entries where the `Ratified(N)` doesn't match `ratified_epoch` (or `enacted_epoch - 1` if `ratified_epoch` is NULL).
+3. **Still-pending proposals**: Proposals with no `ratified_epoch`, `enacted_epoch`, `dropped_epoch`, or `expired_epoch` yet. These correctly return `Unknown` and will need entries added later when resolved.
 
 ## Step 5: Determine if dropped/expired proposals need entries
 
@@ -135,6 +138,7 @@ cargo test --test epoch_pots --release -- --nocapture
 | `tx_id` | bigint | FK to `tx` -- the transaction containing the proposal |
 | `index` | int | Index of the proposal within the transaction |
 | `type` | text | Proposal type enum |
+| `ratified_epoch` | int | Epoch when ratified (null if not ratified). May be set before `enacted_epoch` if enactment hasn't happened yet at the current DBSync tip. |
 | `enacted_epoch` | int | Epoch when enacted (null if not enacted) |
 | `dropped_epoch` | int | Epoch when dropped/superseded (null if not dropped) |
 | `expired_epoch` | int | Epoch when expired (null if not expired) |


### PR DESCRIPTION
## Summary

Updates hardcoded Conway governance proposal mappings in `crates/cardano/src/hacks.rs` by cross-referencing against DBSync, and fixes the `update-proposals` skill to prevent future gaps.

## Changes to hacks.rs

**Mainnet:**
- `c75bb221#0` — ParameterChange, `Ratified(642)` (enacted epoch 643) — was missing
- `4f6e5df9#0` — TreasuryWithdrawals, `Ratified(642)` (enacted epoch 643) — was missing
- `fdd468da#0` — HardForkInitiation (v11 hardfork), `Ratified(643)` — was commented out awaiting ratification; DBSync `ratified_epoch` confirms ratification at 643

**Preprod:**
- `7b8b1d6c#0` — ParameterChange, `Canceled(296)` — superseded by `4aa45fe4#0` (enacted 296); was missing

## Changes to skill

The `update-proposals` skill previously queried only `enacted_epoch` and derived the ratified epoch as `enacted_epoch - 1`. This missed proposals that were ratified but not yet enacted (where `enacted_epoch` is NULL but `ratified_epoch` is set) — making them indistinguishable from still-pending proposals.

- Step 2/3 queries now select `ratified_epoch` and use `COALESCE(ratified_epoch, enacted_epoch - 1)`
- Step 3 WHERE clause broadened to include `ratified_epoch IS NOT NULL`
- Step 4 cross-reference checks updated to use `ratified_epoch`
- Reference table updated with the new column

## Verification

- `cargo clippy -p dolos-cardano` — clean
- `cargo check -p dolos-cardano` — clean
- `cargo test --test epoch_pots --release` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected governance proposal outcome reporting across preprod and mainnet networks.
  * Added accurate canceled and ratified statuses for recently processed proposals, including their corresponding epochs.

* **Documentation**
  * Updated proposal reconciliation guidance to account for ratification timing and pending proposals more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->