### PR TITLE
fix(minibf): render relay IPv6 addresses in network byte order

### DIFF
--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1600,8 +1600,14 @@ impl IntoModel<TxContentPoolCertsInnerRelaysInner> for alonzo::Relay {
                     }
                 }),
                 ipv6: ipv6.map(|ipv6| {
-                    if let Ok(slice) = <[u8; 16]>::try_from(ipv6.as_slice()) {
-                        std::net::Ipv6Addr::from(slice).to_string()
+                    if let Ok(mut bytes) = <[u8; 16]>::try_from(ipv6.as_slice()) {
+                        // cardano-ledger serializes relay IPv6 addresses as
+                        // four 32-bit words in little-endian order; swap each
+                        // word back to network order (same as dbsync).
+                        for word in bytes.chunks_exact_mut(4) {
+                            word.reverse();
+                        }
+                        std::net::Ipv6Addr::from(bytes).to_string()
                     } else {
                         Default::default()
                     }

--- a/crates/minibf/src/routes/pools.rs
+++ b/crates/minibf/src/routes/pools.rs
@@ -1751,6 +1751,27 @@ mod tests {
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 
+    #[test]
+    fn relay_ipv6_words_swapped_to_network_order() {
+        // On-chain bytes of a real preview relay (pool1drrylt...): the ledger
+        // serializes relay IPv6 as four little-endian 32-bit words, so the
+        // mapped address must match what dbsync/Blockfrost display.
+        let onchain: [u8; 16] = [
+            0x61, 0x08, 0x01, 0x20, 0x80, 0x2b, 0x00, 0x40, 0xff, 0x3e, 0x16, 0x02, 0x09, 0x90,
+            0x05, 0xfe,
+        ];
+
+        let relay = Relay::SingleHostAddr(Some(3001), None, Some(Bytes::from(onchain.to_vec())));
+        let model = relay.into_model().expect("relay model");
+
+        assert_eq!(
+            model.ipv6.as_deref(),
+            Some("2001:861:4000:2b80:216:3eff:fe05:9009")
+        );
+        assert_eq!(model.ipv4, None);
+        assert_eq!(model.port, 3001);
+    }
+
     #[tokio::test]
     async fn pools_relays_happy_path() {
         let app = TestApp::new_with_cfg(SyntheticBlockConfig {


### PR DESCRIPTION
## Problem

Pool relay IPv6 addresses come out scrambled. For example, the preview pool `pool1drrylt73ln8jcv0sthcenlkhuan2lfyhthkrrv3vhs9vv4eywdy` has one relay:

- Dolos returned: `6108:120:802b:40:ff3e:1602:990:5fe`
- Blockfrost returns: `2001:861:4000:2b80:216:3eff:fe05:9009`

The Blockfrost one is the real address (a normal `2001:...` global unicast with an EUI-64 suffix). The Dolos one is not routable at all.

## Why

cardano-ledger serializes relay IPv6 addresses as four 32-bit words, each in little-endian byte order. dbsync swaps the words back before storing, so Blockfrost shows the correct address (because our friend db-sync). 

## Fix

Reverse the bytes of each 32-bit word before building the address, in the shared relay mapping. This fixes both `/pools/{pool_id}/relays` and `/txs/{tx_hash}/pool_updates`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IPv6 relay address interpretation so on-chain addresses are displayed accurately.
  * Preserved fallback behavior when IPv6 data cannot be converted.

* **Tests**
  * Added coverage verifying IPv6 address conversion, IPv4 absence, and relay port values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->