### PR TITLE
feat(minibf): implement `/accounts/{stake_address}/transactions`

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -347,6 +347,10 @@ where
             get(routes::accounts::by_stake_withdrawals::<D>),
         )
         .route(
+            "/accounts/{stake_address}/transactions",
+            get(routes::accounts::by_stake_transactions::<D>),
+        )
+        .route(
             "/addresses/{address}",
             get(routes::addresses::by_address::<D>),
         )

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -977,13 +977,17 @@ where
 
         let addresses = account_addresses_in_tx(domain, account, tx).await?;
 
+        let tx_hash = hex::encode(tx.hash().as_slice());
+        let block_height = block.number() as i32;
+        let block_time = chain.slot_time(block.slot()) as i32;
+
         for address in addresses {
             matches.push(AccountTransactionsContentInner {
                 address,
-                tx_hash: hex::encode(tx.hash().as_slice()),
+                tx_hash: tx_hash.clone(),
                 tx_index: idx as i32,
-                block_height: block.number() as i32,
-                block_time: chain.slot_time(block.slot()) as i32,
+                block_height,
+                block_time,
             });
         }
     }

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -11,6 +11,7 @@ use blockfrost_openapi::models::{
     account_delegation_content_inner::AccountDelegationContentInner,
     account_registration_content_inner::{AccountRegistrationContentInner, Action},
     account_reward_content_inner::AccountRewardContentInner,
+    account_transactions_content_inner::AccountTransactionsContentInner,
     account_withdrawal_content_inner::AccountWithdrawalContentInner,
     address_utxo_content_inner::AddressUtxoContentInner,
 };
@@ -21,13 +22,13 @@ use dolos_cardano::{
     pallas_extras, ChainSummary, FixedNamespace, LeaderRewardLog, MemberRewardLog,
     PoolDepositRefundLog,
 };
