### PR TITLE
refactor(minibf): share input resolution across scan endpoints

### DIFF
--- a/crates/minibf/src/inputs.rs
+++ b/crates/minibf/src/inputs.rs
@@ -23,8 +23,8 @@
 //!
 //! The store is request-scoped and bounded: it is pure memoization, so when it
 //! would grow past [`MAX_INPUT_DEPS`] entries it is cleared and the entries
-//! still needed are fetched again. That caps memory on a full-history scan of a
-//! high-activity address.
+//! still needed are fetched again. That caps what a full-history scan of a
+//! high-activity address carries between blocks.
 
 use std::collections::HashMap;
 
@@ -36,10 +36,15 @@ use dolos_core::{Domain, EraCbor, TxHash};
 
 use crate::{Facade, TxMap};
 
-/// Maximum number of dependency txs held by an [`InputDeps`] at once.
+/// How many dependency txs an [`InputDeps`] carries from one prepared batch to
+/// the next.
 ///
 /// Reaching it clears the store: entries are pure memoization, so eviction only
-/// ever costs a re-fetch.
+/// ever costs a re-fetch. It bounds what is *carried over*, not the store's
+/// peak — a resolver has to answer every input of the batch it was handed, so
+/// the current batch is always held whole, however large it is. A batch is one
+/// block's distinct dependency hashes, which the protocol's block size keeps
+/// well under this number.
 pub const MAX_INPUT_DEPS: usize = 4096;
 
 /// Request-scoped, bounded store of the dependency txs consumed by the blocks
