### PR TITLE
fix(cardano): stop dropping StakeVoteDeleg drep leg and drep anchors

### DIFF
--- a/crates/cardano/src/model/dreps.rs
+++ b/crates/cardano/src/model/dreps.rs
@@ -43,6 +43,11 @@ pub struct DRepState {
 
     #[n(6)]
     pub identifier: DRep,
+
+    // Backward-compatible addition: absent in pre-existing rows, decodes as
+    // `None`. Index 7 must not be reused for anything else.
+    #[n(7)]
+    pub anchor: Option<Anchor>,
 }
 
 impl DRepState {
@@ -55,6 +60,7 @@ impl DRepState {
             expired: false,
             deposit: 0,
             identifier,
+            anchor: None,
         }
     }
 
@@ -91,6 +97,7 @@ pub(crate) mod testing {
             unregistered_at in prop::option::of((root::any_slot(), root::any_tx_order())),
             expired in any::<bool>(),
             deposit in root::any_lovelace(),
+            anchor in prop::option::of(root::any_anchor()),
         ) -> DRepState {
             DRepState {
                 identifier,
@@ -100,6 +107,7 @@ pub(crate) mod testing {
                 unregistered_at,
                 expired,
                 deposit,
+                anchor,
             }
         }
     }
@@ -282,6 +290,62 @@ impl dolos_core::EntityDelta for DRepActivity {
     }
 }
 