-use dolos_core::{ArchiveStore as _, Domain, EntityKey, LogKey, TemporalKey};
+use dolos_core::{ArchiveStore as _, Domain, EntityKey, EraCbor, LogKey, TemporalKey};
 use futures_util::StreamExt;
 use pallas::{
     codec::minicbor,
-    crypto::hash::Hash,
+    crypto::hash::{Hash, Hasher},
     ledger::{
-        addresses::{Address, Network, StakeAddress},
+        addresses::{Address, Network, StakeAddress, StakePayload},
         primitives::Epoch,
         traverse::{MultiEraBlock, MultiEraCert, MultiEraTx},
     },
@@ -48,21 +49,51 @@ struct AccountKeyParam {
     entity_key: Vec<u8>,
 }
 
-fn parse_account_key_param(address: &str) -> Result<AccountKeyParam, StatusCode> {
-    let address = pallas::ledger::addresses::Address::from_bech32(address)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
+fn stake_address_from_cip_19_credential(address: &str, network: Network) -> Option<StakeAddress> {
+    let (hrp, payload) = bech32::decode(address).ok()?;
 
-    let address = match address {
-        Address::Shelley(x) => pallas_extras::shelley_address_to_stake_address(&x),
-        Address::Stake(x) => Some(x),
-        _ => None,
+    let payload = match hrp.as_str() {
+        // Ed25519 verification key.
+        "stake_vk" => {
+            let key: [u8; 32] = <[u8; 32]>::try_from(&payload[..]).ok()?;
+            let hash: Hash<28> = Hasher::<224>::hash(&key);
+            StakePayload::Stake(hash)
+        }
+        // Raw key-hash credential.
+        "stake_vkh" => {
+            StakePayload::Stake(Hash::<28>::from(<[u8; 28]>::try_from(&payload[..]).ok()?))
+        }
+        // Raw script-hash credential.
+        "script" => {
+            StakePayload::Script(Hash::<28>::from(<[u8; 28]>::try_from(&payload[..]).ok()?))
+        }
+        _ => return None,
     };
 
-    let address = address.ok_or(StatusCode::BAD_REQUEST)?;
+    Some(StakeAddress::new(network, payload))
+}
+
+fn parse_account_key_param(address: &str, network: Network) -> Result<AccountKeyParam, StatusCode> {
+    let address =
+        if let Some(stake_address) = stake_address_from_cip_19_credential(address, network) {
+            stake_address
+        } else {
+            let parsed = pallas::ledger::addresses::Address::from_bech32(address)
+                .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+            let stake_address = match parsed {
+                Address::Shelley(x) => pallas_extras::shelley_address_to_stake_address(&x),
+                Address::Stake(x) => Some(x),
+                _ => None,
+            };
+
+            stake_address.ok_or(StatusCode::BAD_REQUEST)?
+        };
 
     let stake_cred = dolos_cardano::pallas_extras::stake_address_to_cred(&address);
 
-    let entity_key = minicbor::to_vec(&stake_cred).unwrap();
+    let entity_key =
+        minicbor::to_vec(&stake_cred).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(AccountKeyParam {
         address,
@@ -158,7 +189,8 @@ where
     Option<DRepState>: From<D::Entity>,
     D: Domain + Clone + Send + Sync + 'static,
 {
-    let account_key = parse_account_key_param(&stake_address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
 
     let state = domain
         .read_cardano_entity::<AccountState>(account_key.entity_key.as_slice())
@@ -198,7 +230,8 @@ where
 {
     let pagination = Pagination::try_from(params)?;
     pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
-    let account_key = parse_account_key_param(&stake_address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
     if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
         return Err(StatusCode::NOT_FOUND.into());
     }
@@ -273,7 +306,8 @@ where
 {
     let pagination = Pagination::try_from(params)?;
 
-    let account_key = parse_account_key_param(&address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&address, network)?;
 
     let refs = domain
         .indexes()
@@ -557,7 +591,8 @@ where
     ) -> Result<Option<T>, StatusCode>,
     D: Domain + Clone + Send + Sync + 'static,
 {
-    let account_key = parse_account_key_param(stake_address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(stake_address, network)?;
 
     if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
         return Err(StatusCode::NOT_FOUND.into());
@@ -731,7 +766,8 @@ where
     D: Domain + Clone + Send + Sync + 'static,
 {
     let pagination = Pagination::try_from(params)?;
-    let account_key = parse_account_key_param(&stake_address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
     if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
         return Err(StatusCode::NOT_FOUND.into());
     }
@@ -815,7 +851,8 @@ where
     let pagination = Pagination::try_from(params)?;
     pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
 
-    let account_key = parse_account_key_param(&stake_address)?;
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
     if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
         return Err(StatusCode::NOT_FOUND.into());
     }
@@ -860,6 +897,163 @@ where
     Ok(Json(items))
 }
 
+fn address_belongs_to_account(address: &Address, account: &[u8]) -> bool {
+    match address {
+        Address::Shelley(shelley) => pallas_extras::shelley_address_to_stake_address(shelley)
+            .map(|x| x.to_vec() == account)
+            .unwrap_or(false),
+        Address::Stake(stake) => stake.to_vec() == account,
+        Address::Byron(_) => false,
+    }
+}
+
+async fn account_addresses_in_tx<D>(
+    domain: &Facade<D>,
+    account: &[u8],
+    tx: &MultiEraTx<'_>,
+) -> Result<BTreeSet<String>, StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let mut addresses = BTreeSet::new();
+
+    for (_, output) in tx.produces() {
+        let candidate = output
+            .address()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        if address_belongs_to_account(&candidate, account) {
+            addresses.insert(candidate.to_string());
+        }
+    }
+
+    for input in tx.consumes() {
+        if let Some(EraCbor(era, cbor)) = domain
+            .query()
+            .tx_cbor(input.hash().as_slice().to_vec())
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        {
+            let parsed = MultiEraTx::decode_for_era(
+                era.try_into()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+                &cbor,
+            )
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            if let Some(output) = parsed.produces_at(input.index() as usize) {
+                let candidate = output
+                    .address()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                if address_belongs_to_account(&candidate, account) {
+                    addresses.insert(candidate.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(addresses)
+}
+
+async fn find_account_txs_in_block<D>(
+    domain: &Facade<D>,
+    account: &[u8],
+    chain: &ChainSummary,
+    pagination: &Pagination,
+    block: &[u8],
+) -> Result<Vec<AccountTransactionsContentInner>, StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut matches = vec![];
+
+    for (idx, tx) in block.txs().iter().enumerate() {
+        if pagination.should_skip(block.number(), idx) {
+            continue;
+        }
+
+        let addresses = account_addresses_in_tx(domain, account, tx).await?;
+
+        for address in addresses {
+            matches.push(AccountTransactionsContentInner {
+                address,
+                tx_hash: hex::encode(tx.hash().as_slice()),
+                tx_index: idx as i32,
+                block_height: block.number() as i32,
+                block_time: chain.slot_time(block.slot()) as i32,
+            });
+        }
+    }
+
+    if matches!(pagination.order, Order::Desc) {
+        matches.reverse();
+    }
+
+    Ok(matches)
+}
+
+pub async fn by_stake_transactions<D>(
+    Path(stake_address): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<AccountTransactionsContentInner>>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
+
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
+    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let account = account_key.address.to_vec();
+
+    let (start_slot, end_slot) = pagination.start_and_end_slots(&domain).await?;
+    let chain = domain
+        .get_chain_summary()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let stream = domain.query().blocks_by_stake_stream(
+        &account,
+        start_slot,
+        end_slot,
+        SlotOrder::from(pagination.order),
+    );
+
+    let mut matches = Vec::new();
+    let mut stream = Box::pin(stream);
+
+    while let Some(res) = stream.next().await {
+        let (_slot, block) = res.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        let Some(block) = block else {
+            continue;
+        };
+
+        let mut txs =
+            find_account_txs_in_block(&domain, &account, &chain, &pagination, &block).await?;
+        matches.append(&mut txs);
+
+        if matches.len() >= pagination.from() + pagination.count {
+            break;
+        }
+    }
+
+    let transactions = matches
+        .into_iter()
+        .skip(pagination.from())
+        .take(pagination.count)
+        .collect();
+
+    Ok(Json(transactions))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -870,6 +1064,7 @@ mod tests {
         account_delegation_content_inner::AccountDelegationContentInner,
         account_registration_content_inner::AccountRegistrationContentInner,
         account_reward_content_inner::AccountRewardContentInner,
+        account_transactions_content_inner::AccountTransactionsContentInner,
         account_withdrawal_content_inner::AccountWithdrawalContentInner,
     };
 
@@ -889,6 +1084,71 @@ mod tests {
             "unexpected status {status} with body: {}",
             String::from_utf8_lossy(&bytes)
         );
+    }
+
+    fn encode_bech32(hrp: &str, payload: &[u8]) -> String {
+        let hrp = bech32::Hrp::parse(hrp).expect("invalid hrp");
+        bech32::encode::<bech32::Bech32>(hrp, payload).expect("failed to encode bech32")
+    }
+
+    #[test]
+    fn cip_19_credential_forms_resolve_to_canonical_stake_address() {
+        let network = Network::Testnet;
+
+        let vk = [7u8; 32];
+        let key_hash: Hash<28> = Hasher::<224>::hash(&vk);
+        let script_hash = Hash::<28>::from([9u8; 28]);
+
+        // `stake_vk`: Ed25519 key hashed into a key credential.
+        let canonical_key = StakeAddress::new(network, StakePayload::Stake(key_hash));
+        let expected_key =
+            parse_account_key_param(&canonical_key.to_bech32().expect("bech32"), network)
+                .expect("canonical key address")
+                .entity_key;
+
+        let stake_vk = parse_account_key_param(&encode_bech32("stake_vk", &vk), network)
+            .expect("stake_vk resolves");
+        assert_eq!(stake_vk.entity_key, expected_key);
+        assert_eq!(stake_vk.address, canonical_key);
+
+        // `stake_vkh`: raw key-hash credential.
+        let stake_vkh =
+            parse_account_key_param(&encode_bech32("stake_vkh", key_hash.as_ref()), network)
+                .expect("stake_vkh resolves");
+        assert_eq!(stake_vkh.entity_key, expected_key);
+        assert_eq!(stake_vkh.address, canonical_key);
+
+        // `script`: raw script-hash credential.
+        let canonical_script = StakeAddress::new(network, StakePayload::Script(script_hash));
+        let expected_script =
+            parse_account_key_param(&canonical_script.to_bech32().expect("bech32"), network)
+                .expect("canonical script address")
+                .entity_key;
+
+        let script =
+            parse_account_key_param(&encode_bech32("script", script_hash.as_ref()), network)
+                .expect("script resolves");
+        assert_eq!(script.entity_key, expected_script);
+        assert_eq!(script.address, canonical_script);
+    }
+
+    #[test]
+    fn malformed_credential_forms_are_rejected() {
+        let network = Network::Testnet;
+
+        let assert_bad_request = |address: String| {
+            let result = parse_account_key_param(&address, network).err();
+            assert_eq!(result, Some(StatusCode::BAD_REQUEST));
+        };
+
+        // `stake_vk` requires a 32-byte key.
+        assert_bad_request(encode_bech32("stake_vk", &[7u8; 16]));
+        // `stake_vkh` requires a 28-byte hash.
+        assert_bad_request(encode_bech32("stake_vkh", &[7u8; 20]));
+        // `script` requires a 28-byte hash.
+        assert_bad_request(encode_bech32("script", &[9u8; 32]));
+        // An unknown prefix is not a credential and is not a valid address.
+        assert_bad_request(encode_bech32("addr_vk", &[7u8; 32]));
     }
 
     #[tokio::test]
@@ -1495,6 +1755,126 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/withdrawals");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_happy_path() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/transactions?page=1");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let items: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse account transactions");
+        assert!(!items.is_empty());
+        for item in &items {
+            assert!(!item.address.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_slot_constrained() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let block = app.vectors().blocks.first().expect("missing block vectors");
+        let path = format!(
+            "/accounts/{stake_address}/transactions?from={}&to={}",
+            block.block_number, block.block_number
+        );
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let items: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse account transactions");
+        for item in items {
+            assert!(block.tx_hashes.contains(&item.tx_hash));
+        }
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_paginated() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let path_page_1 = format!("/accounts/{stake_address}/transactions?page=1&count=2");
+        let path_page_2 = format!("/accounts/{stake_address}/transactions?page=2&count=2");
+
+        let (status_1, bytes_1) = app.get_bytes(&path_page_1).await;
+        let (status_2, bytes_2) = app.get_bytes(&path_page_2).await;
+
+        assert_eq!(status_1, StatusCode::OK);
+        assert_eq!(status_2, StatusCode::OK);
+
+        let page_1: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes_1).expect("failed to parse transactions page 1");
+        let page_2: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes_2).expect("failed to parse transactions page 2");
+
+        let key = |x: &AccountTransactionsContentInner| (x.tx_hash.clone(), x.address.clone());
+        let page_1_keys: std::collections::HashSet<_> = page_1.iter().map(key).collect();
+        let page_2_keys: std::collections::HashSet<_> = page_2.iter().map(key).collect();
+        assert!(page_1_keys.is_disjoint(&page_2_keys));
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_order_asc() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/transactions?order=asc&count=5");
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let asc: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse transactions asc");
+        if asc.is_empty() {
+            return;
+        }
+        let asc_pos: Vec<_> = asc.iter().map(|x| (x.block_height, x.tx_index)).collect();
+        assert!(asc_pos.windows(2).all(|w| w[0] <= w[1]));
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_order_desc() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/transactions?order=desc&count=5");
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let desc: Vec<AccountTransactionsContentInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse transactions desc");
+        if desc.is_empty() {
+            return;
+        }
+        let desc_pos: Vec<_> = desc.iter().map(|x| (x.block_height, x.tx_index)).collect();
+        assert!(desc_pos.windows(2).all(|w| w[0] >= w[1]));
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/transactions", invalid_stake_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_not_found() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/transactions", missing_stake_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_transactions_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/transactions");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 }


### PR DESCRIPTION
Resolves #1074.

## Implementation

This adds the account transactions endpoint, listing transactions associated with a stake address. It scans the `stake` archive index and emits one entry per distinct `(transaction, address)` pair the account participates in, through either produced outputs or resolved consumed inputs, mirroring the `/addresses/{address}/transactions` endpoint.

The other six account endpoints now also accept CIP-19 stake credential bech32 forms:(`stake_vk`, `stake_vkh`, `script`) in addition to full stake addresses, resolving them against the node's network. This change was required to make `blockfrost-tests` pass on the new endpoint, and it only makes sense to include it for the already existing ones.

## Testing

The change has been tested by `blockfrost-tests`, and specifically:
- https://github.com/blockfrost/blockfrost-tests/blob/f999931323e74d5dd443a97e88b0e416e2d10b7c/src/fixtures/preview/accounts/stake-address-transactions.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account transactions endpoint for stake addresses (`/accounts/{stake_address}/transactions`).
  * Enhanced account lookup to resolve CIP-19 stake credentials (e.g., stake keys/scripts) into canonical stake addresses for stake-address-based endpoints.
  * Transactions results support stable ordering, pagination, and slot-based filtering.

* **Bug Fixes**
  * Invalid or unrecognized stake-address/account inputs now return clear bad-request responses.
  * Encoding/derivation failures are handled gracefully to avoid unexpected crashes.

* **Tests**
  * Expanded coverage for CIP-19 credential handling and the new transactions endpoint (ordering, pagination, and error cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->