@@ -89,12 +94,7 @@ impl InputDeps {
     {
         let required: Vec<TxHash> = txs
             .into_iter()
-            .flat_map(|tx| {
-                tx.consumes()
-                    .iter()
-                    .map(|input| *input.hash())
-                    .collect::<Vec<_>>()
-            })
+            .flat_map(|tx| tx.consumes().into_iter().map(|input| *input.hash()))
             .unique()
             .collect();
 
@@ -155,6 +155,9 @@ impl<'a> InputResolver<'a> {
     /// The output `input` consumes, or `None` when the source tx is not
     /// available (genesis or pruned) or has no output at that index.
     ///
+    /// Fails if `input` belongs to a tx that was never handed to
+    /// [`prepare`](InputDeps::prepare).
+    ///
     /// The borrow is transient: it ends before the next call.
     pub fn resolve(
         &mut self,
@@ -185,12 +188,14 @@ impl<'a> InputResolver<'a> {
                 }
                 // known miss: the source tx is not in the archive
                 Some(None) => None,
-                // not prepared: treated as a miss, but it means a caller
-                // resolved inputs of a tx it never handed to `prepare`
+                // `prepare` records a miss for every hash it asks for, so an
+                // absent entry is never a pruned or genesis tx: it means a
+                // caller resolved inputs of a tx it never handed to `prepare`.
+                // Answering `None` would silently drop the output from the
+                // caller's totals, so refuse the request instead.
                 None => {
-                    debug_assert!(false, "resolving an input that was never prepared");
-                    tracing::warn!(%hash, "dependency tx was not prepared, treating as missing");
-                    None
+                    tracing::error!(%hash, "resolving an input that was never prepared");
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
                 }
             };
 

--- a/crates/minibf/src/inputs.rs
+++ b/crates/minibf/src/inputs.rs
@@ -10,19 +10,19 @@
 //! dependency tx referenced by N inputs is paid for N times. This module keeps
 //! that work to once per distinct dependency hash:
 //!
-//! - [`InputCache`] owns the fetched bytes for the whole request. Its
-//!   [`prepare`](InputCache::prepare) batches the distinct dependency hashes of
+//! - [`InputDeps`] owns the fetched bytes for the whole request. Its
+//!   [`prepare`](InputDeps::prepare) batches the distinct dependency hashes of
 //!   a block's txs into a single round of deduped fetches (via
 //!   [`Facade::get_tx_batch`]) and only asks for hashes it does not already
 //!   hold, so a dependency shared across blocks is fetched once per request.
-//!   Misses (genesis or pruned txs) are cached too, so they are not retried.
+//!   Misses (genesis or pruned txs) are recorded too, so they are not retried.
 //! - [`InputResolver`] borrows those bytes and memoizes the decoding, handing
 //!   out transient [`MultiEraOutput`] borrows tied to `&mut self` — the same
 //!   ownership constraint `TxModelBuilder` manages for the `/txs/{hash}/*`
 //!   endpoints.
 //!
-//! The cache is request-scoped and bounded: it is pure memoization, so when it
-//! would grow past [`MAX_CACHED_DEPS`] entries it is cleared and the entries
+//! The store is request-scoped and bounded: it is pure memoization, so when it
+//! would grow past [`MAX_INPUT_DEPS`] entries it is cleared and the entries
 //! still needed are fetched again. That caps memory on a full-history scan of a
 //! high-activity address.
 
@@ -36,27 +36,27 @@ use dolos_core::{Domain, EraCbor, TxHash};
 
 use crate::{Facade, TxMap};
 
-/// Maximum number of dependency txs held by an [`InputCache`] at once.
+/// Maximum number of dependency txs held by an [`InputDeps`] at once.
 ///
-/// Reaching it clears the cache: entries are pure memoization, so eviction only
+/// Reaching it clears the store: entries are pure memoization, so eviction only
 /// ever costs a re-fetch.
-pub const MAX_CACHED_DEPS: usize = 4096;
+pub const MAX_INPUT_DEPS: usize = 4096;
 
 /// Request-scoped, bounded store of the dependency txs consumed by the blocks
 /// being scanned.
-pub struct InputCache {
+pub struct InputDeps {
     txs: TxMap,
     cap: usize,
     fetches: usize,
 }
 
-impl Default for InputCache {
+impl Default for InputDeps {
     fn default() -> Self {
-        Self::with_capacity(MAX_CACHED_DEPS)
+        Self::with_capacity(MAX_INPUT_DEPS)
     }
 }
 
-impl InputCache {
+impl InputDeps {
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             txs: TxMap::new(),
@@ -67,16 +67,16 @@ impl InputCache {
 
     /// Number of dependency txs fetched from the domain so far.
     ///
-    /// One per distinct hash that was not already cached — the dedup this
+    /// One per distinct hash that was not already held — the dedup this
     /// module exists for is observable through this counter.
     pub fn fetches(&self) -> usize {
         self.fetches
     }
 
     /// Fetch whatever is missing to resolve the inputs of `txs`, then hand out
-    /// a resolver over the cached bytes.
+    /// a resolver over the bytes it holds.
     ///
-    /// The resolver borrows the cache, so it must be dropped before the next
+    /// The resolver borrows the store, so it must be dropped before the next
     /// block is prepared; the fetched bytes survive it.
     pub async fn prepare<'a, 'b, 'tx, D>(
         &'a mut self,
@@ -106,7 +106,7 @@ impl InputCache {
             .copied()
             .collect();
 
-        // the cache is pure memoization: dropping it all is always safe, as
+        // the store is pure memoization: dropping it all is always safe, as
         // long as everything this batch needs is fetched again right after.
         if !missing.is_empty() && self.txs.len() + missing.len() > self.cap {
             self.txs.clear();
@@ -121,7 +121,7 @@ impl InputCache {
 
         tracing::debug!(
             deps = required_len,
-            cached = self.txs.len(),
+            held = self.txs.len(),
             fetches = self.fetches(),
             "prepared input dependencies"
         );
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn caches_misses() {
+    fn records_misses() {
         let vectors = vectors();
 
         let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
@@ -304,7 +304,7 @@ mod tests {
 
         let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
 
-        let mut cache = InputCache::default();
+        let mut deps = InputDeps::default();
 
         // three txs consuming the same dependency: one fetch, not three
         let scanned = [&tx, &tx, &tx];
@@ -312,17 +312,17 @@ mod tests {
         assert_eq!(inputs, 3);
 
         {
-            let _resolver = cache.prepare(&domain, scanned).await.expect("prepare");
+            let _resolver = deps.prepare(&domain, scanned).await.expect("prepare");
         }
 
-        assert_eq!(cache.fetches(), 1, "one fetch per distinct dependency hash");
+        assert_eq!(deps.fetches(), 1, "one fetch per distinct dependency hash");
 
-        // a later block consuming an already-cached dependency: no new fetch
+        // a later block consuming an already-held dependency: no new fetch
         {
-            let _resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
+            let _resolver = deps.prepare(&domain, [&tx]).await.expect("prepare");
         }
 
-        assert_eq!(cache.fetches(), 1, "cached dependencies are not refetched");
+        assert_eq!(deps.fetches(), 1, "held dependencies are not refetched");
     }
 
     #[tokio::test]
@@ -345,25 +345,25 @@ mod tests {
             "the two txs must depend on different source txs"
         );
 
-        // a cache too small to hold anything alongside the current batch
-        let mut cache = InputCache::with_capacity(1);
+        // a store too small to hold anything alongside the current batch
+        let mut deps = InputDeps::with_capacity(1);
 
         {
-            let _resolver = cache.prepare(&domain, [first]).await.expect("prepare");
+            let _resolver = deps.prepare(&domain, [first]).await.expect("prepare");
         }
 
-        assert_eq!(cache.fetches(), 1);
+        assert_eq!(deps.fetches(), 1);
 
         {
-            // this batch needs a dependency the full cache does not hold, so
-            // the cache is cleared and the batch fetched again
-            let mut resolver = cache.prepare(&domain, [second]).await.expect("prepare");
+            // this batch needs a dependency the full store does not hold, so
+            // the store is cleared and the batch fetched again
+            let mut resolver = deps.prepare(&domain, [second]).await.expect("prepare");
 
             // whatever eviction did, every input of the prepared batch is
             // still answerable without hitting the unprepared path
             resolver.resolve(&second_inputs[0]).expect("resolve failed");
         }
 
-        assert_eq!(cache.fetches(), 2, "the evicting batch is fetched again");
+        assert_eq!(deps.fetches(), 2, "the evicting batch is fetched again");
     }
 }

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -28,9 +28,9 @@ use dolos_core::{
 mod cache;
 mod error;
 pub(crate) mod hacks;
+pub(crate) mod inputs;
 pub(crate) mod mapping;
 mod pagination;
-pub(crate) mod resolver;
 mod routes;
 #[cfg(test)]
 mod test_support;

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -30,6 +30,7 @@ mod error;
 pub(crate) mod hacks;
 pub(crate) mod mapping;
 mod pagination;
+pub(crate) mod resolver;
 mod routes;
 #[cfg(test)]
 mod test_support;

--- a/crates/minibf/src/resolver.rs
+++ b/crates/minibf/src/resolver.rs
@@ -1,0 +1,355 @@
+//! Shared resolution of the source output behind a tx input.
+//!
+//! Several endpoints scan a range of blocks and, for every tx in them, need the
+//! output each input consumes (`/addresses/{address}/transactions`,
+//! `/addresses/{address}/txs`, `/addresses/{address}/total`,
+//! `/assets/{subject}/transactions`). Resolving an input means fetching the
+//! CBOR of the tx that produced it and reading the output at the input's index.
+//!
+//! Done naively that is one fetch plus one full decode per input, so a
+//! dependency tx referenced by N inputs is paid for N times. This module keeps
+//! that work to once per distinct dependency hash:
+//!
+//! - [`InputCache`] owns the fetched bytes for the whole request. Its
+//!   [`prepare`](InputCache::prepare) batches the distinct dependency hashes of
+//!   a block's txs into a single round of deduped fetches (via
+//!   [`Facade::get_tx_batch`]) and only asks for hashes it does not already
+//!   hold, so a dependency shared across blocks is fetched once per request.
+//!   Misses (genesis or pruned txs) are cached too, so they are not retried.
+//! - [`InputResolver`] borrows those bytes and memoizes the decoding, handing
+//!   out transient [`MultiEraOutput`] borrows tied to `&mut self` — the same
+//!   ownership constraint `TxModelBuilder` manages for the `/txs/{hash}/*`
+//!   endpoints.
+//!
+//! The cache is request-scoped and bounded: it is pure memoization, so when it
+//! would grow past [`MAX_CACHED_DEPS`] entries it is cleared and the entries
+//! still needed are fetched again. That caps memory on a full-history scan of a
+//! high-activity address.
+
+use std::collections::HashMap;
+
+use axum::http::StatusCode;
+use itertools::Itertools as _;
+use pallas::ledger::traverse::{MultiEraInput, MultiEraOutput, MultiEraTx};
+
+use dolos_core::{Domain, EraCbor, TxHash};
+
+use crate::{Facade, TxMap};
+
+/// Maximum number of dependency txs held by an [`InputCache`] at once.
+///
+/// Reaching it clears the cache: entries are pure memoization, so eviction only
+/// ever costs a re-fetch.
+pub const MAX_CACHED_DEPS: usize = 4096;
+
+/// Request-scoped, bounded store of the dependency txs consumed by the blocks
+/// being scanned.
+pub struct InputCache {
+    txs: TxMap,
+    cap: usize,
+    fetches: usize,
+}
+
+impl Default for InputCache {
+    fn default() -> Self {
+        Self::with_capacity(MAX_CACHED_DEPS)
+    }
+}
+
+impl InputCache {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            txs: TxMap::new(),
+            cap: cap.max(1),
+            fetches: 0,
+        }
+    }
+
+    /// Number of dependency txs fetched from the domain so far.
+    ///
+    /// One per distinct hash that was not already cached — the dedup this
+    /// module exists for is observable through this counter.
+    pub fn fetches(&self) -> usize {
+        self.fetches
+    }
+
+    /// Fetch whatever is missing to resolve the inputs of `txs`, then hand out
+    /// a resolver over the cached bytes.
+    ///
+    /// The resolver borrows the cache, so it must be dropped before the next
+    /// block is prepared; the fetched bytes survive it.
+    pub async fn prepare<'a, 'b, 'tx, D>(
+        &'a mut self,
+        domain: &Facade<D>,
+        txs: impl IntoIterator<Item = &'b MultiEraTx<'tx>>,
+    ) -> Result<InputResolver<'a>, StatusCode>
+    where
+        D: Domain + Clone + Send + Sync + 'static,
+        'tx: 'b,
+    {
+        let required: Vec<TxHash> = txs
+            .into_iter()
+            .flat_map(|tx| {
+                tx.consumes()
+                    .iter()
+                    .map(|input| *input.hash())
+                    .collect::<Vec<_>>()
+            })
+            .unique()
+            .collect();
+
+        let required_len = required.len();
+
+        let mut missing: Vec<TxHash> = required
+            .iter()
+            .filter(|hash| !self.txs.contains_key(*hash))
+            .copied()
+            .collect();
+
+        // the cache is pure memoization: dropping it all is always safe, as
+        // long as everything this batch needs is fetched again right after.
+        if !missing.is_empty() && self.txs.len() + missing.len() > self.cap {
+            self.txs.clear();
+            missing = required;
+        }
+
+        if !missing.is_empty() {
+            self.fetches += missing.len();
+            let fetched = domain.get_tx_batch(missing).await?;
+            self.txs.extend(fetched);
+        }
+
+        tracing::debug!(
+            deps = required_len,
+            cached = self.txs.len(),
+            fetches = self.fetches(),
+            "prepared input dependencies"
+        );
+
+        Ok(InputResolver::new(&self.txs))
+    }
+}
+
+/// Decodes each dependency tx at most once and resolves inputs against it.
+pub struct InputResolver<'a> {
+    txs: &'a TxMap,
+    decoded: HashMap<TxHash, Option<MultiEraTx<'a>>>,
+    decodes: usize,
+}
+
+impl<'a> InputResolver<'a> {
+    fn new(txs: &'a TxMap) -> Self {
+        Self {
+            txs,
+            decoded: HashMap::new(),
+            decodes: 0,
+        }
+    }
+
+    /// Number of dependency txs decoded so far — one per distinct hash
+    /// actually resolved, however many inputs point at it.
+    pub fn decodes(&self) -> usize {
+        self.decodes
+    }
+
+    /// The output `input` consumes, or `None` when the source tx is not
+    /// available (genesis or pruned) or has no output at that index.
+    ///
+    /// The borrow is transient: it ends before the next call.
+    pub fn resolve(
+        &mut self,
+        input: &MultiEraInput<'_>,
+    ) -> Result<Option<MultiEraOutput<'_>>, StatusCode> {
+        let hash = *input.hash();
+
+        if !self.decoded.contains_key(&hash) {
+            let source = self.txs;
+
+            let decoded = match source.get(&hash) {
+                Some(Some(EraCbor(era, cbor))) => {
+                    let era = (*era).try_into().map_err(|err| {
+                        tracing::error!(error = ?err, "unknown era for dependency tx");
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })?;
+
+                    let tx = MultiEraTx::decode_for_era(era, cbor).map_err(|err| {
+                        tracing::error!(error = ?err, "failed to decode dependency tx");
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })?;
+
+                    self.decodes += 1;
+
+                    tracing::trace!(%hash, decodes = self.decodes(), "decoded dependency tx");
+
+                    Some(tx)
+                }
+                // known miss: the source tx is not in the archive
+                Some(None) => None,
+                // not prepared: treated as a miss, but it means a caller
+                // resolved inputs of a tx it never handed to `prepare`
+                None => {
+                    debug_assert!(false, "resolving an input that was never prepared");
+                    tracing::warn!(%hash, "dependency tx was not prepared, treating as missing");
+                    None
+                }
+            };
+
+            self.decoded.insert(hash, decoded);
+        }
+
+        let output = self
+            .decoded
+            .get(&hash)
+            .and_then(|tx| tx.as_ref())
+            .and_then(|tx| tx.produces_at(input.index() as usize));
+
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_core::config::MinibfConfig;
+    use dolos_testing::{
+        synthetic::{build_synthetic_blocks, SyntheticBlockConfig, SyntheticVectors},
+        toy_domain::ToyDomain,
+    };
+    use pallas::ledger::traverse::Era;
+
+    use crate::test_support::TestDomainBuilder;
+
+    use super::*;
+
+    fn synthetic_cfg() -> SyntheticBlockConfig {
+        SyntheticBlockConfig {
+            block_count: 3,
+            txs_per_block: 2,
+            ..Default::default()
+        }
+    }
+
+    fn vectors() -> SyntheticVectors {
+        let (_, vectors, _) = build_synthetic_blocks(synthetic_cfg());
+        vectors
+    }
+
+    fn facade() -> (Facade<ToyDomain>, SyntheticVectors) {
+        let (domain, vectors) = TestDomainBuilder::new_with_synthetic(synthetic_cfg()).finish();
+
+        let facade = Facade {
+            inner: domain,
+            config: MinibfConfig::new("[::]:0".parse().expect("invalid listen address")),
+            cache: crate::cache::CacheService::default(),
+        };
+
+        (facade, vectors)
+    }
+
+    fn dep_cbor(vectors: &SyntheticVectors) -> EraCbor {
+        EraCbor(Era::Conway.into(), vectors.tx_cbor.clone())
+    }
+
+    #[test]
+    fn decodes_each_dependency_once() {
+        let vectors = vectors();
+
+        let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
+
+        let inputs = tx.consumes();
+        let input = inputs.first().expect("synthetic tx consumes an input");
+
+        // pretend the source of the input is the synthetic tx itself
+        let mut txs = TxMap::new();
+        txs.insert(*input.hash(), Some(dep_cbor(&vectors)));
+
+        let mut resolver = InputResolver::new(&txs);
+
+        for _ in 0..5 {
+            let output = resolver.resolve(input).expect("resolve failed");
+            assert!(output.is_some(), "expected the source output");
+        }
+
+        assert_eq!(
+            resolver.decodes(),
+            1,
+            "the dependency tx must be decoded exactly once"
+        );
+    }
+
+    #[test]
+    fn caches_misses() {
+        let vectors = vectors();
+
+        let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
+
+        let inputs = tx.consumes();
+        let input = inputs.first().expect("synthetic tx consumes an input");
+
+        let mut txs = TxMap::new();
+        txs.insert(*input.hash(), None);
+
+        let mut resolver = InputResolver::new(&txs);
+
+        for _ in 0..5 {
+            let output = resolver.resolve(input).expect("resolve failed");
+            assert!(output.is_none(), "a missing source tx resolves to nothing");
+        }
+
+        assert_eq!(resolver.decodes(), 0, "nothing to decode for a known miss");
+    }
+
+    #[tokio::test]
+    async fn fetches_once_per_distinct_dependency() {
+        let (domain, vectors) = facade();
+
+        let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
+
+        let mut cache = InputCache::default();
+
+        // three txs consuming the same dependency: one fetch, not three
+        let scanned = [&tx, &tx, &tx];
+        let inputs: usize = scanned.iter().map(|tx| tx.consumes().len()).sum();
+        assert_eq!(inputs, 3);
+
+        {
+            let _resolver = cache.prepare(&domain, scanned).await.expect("prepare");
+        }
+
+        assert_eq!(cache.fetches(), 1, "one fetch per distinct dependency hash");
+
+        // a later block consuming an already-cached dependency: no new fetch
+        {
+            let _resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
+        }
+
+        assert_eq!(cache.fetches(), 1, "cached dependencies are not refetched");
+    }
+
+    #[tokio::test]
+    async fn eviction_keeps_the_current_batch_resolvable() {
+        let (domain, vectors) = facade();
+
+        let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
+
+        // a cache too small to hold anything alongside the current batch
+        let mut cache = InputCache::with_capacity(1);
+
+        {
+            let _resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
+        }
+
+        let first = cache.fetches();
+        assert_eq!(first, 1);
+
+        {
+            let mut resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
+
+            let inputs = tx.consumes();
+            let input = inputs.first().expect("synthetic tx consumes an input");
+
+            // whatever eviction did, every input of the prepared batch is
+            // still answerable without panicking on an unprepared hash
+            resolver.resolve(input).expect("resolve failed");
+        }
+    }
+}

--- a/crates/minibf/src/resolver.rs
+++ b/crates/minibf/src/resolver.rs
@@ -214,7 +214,7 @@ mod tests {
         synthetic::{build_synthetic_blocks, SyntheticBlockConfig, SyntheticVectors},
         toy_domain::ToyDomain,
     };
-    use pallas::ledger::traverse::Era;
+    use pallas::ledger::traverse::{Era, MultiEraBlock};
 
     use crate::test_support::TestDomainBuilder;
 
@@ -327,29 +327,43 @@ mod tests {
 
     #[tokio::test]
     async fn eviction_keeps_the_current_batch_resolvable() {
-        let (domain, vectors) = facade();
+        let (domain, _) = facade();
 
-        let tx = MultiEraTx::decode_for_era(Era::Conway, &vectors.tx_cbor).expect("decodable tx");
+        let (blocks, _, _) = build_synthetic_blocks(synthetic_cfg());
+        let raw = blocks.first().expect("at least one synthetic block");
+        let block = MultiEraBlock::decode(raw).expect("decodable block");
+
+        let txs = block.txs();
+        let (first, second) = (&txs[0], &txs[1]);
+
+        let first_inputs = first.consumes();
+        let second_inputs = second.consumes();
+
+        assert_ne!(
+            first_inputs[0].hash(),
+            second_inputs[0].hash(),
+            "the two txs must depend on different source txs"
+        );
 
         // a cache too small to hold anything alongside the current batch
         let mut cache = InputCache::with_capacity(1);
 
         {
-            let _resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
+            let _resolver = cache.prepare(&domain, [first]).await.expect("prepare");
         }
 
-        let first = cache.fetches();
-        assert_eq!(first, 1);
+        assert_eq!(cache.fetches(), 1);
 
         {
-            let mut resolver = cache.prepare(&domain, [&tx]).await.expect("prepare");
-
-            let inputs = tx.consumes();
-            let input = inputs.first().expect("synthetic tx consumes an input");
+            // this batch needs a dependency the full cache does not hold, so
+            // the cache is cleared and the batch fetched again
+            let mut resolver = cache.prepare(&domain, [second]).await.expect("prepare");
 
             // whatever eviction did, every input of the prepared batch is
-            // still answerable without panicking on an unprepared hash
-            resolver.resolve(input).expect("resolve failed");
+            // still answerable without hitting the unprepared path
+            resolver.resolve(&second_inputs[0]).expect("resolve failed");
         }
+
+        assert_eq!(cache.fetches(), 2, "the evicting batch is fetched again");
     }
 }

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -22,12 +22,13 @@ use dolos_cardano::{
     indexes::{AsyncCardanoQueryExt, CardanoIndexExt, SlotOrder},
     pallas_extras, ChainSummary,
 };
-use dolos_core::{BlockBody, BlockSlot, Domain, EraCbor, StateStore as _, TxoRef};
+use dolos_core::{BlockBody, BlockSlot, Domain, StateStore as _, TxoRef};
 
 use crate::{
     error::Error,
     mapping::{aggregate_assets, AddressKind, AddressModelBuilder, AssetTotals, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
+    resolver::{InputCache, InputResolver},
     Facade,
 };
 
@@ -378,14 +379,11 @@ fn address_matches(address: &VKeyOrAddress, candidate: &Address) -> bool {
     }
 }
 
-async fn has_address<D>(
-    domain: &Facade<D>,
+fn has_address(
+    resolver: &mut InputResolver<'_>,
     address: &VKeyOrAddress,
     tx: &MultiEraTx<'_>,
-) -> Result<bool, StatusCode>
-where
-    D: Domain + Clone + Send + Sync + 'static,
-{
+) -> Result<bool, StatusCode> {
     for (_, output) in tx.produces() {
         let candidate = output
             .address()
@@ -397,26 +395,13 @@ where
     }
 
     for input in tx.consumes() {
-        if let Some(EraCbor(era, cbor)) = domain
-            .query()
-            .tx_cbor(input.hash().as_slice().to_vec())
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        {
-            let parsed = MultiEraTx::decode_for_era(
-                era.try_into()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
-                &cbor,
-            )
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-            if let Some(output) = parsed.produces_at(input.index() as usize) {
-                let candidate = output
-                    .address()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if let Some(output) = resolver.resolve(&input)? {
+            let candidate = output
+                .address()
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-                if address_matches(address, &candidate) {
-                    return Ok(true);
-                }
+            if address_matches(address, &candidate) {
+                return Ok(true);
             }
         }
     }
@@ -426,6 +411,7 @@ where
 
 async fn sum_block_txs<D>(
     domain: &Facade<D>,
+    cache: &mut InputCache,
     address: &VKeyOrAddress,
     block: &[u8],
     received: &mut AssetTotals,
@@ -437,7 +423,11 @@ where
 {
     let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    for tx in block.txs() {
+    let txs = block.txs();
+
+    let mut resolver = cache.prepare(domain, txs.iter()).await?;
+
+    for tx in txs.iter() {
         let mut matched = false;
 
         for (_, output) in tx.produces() {
@@ -452,27 +442,14 @@ where
         }
 
         for input in tx.consumes() {
-            if let Some(EraCbor(era, cbor)) = domain
-                .query()
-                .tx_cbor(input.hash().as_slice().to_vec())
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-            {
-                let parsed = MultiEraTx::decode_for_era(
-                    era.try_into()
-                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
-                    &cbor,
-                )
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-                if let Some(output) = parsed.produces_at(input.index() as usize) {
-                    let candidate = output
-                        .address()
-                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            if let Some(output) = resolver.resolve(&input)? {
+                let candidate = output
+                    .address()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-                    if address_matches(address, &candidate) {
-                        sent.add_output(&output);
-                        matched = true;
-                    }
+                if address_matches(address, &candidate) {
+                    sent.add_output(&output);
+                    matched = true;
                 }
             }
         }
@@ -487,6 +464,7 @@ where
 
 async fn find_txs<D>(
     domain: &Facade<D>,
+    cache: &mut InputCache,
     address: &VKeyOrAddress,
     chain: &ChainSummary,
     pagination: &Pagination,
@@ -497,10 +475,22 @@ where
 {
     let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let txs = block.txs();
+
+    // only the txs that will actually be scanned contribute dependencies
+    let scanned = txs
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !pagination.should_skip(block.number(), *idx))
+        .map(|(_, tx)| tx);
+
+    let mut resolver = cache.prepare(domain, scanned).await?;
+
     let mut matches = vec![];
 
-    for (idx, tx) in block.txs().iter().enumerate() {
-        if !pagination.should_skip(block.number(), idx) && has_address(domain, address, tx).await? {
+    for (idx, tx) in txs.iter().enumerate() {
+        if !pagination.should_skip(block.number(), idx) && has_address(&mut resolver, address, tx)?
+        {
             let model = AddressTransactionsContentInner {
                 tx_hash: hex::encode(tx.hash().as_slice()),
                 tx_index: idx as i32,
@@ -544,6 +534,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
+    let mut cache = InputCache::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -556,7 +547,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &address, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut cache, &address, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);
@@ -607,6 +598,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
+    let mut cache = InputCache::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -619,7 +611,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &address, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut cache, &address, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);
@@ -654,6 +646,7 @@ where
     let mut received = AssetTotals::default();
     let mut sent = AssetTotals::default();
     let mut tx_count: usize = 0;
+    let mut cache = InputCache::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -668,6 +661,7 @@ where
 
         sum_block_txs(
             &domain,
+            &mut cache,
             &parsed,
             &block,
             &mut received,

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -26,9 +26,9 @@ use dolos_core::{BlockBody, BlockSlot, Domain, StateStore as _, TxoRef};
 
 use crate::{
     error::Error,
+    inputs::{InputDeps, InputResolver},
     mapping::{aggregate_assets, AddressKind, AddressModelBuilder, AssetTotals, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
-    resolver::{InputCache, InputResolver},
     Facade,
 };
 
@@ -411,7 +411,7 @@ fn has_address(
 
 async fn sum_block_txs<D>(
     domain: &Facade<D>,
-    cache: &mut InputCache,
+    deps: &mut InputDeps,
     address: &VKeyOrAddress,
     block: &[u8],
     received: &mut AssetTotals,
@@ -425,7 +425,7 @@ where
 
     let txs = block.txs();
 
-    let mut resolver = cache.prepare(domain, txs.iter()).await?;
+    let mut resolver = deps.prepare(domain, txs.iter()).await?;
 
     for tx in txs.iter() {
         let mut matched = false;
@@ -464,7 +464,7 @@ where
 
 async fn find_txs<D>(
     domain: &Facade<D>,
-    cache: &mut InputCache,
+    deps: &mut InputDeps,
     address: &VKeyOrAddress,
     chain: &ChainSummary,
     pagination: &Pagination,
@@ -484,7 +484,7 @@ where
         .filter(|(idx, _)| !pagination.should_skip(block.number(), *idx))
         .map(|(_, tx)| tx);
 
-    let mut resolver = cache.prepare(domain, scanned).await?;
+    let mut resolver = deps.prepare(domain, scanned).await?;
 
     let mut matches = vec![];
 
@@ -534,7 +534,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
-    let mut cache = InputCache::default();
+    let mut deps = InputDeps::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -547,7 +547,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &mut cache, &address, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut deps, &address, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);
@@ -598,7 +598,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
-    let mut cache = InputCache::default();
+    let mut deps = InputDeps::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -611,7 +611,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &mut cache, &address, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut deps, &address, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);
@@ -646,7 +646,7 @@ where
     let mut received = AssetTotals::default();
     let mut sent = AssetTotals::default();
     let mut tx_count: usize = 0;
-    let mut cache = InputCache::default();
+    let mut deps = InputDeps::default();
 
     let mut stream = Box::pin(stream);
     while let Some(res) = stream.next().await {
@@ -661,7 +661,7 @@ where
 
         sum_block_txs(
             &domain,
-            &mut cache,
+            &mut deps,
             &parsed,
             &block,
             &mut received,

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -34,9 +34,9 @@ use serde::Deserialize;
 
 use crate::{
     error::Error,
+    inputs::{InputDeps, InputResolver},
     mapping::{asset_fingerprint, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
-    resolver::{InputCache, InputResolver},
     Facade,
 };
 
@@ -637,7 +637,7 @@ fn tx_has_subject(
 
 async fn find_txs<D>(
     domain: &Facade<D>,
-    cache: &mut InputCache,
+    deps: &mut InputDeps,
     subject: &[u8],
     chain: &ChainSummary,
     pagination: &Pagination,
@@ -657,7 +657,7 @@ where
         .filter(|(idx, _)| !pagination.should_skip(block.number(), *idx))
         .map(|(_, tx)| tx);
 
-    let mut resolver = cache.prepare(domain, scanned).await?;
+    let mut resolver = deps.prepare(domain, scanned).await?;
 
     let mut matches = vec![];
 
@@ -709,7 +709,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
-    let mut cache = InputCache::default();
+    let mut deps = InputDeps::default();
     let mut stream = Box::pin(stream);
 
     while let Some(res) = stream.next().await {
@@ -719,7 +719,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &mut cache, &subject, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut deps, &subject, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -36,6 +36,7 @@ use crate::{
     error::Error,
     mapping::{asset_fingerprint, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
+    resolver::{InputCache, InputResolver},
     Facade,
 };
 
@@ -612,14 +613,11 @@ fn output_has_subject(subject: &[u8], output: &MultiEraOutput) -> bool {
     false
 }
 
-async fn tx_has_subject<D>(
-    domain: &Facade<D>,
+fn tx_has_subject(
+    resolver: &mut InputResolver<'_>,
     subject: &[u8],
     tx: &MultiEraTx<'_>,
-) -> Result<bool, StatusCode>
-where
-    D: Domain + Clone + Send + Sync + 'static,
-{
+) -> Result<bool, StatusCode> {
     for (_, output) in tx.produces() {
         if output_has_subject(subject, &output) {
             return Ok(true);
@@ -627,22 +625,9 @@ where
     }
 
     for input in tx.consumes() {
-        if let Some(EraCbor(era, cbor)) = domain
-            .query()
-            .tx_cbor(input.hash().as_slice().to_vec())
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        {
-            let parsed = MultiEraTx::decode_for_era(
-                era.try_into()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
-                &cbor,
-            )
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-            if let Some(output) = parsed.produces_at(input.index() as usize) {
-                if output_has_subject(subject, &output) {
-                    return Ok(true);
-                }
+        if let Some(output) = resolver.resolve(&input)? {
+            if output_has_subject(subject, &output) {
+                return Ok(true);
             }
         }
     }
@@ -652,6 +637,7 @@ where
 
 async fn find_txs<D>(
     domain: &Facade<D>,
+    cache: &mut InputCache,
     subject: &[u8],
     chain: &ChainSummary,
     pagination: &Pagination,
@@ -662,11 +648,22 @@ where
 {
     let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let txs = block.txs();
+
+    // only the txs that will actually be scanned contribute dependencies
+    let scanned = txs
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !pagination.should_skip(block.number(), *idx))
+        .map(|(_, tx)| tx);
+
+    let mut resolver = cache.prepare(domain, scanned).await?;
+
     let mut matches = vec![];
 
-    for (idx, tx) in block.txs().iter().enumerate() {
+    for (idx, tx) in txs.iter().enumerate() {
         if !pagination.should_skip(block.number(), idx)
-            && tx_has_subject(domain, subject, tx).await?
+            && tx_has_subject(&mut resolver, subject, tx)?
         {
             let model = AssetTransactionsInner {
                 tx_hash: hex::encode(tx.hash().as_slice()),
@@ -712,6 +709,7 @@ where
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let mut matches = Vec::new();
+    let mut cache = InputCache::default();
     let mut stream = Box::pin(stream);
 
     while let Some(res) = stream.next().await {
@@ -721,7 +719,7 @@ where
             continue;
         };
 
-        let mut txs = find_txs(&domain, &subject, &chain, &pagination, &block)
+        let mut txs = find_txs(&domain, &mut cache, &subject, &chain, &pagination, &block)
             .await
             .map_err(Error::Code)?;
         matches.append(&mut txs);


### PR DESCRIPTION
## Plan

Plan: "Minibf shared input resolver" (core class → human review gate; not merged by the implementer).

**Done criterion:** *all three call sites route through the shared resolver; `cargo test -p dolos-minibf` and clippy pass unchanged; the PR body demonstrates the dedup.* — **met**, see below.

## Problem

Three block-scan sites in `crates/minibf` hand-rolled the same per-input source-output resolution — raw `query().tx_cbor()` fetch, `MultiEraTx::decode_for_era`, `produces_at(index)` — with no dedup and no caching. A dependency tx referenced by N inputs was fetched and fully decoded N times, per request:

| site | endpoints |
| --- | --- |
| `has_address` (`routes/addresses.rs`) | `/addresses/{address}/transactions`, `/addresses/{address}/txs` |
| `sum_block_txs` (`routes/addresses.rs`) | `/addresses/{address}/total` |
| `tx_has_subject` (`routes/assets.rs`) | `/assets/{subject}/transactions` |

The crate already had the facilities (`Facade::get_tx_batch`, and the `required_deps`/`load_dep` shape used by `TxModelBuilder` for `/txs/{hash}/*`); these sites just did not use them.

## What changed

New `crates/minibf/src/inputs.rs`:

- **`InputDeps`** — request-scoped, owns the fetched dependency bytes. `prepare(domain, txs)` collects the distinct hashes consumed by the txs about to be scanned, asks `Facade::get_tx_batch` only for the ones it does not already hold, and hands out a resolver. Misses are recorded too, so genesis/pruned inputs are not retried. Bounded at `MAX_INPUT_DEPS = 4096`: the store is pure memoization, so passing the cap clears it and re-fetches what the current batch needs — this caps memory on a full-history `/total` scan of a high-activity address.
- **`InputResolver<'a>`** — borrows those bytes, decodes each dependency tx at most once, and returns transient `MultiEraOutput` borrows tied to `&mut self` (the same ownership constraint `TxModelBuilder` manages). All three call sites use the output transiently, so the borrow-returning shape fits without a callback.

Call sites: `has_address` and `tx_has_subject` become synchronous and take `&mut InputResolver`; `sum_block_txs` and both `find_txs` prepare the resolver once per block. **Control flow is preserved exactly**, including the early exits (a tx that pays the address / carries the subject in its own outputs still returns before any input is touched) and `sum_block_txs`'s full pass over every input. `find_txs` only prepares the txs that pagination will actually scan.

Out of scope, untouched as the plan requires: `TxModelBuilder`, the single-point `tx_cbor` lookups in `assets.rs` (metadata / initial-tx fetches), and any new endpoint.

**No semantic divergence between the three sites** — the plan flagged this as an escalation trigger. Verified before unifying: all three did fetch → `decode_for_era` → `produces_at(index)`, skipped silently on a missing source tx or missing output index, and returned 500 on an era or decode failure. Only the predicate applied to the resolved output differed, and each keeps its own.

## Behavior

No response change on any endpoint; the existing endpoint suites are the behavior lock and pass unchanged.

One deliberate I/O-shape change worth naming: because a block's dependencies are now batched up front, a scanned tx that would have early-exited on its own outputs still contributes its input hashes to that block's batch. The batch is deduped and bounded by the block's distinct dependency hashes, and it replaces the sequential per-input round trips, so the worst case is strictly better than the old one; it is not free in the pathological "every tx matches on its outputs" case.

**Memoization scope.** Fetched bytes are memoized for the whole request (bounded); *decoding* is memoized per prepared block, because a decoded `MultiEraTx` borrows the held bytes while the store has to stay mutable between blocks to fetch the next batch. That is above the plan's sanctioned fallback (per-block batching without cross-block memoization) — the fetches, which are the round trips, do memoize across blocks. Lifting decode memoization to the whole request needs a self-referential owner (arena / `self_cell`) and is left as follow-up residue rather than widened into this PR.

## Dedup demonstration

`InputDeps::fetches()` and `InputResolver::decodes()` are the counters (also emitted as `debug`/`trace` spans: `prepared input dependencies`, `decoded dependency tx`). Four tests in `inputs.rs` assert the property:

- `fetches_once_per_distinct_dependency` — three txs sharing one dependency (3 inputs, 1 distinct hash) → `deps.fetches() == 1`; preparing a later block over the same dependency leaves it at `1` (cross-block memoization).
- `decodes_each_dependency_once` — five resolutions of the same dependency → `resolver.decodes() == 1`, each returning the source output.
- `records_misses` — a known-missing source tx resolves to `None` five times with zero decodes.
- `eviction_keeps_the_current_batch_resolvable` — with a store too small to hold anything alongside the current batch, a batch needing an unheld dependency clears it and is fetched again, and every input of that batch is still resolvable afterwards.

```
test inputs::tests::records_misses ... ok
test inputs::tests::decodes_each_dependency_once ... ok
test inputs::tests::fetches_once_per_distinct_dependency ... ok
test inputs::tests::eviction_keeps_the_current_batch_resolvable ... ok
```

## Verification

```
cargo test -p dolos-minibf
  test result: ok. 240 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

cargo test --workspace --all-targets
  all suites ok; 0 failed

cargo clippy --all-targets --all-features -- -D warnings
  Finished `dev` profile

cargo +nightly fmt --all -- --check
  clean
```

(The one ignored minibf test is the pre-existing `#[ignore]` in `routes/tx/submit`.)

## Naming (commit `47eff4cc`)

Added after the first review pass. The module was originally `resolver.rs` with an `InputCache` — `resolver` said nothing about *what* was resolved, and `InputCache` collided with the crate's other cache concept: `cache.rs`'s `CacheService`, a shared `Arc`/TTL stale-while-revalidate cache hanging off `Facade::cache`, declared five lines above it in `lib.rs`. The two are unrelated animals, and route handlers made it worse by binding a local `cache` inside functions whose `Facade` also has a `.cache`.

| Was | Now |
|---|---|
| `resolver.rs` | `inputs.rs` |
| `InputCache` | `InputDeps` |
| `MAX_CACHED_DEPS` | `MAX_INPUT_DEPS` |
| local `cache` | `deps` |

`InputDeps` adopts the vocabulary `mapping.rs` already uses for the same job on `/txs/{hash}/*` (`required_deps`, `load_dep`, `consumed_deps`), which this module's own tracing was already speaking (`deps = …`, `"prepared input dependencies"`). `InputResolver` and `resolve()` are unchanged — both are tied to inputs by name and now by module, and "resolve an input" is the standard phrasing (`dolos-cardano` has `resolved_inputs`). Docs follow: sentences that used "cache" as a noun for this type now say "store".

Rename only — `git` tracks it as a rename and the diff is 49 insertions / 49 deletions with no net line change. Behavior, signature semantics, and test coverage are untouched; the same 240 tests pass.

## Escalations

None.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved address-based transaction searches across blocks and transaction histories.
  - Improved asset-subject transaction searches, especially across larger result sets.
  - Reduced repeated processing of transaction inputs for more consistent response times.

- **Reliability**
  - Improved handling of unavailable or pruned transaction inputs during search operations.
  - Added safeguards when processing large sets of transaction dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
