### PR TITLE
fix(minibf): return affected addresses from /blocks/{hash_or_number}/addresses

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -22,7 +22,7 @@ use pallas::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::Deref,
     time::Duration,
 };
@@ -1986,6 +1986,7 @@ pub struct BlockModelBuilder<'a> {
     previous: Option<MultiEraBlock<'a>>,
     next: Option<MultiEraBlock<'a>>,
     tip: Option<MultiEraBlock<'a>>,
+    deps: HashMap<TxHash, MultiEraTx<'a>>,
 }
 
 impl<'a> BlockModelBuilder<'a> {
@@ -1998,7 +1999,31 @@ impl<'a> BlockModelBuilder<'a> {
             next: None,
             tip: None,
             chain: None,
+            deps: HashMap::new(),
         })
+    }
+
+    pub fn required_input_deps(&self) -> Vec<TxHash> {
+        let mut seen_tx_hashes = HashSet::new();
+
+        self.block
+            .txs()
+            .iter()
+            .flat_map(|tx| tx.consumes())
+            .map(|input| *input.hash())
+            .filter(|hash| seen_tx_hashes.insert(*hash))
+            .collect()
+    }
+
+    pub fn load_dep(&mut self, key: TxHash, cbor: &'a EraCbor) -> Result<(), StatusCode> {
+        let era = try_into_or_500!(cbor.0);
+
+        let tx = MultiEraTx::decode_for_era(era, &cbor.1)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        self.deps.insert(key, tx);
+
+        Ok(())
     }
 
     pub fn with_chain(self, chain: &'a ChainSummary) -> Self {
@@ -2311,21 +2336,58 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
 
     fn into_model(self) -> Result<Vec<BlockContentAddressesInner>, StatusCode> {
         let block = &self.block;
-        let addresses = block
-            .txs()
-            .iter()
-            .flat_map(|tx| {
-                tx.produces()
-                    .iter()
-                    .map(|(_, output)| BlockContentAddressesInner {
-                        address: output.address().unwrap().to_string(),
-                        transactions: vec![BlockContentAddressesInnerTransactionsInner {
-                            tx_hash: tx.hash().to_string(),
-                        }],
-                    })
-                    .collect::<Vec<_>>()
+
+        // BTreeMap keeps entries sorted alphabetically by address, matching
+        // Blockfrost. Tx hashes are appended in block order and deduped per
+        // address by collecting each tx's touched addresses into a set first.
+        let mut by_address: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+        // Phase-2-failed txs are deliberately NOT skipped here, diverging
+        // from Blockfrost: their collateral inputs and collateral-return
+        // outputs move funds, so those addresses are affected in ledger
+        // terms - considered a bug in BF, not behavior worth reproducing
+        for tx in block.txs() {
+            let mut touched = BTreeSet::new();
+
+            for (_, output) in tx.produces() {
+                let address = output
+                    .address()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                touched.insert(address.to_string());
+            }
+
+            for input in tx.consumes() {
+                let as_output = self
+                    .deps
+                    .get(input.hash())
+                    .and_then(|dep| dep.output_at(input.index() as usize));
+
+                if let Some(output) = as_output {
+                    let address = output
+                        .address()
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                    touched.insert(address.to_string());
+                }
+            }
+
+            let tx_hash = tx.hash().to_string();
+
+            for address in touched {
+                by_address.entry(address).or_default().push(tx_hash.clone());
+            }
+        }
+
+        let addresses = by_address
+            .into_iter()
+            .map(|(address, tx_hashes)| BlockContentAddressesInner {
+                address,
+                transactions: tx_hashes
+                    .into_iter()
+                    .map(|tx_hash| BlockContentAddressesInnerTransactionsInner { tx_hash })
+                    .collect(),
             })
-            .sorted_by(|x, y| x.address.cmp(&y.address))
             .collect();
 
         Ok(addresses)

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2016,9 +2016,9 @@ impl<'a> BlockModelBuilder<'a> {
     }
 
     pub fn load_dep(&mut self, key: TxHash, cbor: &'a EraCbor) -> Result<(), StatusCode> {
-        let era = try_into_or_500!(cbor.0);
+        let era = try_into_or_500!(cbor.era());
 
-        let tx = MultiEraTx::decode_for_era(era, &cbor.1)
+        let tx = MultiEraTx::decode_for_era(era, cbor.cbor())
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
         self.deps.insert(key, tx);

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2361,7 +2361,7 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
                 let as_output = self
                     .deps
                     .get(input.hash())
-                    .and_then(|dep| dep.output_at(input.index() as usize));
+                    .and_then(|dep| dep.produces_at(input.index() as usize));
 
                 if let Some(output) = as_output {
                     let address = output

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -449,6 +449,9 @@ where
     let deps = builder.required_input_deps();
     let deps = domain.get_tx_batch(deps).await?;
 
+    // deps missing from the archive (possible on nodes without full history)
+    // are skipped, omitting their addresses from the response — the same
+    // graceful degradation as /txs/{hash}/utxos
     for (key, cbor) in deps.iter() {
         if let Some(cbor) = cbor {
             builder.load_dep(*key, cbor)?;

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -909,6 +909,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_past_the_end_page() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+
+        let path = format!("/blocks/{}/addresses?count=100&page=99", block.block_hash);
+        let addresses = get_addresses(&app, &path).await;
+
+        assert!(
+            addresses.is_empty(),
+            "past-the-end page must be an empty 200"
+        );
+    }
+
+    /// Exercises the `produces_at` edge for input-side address resolution.
+    /// Invalid script txs don't produce their regular outputs, but they can
+    /// produce a collateral return at the next output index. When a later tx
+    /// spends that collateral return, block-address mapping must resolve the
+    /// collateral-return address from the dependency tx CBOR.
+    #[test]
+    fn block_addresses_resolves_spent_collateral_return_address() {
+        use dolos_core::EraCbor;
+        use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
+        use pallas::ledger::traverse::{Era, MultiEraBlock, MultiEraTx};
+
+        // Invalid Conway tx with no regular outputs and one collateral-return
+        // output at index 0.
+        let dep_tx_cbor = hex::decode(
+            "84a600d9010281825820010101010101010101010101010101010101010101010101010101010101010100018002070dd901028182582002020202020202020202020202020202020202020202020202020202020202020010a200581d607393621349f3555f70c975392c84879ba400d08d14ab3d572d7ece80011a0016e360111a0007a120a0f4f6",
+        )
+        .expect("invalid dep tx fixture hex");
+        let collateral_return_index = 0usize;
+
+        let dep_tx =
+            MultiEraTx::decode_for_era(Era::Conway, &dep_tx_cbor).expect("failed to decode dep tx");
+        assert!(
+            dep_tx.output_at(collateral_return_index).is_none(),
+            "regular outputs do not include collateral return index"
+        );
+        let collateral_return_address = dep_tx
+            .produces_at(collateral_return_index)
+            .expect("collateral return must be produced at index 0")
+            .address()
+            .expect("collateral return must have an address")
+            .to_string();
+
+        let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig::default());
+        let raw = blocks.first().expect("missing synthetic block");
+
+        let block = MultiEraBlock::decode(raw).expect("failed to decode block");
+        let txs = block.txs();
+        let spender = txs.get(1).expect("fixture needs a second tx");
+        let consumed = spender.consumes();
+        let input = consumed.first().expect("spender must consume");
+        assert_eq!(input.index() as usize, collateral_return_index);
+
+        let mut builder = BlockModelBuilder::new(raw).expect("failed to build block model");
+        let dep_cbor = EraCbor(Era::Conway.into(), dep_tx_cbor);
+        builder
+            .load_dep(*input.hash(), &dep_cbor)
+            .expect("failed to load dep");
+        let addresses: Vec<BlockContentAddressesInner> =
+            builder.into_model().expect("failed to map block addresses");
+
+        let entry = addresses
+            .iter()
+            .find(|entry| entry.address == collateral_return_address)
+            .expect("collateral-return address missing from response");
+
+        assert!(
+            entry
+                .transactions
+                .iter()
+                .any(|tx| tx.tx_hash == spender.hash().to_string()),
+            "spender tx must be attributed to the consumed collateral-return address"
+        );
+    }
+
+    #[tokio::test]
     async fn blocks_by_hash_or_number_addresses_bad_request() {
         let app = TestApp::new();
         let path = format!("/blocks/{}/addresses", invalid_block());

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -929,30 +929,27 @@ mod tests {
     /// collateral-return address from the dependency tx CBOR.
     #[test]
     fn block_addresses_resolves_spent_collateral_return_address() {
-        use dolos_core::EraCbor;
-        use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
-        use pallas::ledger::traverse::{Era, MultiEraBlock, MultiEraTx};
+        use dolos_core::{EraCbor, TxoRef};
+        use dolos_testing::{
+            synthetic::{
+                build_phase2_invalid_tx_cbor, build_synthetic_blocks, SyntheticBlockConfig,
+            },
+            TestAddress,
+        };
+        use pallas::ledger::traverse::{Era, MultiEraBlock};
 
-        // Invalid Conway tx with no regular outputs and one collateral-return
-        // output at index 0.
-        let dep_tx_cbor = hex::decode(
-            "84a600d9010281825820010101010101010101010101010101010101010101010101010101010101010100018002070dd901028182582002020202020202020202020202020202020202020202020202020202020202020010a200581d607393621349f3555f70c975392c84879ba400d08d14ab3d572d7ece80011a0016e360111a0007a120a0f4f6",
-        )
-        .expect("invalid dep tx fixture hex");
-        let collateral_return_index = 0usize;
-
-        let dep_tx =
-            MultiEraTx::decode_for_era(Era::Conway, &dep_tx_cbor).expect("failed to decode dep tx");
-        assert!(
-            dep_tx.output_at(collateral_return_index).is_none(),
-            "regular outputs do not include collateral return index"
+        // Phase-2-invalid dep tx with no regular outputs. A collateral return
+        // is indexed after the regular outputs, so with none it sits at
+        // index 0.
+        let collateral_return_address = TestAddress::Alice;
+        let dep_tx_cbor = build_phase2_invalid_tx_cbor(
+            // arbitrary, never resolved in this test
+            TxoRef([1u8; 32].into(), 0),
+            // arbitrary, never resolved in this test
+            TxoRef([2u8; 32].into(), 16),
+            collateral_return_address.clone(), // what the spender's input must resolve to
+            1_500_000,
         );
-        let collateral_return_address = dep_tx
-            .produces_at(collateral_return_index)
-            .expect("collateral return must be produced at index 0")
-            .address()
-            .expect("collateral return must have an address")
-            .to_string();
 
         let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig::default());
         let raw = blocks.first().expect("missing synthetic block");
@@ -962,7 +959,12 @@ mod tests {
         let spender = txs.get(1).expect("fixture needs a second tx");
         let consumed = spender.consumes();
         let input = consumed.first().expect("spender must consume");
-        assert_eq!(input.index() as usize, collateral_return_index);
+        // check test wiring
+        assert_eq!(
+            input.index(),
+            0,
+            "the spender's input index must match the index of the dep's collateral return (0)"
+        );
 
         let mut builder = BlockModelBuilder::new(raw).expect("failed to build block model");
         let dep_cbor = EraCbor(Era::Conway.into(), dep_tx_cbor);
@@ -974,7 +976,7 @@ mod tests {
 
         let entry = addresses
             .iter()
-            .find(|entry| entry.address == collateral_return_address)
+            .find(|entry| entry.address == collateral_return_address.as_str())
             .expect("collateral-return address missing from response");
 
         assert!(

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -4,7 +4,8 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
-    block_content::BlockContent, block_content_txs_cbor_inner::BlockContentTxsCborInner,
+    block_content::BlockContent, block_content_addresses_inner::BlockContentAddressesInner,
+    block_content_txs_cbor_inner::BlockContentTxsCborInner,
 };
 use dolos_cardano::ChainSummary;
 use dolos_core::{archive::Skippable as _, ArchiveStore as _, BlockBody, Domain};
@@ -435,7 +436,7 @@ pub async fn by_hash_or_number_addresses<D>(
     Path(hash_or_number): Path<String>,
     Query(params): Query<PaginationParameters>,
     State(domain): State<Facade<D>>,
-) -> Result<Json<Vec<String>>, Error>
+) -> Result<Json<Vec<BlockContentAddressesInner>>, Error>
 where
     D: Domain + Clone + Send + Sync + 'static,
 {
@@ -443,16 +444,24 @@ where
     let hash_or_number = parse_hash_or_number(&hash_or_number)?;
     let block = load_block_by_hash_or_number(&domain, &hash_or_number).await?;
 
-    let model = BlockModelBuilder::new(&block)?;
+    let mut builder = BlockModelBuilder::new(&block)?;
 
-    let txs: Vec<String> = model.into_model()?;
-    let txs = match pagination.order {
-        Order::Asc => txs,
-        Order::Desc => txs.into_iter().rev().collect(),
-    };
+    let deps = builder.required_input_deps();
+    let deps = domain.get_tx_batch(deps).await?;
 
+    for (key, cbor) in deps.iter() {
+        if let Some(cbor) = cbor {
+            builder.load_dep(*key, cbor)?;
+        }
+    }
+
+    let addresses: Vec<BlockContentAddressesInner> = builder.into_model()?;
+
+    // Blockfrost sorts this endpoint alphabetically by address and ignores
+    // the `order` param; only count/page apply.
     Ok(Json(
-        txs.into_iter()
+        addresses
+            .into_iter()
             .skip(pagination.skip())
             .take(pagination.count)
             .collect(),
@@ -808,6 +817,114 @@ mod tests {
         assert_status(
             &app,
             "/blocks/latest/txs/cbor",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+    }
+
+    async fn get_addresses(app: &TestApp, path: &str) -> Vec<BlockContentAddressesInner> {
+        let (status, bytes) = app.get_bytes(path).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        serde_json::from_slice(&bytes).expect("failed to parse block addresses")
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_happy_path() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+        let address = app.vectors().address.clone();
+
+        let path = format!("/blocks/{}/addresses", block.block_hash);
+        let addresses = get_addresses(&app, &path).await;
+
+        // entries are sorted alphabetically by address
+        let sorted: Vec<_> = addresses.iter().map(|a| a.address.clone()).collect();
+        let mut expected = sorted.clone();
+        expected.sort();
+        assert_eq!(sorted, expected, "addresses must be sorted alphabetically");
+
+        // the first tx of each fixture block pays the fixture address; its
+        // entry must reference that tx exactly once even though the address
+        // can appear in multiple outputs of it (dedup per address per tx)
+        let entry = addresses
+            .iter()
+            .find(|a| a.address == address)
+            .expect("fixture address missing from block addresses");
+
+        let tx_hashes: Vec<_> = entry
+            .transactions
+            .iter()
+            .map(|t| t.tx_hash.clone())
+            .collect();
+        assert_eq!(tx_hashes, vec![block.tx_hashes[0].clone()]);
+
+        // every tx must contribute at least its own output address
+        assert!(addresses.len() >= block.tx_hashes.len());
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_ignores_order_param() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+
+        let asc = get_addresses(
+            &app,
+            &format!("/blocks/{}/addresses?order=asc", block.block_hash),
+        )
+        .await;
+        let desc = get_addresses(
+            &app,
+            &format!("/blocks/{}/addresses?order=desc", block.block_hash),
+        )
+        .await;
+
+        // Blockfrost sorts alphabetically regardless of the order param
+        assert_eq!(asc, desc);
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_paginated() {
+        let app = TestApp::new();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+
+        let all = get_addresses(&app, &format!("/blocks/{}/addresses", block.block_hash)).await;
+        assert!(all.len() > 1, "fixture must produce multiple addresses");
+
+        let page = get_addresses(
+            &app,
+            &format!("/blocks/{}/addresses?count=1&page=2", block.block_hash),
+        )
+        .await;
+
+        assert_eq!(page, vec![all[1].clone()]);
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/blocks/{}/addresses", invalid_block());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_not_found() {
+        let app = TestApp::new();
+        let path = format!("/blocks/{}/addresses", missing_block());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn blocks_by_hash_or_number_addresses_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        assert_status(
+            &app,
+            "/blocks/1/addresses",
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .await;

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -832,6 +832,85 @@ fn build_submit_tx_cbor(
     minicbor::to_vec(tx).expect("failed to encode submit tx")
 }
 
+/// A phase-2-invalid (`success: false`) Conway tx. It has no regular outputs;
+/// the only output it produces is the collateral return. Collateral returns
+/// are indexed after the regular outputs, so here it sits at index 0. Use it
+/// to inject phase-2-invalid txs into scenarios that exercise collateral
+/// handling.
+pub fn build_phase2_invalid_tx_cbor(
+    input: TxoRef,
+    collateral: TxoRef,
+    collateral_return_address: impl Into<crate::TestAddress>,
+    collateral_return_amount: u64,
+) -> Vec<u8> {
+    let input = TransactionInput {
+        transaction_id: input.0,
+        index: input.1.into(),
+    };
+
+    let collateral = TransactionInput {
+        transaction_id: collateral.0,
+        index: collateral.1.into(),
+    };
+
+    let collateral_return = PostAlonzoTransactionOutput {
+        address: Bytes::from(collateral_return_address.into().to_bytes()),
+        value: Value::Coin(collateral_return_amount),
+        datum_option: None,
+        script_ref: None,
+    };
+
+    let body = TransactionBody {
+        inputs: Set::from(vec![input]),
+        outputs: vec![],
+        fee: 200_000,
+        ttl: None,
+        certificates: None,
+        withdrawals: None,
+        auxiliary_data_hash: None,
+        validity_interval_start: None,
+        mint: None,
+        script_data_hash: None,
+        collateral: Some(NonEmptySet::try_from(vec![collateral]).expect("non-empty collateral")),
+        required_signers: None,
+        network_id: None,
+        collateral_return: Some(TransactionOutput::PostAlonzo(KeepRaw::from(
+            collateral_return,
+        ))),
+        total_collateral: Some(500_000),
+        reference_inputs: None,
+        voting_procedures: None,
+        proposal_procedures: None,
+        treasury_value: None,
+        donation: None,
+    };
+
+    let body_cbor = minicbor::to_vec(&body).expect("failed to encode phase-2-invalid tx body");
+    let body_keep = minicbor::decode::<KeepRaw<'_, TransactionBody<'_>>>(&body_cbor)
+        .expect("failed to decode phase-2-invalid tx body")
+        .to_owned();
+
+    let witness_set = WitnessSet {
+        vkeywitness: None,
+        native_script: None,
+        bootstrap_witness: None,
+        plutus_v1_script: None,
+        plutus_data: None,
+        redeemer: None,
+        plutus_v2_script: None,
+        plutus_v3_script: None,
+    };
+
+    let tx = pallas::ledger::primitives::conway::Tx {
+        transaction_body: body_keep,
+        transaction_witness_set: KeepRaw::from(witness_set),
+        success: false,
+        auxiliary_data: Nullable::Null,
+    };
+
+    minicbor::to_vec(tx).expect("failed to encode phase-2-invalid tx")
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Closes #1068

## Problem

`/blocks/{hash_or_number}/addresses` returned a plain list of tx hashes — the same shape as `/blocks/{hash_or_number}/txs` — instead of Blockfrost's contract: one entry per affected address with the transactions that affected it. The existing `IntoModel<Vec<BlockContentAddressesInner>>` impl was dead code, and it only looked at outputs, emitted one entry per output (no grouping), and `unwrap()`ed address decoding.

## Implementation

An address is affected by a tx if it received a regular output or had a UTxO spent by a regular input. Since inputs are only `(tx_hash, index)` pointers, input-side addresses require resolving the referenced transactions — done with the same dep-resolution pattern `TxModelBuilder` uses for `/txs/{hash}/utxos`: `BlockModelBuilder::required_input_deps()` collects the deduped source-tx hashes across the block, the handler fetches them via `get_tx_batch`, and `load_dep` feeds them back for resolution during mapping.

Response semantics (matching Blockfrost):
- one entry per address, sorted bytewise-ascending by encoded address string; the `order` param is ignored, as in Blockfrost
- per address, tx hashes in block order, each at most once regardless of how many outputs/inputs touched it
- `count`/`page` paginate whole address entries; past-the-end pages return `200 []`

## Deliberate divergences from Blockfrost

- **Phase-2-failed txs are included**: their collateral inputs and collateral-return outputs move funds, so those addresses are affected in ledger terms. Blockfrost omits them only because its SQL reads db-sync's `tx_in`/`tx_out` (valid txs only) — treated as a Blockfrost bug rather than behavior to reproduce. Documented in a code comment.
- **Genesis virtual block**: Blockfrost returns `200 []` for `/blocks/0/addresses` / the genesis hash; dolos returns 404 (the genesis block isn't in the archive). Kept simple deliberately — no practical traffic on that path.

## Testing

Verified locally against the official [blockfrost-tests](https://github.com/blockfrost/blockfrost-tests) suite targeting a dolos preview node bootstrapped from a full snapshot and synced to tip:

```
SERVICE_NAME=blockfrost-tests yarn test:preview -t "blocks/:hash_or_number/addresses"
```

Result: **4/4 passed** — `blocks/d452532f…/addresses`, `blocks/1846333/addresses`, and both `?count=3&page=1` variants, matching the pinned fixture responses (which include input-side addresses on a deep-history block).

- 7 new unit tests: happy path (grouping/dedup + alphabetical ordering), `order` param ignored, pagination, bad request, not found, fault-injected 500.
- Live verification against Blockfrost preview: **28/28 blocks byte-identical** (including empty blocks and a block with intra-block tx chaining), plus pagination windows, past-the-end pages, by-hash lookups, and 400/404 error bodies.
- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features` (zero warnings), `cargo test -p dolos-minibf` (227 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Block address endpoints now return, for each address, the set of transaction hashes that “touch” it, combining both produced outputs and effects from consumed inputs.

- **Bug Fixes**
  - Address ordering is now deterministic (alphabetical) and consistently ignores the `order` parameter.
  - Missing archive dependencies are handled gracefully to keep address mappings correct, including collateral-return resolution.

- **Tests**
  - Expanded `/blocks/{hash}/addresses` coverage for alphabetical sorting, `count`/`page` pagination (including past-the-end returning empty), and 400/404/500 error handling, plus an updated collateral-return regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->