+/// Sets the anchor advertised by a DRep.
+///
+/// Emitted for `RegDRepCert` (alongside `DRepRegistration`, whose on-disk
+/// shape is frozen and can't grow the undo field) and for `UpdateDRepCert`,
+/// whose anchor was previously discarded. Carries the cert's anchor verbatim:
+/// a cert without an anchor clears the stored one, matching the ledger rules
+/// where both certs replace `drepAnchor` wholesale.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepAnchorUpdate {
+    pub(crate) drep: DRep,
+    pub(crate) anchor: Option<Anchor>,
+
+    // undo
+    pub(crate) was_new: bool,
+    pub(crate) prev_anchor: Option<Anchor>,
+}
+
+impl DRepAnchorUpdate {
+    pub fn new(drep: DRep, anchor: Option<Anchor>) -> Self {
+        Self {
+            drep,
+            anchor,
+            was_new: false,
+            prev_anchor: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for DRepAnchorUpdate {
+    type Entity = DRepState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((DRepState::NS, drep_to_entity_key(&self.drep)))
+    }
+
+    fn apply(&mut self, entity: &mut Option<DRepState>) {
+        self.was_new = entity.is_none();
+
+        let entity = entity.get_or_insert_with(|| DRepState::new(self.drep.clone()));
+
+        // save undo info
+        self.prev_anchor = entity.anchor.clone();
+
+        // apply changes
+        entity.anchor = self.anchor.clone();
+    }
+
+    fn undo(&self, entity: &mut Option<DRepState>) {
+        if self.was_new {
+            *entity = None;
+        } else if let Some(state) = entity {
+            state.anchor = self.prev_anchor.clone();
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DRepExpiration {
     pub(crate) drep_id: EntityKey,
@@ -359,6 +423,15 @@ mod prop_tests {
     }
 
     prop_compose! {
+        fn any_drep_anchor_update()(
+            drep in root::any_drep(),
+            anchor in prop::option::of(root::any_anchor()),
+        ) -> DRepAnchorUpdate {
+            DRepAnchorUpdate::new(drep, anchor)
+        }
+    }
+
+    prop_compose! {
         fn any_drep_expiration()(
             drep in root::any_drep(),
         ) -> DRepExpiration {
@@ -389,6 +462,22 @@ mod prop_tests {
             delta in any_drep_activity(),
         ) {
             assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn drep_anchor_update_roundtrip(
+            entity in prop::option::of(any_drep_state()),
+            delta in any_drep_anchor_update(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn drep_anchor_update_serde_roundtrip(
+            entity in prop::option::of(any_drep_state()),
+            delta in any_drep_anchor_update(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
         }
 
         #[test]

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -230,6 +230,7 @@ pub enum CardanoDelta {
     EpochWrapUpV2(Box<EpochWrapUpV2>),
     EpochTransitionV2(Box<EpochTransitionV2>),
     EpochWrapUpV3(Box<EpochWrapUpV3>),
+    DRepAnchorUpdate(Box<DRepAnchorUpdate>),
 }
 
 impl CardanoDelta {
@@ -315,6 +316,7 @@ delta_from!(EStartProgress);
 delta_from!(RupdProgress);
 delta_from!(EpochTransitionV2);
 delta_from!(EpochWrapUpV3);
+delta_from!(DRepAnchorUpdate);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -337,6 +339,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::DRepActivity(x) => x.key(),
             Self::DRepUnRegistration(x) => x.key(),
             Self::DRepExpiration(x) => x.key(),
+            Self::DRepAnchorUpdate(x) => x.key(),
             Self::WithdrawalInc(x) => x.key(),
             Self::VoteDelegation(x) => x.key(),
             Self::PParamsUpdate(x) => x.key(),
@@ -387,6 +390,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::DRepUnRegistration(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::DRepActivity(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::DRepExpiration(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::DRepAnchorUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::WithdrawalInc(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::VoteDelegation(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PParamsUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -437,6 +441,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::DRepUnRegistration(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::DRepActivity(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::DRepExpiration(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::DRepAnchorUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::WithdrawalInc(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::VoteDelegation(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PParamsUpdate(x) => Self::downcast_undo(x.as_ref(), entity),

--- a/crates/cardano/src/pallas_extras.rs
+++ b/crates/cardano/src/pallas_extras.rs
@@ -133,6 +133,10 @@ pub fn cert_as_vote_delegation(cert: &MultiEraCert) -> Option<MultiEraVoteDelega
                 delegator: delegator.clone(),
                 drep: drep.clone(),
             }),
+            ConwayCert::StakeVoteDeleg(delegator, _, drep) => Some(MultiEraVoteDelegation {
+                delegator: delegator.clone(),
+                drep: drep.clone(),
+            }),
             _ => None,
         },
         _ => None,

--- a/crates/cardano/src/roll/dreps.rs
+++ b/crates/cardano/src/roll/dreps.rs
@@ -9,7 +9,7 @@ use pallas::ledger::{
 use super::WorkDeltas;
 use crate::{
     owned::OwnedMultiEraOutput, pallas_extras::stake_cred_to_drep, roll::BlockVisitor,
-    DRepActivity, DRepRegistration, DRepUnRegistration,
+    DRepActivity, DRepAnchorUpdate, DRepRegistration, DRepUnRegistration,
 };
 
 fn cert_drep(cert: &MultiEraCert) -> Option<DRep> {
@@ -78,6 +78,8 @@ impl BlockVisitor for DRepStateVisitor {
                         *deposit,
                         anchor.clone(),
                     ));
+
+                    deltas.add_for_entity(DRepAnchorUpdate::new(drep.clone(), anchor.clone()));
                 }
                 conway::Certificate::UnRegDRepCert(_, _) => {
                     deltas.add_for_entity(DRepUnRegistration::new(
@@ -85,6 +87,9 @@ impl BlockVisitor for DRepStateVisitor {
                         block.slot(),
                         *order,
                     ));
+                }
+                conway::Certificate::UpdateDRepCert(_, anchor) => {
+                    deltas.add_for_entity(DRepAnchorUpdate::new(drep.clone(), anchor.clone()));
                 }
                 _ => (),
             }


### PR DESCRIPTION
## Summary

Two Conway cert-handling gaps in delegation/DRep tracking, both on the block-roll path:

### 1. `StakeVoteDeleg`'s DRep leg was silently dropped

`cert_as_vote_delegation` (`pallas_extras.rs`) matched `VoteDeleg`, `VoteRegDeleg` and `StakeVoteRegDeleg` but not `StakeVoteDeleg`, so a combined stake+vote delegation cert updated the account's pool delegation (its pool leg is handled by `cert_as_stake_delegation`) while the DRep delegation was never recorded. This is a live correctness bug: any account that delegated to a DRep via that cert shows no vote delegation. Fixed by adding the missing arm, emitting the existing `VoteDelegation` delta.

### 2. DRep anchors were discarded

`DRepState` had no anchor field: the anchor carried by `RegDRepCert` was stashed in the `DRepRegistration` delta but never written to the entity, and `UpdateDRepCert` only refreshed activity, discarding its anchor entirely.

- `DRepState` gains `anchor: Option<Anchor>` at CBOR index 7 — a backward-compatible addition: pre-existing rows decode with `None`, no migration.
- A new `DRepAnchorUpdate` delta (appended to `CardanoDelta`, preserving the frozen bincode variant order) writes it, emitted for both `RegDRepCert` and `UpdateDRepCert`. A separate delta rather than extending `DRepRegistration` because existing delta shapes are frozen for WAL decode compatibility (same reason as the `EpochWrapUp` → V2/V3 lineage).
- Semantics match the ledger's CERT rules: both certs replace `drepAnchor` wholesale (`anchor := anchor`), so a cert without an anchor clears the stored one. The activity/expiry refresh side of `UpdateDRepCert` remains covered by the existing `DRepActivity` delta.

This is the first step of making Conway governance tracking real (DRep delegation at the transaction level); vote/proposal capture and ratification come separately.

## Testing

- New proptests: `drep_anchor_update_roundtrip` (apply→undo reversibility) and `drep_anchor_update_serde_roundtrip` (undo survives the WAL wire format); `any_drep_state` extended with the anchor field.
- `cargo clippy --workspace --all-targets --all-features`: clean.
- `cargo test --workspace --all-features`: all green.
- `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for storing and updating DRep anchors.
  - DRep registration and anchor update certificates now appear in state changes.
  - Anchors can be cleared when no longer provided.

- **Bug Fixes**
  - Improved handling of Conway-era vote delegation certificates.
  - Existing persisted DRep records remain compatible when no anchor is present.

- **Tests**
  - Added coverage for anchor updates, serialization, undo operations, and state round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->