### PR TITLE
feat(minibf): add /accounts/{stake_address}/addresses/assets endpoint

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -335,6 +335,10 @@ where
             get(routes::accounts::by_stake_addresses::<D>),
         )
         .route(
+            "/accounts/{stake_address}/addresses/assets",
+            get(routes::accounts::by_stake_addresses_assets::<D>),
+        )
+        .route(
             "/accounts/{stake_address}/utxos",
             get(routes::accounts::by_stake_utxos::<D>),
         )

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -336,6 +336,10 @@ where
             get(routes::accounts::by_stake_addresses::<D>),
         )
         .route(
+            "/accounts/{stake_address}/addresses/assets",
+            get(routes::accounts::by_stake_addresses_assets::<D>),
+        )
+        .route(
             "/accounts/{stake_address}/utxos",
             get(routes::accounts::by_stake_utxos::<D>),
         )

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -22,8 +22,9 @@ use pallas::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::Deref,
+    sync::Arc,
     time::Duration,
 };
 
@@ -283,6 +284,54 @@ pub fn list_assets<'a>(
     assets.sort_by_key(|a| a.unit.clone());
 
     std::iter::once(lovelace).chain(assets).collect()
+}
+
+pub struct AssetAggregate {
+    pub quantity: u128,
+    pub oldest: Option<(u64, usize, TxoIdx)>,
+    pub newest: Option<(u64, usize, TxoIdx)>,
+}
+
+/// Aggregates asset quantities per unit over a set of utxos, tracking the
+/// chain position of the oldest and newest utxo holding each asset —
+/// Blockfrost orders account assets by these. The BTreeMap keeps units
+/// sorted, providing the tie-break order for assets sharing a position.
+pub fn aggregate_account_assets(
+    utxos: &HashMap<TxoRef, Arc<EraCbor>>,
+    block_deps: &HashMap<TxHash, BlockRefMeta>,
+) -> Result<BTreeMap<String, AssetAggregate>, StatusCode> {
+    let mut by_unit: BTreeMap<String, AssetAggregate> = BTreeMap::new();
+
+    for (txo_ref, cbor) in utxos.iter() {
+        let output = MultiEraOutput::try_from(cbor.as_ref())
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        let position = block_deps
+            .get(&txo_ref.0)
+            .map(|meta| (meta.slot, meta.tx_index, txo_ref.1));
+
+        for ma in output.value().assets() {
+            for asset in ma.assets() {
+                let unit = format!("{}{}", ma.policy(), hex::encode(asset.name()));
+                let quantity = asset.output_coin().unwrap_or_default() as u128;
+
+                let agg = by_unit.entry(unit).or_insert(AssetAggregate {
+                    quantity: 0,
+                    oldest: None,
+                    newest: None,
+                });
+
+                agg.quantity += quantity;
+
+                if let Some(position) = position {
+                    agg.oldest = Some(agg.oldest.map_or(position, |x| x.min(position)));
+                    agg.newest = Some(agg.newest.map_or(position, |x| x.max(position)));
+                }
+            }
+        }
+    }
+
+    Ok(by_unit)
 }
 
 pub enum AddressKind {

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::Deref,
+    sync::Arc,
     time::Duration,
 };
 
@@ -300,6 +301,54 @@ pub fn list_assets<'a>(
     assets.sort_by_key(|a| a.unit.clone());
 
     std::iter::once(lovelace).chain(assets).collect()
