### PR TITLE
feat(minibf): implement `/pools/{pool_id}/relays`

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -484,6 +484,7 @@ where
             "/pools/{id}/metadata",
             get(routes::pools::by_id_metadata::<D>),
         )
+        .route("/pools/{id}/relays", get(routes::pools::by_id_relays::<D>))
         .route("/pools/extended", get(routes::pools::all_extended::<D>))
         .route("/pools/retiring", get(routes::pools::all_retiring::<D>))
         .route("/pools/{id}", get(routes::pools::by_id::<D>))

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1603,8 +1603,8 @@ impl IntoModel<TxContentPoolCertsInnerRelaysInner> for alonzo::Relay {
             alonzo::Relay::MultiHostName(dns) => TxContentPoolCertsInnerRelaysInner {
                 ipv4: None,
                 ipv6: None,
-                dns: Some(dns.to_string()),
-                dns_srv: None,
+                dns: None,
+                dns_srv: Some(dns.to_string()),
                 port: Default::default(),
             },
         };

--- a/crates/minibf/src/routes/pools.rs
+++ b/crates/minibf/src/routes/pools.rs
@@ -12,6 +12,7 @@ use blockfrost_openapi::models::{
     dreps_inner_metadata_error::Code, pool::Pool, pool_calidus_key::PoolCalidusKey,
     pool_delegators_inner::PoolDelegatorsInner, pool_history_inner::PoolHistoryInner,
     pool_list_extended_inner::PoolListExtendedInner, pool_list_retire_inner::PoolListRetireInner,
+    tx_content_pool_certs_inner_relays_inner::TxContentPoolCertsInnerRelaysInner,
     DrepsInnerMetadataError, PoolListExtendedInnerMetadata, PoolMetadata as PoolMetadataModel,
 };
 use dolos_cardano::{
@@ -854,6 +855,34 @@ where
     )?))
 }
 
