### PR TITLE
feat(minibf): implement /addresses/{address}/total endpoint

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -362,6 +362,10 @@ where
             "/addresses/{address}/transactions",
             get(routes::addresses::transactions::<D>),
         )
+        .route(
+            "/addresses/{address}/total",
+            get(routes::addresses::total::<D>),
+        )
         .route("/addresses/{address}/txs", get(routes::addresses::txs::<D>))
         .route("/blocks/latest", get(routes::blocks::latest::<D>))
         .route("/blocks/latest/txs", get(routes::blocks::latest_txs::<D>))

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -210,44 +210,60 @@ where
     }
 }
 
-pub fn aggregate_assets<'a>(
-    txouts: impl Iterator<Item = &'a MultiEraOutput<'a>>,
-) -> Vec<TxContentOutputAmountInner> {
-    let mut lovelace = 0;
-    let mut by_asset: HashMap<String, u64> = HashMap::new();
+#[derive(Default)]
+pub struct AssetTotals {
+    lovelace: u128,
+    by_asset: HashMap<String, u128>,
+}
 
-    for txout in txouts {
+impl AssetTotals {
+    pub fn add_output(&mut self, txout: &MultiEraOutput) {
         let value = txout.value();
 
         // Add lovelace amount
-        lovelace += value.coin();
+        self.lovelace += value.coin() as u128;
 
         // Add other assets
         for ma in value.assets() {
             for asset in ma.assets() {
                 let unit = format!("{}{}", ma.policy(), hex::encode(asset.name()));
-                let amount = asset.output_coin().unwrap_or_default();
-                *by_asset.entry(unit).or_insert(0) += amount;
+                let amount = asset.output_coin().unwrap_or_default() as u128;
+                *self.by_asset.entry(unit).or_insert(0) += amount;
             }
         }
     }
 
-    let lovelace = TxContentOutputAmountInner {
-        unit: "lovelace".to_string(),
-        quantity: lovelace.to_string(),
-    };
+    pub fn into_amounts(self) -> Vec<TxContentOutputAmountInner> {
+        let lovelace = TxContentOutputAmountInner {
+            unit: "lovelace".to_string(),
+            quantity: self.lovelace.to_string(),
+        };
 
-    let mut assets: Vec<_> = by_asset
-        .into_iter()
-        .map(|(unit, quantity)| TxContentOutputAmountInner {
-            unit,
-            quantity: quantity.to_string(),
-        })
-        .collect();
+        let mut assets: Vec<_> = self
+            .by_asset
+            .into_iter()
+            .map(|(unit, quantity)| TxContentOutputAmountInner {
+                unit,
+                quantity: quantity.to_string(),
+            })
+            .collect();
 
-    assets.sort_by_key(|a| a.unit.clone());
+        assets.sort_by_key(|a| a.unit.clone());
 
-    std::iter::once(lovelace).chain(assets).collect()
+        std::iter::once(lovelace).chain(assets).collect()
+    }
+}
+
+pub fn aggregate_assets<'a>(
+    txouts: impl Iterator<Item = &'a MultiEraOutput<'a>>,
+) -> Vec<TxContentOutputAmountInner> {
+    let mut totals = AssetTotals::default();
+
+    for txout in txouts {
+        totals.add_output(txout);
+    }
+
+    totals.into_amounts()
 }
 
 pub fn list_assets<'a>(

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -6,8 +6,7 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
-    address_content::AddressContent,
-    address_content_total::AddressContentTotal,
+    address_content::AddressContent, address_content_total::AddressContentTotal,
     address_transactions_content_inner::AddressTransactionsContentInner,
     address_utxo_content_inner::AddressUtxoContentInner,
     tx_content_output_amount_inner::TxContentOutputAmountInner,

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use blockfrost_openapi::models::{
     address_content::AddressContent,
+    address_content_total::AddressContentTotal,
     address_transactions_content_inner::AddressTransactionsContentInner,
     address_utxo_content_inner::AddressUtxoContentInner,
     tx_content_output_amount_inner::TxContentOutputAmountInner,
@@ -26,7 +27,7 @@ use dolos_core::{BlockBody, BlockSlot, Domain, EraCbor, StateStore as _, TxoRef}
 
 use crate::{
     error::Error,
-    mapping::{aggregate_assets, AddressKind, AddressModelBuilder, IntoModel},
+    mapping::{aggregate_assets, AddressKind, AddressModelBuilder, AssetTotals, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
 };
@@ -424,6 +425,67 @@ where
     Ok(false)
 }
 
+async fn sum_block_txs<D>(
+    domain: &Facade<D>,
+    address: &VKeyOrAddress,
+    block: &[u8],
+    received: &mut AssetTotals,
+    sent: &mut AssetTotals,
+    tx_count: &mut usize,
+) -> Result<(), StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    for tx in block.txs() {
+        let mut matched = false;
+
+        for (_, output) in tx.produces() {
+            let candidate = output
+                .address()
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            if address_matches(address, &candidate) {
+                received.add_output(&output);
+                matched = true;
+            }
+        }
+
+        for input in tx.consumes() {
+            if let Some(EraCbor(era, cbor)) = domain
+                .query()
+                .tx_cbor(input.hash().as_slice().to_vec())
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            {
+                let parsed = MultiEraTx::decode_for_era(
+                    era.try_into()
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+                    &cbor,
+                )
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+                if let Some(output) = parsed.produces_at(input.index() as usize) {
+                    let candidate = output
+                        .address()
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                    if address_matches(address, &candidate) {
+                        sent.add_output(&output);
+                        matched = true;
+                    }
+                }
+            }
+        }
+
+        if matched {
+            *tx_count += 1;
+        }
+    }
+
+    Ok(())
+}
+
 async fn find_txs<D>(
     domain: &Facade<D>,
     address: &VKeyOrAddress,
@@ -578,6 +640,59 @@ where
     Ok(Json(transactions))
 }
 
+pub async fn total<D>(
+    Path(address): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<AddressContentTotal>, Error>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let end_slot = domain.get_tip_slot()?;
+
+    let (stream, parsed) =
+        blocks_for_address_stream(&domain, &address, 0, end_slot, SlotOrder::Asc)?;
+
+    let mut received = AssetTotals::default();
+    let mut sent = AssetTotals::default();
+    let mut tx_count: usize = 0;
+
+    let mut stream = Box::pin(stream);
+    while let Some(res) = stream.next().await {
+        let (_slot, block) = res.map_err(|err| {
+            tracing::error!(?err);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        let Some(block) = block else {
+            continue;
+        };
+
+        sum_block_txs(
+            &domain,
+            &parsed,
+            &block,
+            &mut received,
+            &mut sent,
+            &mut tx_count,
+        )
+        .await
+        .map_err(Error::Code)?;
+    }
+
+    if tx_count == 0 {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let model = AddressContentTotal {
+        address,
+        received_sum: received.into_amounts(),
+        sent_sum: sent.into_amounts(),
+        tx_count: tx_count as i32,
+    };
+
+    Ok(Json(model))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -686,6 +801,113 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
         let address = app.vectors().address.as_str();
         let path = format!("/addresses/{address}");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    fn assert_total_sums(app: &TestApp, item: &AddressContentTotal) {
+        let block_count = app.vectors().blocks.len();
+
+        assert_eq!(item.tx_count, block_count as i32);
+
+        assert_eq!(item.received_sum[0].unit, "lovelace");
+        assert_eq!(
+            item.received_sum[0].quantity,
+            (block_count as u64 * dolos_testing::MIN_UTXO_AMOUNT).to_string()
+        );
+
+        let asset = item
+            .received_sum
+            .iter()
+            .find(|x| x.unit == app.vectors().asset_unit)
+            .expect("expected synthetic asset in received_sum");
+        assert_eq!(asset.quantity, block_count.to_string());
+
+        // the synthetic address never spends, but lovelace must still be
+        // present (and first) with a zero quantity
+        assert_eq!(
+            item.sent_sum,
+            vec![TxContentOutputAmountInner {
+                unit: "lovelace".to_string(),
+                quantity: "0".to_string(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn addresses_total_happy_path() {
+        let app = TestApp::new();
+        let address = app.vectors().address.as_str();
+        let path = format!("/addresses/{address}/total");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AddressContentTotal =
+            serde_json::from_slice(&bytes).expect("failed to parse address total");
+
+        assert_eq!(item.address, address);
+        assert_total_sums(&app, &item);
+    }
+
+    #[tokio::test]
+    async fn addresses_total_payment_credential_happy_path() {
+        let app = TestApp::new();
+        let address = Address::from_bech32(app.vectors().address.as_str())
+            .expect("invalid synthetic test address");
+
+        let Address::Shelley(shelley) = address else {
+            panic!("expected shelley test address")
+        };
+
+        let payment = shelley.payment().to_vec();
+
+        let payment_cred = bech32::encode::<bech32::Bech32>(
+            bech32::Hrp::parse("addr_vkh").expect("invalid hrp"),
+            &payment,
+        )
+        .expect("failed to encode payment credential");
+
+        let path = format!("/addresses/{payment_cred}/total");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AddressContentTotal =
+            serde_json::from_slice(&bytes).expect("failed to parse address total");
+
+        assert_eq!(item.address, payment_cred);
+        assert_total_sums(&app, &item);
+    }
+
+    #[tokio::test]
+    async fn addresses_total_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/addresses/{}/total", invalid_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn addresses_total_not_found() {
+        let app = TestApp::new();
+        let path = format!("/addresses/{}/total", missing_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn addresses_total_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let address = app.vectors().address.as_str();
+        let path = format!("/addresses/{address}/total");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -111,6 +111,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}/utxos`          | Get UTXOs for a stake address                            |
 | `/accounts/{stake_address}/withdrawals`    | Get withdrawals for a stake address                      |
 | `/addresses/{address}`                     | Get general information for a specific address           |
+| `/addresses/{address}/total`               | Get lifetime received/sent totals for a specific address |
 | `/addresses/{address}/transactions`        | Get transactions for a specific address                  |
 | `/addresses/{address}/txs`                 | Alias of `/addresses/{address}/transactions`             |
 | `/addresses/{address}/utxos`               | Get UTXOs for a specific address                         |


### PR DESCRIPTION
## Summary

Implements the Blockfrost-compatible `GET /addresses/{address}/total` endpoint in minibf, returning lifetime `received_sum`, `sent_sum` and `tx_count` for an address.

Semantics match the Blockfrost OpenAPI spec (vendored `openapi.yaml`, `address_content_total` schema) and the blockfrost-backend-ryo reference implementation:

- `received_sum` = lifetime sum of all tx outputs ever created at the address (spent or unspent); `sent_sum` = the subset consumed as inputs. Quantities as strings, unit = policy hex ++ asset-name hex, lovelace always first even when zero.
- `tx_count` = distinct transactions that produced an output at the address or consumed one from it — the same tx set as `/addresses/{address}/transactions`.
- Accepts full bech32/base58 addresses and payment credentials (`addr_vkh…`/`script…`, echoed back as `address`).
- 400 on malformed address, 404 when the address never appeared on chain.

## Implementation

- **mapping.rs** — extracted the fold/render internals of `aggregate_assets` into a public `AssetTotals` accumulator (`add_output`/`into_amounts`) so totals can be accumulated across blocks without holding borrowed `MultiEraOutput`s. `aggregate_assets` signature and behavior unchanged; counters widened to `u128`.
- **routes/addresses.rs** — new `sum_block_txs` helper (same produce/consume traversal as `has_address`, accumulating instead of early-returning) and the `total` handler: full 0..tip scan via the existing `blocks_for_address_stream`. The spec has no pagination params and partial totals would be wrong, so no `max_scan_items` enforcement — same precedent as `is_address_in_chain`; the stream is index-driven so cost scales with address activity.
- **lib.rs** — route registration.

## Tests

Standard per-endpoint set plus a payment-credential variant, asserting exact totals against the synthetic fixtures (5 blocks × 1 matching tx: 5,555,555 lovelace + 5 SYNTH received, `[{lovelace, "0"}]` sent, tx_count 5):

- `addresses_total_happy_path`
- `addresses_total_payment_credential_happy_path`
- `addresses_total_bad_request` / `_not_found` / `_internal_error`

`cargo test -p dolos-minibf`: 226 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /addresses/{address}/total` to return lifetime received/sent asset totals and transaction count for an address.
  * Supports payment-credential address formats.
  * Returns `404` when no matching transactions are found.
* **Bug Fixes**
  * Improved asset aggregation to handle larger cumulative amounts more safely.
* **Documentation**
  * Updated MiniBF API coverage to include the new `/addresses/{address}/total` endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1071.