+}
+
+pub struct AssetAggregate {
+    pub quantity: u128,
+    pub oldest: Option<(u64, usize, TxoIdx)>,
+    pub newest: Option<(u64, usize, TxoIdx)>,
+}
+
+/// Aggregates asset quantities per unit over a set of utxos, tracking the
+/// chain position of the oldest and newest utxo holding each asset —
+/// Blockfrost orders account assets by these. The BTreeMap keeps units
+/// sorted, providing the tie-break order for assets sharing a position.
+pub fn aggregate_account_assets(
+    utxos: &HashMap<TxoRef, Arc<EraCbor>>,
+    block_deps: &HashMap<TxHash, BlockRefMeta>,
+) -> Result<BTreeMap<String, AssetAggregate>, StatusCode> {
+    let mut by_unit: BTreeMap<String, AssetAggregate> = BTreeMap::new();
+
+    for (txo_ref, cbor) in utxos.iter() {
+        let output = MultiEraOutput::try_from(cbor.as_ref())
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        let position = block_deps
+            .get(&txo_ref.0)
+            .map(|meta| (meta.slot, meta.tx_index, txo_ref.1));
+
+        for ma in output.value().assets() {
+            for asset in ma.assets() {
+                let unit = format!("{}{}", ma.policy(), hex::encode(asset.name()));
+                let quantity = asset.output_coin().unwrap_or_default() as u128;
+
+                let agg = by_unit.entry(unit).or_insert(AssetAggregate {
+                    quantity: 0,
+                    oldest: None,
+                    newest: None,
+                });
+
+                agg.quantity += quantity;
+
+                if let Some(position) = position {
+                    agg.oldest = Some(agg.oldest.map_or(position, |x| x.min(position)));
+                    agg.newest = Some(agg.newest.map_or(position, |x| x.max(position)));
+                }
+            }
+        }
+    }
+
+    Ok(by_unit)
 }
 
 pub enum AddressKind {

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, ops::Deref};
+use std::{
+    collections::{BTreeSet, HashMap},
+    ops::Deref,
+};
 
 use axum::{
     extract::{Path, Query, State},
@@ -6,6 +9,7 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
+    account_addresses_assets_inner::AccountAddressesAssetsInner,
     account_addresses_content_inner::AccountAddressesContentInner,
     account_content::AccountContent,
     account_delegation_content_inner::AccountDelegationContentInner,
@@ -21,8 +25,13 @@ use dolos_cardano::{
     pallas_extras, ChainSummary, FixedNamespace, LeaderRewardLog, MemberRewardLog,
     PoolDepositRefundLog,
 };
-use dolos_core::{ArchiveStore as _, Domain, EntityKey, LogKey, TemporalKey};
+use dolos_core::{
+    async_query::BlockRefMeta, ArchiveStore as _, Domain, EntityKey, LogKey, StateStore as _,
+    TemporalKey, TxHash,
+};
+use futures::future::join_all;
 use futures_util::StreamExt;
+use itertools::Itertools;
 use pallas::{
     codec::minicbor,
     crypto::hash::Hash,
@@ -283,6 +292,76 @@ where
     let utxos = super::utxos::load_utxo_models(&domain, refs, pagination).await?;
 
     Ok(Json(utxos))
+}
+
+pub async fn by_stake_addresses_assets<D>(
+    Path(stake_address): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<AccountAddressesAssetsInner>>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+    let account_key = parse_account_key_param(&stake_address)?;
+
+    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let refs = domain
+        .indexes()
+        .utxos_by_stake(&account_key.address.to_vec())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let utxos = domain
+        .state()
+        .get_utxos(refs.into_iter().collect())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // chain position of each utxo's tx: Blockfrost orders assets by the
+    // position of the oldest (asc) or newest (desc) utxo holding them
+    let tx_deps: Vec<TxHash> = utxos.keys().map(|txo_ref| txo_ref.0).unique().collect();
+
+    // one facade for the whole fan-out so its blocking-task limiter is shared
+    let query = domain.query();
+
+    let block_deps: HashMap<TxHash, BlockRefMeta> = join_all(tx_deps.iter().map(|tx| {
+        let tx = *tx;
+        let query = &query;
+        async move {
+            match query.block_meta_by_tx_hash(tx.to_vec()).await {
+                Ok(Some(block_data)) => Some(Ok((tx, block_data))),
+                Ok(None) => None,
+                Err(_) => Some(Err(StatusCode::INTERNAL_SERVER_ERROR)),
+            }
+        }
+    }))
+    .await
+    .into_iter()
+    .flatten()
+    .collect::<Result<_, _>>()?;
+
+    let by_unit = mapping::aggregate_account_assets(&utxos, &block_deps)?;
+
+    let mut entries: Vec<(String, mapping::AssetAggregate)> = by_unit.into_iter().collect();
+    match pagination.order {
+        Order::Asc => entries.sort_by(|x, y| x.1.oldest.cmp(&y.1.oldest)),
+        Order::Desc => entries.sort_by(|x, y| y.1.newest.cmp(&x.1.newest)),
+    }
+
+    let assets = entries
+        .into_iter()
+        .skip(pagination.skip())
+        .take(pagination.count)
+        .map(|(unit, agg)| AccountAddressesAssetsInner {
+            unit,
+            quantity: agg.quantity.to_string(),
+        })
+        .collect();
+
+    Ok(Json(assets))
 }
 
 fn build_delegation<D: Domain>(
@@ -865,6 +944,7 @@ mod tests {
     use super::*;
     use crate::test_support::{TestApp, TestFault};
     use blockfrost_openapi::models::{
+        account_addresses_assets_inner::AccountAddressesAssetsInner,
         account_addresses_content_inner::AccountAddressesContentInner,
         account_content::AccountContent,
         account_delegation_content_inner::AccountDelegationContentInner,
@@ -872,6 +952,10 @@ mod tests {
         account_reward_content_inner::AccountRewardContentInner,
         account_withdrawal_content_inner::AccountWithdrawalContentInner,
     };
+    use dolos_core::{EraCbor, StateWriter as _, UtxoSetDelta};
+    use dolos_testing::{synthetic::SyntheticBlockConfig, utxo_with_value, MIN_UTXO_AMOUNT};
+    use pallas::ledger::primitives::conway::{PositiveCoin, Value};
+    use std::{collections::BTreeMap, sync::Arc};
 
     fn invalid_stake_address() -> &'static str {
         "not-a-stake"
@@ -889,6 +973,30 @@ mod tests {
             "unexpected status {status} with body: {}",
             String::from_utf8_lossy(&bytes)
         );
+    }
+
+    fn asset_utxo(address: &str, assets: &[([u8; 28], u64)]) -> Arc<EraCbor> {
+        let multi: BTreeMap<_, _> = assets
+            .iter()
+            .map(|(policy, quantity)| {
+                (
+                    Hash::from(*policy),
+                    BTreeMap::from_iter([(
+                        pallas::codec::utils::Bytes::from(b"tok".to_vec()),
+                        PositiveCoin::try_from(*quantity).unwrap(),
+                    )]),
+                )
+            })
+            .collect();
+
+        Arc::new(utxo_with_value(
+            address,
+            Value::Multiasset(MIN_UTXO_AMOUNT, multi),
+        ))
+    }
+
+    fn asset_unit(policy: [u8; 28]) -> String {
+        format!("{}{}", hex::encode(policy), hex::encode(b"tok"))
     }
 
     #[tokio::test]
@@ -968,6 +1076,188 @@ mod tests {
         assert_eq!(page_1.len(), 1);
         assert_eq!(page_2.len(), 1);
         assert_ne!(page_1[0].address, page_2[0].address);
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_happy_path() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let asset_unit = app.vectors().asset_unit.clone();
+
+        let path = format!("/accounts/{stake_address}/addresses/assets");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let assets: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse account assets");
+
+        let entry = assets
+            .iter()
+            .find(|a| a.unit == asset_unit)
+            .expect("fixture asset missing from account assets");
+
+        // cross-check the aggregate against the per-utxo amounts served by
+        // the utxos endpoint for the same account
+        let (status, bytes) = app
+            .get_bytes(&format!("/accounts/{stake_address}/utxos?count=100"))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let utxos: Vec<
+            blockfrost_openapi::models::address_utxo_content_inner::AddressUtxoContentInner,
+        > = serde_json::from_slice(&bytes).expect("failed to parse account utxos");
+
+        let expected: u128 = utxos
+            .iter()
+            .flat_map(|u| u.amount.iter())
+            .filter(|a| a.unit == asset_unit)
+            .map(|a| a.quantity.parse::<u128>().expect("bad quantity"))
+            .sum();
+
+        assert!(expected > 0, "fixture must hold the asset in some utxo");
+        assert_eq!(entry.quantity, expected.to_string());
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/assets", invalid_stake_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_not_found() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/assets", missing_stake_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/addresses/assets");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_orders_by_oldest_and_newest_utxos() {
+        const ASSET_A: [u8; 28] = [0xAA; 28];
+        const ASSET_B: [u8; 28] = [0xBB; 28];
+        const ASSET_C: [u8; 28] = [0xCC; 28];
+
+        let fixture_config = SyntheticBlockConfig {
+            block_count: 3,
+            txs_per_block: 1,
+            ..Default::default()
+        };
+        let app = TestApp::new_with_cfg_and_setup(fixture_config, |domain, vectors| {
+            let stake_address = Address::from_bech32(&vectors.stake_address)
+                .expect("invalid fixture stake address")
+                .to_vec();
+            let mut ordered_refs: Vec<_> = domain
+                .indexes()
+                .utxos_by_stake(&stake_address)
+                .expect("failed to load fixture utxos")
+                .into_iter()
+                .collect();
+            ordered_refs.sort_by_key(|txo_ref| {
+                let (block_number, tx_index) = vectors.tx_position(&txo_ref.0.to_string());
+                (block_number, tx_index, txo_ref.1)
+            });
+            assert_eq!(ordered_refs.len(), 3, "fixture needs three ordered utxos");
+
+            let oldest_ref = ordered_refs[0].clone();
+            let middle_ref = ordered_refs[1].clone();
+            let newest_ref = ordered_refs[2].clone();
+
+            // Three distinct assets are distributed across three UTxOs:
+            // oldest UTxO: 5 units of ASSET_A
+            // middle UTxO: 3 units of ASSET_B
+            // newest UTxO: 7 units of ASSET_A and 1 unit of ASSET_C
+            //
+            // ASSET_A sorts first ascending because its oldest occurrence is
+            // first, and first descending because its newest occurrence is
+            // last.
+            let produced_utxo = HashMap::from([
+                (oldest_ref, asset_utxo(&vectors.address, &[(ASSET_A, 5)])),
+                (middle_ref, asset_utxo(&vectors.address, &[(ASSET_B, 3)])),
+                (
+                    newest_ref,
+                    asset_utxo(&vectors.address, &[(ASSET_A, 7), (ASSET_C, 1)]),
+                ),
+            ]);
+
+            let writer = domain
+                .state()
+                .start_writer()
+                .expect("failed to write state");
+            writer
+                .apply_utxoset(&UtxoSetDelta {
+                    produced_utxo,
+                    ..Default::default()
+                })
+                .expect("failed to replace fixture utxos");
+            writer.commit().expect("failed to commit fixture utxos");
+        });
+
+        let stake_address = app.vectors().stake_address.as_str();
+        let extract_units = |items: Vec<AccountAddressesAssetsInner>| {
+            items.into_iter().map(|item| item.unit).collect::<Vec<_>>()
+        };
+        let asset_a_unit = asset_unit(ASSET_A);
+        let asset_b_unit = asset_unit(ASSET_B);
+        let asset_c_unit = asset_unit(ASSET_C);
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=asc"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let ascending_assets: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse asc assets");
+        assert_eq!(ascending_assets[0].quantity, "12");
+        let ascending_units = extract_units(ascending_assets);
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=desc"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let descending_units =
+            extract_units(serde_json::from_slice(&bytes).expect("failed to parse desc assets"));
+
+        // Ascending uses each asset's oldest UTxO.
+        assert_eq!(
+            ascending_units,
+            vec![
+                asset_a_unit.clone(),
+                asset_b_unit.clone(),
+                asset_c_unit.clone(),
+            ]
+        );
+        // Descending uses each asset's newest UTxO. ASSET_A and ASSET_C share
+        // that position, so unit order breaks the tie.
+        assert_eq!(
+            descending_units,
+            vec![asset_a_unit, asset_c_unit, asset_b_unit.clone()]
+        );
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=asc&count=1&page=2"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let second_page: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse second assets page");
+        assert_eq!(extract_units(second_page), vec![asset_b_unit]);
     }
 
     #[tokio::test]

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, ops::Deref};
+use std::{
+    collections::{BTreeSet, HashMap},
+    ops::Deref,
+};
 
 use axum::{
     extract::{Path, Query, State},
@@ -6,6 +9,7 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
+    account_addresses_assets_inner::AccountAddressesAssetsInner,
     account_addresses_content_inner::AccountAddressesContentInner,
     account_content::AccountContent,
     account_delegation_content_inner::AccountDelegationContentInner,
@@ -22,8 +26,13 @@ use dolos_cardano::{
     pallas_extras, ChainSummary, FixedNamespace, LeaderRewardLog, MemberRewardLog,
     PoolDepositRefundLog,
 };
-use dolos_core::{ArchiveStore as _, Domain, EntityKey, EraCbor, LogKey, TemporalKey};
+use dolos_core::{
+    async_query::BlockRefMeta, ArchiveStore as _, Domain, EntityKey, EraCbor, LogKey,
+    StateStore as _, TemporalKey, TxHash,
+};
+use futures::future::join_all;
 use futures_util::StreamExt;
+use itertools::Itertools;
 use pallas::{
     codec::minicbor,
     crypto::hash::{Hash, Hasher},
@@ -317,6 +326,78 @@ where
     let utxos = super::utxos::load_utxo_models(&domain, refs, pagination).await?;
 
     Ok(Json(utxos))
+}
+
+pub async fn by_stake_addresses_assets<D>(
+    Path(stake_address): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<AccountAddressesAssetsInner>>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
+
+    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let refs = domain
+        .indexes()
+        .utxos_by_stake(&account_key.address.to_vec())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let utxos = domain
+        .state()
+        .get_utxos(refs.into_iter().collect())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // chain position of each utxo's tx: Blockfrost orders assets by the
+    // position of the oldest (asc) or newest (desc) utxo holding them
+    let tx_deps: Vec<TxHash> = utxos.keys().map(|txo_ref| txo_ref.0).unique().collect();
+
+    // one facade for the whole fan-out so its blocking-task limiter is shared
+    let query = domain.query();
+
+    let block_deps: HashMap<TxHash, BlockRefMeta> = join_all(tx_deps.iter().map(|tx| {
+        let tx = *tx;
+        let query = &query;
+        async move {
+            match query.block_meta_by_tx_hash(tx.to_vec()).await {
+                Ok(Some(block_data)) => Some(Ok((tx, block_data))),
+                Ok(None) => None,
+                Err(_) => Some(Err(StatusCode::INTERNAL_SERVER_ERROR)),
+            }
+        }
+    }))
+    .await
+    .into_iter()
+    .flatten()
+    .collect::<Result<_, _>>()?;
+
+    let by_unit = mapping::aggregate_account_assets(&utxos, &block_deps)?;
+
+    let mut entries: Vec<(String, mapping::AssetAggregate)> = by_unit.into_iter().collect();
+    match pagination.order {
+        Order::Asc => entries.sort_by(|x, y| x.1.oldest.cmp(&y.1.oldest)),
+        Order::Desc => entries.sort_by(|x, y| y.1.newest.cmp(&x.1.newest)),
+    }
+
+    let assets = entries
+        .into_iter()
+        .skip(pagination.skip())
+        .take(pagination.count)
+        .map(|(unit, agg)| AccountAddressesAssetsInner {
+            unit,
+            quantity: agg.quantity.to_string(),
+        })
+        .collect();
+
+    Ok(Json(assets))
 }
 
 fn build_delegation<D: Domain>(
@@ -1063,6 +1144,7 @@ mod tests {
     use super::*;
     use crate::test_support::{TestApp, TestFault};
     use blockfrost_openapi::models::{
+        account_addresses_assets_inner::AccountAddressesAssetsInner,
         account_addresses_content_inner::AccountAddressesContentInner,
         account_content::AccountContent,
         account_delegation_content_inner::AccountDelegationContentInner,
@@ -1071,6 +1153,10 @@ mod tests {
         account_transactions_content_inner::AccountTransactionsContentInner,
         account_withdrawal_content_inner::AccountWithdrawalContentInner,
     };
+    use dolos_core::{EraCbor, StateWriter as _, UtxoSetDelta};
+    use dolos_testing::{synthetic::SyntheticBlockConfig, utxo_with_value, MIN_UTXO_AMOUNT};
+    use pallas::ledger::primitives::conway::{PositiveCoin, Value};
+    use std::{collections::BTreeMap, sync::Arc};
 
     fn invalid_stake_address() -> &'static str {
         "not-a-stake"
@@ -1155,6 +1241,30 @@ mod tests {
         assert_bad_request(encode_bech32("addr_vk", &[7u8; 32]));
     }
 
+    fn asset_utxo(address: &str, assets: &[([u8; 28], u64)]) -> Arc<EraCbor> {
+        let multi: BTreeMap<_, _> = assets
+            .iter()
+            .map(|(policy, quantity)| {
+                (
+                    Hash::from(*policy),
+                    BTreeMap::from_iter([(
+                        pallas::codec::utils::Bytes::from(b"tok".to_vec()),
+                        PositiveCoin::try_from(*quantity).unwrap(),
+                    )]),
+                )
+            })
+            .collect();
+
+        Arc::new(utxo_with_value(
+            address,
+            Value::Multiasset(MIN_UTXO_AMOUNT, multi),
+        ))
+    }
+
+    fn asset_unit(policy: [u8; 28]) -> String {
+        format!("{}{}", hex::encode(policy), hex::encode(b"tok"))
+    }
+
     #[tokio::test]
     async fn accounts_by_stake_happy_path() {
         let app = TestApp::new();
@@ -1232,6 +1342,188 @@ mod tests {
         assert_eq!(page_1.len(), 1);
         assert_eq!(page_2.len(), 1);
         assert_ne!(page_1[0].address, page_2[0].address);
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_happy_path() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let asset_unit = app.vectors().asset_unit.clone();
+
+        let path = format!("/accounts/{stake_address}/addresses/assets");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let assets: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse account assets");
+
+        let entry = assets
+            .iter()
+            .find(|a| a.unit == asset_unit)
+            .expect("fixture asset missing from account assets");
+
+        // cross-check the aggregate against the per-utxo amounts served by
+        // the utxos endpoint for the same account
+        let (status, bytes) = app
+            .get_bytes(&format!("/accounts/{stake_address}/utxos?count=100"))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let utxos: Vec<
+            blockfrost_openapi::models::address_utxo_content_inner::AddressUtxoContentInner,
+        > = serde_json::from_slice(&bytes).expect("failed to parse account utxos");
+
+        let expected: u128 = utxos
+            .iter()
+            .flat_map(|u| u.amount.iter())
+            .filter(|a| a.unit == asset_unit)
+            .map(|a| a.quantity.parse::<u128>().expect("bad quantity"))
+            .sum();
+
+        assert!(expected > 0, "fixture must hold the asset in some utxo");
+        assert_eq!(entry.quantity, expected.to_string());
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/assets", invalid_stake_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_not_found() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/assets", missing_stake_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/addresses/assets");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_assets_orders_by_oldest_and_newest_utxos() {
+        const ASSET_A: [u8; 28] = [0xAA; 28];
+        const ASSET_B: [u8; 28] = [0xBB; 28];
+        const ASSET_C: [u8; 28] = [0xCC; 28];
+
+        let fixture_config = SyntheticBlockConfig {
+            block_count: 3,
+            txs_per_block: 1,
+            ..Default::default()
+        };
+        let app = TestApp::new_with_cfg_and_setup(fixture_config, |domain, vectors| {
+            let stake_address = Address::from_bech32(&vectors.stake_address)
+                .expect("invalid fixture stake address")
+                .to_vec();
+            let mut ordered_refs: Vec<_> = domain
+                .indexes()
+                .utxos_by_stake(&stake_address)
+                .expect("failed to load fixture utxos")
+                .into_iter()
+                .collect();
+            ordered_refs.sort_by_key(|txo_ref| {
+                let (block_number, tx_index) = vectors.tx_position(&txo_ref.0.to_string());
+                (block_number, tx_index, txo_ref.1)
+            });
+            assert_eq!(ordered_refs.len(), 3, "fixture needs three ordered utxos");
+
+            let oldest_ref = ordered_refs[0].clone();
+            let middle_ref = ordered_refs[1].clone();
+            let newest_ref = ordered_refs[2].clone();
+
+            // Three distinct assets are distributed across three UTxOs:
+            // oldest UTxO: 5 units of ASSET_A
+            // middle UTxO: 3 units of ASSET_B
+            // newest UTxO: 7 units of ASSET_A and 1 unit of ASSET_C
+            //
+            // ASSET_A sorts first ascending because its oldest occurrence is
+            // first, and first descending because its newest occurrence is
+            // last.
+            let produced_utxo = HashMap::from([
+                (oldest_ref, asset_utxo(&vectors.address, &[(ASSET_A, 5)])),
+                (middle_ref, asset_utxo(&vectors.address, &[(ASSET_B, 3)])),
+                (
+                    newest_ref,
+                    asset_utxo(&vectors.address, &[(ASSET_A, 7), (ASSET_C, 1)]),
+                ),
+            ]);
+
+            let writer = domain
+                .state()
+                .start_writer()
+                .expect("failed to write state");
+            writer
+                .apply_utxoset(&UtxoSetDelta {
+                    produced_utxo,
+                    ..Default::default()
+                })
+                .expect("failed to replace fixture utxos");
+            writer.commit().expect("failed to commit fixture utxos");
+        });
+
+        let stake_address = app.vectors().stake_address.as_str();
+        let extract_units = |items: Vec<AccountAddressesAssetsInner>| {
+            items.into_iter().map(|item| item.unit).collect::<Vec<_>>()
+        };
+        let asset_a_unit = asset_unit(ASSET_A);
+        let asset_b_unit = asset_unit(ASSET_B);
+        let asset_c_unit = asset_unit(ASSET_C);
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=asc"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let ascending_assets: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse asc assets");
+        assert_eq!(ascending_assets[0].quantity, "12");
+        let ascending_units = extract_units(ascending_assets);
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=desc"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let descending_units =
+            extract_units(serde_json::from_slice(&bytes).expect("failed to parse desc assets"));
+
+        // Ascending uses each asset's oldest UTxO.
+        assert_eq!(
+            ascending_units,
+            vec![
+                asset_a_unit.clone(),
+                asset_b_unit.clone(),
+                asset_c_unit.clone(),
+            ]
+        );
+        // Descending uses each asset's newest UTxO. ASSET_A and ASSET_C share
+        // that position, so unit order breaks the tie.
+        assert_eq!(
+            descending_units,
+            vec![asset_a_unit, asset_c_unit, asset_b_unit.clone()]
+        );
+
+        let (status, bytes) = app
+            .get_bytes(&format!(
+                "/accounts/{stake_address}/addresses/assets?order=asc&count=1&page=2"
+            ))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let second_page: Vec<AccountAddressesAssetsInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse second assets page");
+        assert_eq!(extract_units(second_page), vec![asset_b_unit]);
     }
 
     #[tokio::test]

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -382,6 +382,11 @@ where
     let by_unit = mapping::aggregate_account_assets(&utxos, &block_deps)?;
 
     let mut entries: Vec<(String, mapping::AssetAggregate)> = by_unit.into_iter().collect();
+
+    // mirrors the Blockfrost ordering: asc by the oldest utxo holding the
+    // asset, desc by the newest (deliberately not reverses of each other).
+    // ties resolve unit-ascending: entries iterate out of the BTreeMap in
+    // unit order and sort_by is stable, so equal positions keep it
     match pagination.order {
         Order::Asc => entries.sort_by(|x, y| x.1.oldest.cmp(&y.1.oldest)),
         Order::Desc => entries.sort_by(|x, y| y.1.newest.cmp(&x.1.newest)),

--- a/crates/minibf/src/test_support.rs
+++ b/crates/minibf/src/test_support.rs
@@ -109,7 +109,19 @@ impl TestApp {
 
     pub fn new_with_cfg_and_fault(cfg: SyntheticBlockConfig, fault: Option<TestFault>) -> Self {
         let (domain, vectors) = TestDomainBuilder::new_with_synthetic(cfg).finish();
+        Self::from_domain(domain, vectors, fault)
+    }
 
+    pub fn new_with_cfg_and_setup(
+        cfg: SyntheticBlockConfig,
+        setup: impl FnOnce(&ToyDomain, &SyntheticVectors),
+    ) -> Self {
+        let (domain, vectors) = TestDomainBuilder::new_with_synthetic(cfg).finish();
+        setup(&domain, &vectors);
+        Self::from_domain(domain, vectors, None)
+    }
+
+    fn from_domain(domain: ToyDomain, vectors: SyntheticVectors, fault: Option<TestFault>) -> Self {
         let domain = match fault {
             Some(fault) => dolos_testing::faults::FaultyToyDomain::new(domain, fault),
             None => dolos_testing::faults::FaultyToyDomain::new(domain, TestFault::None),

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -105,6 +105,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/metrics`                                 | Prometheus metrics                                       |
 | `/accounts/{stake_address}`                | Get account information for a stake address              |
 | `/accounts/{stake_address}/addresses`      | Get addresses for a stake address                        |
+| `/accounts/{stake_address}/addresses/assets` | Get assets held across a stake address's addresses     |
 | `/accounts/{stake_address}/delegations`    | Get delegations for a stake address                      |
 | `/accounts/{stake_address}/registrations`  | Get registrations for a stake address                    |
 | `/accounts/{stake_address}/rewards`        | Get rewards for a stake address                          |


### PR DESCRIPTION
## Summary

Closes #1067 by adding the Blockfrost-compatible `GET /accounts/{stake_address}/addresses/assets` endpoint.

- Aggregates native assets across the account’s current UTxOs, excluding lovelace
- Supports `count`, `page`, and `order`
- Returns `404` for unknown accounts and existing MiniBF errors for invalid requests and storage failures
- Shares one query facade across block-metadata lookups to respect the blocking-task limit
- Updates MiniBF documentation

## Ordering semantics
Because the directions use different keys, `desc` is not necessarily the reverse of `asc`.

- `asc`: each asset’s oldest current UTxO
- `desc`: each asset’s newest current UTxO
- ties: asset unit ascending

This reproduces the reference implementation (`blockfrost-backend-ryo`, `accounts_stake_address_addresses_assets.sql`: `MIN(txo.id) ASC` / `MAX(txo.id) DESC`, tie-break `(policy, name) ASC`), with the tuple `(slot, tx_index, output_index)` standing in for db-sync's monotone `txo.id`. The route test `accounts_by_stake_addresses_assets_uses_directional_ordering` pins the exact `asc` and `desc` sequences, including the non-reversal and the tie-break cases.

## Testing


- Route-level coverage: aggregation across UTxOs, direction-dependent ordering with position ties and unit tie-breaking (custom fixture state injected via the new `TestApp::new_with_cfg_and_setup`), pagination including past-the-end pages, invalid stake addresses, unknown accounts, storage failures
- Verified against **live Blockfrost preview**: the full 116-unit asset list of the blockfrost-tests fixture account is byte-identical in both `asc` and `desc`, as are pagination windows and the `400`/`404` error responses. 

## Known deviations

- **Collateral-return UTxOs of failed txs are included.** The reference blockfrost-backend-ryo query predates collateral-return outputs so Blockfrost misses assets held via unspent collateral returns. Dolos aggregates from the ledger-true UTxO set, so these appear naturally. Practically unobservable outside that rare case; same ledger-truth stance as #1124
- **Invalid stake addresses return a bare `400`** (no JSON error body) — pre-existing behavior shared by all account endpoints, deliberately left untouched here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve assets held across all addresses associated with a stake address.
  * Aggregates asset quantities across relevant UTxOs.
  * Supports sorting holdings by oldest or newest and paginating results.
  * Provides validation and error handling for invalid stake addresses or unavailable asset data.

* **Documentation**
  * Updated the Mini Blockfrost API documentation to include the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->