### PR TITLE
feat(cardano): capture governance votes and full proposal state

### DIFF
--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -231,6 +231,8 @@ pub enum CardanoDelta {
     EpochTransitionV2(Box<EpochTransitionV2>),
     EpochWrapUpV3(Box<EpochWrapUpV3>),
     DRepAnchorUpdate(Box<DRepAnchorUpdate>),
+    NewProposalV2(Box<NewProposalV2>),
+    VoteCast(Box<VoteCast>),
 }
 
 impl CardanoDelta {
@@ -317,6 +319,8 @@ delta_from!(RupdProgress);
 delta_from!(EpochTransitionV2);
 delta_from!(EpochWrapUpV3);
 delta_from!(DRepAnchorUpdate);
+delta_from!(NewProposalV2);
+delta_from!(VoteCast);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -345,6 +349,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::PParamsUpdate(x) => x.key(),
             Self::NoncesUpdate(x) => x.key(),
             Self::NewProposal(x) => x.key(),
+            Self::NewProposalV2(x) => x.key(),
+            Self::VoteCast(x) => x.key(),
             Self::AssignRewards(x) => x.key(),
             Self::NonceTransition(x) => x.key(),
             Self::PoolTransition(x) => x.key(),
@@ -396,6 +402,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::PParamsUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NoncesUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NewProposal(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::NewProposalV2(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::VoteCast(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::AssignRewards(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NonceTransition(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolTransition(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -447,6 +455,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::PParamsUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NoncesUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NewProposal(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::NewProposalV2(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::VoteCast(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::AssignRewards(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NonceTransition(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolTransition(x) => Self::downcast_undo(x.as_ref(), entity),

--- a/crates/cardano/src/model/proposals.rs
+++ b/crates/cardano/src/model/proposals.rs
@@ -1,12 +1,17 @@
+use std::collections::BTreeMap;
+
 use dolos_core::{BlockSlot, EntityKey, NsKey};
 use pallas::{
     codec::minicbor::{self, Decode, Encode},
     crypto::hash::Hash,
-    ledger::primitives::{Coin, Epoch, ProtocolVersion, StakeCredential},
+    ledger::primitives::{
+        conway::{Anchor, GovActionId, Vote, Voter},
+        Coin, Epoch, ProtocolVersion, RationalNumber, ScriptHash, StakeCredential,
+    },
 };
 use serde::{Deserialize, Serialize};
 
-use super::{epochs::Lovelace, pparams::PParamsSet, FixedNamespace as _};
+use super::{epochs::Lovelace, pools::PoolHash, pparams::PParamsSet, FixedNamespace as _};
 use crate::hacks::{self, proposals::ProposalOutcome};
 
 #[derive(Debug, Encode, Decode, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -20,11 +25,70 @@ pub enum ProposalAction {
     #[n(2)]
     TreasuryWithdrawal(#[n(0)] Vec<(StakeCredential, Coin)>),
 
-    /// Used to track any other proposal that isn't relevant for Dolos'
-    /// purposes.
+    /// Legacy catch-all for governance actions that weren't tracked in full.
+    /// Kept so pre-existing rows decode; new rows use the specific variants
+    /// below.
     #[n(3)]
     Other,
+
+    // Variants below are backward-compatible additions: old rows only carry
+    // indexes 0..=3, so they keep decoding. Variant order is also part of the
+    // WAL format (bincode positional encoding) — append only, never reorder.
+    #[n(4)]
+    NoConfidence,
+
+    #[n(5)]
+    UpdateCommittee {
+        #[n(0)]
+        to_remove: Vec<StakeCredential>,
+
+        /// Members to add, each with its term-expiry epoch (inclusive).
+        #[n(1)]
+        to_add: Vec<(StakeCredential, Epoch)>,
+
+        #[n(2)]
+        threshold: RationalNumber,
+    },
+
+    #[n(6)]
+    NewConstitution {
+        #[n(0)]
+        anchor: Anchor,
+
+        #[n(1)]
+        guardrail_script: Option<ScriptHash>,
+    },
+
+    #[n(7)]
+    Info,
 }
+
+/// The four independent lineage trees a governance action can belong to.
+///
+/// `TreasuryWithdrawal` and `Info` actions have no lineage (no parent field,
+/// never become a root), so their proposals carry no purpose.
+#[derive(Debug, Encode, Decode, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cbor(index_only)]
+pub enum GovPurpose {
+    #[n(0)]
+    PParamUpdate,
+
+    #[n(1)]
+    HardFork,
+
+    #[n(2)]
+    Committee,
+
+    #[n(3)]
+    Constitution,
+}
+
+/// Slot-stamped, append-only vote history for a single voter on a single
+/// proposal. The last entry is the effective vote (last vote wins); keeping
+/// the full history is what makes as-of reads possible at epoch boundaries,
+/// where the tally must use the votes as of the previous boundary even if the
+/// voter re-voted since.
+pub type VoteHistory = Vec<(BlockSlot, Vote)>;
 
 #[derive(Debug, Encode, Decode, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalState {
@@ -56,6 +120,44 @@ pub struct ProposalState {
 
     #[n(8)]
     pub reward_account: Option<StakeCredential>,
+
+    // Fields below are backward-compatible additions: absent in pre-existing
+    // rows, they decode as `None` / empty. Indexes 9..=15 must not be reused
+    // for anything else, and existing indexes are frozen.
+    /// Epoch in which the proposal was submitted. Drives the snapshot filter
+    /// at epoch boundaries (`max_epoch` stays as the expiry bound).
+    #[n(9)]
+    pub proposed_in: Option<Epoch>,
+
+    /// Lineage parent declared by the action: the previous governance action
+    /// id of the same purpose (`None` for the root of the tree, and always
+    /// `None` for TreasuryWithdrawal/Info, which have no lineage).
+    #[n(10)]
+    pub parent: Option<GovActionId>,
+
+    /// Which lineage tree the action belongs to (`None` for
+    /// TreasuryWithdrawal/Info).
+    #[n(11)]
+    pub purpose: Option<GovPurpose>,
+
+    /// Metadata anchor as submitted in the proposal procedure.
+    #[n(12)]
+    pub anchor: Option<Anchor>,
+
+    /// Constitutional-committee votes, keyed by the member's hot credential.
+    #[n(13)]
+    #[cbor(default)]
+    pub cc_votes: BTreeMap<StakeCredential, VoteHistory>,
+
+    /// DRep votes, keyed by the DRep credential.
+    #[n(14)]
+    #[cbor(default)]
+    pub drep_votes: BTreeMap<StakeCredential, VoteHistory>,
+
+    /// Stake-pool operator votes, keyed by the pool operator key hash.
+    #[n(15)]
+    #[cbor(default)]
+    pub spo_votes: BTreeMap<PoolHash, VoteHistory>,
 }
 
 entity_boilerplate!(ProposalState, "proposals");
@@ -66,35 +168,170 @@ pub(crate) mod testing {
     use crate::model::testing as root;
     use proptest::prelude::*;
 
+    pub fn any_gov_purpose() -> impl Strategy<Value = GovPurpose> {
+        prop_oneof![
+            Just(GovPurpose::PParamUpdate),
+            Just(GovPurpose::HardFork),
+            Just(GovPurpose::Committee),
+            Just(GovPurpose::Constitution),
+        ]
+    }
+
+    pub fn any_proposal_action() -> impl Strategy<Value = ProposalAction> {
+        prop_oneof![
+            Just(ProposalAction::ParamChange(PParamsSet::default())),
+            Just(ProposalAction::HardFork((9, 0))),
+            root::any_stake_credential()
+                .prop_map(|cred| { ProposalAction::TreasuryWithdrawal(vec![(cred, 1_000_000)]) }),
+            Just(ProposalAction::Other),
+            Just(ProposalAction::NoConfidence),
+            (
+                root::any_stake_credential(),
+                root::any_stake_credential(),
+                root::any_epoch(),
+                root::any_rational(),
+            )
+                .prop_map(|(rm, add, epoch, threshold)| {
+                    ProposalAction::UpdateCommittee {
+                        to_remove: vec![rm],
+                        to_add: vec![(add, epoch)],
+                        threshold,
+                    }
+                }),
+            (root::any_anchor(), prop::option::of(root::any_hash_28())).prop_map(
+                |(anchor, guardrail_script)| ProposalAction::NewConstitution {
+                    anchor,
+                    guardrail_script,
+                }
+            ),
+            Just(ProposalAction::Info),
+        ]
+    }
+
+    pub fn any_vote_history() -> impl Strategy<Value = VoteHistory> {
+        prop::collection::vec((root::any_slot(), root::any_vote()), 0..3)
+    }
+
     prop_compose! {
         pub fn any_proposal_state()(
             slot in root::any_slot(),
             tx in root::any_hash_32(),
             idx in 0u32..16u32,
+            action in any_proposal_action(),
             deposit in prop::option::of(root::any_lovelace()),
             reward_account in prop::option::of(root::any_stake_credential()),
             max_epoch in prop::option::of(root::any_epoch()),
             ratified_epoch in prop::option::of(root::any_epoch()),
             canceled_epoch in prop::option::of(root::any_epoch()),
+            proposed_in in prop::option::of(root::any_epoch()),
+            parent in prop::option::of(root::any_gov_action_id()),
+            purpose in prop::option::of(any_gov_purpose()),
+            anchor in prop::option::of(root::any_anchor()),
+            cc_votes in prop::collection::btree_map(root::any_stake_credential(), any_vote_history(), 0..3),
+            drep_votes in prop::collection::btree_map(root::any_stake_credential(), any_vote_history(), 0..3),
+            spo_votes in prop::collection::btree_map(root::any_hash_28(), any_vote_history(), 0..3),
         ) -> ProposalState {
             ProposalState {
                 slot,
                 tx,
                 idx,
-                action: ProposalAction::Other,
+                action,
                 max_epoch,
                 ratified_epoch,
                 canceled_epoch,
                 deposit,
                 reward_account,
+                proposed_in,
+                parent,
+                purpose,
+                anchor,
+                cc_votes,
+                drep_votes,
+                spo_votes,
             }
         }
+    }
+}
+
+/// Ensures `key` has a (possibly empty) history in `map`, returning whether
+/// the entry had to be created alongside the history itself.
+fn history_or_default<K: Ord>(
+    map: &mut BTreeMap<K, VoteHistory>,
+    key: K,
+) -> (bool, &mut VoteHistory) {
+    let created = !map.contains_key(&key);
+    (created, map.entry(key).or_default())
+}
+
+fn history_pop<K: Ord>(map: &mut BTreeMap<K, VoteHistory>, key: &K, created: bool) {
+    if let Some(history) = map.get_mut(key) {
+        history.pop();
+    }
+
+    if created {
+        map.remove(key);
     }
 }
 
 impl ProposalState {
     pub fn key(&self) -> EntityKey {
         Self::build_entity_key(self.tx, self.idx)
+    }
+
+    pub fn gov_action_id(&self) -> GovActionId {
+        GovActionId {
+            transaction_id: self.tx,
+            action_index: self.idx,
+        }
+    }
+
+    /// Mutable access to `voter`'s history in the vote map matching its
+    /// class, creating the entry if absent. Returns whether the entry was
+    /// created (needed for exact delta undo).
+    fn vote_history_mut(&mut self, voter: &Voter) -> (bool, &mut VoteHistory) {
+        match voter {
+            Voter::ConstitutionalCommitteeKey(hash) => {
+                history_or_default(&mut self.cc_votes, StakeCredential::AddrKeyhash(*hash))
+            }
+            Voter::ConstitutionalCommitteeScript(hash) => {
+                history_or_default(&mut self.cc_votes, StakeCredential::ScriptHash(*hash))
+            }
+            Voter::DRepKey(hash) => {
+                history_or_default(&mut self.drep_votes, StakeCredential::AddrKeyhash(*hash))
+            }
+            Voter::DRepScript(hash) => {
+                history_or_default(&mut self.drep_votes, StakeCredential::ScriptHash(*hash))
+            }
+            Voter::StakePoolKey(hash) => history_or_default(&mut self.spo_votes, *hash),
+        }
+    }
+
+    /// Pops the most recent vote of `voter`, removing the map entry if this
+    /// delta's apply created it.
+    fn vote_history_pop(&mut self, voter: &Voter, created: bool) {
+        match voter {
+            Voter::ConstitutionalCommitteeKey(hash) => history_pop(
+                &mut self.cc_votes,
+                &StakeCredential::AddrKeyhash(*hash),
+                created,
+            ),
+            Voter::ConstitutionalCommitteeScript(hash) => history_pop(
+                &mut self.cc_votes,
+                &StakeCredential::ScriptHash(*hash),
+                created,
+            ),
+            Voter::DRepKey(hash) => history_pop(
+                &mut self.drep_votes,
+                &StakeCredential::AddrKeyhash(*hash),
+                created,
+            ),
+            Voter::DRepScript(hash) => history_pop(
+                &mut self.drep_votes,
+                &StakeCredential::ScriptHash(*hash),
+                created,
+            ),
+            Voter::StakePoolKey(hash) => history_pop(&mut self.spo_votes, hash, created),
+        }
     }
 
     /// Build the ID of the proposal in its string form, as found on explorers.
@@ -271,6 +508,16 @@ impl dolos_core::EntityDelta for NewProposal {
             max_epoch,
             ratified_epoch,
             canceled_epoch,
+            // `proposed_in` derives from data this legacy delta already
+            // carries, so WAL replay of old rows populates it too. The
+            // remaining phase-2 fields weren't captured at the time.
+            proposed_in: Some(self.current_epoch),
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
         };
 
         let _ = entity.insert(state);
@@ -281,9 +528,373 @@ impl dolos_core::EntityDelta for NewProposal {
     }
 }
 
+/// Creation of a proposal with full governance capture.
+///
+/// Supersedes [`NewProposal`] as the emitted delta: it additionally records
+/// the lineage parent, the purpose, and the metadata anchor of the submitted
+/// action (the full seven-variant action mapping flows through the shared
+/// `ProposalAction`). [`NewProposal`] remains only so pre-existing WAL rows
+/// keep decoding and replaying — its field layout is frozen (bincode) and
+/// can't grow.
+///
+/// Outcome stamping still consults `hacks::proposals`: ratification isn't
+/// computed for real until the RATIFY engine lands, at which point the hack
+/// table becomes the validation oracle before deletion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewProposalV2 {
+    pub(crate) slot: BlockSlot,
+    pub(crate) tx: Hash<32>,
+    pub(crate) idx: u32,
+    pub(crate) action: ProposalAction,
+    pub(crate) deposit: Option<Lovelace>,
+    pub(crate) reward_account: Option<StakeCredential>,
+    pub(crate) validity_period: Option<u64>,
+    pub(crate) current_epoch: Epoch,
+    pub(crate) network_magic: u32,
+    pub(crate) protocol: u16,
+    pub(crate) parent: Option<GovActionId>,
+    pub(crate) purpose: Option<GovPurpose>,
+    pub(crate) anchor: Option<Anchor>,
+
+    pub(crate) prev: Option<ProposalState>,
+}
+
+impl NewProposalV2 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        slot: BlockSlot,
+        tx: Hash<32>,
+        idx: u32,
+        action: ProposalAction,
+        deposit: Option<Lovelace>,
+        reward_account: Option<StakeCredential>,
+        validity_period: Option<u64>,
+        current_epoch: Epoch,
+        network_magic: u32,
+        protocol: u16,
+        parent: Option<GovActionId>,
+        purpose: Option<GovPurpose>,
+        anchor: Option<Anchor>,
+    ) -> Self {
+        Self {
+            slot,
+            tx,
+            idx,
+            action,
+            deposit,
+            reward_account,
+            validity_period,
+            current_epoch,
+            network_magic,
+            protocol,
+            parent,
+            purpose,
+            anchor,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for NewProposalV2 {
+    type Entity = ProposalState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((
+            ProposalState::NS,
+            ProposalState::build_entity_key(self.tx, self.idx),
+        ))
+    }
+
+    fn apply(&mut self, entity: &mut Option<ProposalState>) {
+        self.prev = entity.clone();
+
+        let id = ProposalState::id(self.tx, self.idx);
+
+        let outcome = hacks::proposals::outcome(self.network_magic, self.protocol, &id);
+
+        let max_epoch = self.validity_period.map(|x| self.current_epoch + x);
+
+        let ratified_epoch = match &outcome {
+            ProposalOutcome::Ratified(epoch) => Some(*epoch),
+            ProposalOutcome::RatifiedCurrentEpoch => Some(self.current_epoch),
+            _ => None,
+        };
+
+        let canceled_epoch = match &outcome {
+            ProposalOutcome::Canceled(epoch) => Some(*epoch),
+            _ => None,
+        };
+
+        let state = ProposalState {
+            slot: self.slot,
+            tx: self.tx,
+            idx: self.idx,
+            action: self.action.clone(),
+            reward_account: self.reward_account.clone(),
+            deposit: self.deposit,
+            max_epoch,
+            ratified_epoch,
+            canceled_epoch,
+            proposed_in: Some(self.current_epoch),
+            parent: self.parent.clone(),
+            purpose: self.purpose,
+            anchor: self.anchor.clone(),
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        };
+
+        let _ = entity.insert(state);
+    }
+
+    fn undo(&self, entity: &mut Option<ProposalState>) {
+        *entity = self.prev.clone();
+    }
+}
+
+/// A vote cast on a live proposal by any of the three voter classes
+/// (constitutional committee, DRep, or stake-pool operator).
+///
+/// Appends `(slot, vote)` to the voter's history on the target
+/// [`ProposalState`]; undo pops exactly the appended entry. The history is
+/// append-only — the last entry is the effective vote — so epoch-boundary
+/// tallies can read the votes as of a past slot even if the voter re-voted
+/// since.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoteCast {
+    pub(crate) proposal_tx: Hash<32>,
+    pub(crate) proposal_idx: u32,
+    pub(crate) voter: Voter,
+    pub(crate) vote: Vote,
+    pub(crate) slot: BlockSlot,
+
+    // undo
+    pub(crate) applied: bool,
+    pub(crate) created_entry: bool,
+}
+
+impl VoteCast {
+    pub fn new(
+        proposal_tx: Hash<32>,
+        proposal_idx: u32,
+        voter: Voter,
+        vote: Vote,
+        slot: BlockSlot,
+    ) -> Self {
+        Self {
+            proposal_tx,
+            proposal_idx,
+            voter,
+            vote,
+            slot,
+            applied: false,
+            created_entry: false,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for VoteCast {
+    type Entity = ProposalState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((
+            ProposalState::NS,
+            ProposalState::build_entity_key(self.proposal_tx, self.proposal_idx),
+        ))
+    }
+
+    fn apply(&mut self, entity: &mut Option<ProposalState>) {
+        let Some(state) = entity.as_mut() else {
+            // Valid chains only carry votes for existing proposals; an
+            // in-place-upgraded store tracked proposals before this delta
+            // existed, so the target should always be present. Tolerate the
+            // gap instead of corrupting state.
+            tracing::warn!(
+                tx = %self.proposal_tx,
+                idx = self.proposal_idx,
+                "vote cast on unknown proposal; skipping"
+            );
+
+            self.applied = false;
+            self.created_entry = false;
+            return;
+        };
+
+        let (created, history) = state.vote_history_mut(&self.voter);
+        history.push((self.slot, self.vote.clone()));
+
+        self.applied = true;
+        self.created_entry = created;
+    }
+
+    fn undo(&self, entity: &mut Option<ProposalState>) {
+        if !self.applied {
+            return;
+        }
+
+        let Some(state) = entity.as_mut() else {
+            return;
+        };
+
+        state.vote_history_pop(&self.voter, self.created_entry);
+    }
+}
+
+#[cfg(test)]
+mod compat_tests {
+    use super::*;
+
+    /// Replica of the on-disk `ProposalState` shape before the phase-2
+    /// governance additions (indexes 0..=8, four-variant action). Encoding
+    /// this and decoding it as the current `ProposalState` proves that
+    /// pre-existing rows keep decoding, with the new fields empty.
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+    enum LegacyProposalAction {
+        #[n(0)]
+        ParamChange(#[n(0)] PParamsSet),
+
+        #[n(1)]
+        HardFork(#[n(0)] ProtocolVersion),
+
+        #[n(2)]
+        TreasuryWithdrawal(#[n(0)] Vec<(StakeCredential, Coin)>),
+
+        #[n(3)]
+        Other,
+    }
+
+    #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+    struct LegacyProposalState {
+        #[n(0)]
+        slot: BlockSlot,
+
+        #[n(1)]
+        tx: Hash<32>,
+
+        #[n(2)]
+        idx: u32,
+
+        #[n(3)]
+        action: LegacyProposalAction,
+
+        #[n(4)]
+        max_epoch: Option<Epoch>,
+
+        #[n(5)]
+        ratified_epoch: Option<Epoch>,
+
+        #[n(6)]
+        canceled_epoch: Option<Epoch>,
+
+        #[n(7)]
+        deposit: Option<Lovelace>,
+
+        #[n(8)]
+        reward_account: Option<StakeCredential>,
+    }
+
+    #[test]
+    fn legacy_rows_decode_with_new_fields_empty() {
+        let actions = [
+            LegacyProposalAction::ParamChange(PParamsSet::default()),
+            LegacyProposalAction::HardFork((9, 0)),
+            LegacyProposalAction::TreasuryWithdrawal(vec![(
+                StakeCredential::AddrKeyhash([7u8; 28].into()),
+                42,
+            )]),
+            LegacyProposalAction::Other,
+        ];
+
+        for action in actions {
+            let legacy = LegacyProposalState {
+                slot: 1234,
+                tx: [1u8; 32].into(),
+                idx: 3,
+                action,
+                max_epoch: Some(500),
+                ratified_epoch: None,
+                canceled_epoch: Some(400),
+                deposit: Some(100_000_000),
+                reward_account: Some(StakeCredential::AddrKeyhash([2u8; 28].into())),
+            };
+
+            let bytes = minicbor::to_vec(&legacy).unwrap();
+            let decoded: ProposalState = minicbor::decode(&bytes).unwrap();
+
+            assert_eq!(decoded.slot, legacy.slot);
+            assert_eq!(decoded.tx, legacy.tx);
+            assert_eq!(decoded.idx, legacy.idx);
+            assert_eq!(decoded.max_epoch, legacy.max_epoch);
+            assert_eq!(decoded.ratified_epoch, legacy.ratified_epoch);
+            assert_eq!(decoded.canceled_epoch, legacy.canceled_epoch);
+            assert_eq!(decoded.deposit, legacy.deposit);
+            assert_eq!(decoded.reward_account, legacy.reward_account);
+
+            assert_eq!(decoded.proposed_in, None);
+            assert_eq!(decoded.parent, None);
+            assert_eq!(decoded.purpose, None);
+            assert_eq!(decoded.anchor, None);
+            assert!(decoded.cc_votes.is_empty());
+            assert!(decoded.drep_votes.is_empty());
+            assert!(decoded.spo_votes.is_empty());
+        }
+    }
+
+    #[test]
+    fn new_rows_roundtrip() {
+        let mut state = ProposalState {
+            slot: 1234,
+            tx: [1u8; 32].into(),
+            idx: 3,
+            action: ProposalAction::NewConstitution {
+                anchor: Anchor {
+                    url: "https://example.com".to_string(),
+                    content_hash: [9u8; 32].into(),
+                },
+                guardrail_script: Some([8u8; 28].into()),
+            },
+            max_epoch: Some(500),
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: Some(100_000_000),
+            reward_account: Some(StakeCredential::AddrKeyhash([2u8; 28].into())),
+            proposed_in: Some(490),
+            parent: Some(GovActionId {
+                transaction_id: [3u8; 32].into(),
+                action_index: 0,
+            }),
+            purpose: Some(GovPurpose::Constitution),
+            anchor: Some(Anchor {
+                url: "ipfs://meta".to_string(),
+                content_hash: [4u8; 32].into(),
+            }),
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        };
+
+        state.cc_votes.insert(
+            StakeCredential::AddrKeyhash([5u8; 28].into()),
+            vec![(100, Vote::Yes), (200, Vote::No)],
+        );
+        state.drep_votes.insert(
+            StakeCredential::ScriptHash([6u8; 28].into()),
+            vec![(150, Vote::Abstain)],
+        );
+        state
+            .spo_votes
+            .insert([7u8; 28].into(), vec![(160, Vote::Yes)]);
+
+        let bytes = minicbor::to_vec(&state).unwrap();
+        let decoded: ProposalState = minicbor::decode(&bytes).unwrap();
+
+        assert_eq!(decoded, state);
+    }
+}
+
 #[cfg(test)]
 mod prop_tests {
-    use super::testing::any_proposal_state;
+    use super::testing::{any_proposal_action, any_proposal_state};
     use super::*;
     use crate::model::testing::{self as root, assert_delta_roundtrip};
     use proptest::prelude::*;
@@ -309,6 +920,50 @@ mod prop_tests {
         }
     }
 
+    prop_compose! {
+        fn any_new_proposal_v2()(
+            slot in root::any_slot(),
+            tx in root::any_hash_32(),
+            idx in 0u32..16u32,
+            action in any_proposal_action(),
+            deposit in prop::option::of(root::any_lovelace()),
+            reward_account in prop::option::of(root::any_stake_credential()),
+            validity_period in prop::option::of(1u64..10u64),
+            current_epoch in root::any_epoch(),
+            network_magic in any::<u32>(),
+            protocol in 0u16..10u16,
+            parent in prop::option::of(root::any_gov_action_id()),
+            purpose in prop::option::of(super::testing::any_gov_purpose()),
+            anchor in prop::option::of(root::any_anchor()),
+        ) -> NewProposalV2 {
+            NewProposalV2::new(
+                slot, tx, idx, action,
+                deposit, reward_account, validity_period,
+                current_epoch, network_magic, protocol,
+                parent, purpose, anchor,
+            )
+        }
+    }
+
+    prop_compose! {
+        fn any_vote_cast()(
+            proposal_tx in root::any_hash_32(),
+            proposal_idx in 0u32..16u32,
+            voter in root::any_voter(),
+            vote in root::any_vote(),
+            slot in root::any_slot(),
+        ) -> VoteCast {
+            VoteCast::new(proposal_tx, proposal_idx, voter, vote, slot)
+        }
+    }
+
+    /// A vote cast targeting a proposal that exists, aimed at the entity the
+    /// strategy pairs it with (`any_proposal_state` fixes tx/idx per sample).
+    fn any_matching_vote_cast(tx: Hash<32>, idx: u32) -> impl Strategy<Value = VoteCast> {
+        (root::any_voter(), root::any_vote(), root::any_slot())
+            .prop_map(move |(voter, vote, slot)| VoteCast::new(tx, idx, voter, vote, slot))
+    }
+
     proptest! {
         #[test]
         fn new_proposal_roundtrip(
@@ -317,5 +972,95 @@ mod prop_tests {
         ) {
             assert_delta_roundtrip(entity, delta);
         }
+
+        #[test]
+        fn new_proposal_v2_roundtrip(
+            entity in prop::option::of(any_proposal_state()),
+            delta in any_new_proposal_v2(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn new_proposal_v2_serde_roundtrip(
+            entity in prop::option::of(any_proposal_state()),
+            delta in any_new_proposal_v2(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn vote_cast_roundtrip(
+            entity in prop::option::of(any_proposal_state()),
+            delta in any_vote_cast(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn vote_cast_serde_roundtrip(
+            entity in prop::option::of(any_proposal_state()),
+            delta in any_vote_cast(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn vote_cast_on_existing_proposal_roundtrip(
+            (entity, delta) in any_proposal_state()
+                .prop_flat_map(|state| {
+                    let deltas = any_matching_vote_cast(state.tx, state.idx);
+                    (Just(state), deltas)
+                }),
+        ) {
+            assert_delta_roundtrip(Some(entity), delta);
+        }
+    }
+
+    #[test]
+    fn vote_cast_appends_and_replaces() {
+        let mut entity = Some(ProposalState {
+            slot: 10,
+            tx: [1u8; 32].into(),
+            idx: 0,
+            action: ProposalAction::Info,
+            max_epoch: None,
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: None,
+            reward_account: None,
+            proposed_in: Some(1),
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        });
+
+        let voter = Voter::DRepKey([5u8; 28].into());
+
+        let mut first = VoteCast::new([1u8; 32].into(), 0, voter.clone(), Vote::No, 100);
+        let mut second = VoteCast::new([1u8; 32].into(), 0, voter.clone(), Vote::Yes, 200);
+
+        use dolos_core::EntityDelta as _;
+
+        first.apply(&mut entity);
+        second.apply(&mut entity);
+
+        let state = entity.as_ref().unwrap();
+        let history = state
+            .drep_votes
+            .get(&StakeCredential::AddrKeyhash([5u8; 28].into()))
+            .unwrap();
+
+        // Append-only history: both votes retained, last one effective.
+        assert_eq!(history, &vec![(100, Vote::No), (200, Vote::Yes)]);
+
+        second.undo(&mut entity);
+        first.undo(&mut entity);
+
+        let state = entity.as_ref().unwrap();
+        assert!(state.drep_votes.is_empty());
     }
 }

--- a/crates/cardano/src/model/testing.rs
+++ b/crates/cardano/src/model/testing.rs
@@ -10,7 +10,7 @@
 use dolos_core::EntityDelta;
 use pallas::crypto::hash::Hash;
 use pallas::ledger::primitives::{
-    conway::{Anchor, DRep, RationalNumber},
+    conway::{Anchor, DRep, GovActionId, RationalNumber, Vote, Voter},
     Epoch, StakeCredential,
 };
 use proptest::prelude::*;
@@ -140,5 +140,28 @@ prop_compose! {
 prop_compose! {
     pub fn any_rational()(num in 1u64..100u64, den in 1u64..100u64) -> RationalNumber {
         RationalNumber { numerator: num, denominator: den }
+    }
+}
+
+pub fn any_vote() -> impl Strategy<Value = Vote> {
+    prop_oneof![Just(Vote::Yes), Just(Vote::No), Just(Vote::Abstain)]
+}
+
+pub fn any_voter() -> impl Strategy<Value = Voter> {
+    prop_oneof![
+        any_hash_28().prop_map(Voter::ConstitutionalCommitteeKey),
+        any_hash_28().prop_map(Voter::ConstitutionalCommitteeScript),
+        any_hash_28().prop_map(Voter::DRepKey),
+        any_hash_28().prop_map(Voter::DRepScript),
+        any_hash_28().prop_map(Voter::StakePoolKey),
+    ]
+}
+
+prop_compose! {
+    pub fn any_gov_action_id()(
+        transaction_id in any_hash_32(),
+        action_index in 0u32..16u32,
+    ) -> GovActionId {
+        GovActionId { transaction_id, action_index }
     }
 }

--- a/crates/cardano/src/roll/proposals.rs
+++ b/crates/cardano/src/roll/proposals.rs
@@ -1,11 +1,11 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
-use dolos_core::{ChainError, Genesis};
+use dolos_core::{ChainError, Genesis, TxoRef};
 use pallas::{
     codec::utils::Bytes,
     ledger::{
         primitives::{
-            conway::{GovAction, ProtocolParamUpdate},
+            conway::{GovAction, GovActionId, ProtocolParamUpdate},
             Epoch, ExUnitPrices, RationalNumber,
         },
         traverse::{MultiEraBlock, MultiEraTx, MultiEraUpdate},
@@ -14,7 +14,8 @@ use pallas::{
 
 use super::WorkDeltas;
 use crate::{
-    pallas_extras, roll::BlockVisitor, NewProposal, PParamValue, PParamsSet, ProposalAction,
+    owned::OwnedMultiEraOutput, pallas_extras, roll::BlockVisitor, GovPurpose, NewProposalV2,
+    PParamValue, PParamsSet, ProposalAction, VoteCast,
 };
 
 macro_rules! map_conway_pparam {
@@ -247,12 +248,63 @@ fn pre_conway_to_pparamset(update: &MultiEraUpdate) -> PParamsSet {
     set
 }
 
+/// Maps a Conway governance action to its dolos representation plus the
+/// lineage data the action declares: the parent (previous governance action
+/// id of the same purpose) and the purpose tree it belongs to.
+/// TreasuryWithdrawals and Info have no lineage.
+fn parse_gov_action(
+    action: &GovAction,
+) -> (ProposalAction, Option<GovActionId>, Option<GovPurpose>) {
+    match action {
+        GovAction::ParameterChange(parent, update, _) => (
+            ProposalAction::ParamChange(conway_to_pparamset(update)),
+            parent.clone(),
+            Some(GovPurpose::PParamUpdate),
+        ),
+        GovAction::HardForkInitiation(parent, version) => (
+            ProposalAction::HardFork(*version),
+            parent.clone(),
+            Some(GovPurpose::HardFork),
+        ),
+        GovAction::TreasuryWithdrawals(withdrawals, _) => {
+            (parse_treasury_withdrawals(withdrawals), None, None)
+        }
+        GovAction::NoConfidence(parent) => (
+            ProposalAction::NoConfidence,
+            parent.clone(),
+            Some(GovPurpose::Committee),
+        ),
+        GovAction::UpdateCommittee(parent, to_remove, to_add, threshold) => (
+            ProposalAction::UpdateCommittee {
+                to_remove: to_remove.iter().cloned().collect(),
+                to_add: to_add
+                    .iter()
+                    .map(|(cred, epoch)| (cred.clone(), *epoch))
+                    .collect(),
+                threshold: threshold.clone(),
+            },
+            parent.clone(),
+            Some(GovPurpose::Committee),
+        ),
+        GovAction::NewConstitution(parent, constitution) => (
+            ProposalAction::NewConstitution {
+                anchor: constitution.anchor.clone(),
+                guardrail_script: constitution.guardrail_script,
+            },
+            parent.clone(),
+            Some(GovPurpose::Constitution),
+        ),
+        GovAction::Information => (ProposalAction::Info, None, None),
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct ProposalVisitor {
     validity_period: Option<u64>,
     current_epoch: Option<Epoch>,
     network_magic: Option<u32>,
     protocol: Option<u16>,
+    pending_votes: Vec<VoteCast>,
 }
 
 impl BlockVisitor for ProposalVisitor {
@@ -274,6 +326,42 @@ impl BlockVisitor for ProposalVisitor {
         Ok(())
     }
 
+    fn visit_tx(
+        &mut self,
+        _: &mut WorkDeltas,
+        block: &MultiEraBlock,
+        tx: &MultiEraTx,
+        _: &HashMap<TxoRef, OwnedMultiEraOutput>,
+    ) -> Result<(), ChainError> {
+        let MultiEraTx::Conway(conway_tx) = tx else {
+            return Ok(());
+        };
+
+        // Phase-2-invalid transactions contribute nothing to governance
+        // state: CERTS / GOV only run for valid transactions.
+        if !tx.is_valid() {
+            return Ok(());
+        }
+
+        let Some(voting_procedures) = &conway_tx.transaction_body.voting_procedures else {
+            return Ok(());
+        };
+
+        for (voter, votes) in voting_procedures.iter() {
+            for (gov_action_id, procedure) in votes.iter() {
+                self.pending_votes.push(VoteCast::new(
+                    gov_action_id.transaction_id,
+                    gov_action_id.action_index,
+                    voter.clone(),
+                    procedure.vote.clone(),
+                    block.slot(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     fn visit_update(
         &mut self,
         deltas: &mut WorkDeltas,
@@ -283,7 +371,7 @@ impl BlockVisitor for ProposalVisitor {
     ) -> Result<(), ChainError> {
         let action = pre_conway_to_pparamset(update);
 
-        deltas.add_for_entity(NewProposal::new(
+        deltas.add_for_entity(NewProposalV2::new(
             block.slot(),
             tx.map(|tx| tx.hash()).unwrap_or_else(|| block.hash()),
             0,
@@ -294,6 +382,10 @@ impl BlockVisitor for ProposalVisitor {
             self.current_epoch.expect("value set in root"),
             self.network_magic.expect("value set in root"),
             self.protocol.expect("value set in root"),
+            // pre-Conway updates carry no Conway lineage or anchor
+            None,
+            None,
+            None,
         ));
 
         Ok(())
@@ -311,22 +403,12 @@ impl BlockVisitor for ProposalVisitor {
             return Ok(());
         };
 
-        let action = match &proposal.gov_action {
-            GovAction::ParameterChange(_, x, _) => {
-                ProposalAction::ParamChange(conway_to_pparamset(x))
-            }
-            GovAction::HardForkInitiation(_, version) => ProposalAction::HardFork(*version),
-            GovAction::TreasuryWithdrawals(x, _) => parse_treasury_withdrawals(x),
-            GovAction::Information => ProposalAction::Other,
-            GovAction::NoConfidence(..) => ProposalAction::Other,
-            GovAction::UpdateCommittee(..) => ProposalAction::Other,
-            GovAction::NewConstitution(..) => ProposalAction::Other,
-        };
+        let (action, parent, purpose) = parse_gov_action(&proposal.gov_action);
 
         let reward_account = pallas_extras::parse_reward_account(&proposal.reward_account)
             .ok_or(ChainError::InvalidProposalParams)?;
 
-        deltas.add_for_entity(NewProposal::new(
+        deltas.add_for_entity(NewProposalV2::new(
             block.slot(),
             tx.hash(),
             idx as u32,
@@ -337,7 +419,22 @@ impl BlockVisitor for ProposalVisitor {
             self.current_epoch.expect("value set in root"),
             self.network_magic.expect("value set in root"),
             self.protocol.expect("value set in root"),
+            parent,
+            purpose,
+            Some(proposal.anchor.clone()),
         ));
+
+        Ok(())
+    }
+
+    fn flush(&mut self, deltas: &mut WorkDeltas) -> Result<(), ChainError> {
+        // Votes buffered during `visit_tx` are emitted at block flush so a
+        // vote targeting a proposal submitted in the same block (legal in
+        // Conway, even within the same tx) lands *after* that proposal's
+        // `NewProposalV2` in the per-entity delta ordering.
+        for vote in self.pending_votes.drain(..) {
+            deltas.add_for_entity(vote);
+        }
 
         Ok(())
     }

--- a/src/bin/dolos/data/dump_state.rs
+++ b/src/bin/dolos/data/dump_state.rs
@@ -349,6 +349,14 @@ impl TableRow for ProposalState {
             }
             ProposalAction::TreasuryWithdrawal(x) => format!("TreasuryWithdrawal({:?})", x.len()),
             ProposalAction::Other => "Other".to_string(),
+            ProposalAction::NoConfidence => "NoConfidence".to_string(),
+            ProposalAction::UpdateCommittee {
+                to_remove, to_add, ..
+            } => {
+                format!("UpdateCommittee(-{}, +{})", to_remove.len(), to_add.len())
+            }
+            ProposalAction::NewConstitution { .. } => "NewConstitution".to_string(),
+            ProposalAction::Info => "Info".to_string(),
         };
 
         vec![


### PR DESCRIPTION
## Plan

Executes **phase 2 (Vote & proposal capture)** of the Cardano ledger governance-gaps initiative — requirement 2. Semantics per the Haskell ledger research; shapes per the implementation design §3.1, §4, §5.1 (phase 1 landed in #1128).

**Done criterion**: `ProposalState` extended with the full 7-variant governance action, lineage parent, `proposed_in`, and slot-stamped per-voter vote histories; `VoteCast` deltas emitted for all three voter classes (CC members, DReps, SPOs). **Met.**

## What changed

- `crates/cardano/src/model/proposals.rs`
  - `ProposalAction`: appended `NoConfidence`, `UpdateCommittee`, `NewConstitution`, `Info` variants (CBOR indexes 4..=7; `Other` kept at 3 for old rows). All 7 Conway actions now map to a concrete variant.
  - `ProposalState`: backward-compatible additions at frozen-index-safe positions 9..=15 — `proposed_in`, `parent: Option<GovActionId>`, `purpose: Option<GovPurpose>` (new 4-purpose enum), `anchor`, and `cc_votes` / `drep_votes` / `spo_votes` maps of `voter → Vec<(BlockSlot, Vote)>` (append-only history; last entry is the effective vote, enabling as-of reads at epoch boundaries). Old rows decode with the new fields empty (`#[cbor(default)]` / `Option`); no data migration.
  - `VoteCast` delta: appends `(slot, vote)` to the voter's history; undo pops exactly the appended entry (tracks entry creation for exact rollback).
  - `NewProposalV2` delta: records action + parent + purpose + anchor + `proposed_in`. The legacy `NewProposal` stays for WAL replay only — its bincode field layout is frozen and can't grow (same discipline as #1128's `DRepAnchorUpdate`). Legacy replay now also populates `proposed_in`, derived from the `current_epoch` the old delta already carries.
- `crates/cardano/src/model/mod.rs`: `NewProposalV2` and `VoteCast` appended at the end of `CardanoDelta` (bincode variant order frozen, append-only).
- `crates/cardano/src/roll/proposals.rs`: `ProposalVisitor` maps all 7 `GovAction`s with lineage/anchor capture and now walks `voting_procedures` in `visit_tx`, emitting `VoteCast` for CC/DRep/SPO voters. Votes are buffered and emitted at block `flush` so a vote on a proposal submitted in the same block (legal in Conway, even same-tx) lands after that proposal's creation delta in the per-entity ordering. Phase-2-invalid txs are skipped (research §8). The existing `DRepActivity` bump in `DRepStateVisitor` is untouched.
- `src/bin/dolos/data/dump_state.rs`: display arms for the new action variants.

## Interpretation notes (for review)

- **Hack table retained on purpose.** The design doc's delta table says the extended proposal delta "no longer consults `hacks::proposals`", but that describes the end-state: outcome stamping still feeds the boundary enact/drop classification, and the plan keeps the real RATIFY engine for phase 5 (shadow mode) and hack deletion for phase 6. Dropping the lookup here would break ratification tracking for three phases. `NewProposalV2` documents this.
- **DRep expiry-refresh on vote and `DormancyFold`** (design §5.1 voting bullet) are deferred to phase 3, which owns epoch-based DRep expiry + dormancy bookkeeping.
- **Delta shape**: `VoteCast` carries the pallas `Voter` enum, which is the voter class and credential in one value (the design lists `voter_class` + `voter` separately; the enum encodes the same information without invalid combinations).

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-targets` — all suites pass (19 suites, 0 failures; includes new prop tests: apply/undo and WAL serde roundtrips for `NewProposalV2`/`VoteCast`, vote append/replace unit test)
- Backward-compat regression test: encodes a replica of the pre-phase-2 `ProposalState` shape (indexes 0..=8, 4-variant action) and decodes it as the new entity, asserting the new fields come back empty — the design §6 guarantee, now checked mechanically.

## Finding (not addressed here)

Existing visitors don't gate on `tx.is_valid()`: an invalid tx's certs/proposals currently mutate entity state (e.g. `DRepActivity` bumps, `NewProposal` emission), contrary to research §8. The new vote path gates explicitly; fixing the pre-existing paths is left as a follow-up for the plan owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanded governance proposal actions, including committee updates, no-confidence motions, constitutional changes, and informational actions.
  * Added proposal lineage, purpose, metadata anchors, and voter-specific vote histories.
  * Added vote tracking with append-only histories and undo support.
  * Updated governance processing to record proposals and votes in the correct order.

* **Bug Fixes**
  * Preserved compatibility with legacy proposal data while populating new fields.
  * Improved state output for newly supported proposal actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
