### PR TITLE
feat(minibf): add block txs CBOR endpoints

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -366,6 +366,10 @@ where
         .route("/blocks/latest", get(routes::blocks::latest::<D>))
         .route("/blocks/latest/txs", get(routes::blocks::latest_txs::<D>))
         .route(
+            "/blocks/latest/txs/cbor",
+            get(routes::blocks::latest_txs_cbor::<D>),
+        )
+        .route(
             "/blocks/{hash_or_number}",
             get(routes::blocks::by_hash_or_number::<D>),
         )
@@ -380,6 +384,10 @@ where
         .route(
             "/blocks/{hash_or_number}/txs",
             get(routes::blocks::by_hash_or_number_txs::<D>),
+        )
+        .route(
+            "/blocks/{hash_or_number}/txs/cbor",
+            get(routes::blocks::by_hash_or_number_txs_cbor::<D>),
         )
         .route(
             "/blocks/{hash_or_number}/addresses",

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -33,6 +33,7 @@ use blockfrost_openapi::models::{
     block_content::BlockContent,
     block_content_addresses_inner::BlockContentAddressesInner,
     block_content_addresses_inner_transactions_inner::BlockContentAddressesInnerTransactionsInner,
+    block_content_txs_cbor_inner::BlockContentTxsCborInner,
     tx_content::TxContent,
     tx_content_cbor::TxContentCbor,
     tx_content_delegations_inner::TxContentDelegationsInner,
@@ -2264,6 +2265,25 @@ impl<'a> IntoModel<Vec<String>> for BlockModelBuilder<'a> {
             .map(|tx| tx.hash().to_string())
             //.sorted()
             //.map(|tx| BlockContentAddressesInnerTransactionsInner { tx_hash: tx })
+            .collect();
+
+        Ok(txs)
+    }
+}
+
+impl<'a> IntoModel<Vec<BlockContentTxsCborInner>> for BlockModelBuilder<'a> {
+    type SortKey = ();
+
+    fn into_model(self) -> Result<Vec<BlockContentTxsCborInner>, StatusCode> {
+        let block = &self.block;
+
+        let txs = block
+            .txs()
+            .iter()
+            .map(|tx| BlockContentTxsCborInner {
+                tx_hash: tx.hash().to_string(),
+                cbor: hex::encode(tx.encode()),
+            })
             .collect();
 
         Ok(txs)

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -786,6 +786,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocks_latest_txs_cbor_paginated() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.last().expect("missing block vectors");
+        let (status, bytes) = app
+            .get_bytes("/blocks/latest/txs/cbor?count=1&page=2")
+            .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse paginated latest txs cbor");
+
+        let expected: Vec<String> = block.tx_hashes.iter().skip(1).take(1).cloned().collect();
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        assert_eq!(hashes, expected);
+    }
+
+    #[tokio::test]
     async fn blocks_latest_txs_cbor_internal_error() {
         let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         assert_status(

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -3,7 +3,9 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use blockfrost_openapi::models::block_content::BlockContent;
+use blockfrost_openapi::models::{
+    block_content::BlockContent, block_content_txs_cbor_inner::BlockContentTxsCborInner,
+};
 use dolos_cardano::ChainSummary;
 use dolos_core::{archive::Skippable as _, ArchiveStore as _, BlockBody, Domain};
 use futures::future::try_join_all;
@@ -401,6 +403,34 @@ where
     ))
 }
 
+pub async fn by_hash_or_number_txs_cbor<D>(
+    Path(hash_or_number): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<BlockContentTxsCborInner>>, Error>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+    let hash_or_number = parse_hash_or_number(&hash_or_number)?;
+    let block = load_block_by_hash_or_number(&domain, &hash_or_number).await?;
+
+    let model = BlockModelBuilder::new(&block)?;
+
+    let txs: Vec<BlockContentTxsCborInner> = model.into_model()?;
+    let txs = match pagination.order {
+        Order::Asc => txs,
+        Order::Desc => txs.into_iter().rev().collect(),
+    };
+
+    Ok(Json(
+        txs.into_iter()
+            .skip(pagination.skip())
+            .take(pagination.count)
+            .collect(),
+    ))
+}
+
 pub async fn by_hash_or_number_addresses<D>(
     Path(hash_or_number): Path<String>,
     Query(params): Query<PaginationParameters>,
@@ -446,6 +476,36 @@ where
     let model = BlockModelBuilder::new(&tip)?;
 
     let txs: Vec<String> = model.into_model()?;
+    let txs = match pagination.order {
+        Order::Asc => txs,
+        Order::Desc => txs.into_iter().rev().collect(),
+    };
+
+    Ok(Json(
+        txs.into_iter()
+            .skip(pagination.skip())
+            .take(pagination.count)
+            .collect(),
+    ))
+}
+
+pub async fn latest_txs_cbor<D>(
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<BlockContentTxsCborInner>>, Error>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+    let (_, tip) = domain
+        .archive()
+        .get_tip()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let model = BlockModelBuilder::new(&tip)?;
+
+    let txs: Vec<BlockContentTxsCborInner> = model.into_model()?;
     let txs = match pagination.order {
         Order::Asc => txs,
         Order::Desc => txs.into_iter().rev().collect(),
@@ -571,6 +631,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_happy_path() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+        let path = format!("/blocks/{}/txs/cbor", block.block_hash);
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse txs cbor");
+
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        assert_eq!(hashes, block.tx_hashes);
+
+        for tx in txs {
+            let cbor = hex::decode(&tx.cbor).expect("cbor is not valid hex");
+            let decoded = pallas::ledger::traverse::MultiEraTx::decode(&cbor)
+                .expect("cbor is not a decodable tx");
+            assert_eq!(decoded.hash().to_string(), tx.tx_hash);
+        }
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_order_desc() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+        let path = format!("/blocks/{}/txs/cbor?order=desc", block.block_hash);
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse desc txs cbor");
+
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        let mut reversed = block.tx_hashes.clone();
+        reversed.reverse();
+        assert_eq!(hashes, reversed);
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_paginated() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+        let path = format!("/blocks/{}/txs/cbor?count=1&page=2", block.block_hash);
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse paginated txs cbor");
+
+        let expected: Vec<String> = block.tx_hashes.iter().skip(1).take(1).cloned().collect();
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        assert_eq!(hashes, expected);
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/blocks/{}/txs/cbor", invalid_block());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_not_found() {
+        let app = TestApp::new();
+        let path = format!("/blocks/{}/txs/cbor", missing_block());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_txs_cbor_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        assert_status(
+            &app,
+            "/blocks/1/txs/cbor",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn blocks_latest_txs_order_asc() {
         let app = TestApp::new();
         let block = app.vectors().blocks.last().expect("missing block vectors");
@@ -594,5 +740,59 @@ mod tests {
         let mut reversed = block.tx_hashes.clone();
         reversed.reverse();
         assert_eq!(txs, reversed);
+    }
+
+    #[tokio::test]
+    async fn blocks_latest_txs_cbor_happy_path() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.last().expect("missing block vectors");
+        let (status, bytes) = app.get_bytes("/blocks/latest/txs/cbor").await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse latest txs cbor");
+
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        assert_eq!(hashes, block.tx_hashes);
+
+        for tx in txs {
+            let cbor = hex::decode(&tx.cbor).expect("cbor is not valid hex");
+            let decoded = pallas::ledger::traverse::MultiEraTx::decode(&cbor)
+                .expect("cbor is not a decodable tx");
+            assert_eq!(decoded.hash().to_string(), tx.tx_hash);
+        }
+    }
+
+    #[tokio::test]
+    async fn blocks_latest_txs_cbor_order_desc() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.last().expect("missing block vectors");
+        let (status, bytes) = app.get_bytes("/blocks/latest/txs/cbor?order=desc").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let txs: Vec<BlockContentTxsCborInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse desc latest txs cbor");
+
+        let hashes: Vec<String> = txs.iter().map(|tx| tx.tx_hash.clone()).collect();
+        let mut reversed = block.tx_hashes.clone();
+        reversed.reverse();
+        assert_eq!(hashes, reversed);
+    }
+
+    #[tokio::test]
+    async fn blocks_latest_txs_cbor_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        assert_status(
+            &app,
+            "/blocks/latest/txs/cbor",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
     }
 }

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -120,12 +120,14 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/assets/{subject}/transactions`           | Get transactions involving a specific asset              |
 | `/blocks/latest`                           | Get latest block information                             |
 | `/blocks/latest/txs`                       | Get transactions for the latest block                    |
+| `/blocks/latest/txs/cbor`                  | Get transactions with CBOR data for the latest block     |
 | `/blocks/slot/{slot_number}`               | Get block by slot number                                 |
 | `/blocks/{hash_or_number}`                 | Get block information                                    |
 | `/blocks/{hash_or_number}/addresses`       | Get addresses in a specific block                        |
 | `/blocks/{hash_or_number}/next`            | Get next block                                           |
 | `/blocks/{hash_or_number}/previous`        | Get previous block                                       |
 | `/blocks/{hash_or_number}/txs`             | Get transactions for a specific block                    |
+| `/blocks/{hash_or_number}/txs/cbor`        | Get transactions with CBOR data for a specific block     |
 | `/epochs/latest/parameters`                | Get latest epoch parameters                              |
 | `/epochs/{epoch}/blocks`                   | Get blocks in a specific epoch                           |
 | `/epochs/{epoch}/parameters`               | Get epoch parameters                                     |


### PR DESCRIPTION
## Summary

Implements the Blockfrost-compatible block transaction CBOR endpoints:

- `GET /blocks/{hash_or_number}/txs/cbor`
- `GET /blocks/latest/txs/cbor`

Both return `[{ tx_hash, cbor }]` per transaction in the block, supporting the standard `count`/`page`/`order` pagination parameters.

## Implementation

- New `IntoModel<Vec<BlockContentTxsCborInner>>` impl on `BlockModelBuilder` — the CBOR is emitted from the transaction bytes preserved in the raw block body (Pallas `KeepRaw`): `MultiEraTx::encode` re-serializes only the thin outer envelope (array header + validity flag), while body, witness set, and auxiliary data are written verbatim from the preserved raw slices — so the output is byte-identical to the on-wire encoding (verified against live Blockfrost).
- Handlers mirror the existing `by_hash_or_number_txs` / `latest_txs` shape, including 400-vs-404 semantics (`Error::InvalidBlockHash`/`InvalidBlockNumber` for malformed input, 404 for well-formed but absent blocks).
- Docs endpoint table updated in `docs/content/apis/minibf.mdx`.

## Testing

- 9 new unit tests following the crate's standard matrix: happy path (with CBOR round-trip decode asserting hash consistency), order asc/desc, pagination, bad request, not found, and fault-injected internal error.
- Verified against **live Blockfrost preview API**: responses are byte-identical for blocks by hash and by number, with `order=desc`, with `count`/`page` pagination, and for the 400/404 error bodies.
- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features` (zero warnings), `cargo test -p dolos-minibf` all green after rebasing onto v1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves https://github.com/txpipe/dolos/issues/1116
resolves https://github.com/txpipe/dolos/issues/1069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoints to retrieve transactions from the latest or a specified block with CBOR-encoded data.
  * Added pagination and ascending/descending ordering support for CBOR transaction results.
  * Responses include transaction hashes and encoded transaction payloads.

* **Documentation**
  * Updated the API documentation with the new CBOR transaction endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->