+pub async fn by_id_relays<D: Domain>(
+    Path(id): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<TxContentPoolCertsInnerRelaysInner>>, Error>
+where
+    Option<PoolState>: From<D::Entity>,
+{
+    let operator = decode_pool_id(&id)?;
+    let pool = domain
+        .read_cardano_entity::<PoolState>(operator.as_slice())?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let relays = pool
+        .snapshot
+        .live()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?
+        .params
+        .relays
+        .clone();
+
+    let out = relays
+        .into_iter()
+        .map(|relay| relay.into_model())
+        .collect::<Result<Vec<_>, StatusCode>>()?;
+
+    Ok(Json(out))
+}
+
 struct PoolDelegatorModelBuilder {
     delegator: StakeCredential,
     account: Option<dolos_cardano::model::AccountState>,
@@ -1025,7 +1054,7 @@ mod tests {
     use pallas::{
         codec::utils::Bytes,
         crypto::hash::Hash,
-        ledger::primitives::{alonzo, Int, PoolMetadata, StakeCredential},
+        ledger::primitives::{alonzo, Int, PoolMetadata, Relay, StakeCredential},
     };
     use serde_json::Value;
 
@@ -1719,6 +1748,100 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
         let pool_id = app.vectors().pool_id.as_str();
         let path = format!("/pools/{pool_id}/metadata");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn pools_relays_happy_path() {
+        let app = TestApp::new_with_cfg(SyntheticBlockConfig {
+            pool_relays: vec![
+                Relay::SingleHostAddr(Some(3001), Some(Bytes::from(vec![192, 168, 0, 1])), None),
+                Relay::SingleHostName(Some(3002), "relay.example.com".to_string()),
+                Relay::MultiHostName("_relays._tcp.example.com".to_string()),
+            ],
+            ..Default::default()
+        });
+
+        let pool_id = app.vectors().pool_id.as_str();
+        let path = format!("/pools/{pool_id}/relays");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let relays: Vec<TxContentPoolCertsInnerRelaysInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse pool relays");
+
+        assert_eq!(
+            relays,
+            vec![
+                TxContentPoolCertsInnerRelaysInner {
+                    ipv4: Some("192.168.0.1".to_string()),
+                    ipv6: None,
+                    dns: None,
+                    dns_srv: None,
+                    port: 3001,
+                },
+                TxContentPoolCertsInnerRelaysInner {
+                    ipv4: None,
+                    ipv6: None,
+                    dns: Some("relay.example.com".to_string()),
+                    dns_srv: None,
+                    port: 3002,
+                },
+                TxContentPoolCertsInnerRelaysInner {
+                    ipv4: None,
+                    ipv6: None,
+                    dns: None,
+                    dns_srv: Some("_relays._tcp.example.com".to_string()),
+                    port: 0,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn pools_relays_empty_without_registered_relays() {
+        let app = TestApp::new();
+        let pool_id = app.vectors().pool_id.as_str();
+        let path = format!("/pools/{pool_id}/relays");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let relays: Vec<TxContentPoolCertsInnerRelaysInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse pool relays");
+        assert!(relays.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pools_relays_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/pools/{}/relays", invalid_pool_id());
+        assert_error_message(&app, &path, "Invalid or malformed pool id format.").await;
+    }
+
+    #[tokio::test]
+    async fn pools_relays_not_found() {
+        let app = TestApp::new();
+        let path = format!("/pools/{}/relays", missing_pool_id());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn pools_relays_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let pool_id = app.vectors().pool_id.as_str();
+        let path = format!("/pools/{pool_id}/relays");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -26,7 +26,7 @@ use pallas::{
                 Certificate, DatumOption, PlutusData, PostAlonzoTransactionOutput, ScriptRef,
                 TransactionBody, TransactionOutput, Value, WitnessSet,
             },
-            AddrKeyhash, Bytes, NonEmptySet, NonZeroInt, PositiveCoin, Set, StakeCredential,
+            AddrKeyhash, Bytes, NonEmptySet, NonZeroInt, PositiveCoin, Relay, Set, StakeCredential,
             TransactionInput, VrfKeyhash,
         },
         traverse::ComputeHash,
@@ -51,6 +51,7 @@ pub struct SyntheticBlockConfig {
     pub mint_amount: i64,
     pub seed_amount: u64,
     pub pool_id: String,
+    pub pool_relays: Vec<Relay>,
     pub drep_keyhash: [u8; 28],
     pub drep_deposit: u64,
 }
@@ -105,6 +106,7 @@ impl Default for SyntheticBlockConfig {
             seed_amount: crate::MIN_UTXO_AMOUNT,
             pool_id: "pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
                 .to_string(),
+            pool_relays: vec![],
             drep_keyhash: [7u8; 28],
             drep_deposit: 1000,
         }
@@ -335,6 +337,7 @@ pub fn build_synthetic_blocks(
                 cfg.mint_amount,
                 stake_cred.clone(),
                 pool_keyhash,
+                cfg.pool_relays.clone(),
                 cfg.drep_keyhash,
                 cfg.drep_deposit,
                 withdrawal_amount,
@@ -546,6 +549,7 @@ fn sample_transaction(
     mint_amount: i64,
     stake_cred: StakeCredential,
     pool_keyhash: Hash<28>,
+    pool_relays: Vec<Relay>,
     drep_keyhash: [u8; 28],
     drep_deposit: u64,
     withdrawal_amount: Option<u64>,
@@ -604,7 +608,7 @@ fn sample_transaction(
         },
         reward_account: Bytes::from(reward_account.to_vec()),
         pool_owners: Set::from(vec![pool_owner]),
-        relays: vec![],
+        relays: pool_relays,
         pool_metadata,
     };
 


### PR DESCRIPTION
Resolves #1088.

## How?

Reads the pool's live `PoolState` snapshot and maps `params.relays` (already stored, just unmapped) to the Blockfrost pool relays response. The response reuses the existing relay model/mapping from tx pool certs, since the schemas are identical.

While wiring this up, fixed a bug in that shared relay mapping: `MultiHostName` relays were populating `dns` instead of `dns_srv`. Blockfrost (dbsync) stores multi-host relays as `pool_relay.dns_srv_name` and returns them in `dns_srv`, so this also corrects `/txs/{tx_hash}/pool_updates`.

## Testing

Added a `pool_relays` knob to `SyntheticBlockConfig` (default empty, so existing fixtures are unchanged) and covered:

- happy path with all three relay variants (`SingleHostAddr`, `SingleHostName`, `MultiHostName`), asserting the exact mapped payload
- empty relay list
- invalid pool id (400), unknown pool (404), state store fault (500)

Also:

- validating againts the hosted version with blockfrost-tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new `GET /pools/{pool_id}/relays` API endpoint to list relays for a specific pool.
  - Synthetic pool configurations can now include custom relay information.

- **Bug Fixes**
  - Fixed relay mapping for multi-hostname relays so DNS SRV data is returned in the correct field.

- **Tests**
  - Expanded route coverage for success, empty results, bad requests, not found, and internal failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->