### PR TITLE
feat(stelae): read layers as a stream, bounded by one record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5284,6 +5284,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "sha2",
+ "stats_alloc",
  "tempfile",
  "thiserror 2.0.18",
  "zstd",

--- a/crates/stelae/Cargo.toml
+++ b/crates/stelae/Cargo.toml
@@ -19,4 +19,9 @@ thiserror.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+# The peak-allocation test instruments the global allocator, the same idiom the
+# root package's tests/memory.rs uses for store iteration. A dev-dependency, so
+# it does not appear in `cargo tree -p stelae -e normal` and the boundary check
+# above is unaffected.
+stats_alloc = "0.1"
 tempfile = "3.20.0"

--- a/crates/stelae/src/digest.rs
+++ b/crates/stelae/src/digest.rs
@@ -275,14 +275,18 @@ fn digest_blob<R: Read, W: Write>(
 }
 
 /// Hashes and counts every byte that passes through, in either direction.
-struct Tap<T> {
+///
+/// Shared with [`crate::layer`], which puts the same tap under a streaming read
+/// so that the buffered and streaming paths compute the blob digest from
+/// identical bytes rather than from two similar-looking loops.
+pub(crate) struct Tap<T> {
     inner: T,
     hasher: Sha256,
     bytes: u64,
 }
 
 impl<T> Tap<T> {
-    fn new(inner: T) -> Self {
+    pub(crate) fn new(inner: T) -> Self {
         Self {
             inner,
             hasher: Sha256::new(),
@@ -290,7 +294,7 @@ impl<T> Tap<T> {
         }
     }
 
-    fn finish(self) -> (T, Digest, u64) {
+    pub(crate) fn finish(self) -> (T, Digest, u64) {
         (
             self.inner,
             Digest(self.hasher.finalize().into()),

--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -40,8 +40,9 @@ use std::{
 
 use crate::{
     digest::{digest_reader, read_blob, scan_blob, LayerDigests, LayerWriter},
-    frame::{CanonicalCbor, LayerHeader, SeqReader, SeqWriter},
+    frame::{CanonicalCbor, LayerHeader, Limits, SeqReader, SeqWriter},
     inscription::LayerDescriptor,
+    layer::{check_header, check_identity, check_record_count, LayerReader},
     profile::{checked_layer_media_type, Profile},
     Digest, Error, Inscription,
 };
@@ -369,18 +370,8 @@ impl SteleDir {
         Ok(BlobIndex(index))
     }
 
-    /// Read one layer, verifying it against its descriptor and its own header.
-    ///
-    /// Everything the descriptor claims is checked: the identity digest, the
-    /// uncompressed size, the record count, and that the header record inside
-    /// the blob names the same profile and kind. A layer that disagrees with
-    /// the document that points at it is refused.
-    pub fn read_layer(
-        &self,
-        index: &BlobIndex,
-        profile: &dyn Profile,
-        descriptor: &LayerDescriptor,
-    ) -> Result<Layer, Error> {
+    /// Locate the blob holding a layer, or say which layer is missing.
+    fn blob_of(&self, index: &BlobIndex, descriptor: &LayerDescriptor) -> Result<PathBuf, Error> {
         let blob_digest =
             index
                 .blob_for(&descriptor.diff_id)
@@ -389,7 +380,28 @@ impl SteleDir {
                     diff_id: descriptor.diff_id.to_string(),
                 })?;
 
-        let path = self.blob_path(&blob_digest);
+        Ok(self.blob_path(&blob_digest))
+    }
+
+    /// Read one layer, verifying it against its descriptor and its own header.
+    ///
+    /// Everything the descriptor claims is checked: the identity digest, the
+    /// uncompressed size, the record count, and that the header record inside
+    /// the blob names the same profile and kind. A layer that disagrees with
+    /// the document that points at it is refused.
+    ///
+    /// The layer is held whole, which is what makes this a fixture: the
+    /// descriptor's `uncompressedSize` is allocated outright, and on a Dolos
+    /// state shard that is 402 MB. Callers that only need to walk the records
+    /// want [`SteleDir::stream_layer`], which checks exactly the same claims
+    /// out of a bounded window.
+    pub fn read_layer(
+        &self,
+        index: &BlobIndex,
+        profile: &dyn Profile,
+        descriptor: &LayerDescriptor,
+    ) -> Result<Layer, Error> {
+        let path = self.blob_of(index, descriptor)?;
 
         // The descriptor's claim doubles as the ceiling on decompression. A
         // blob that expands past it is refused mid-stream instead of being
@@ -397,23 +409,7 @@ impl SteleDir {
         // bounded cost.
         let (content, digests) = read_blob(fs::File::open(&path)?, descriptor.uncompressed_size)?;
 
-        if digests.diff_id != descriptor.diff_id {
-            return Err(Error::DigestMismatch {
-                subject: format!("layer {:?}", descriptor.kind),
-                expected: descriptor.diff_id.to_string(),
-                actual: digests.diff_id.to_string(),
-            });
-        }
-
-        if digests.uncompressed_size != descriptor.uncompressed_size {
-            return Err(Error::LayerMismatch {
-                kind: descriptor.kind.clone(),
-                reason: format!(
-                    "descriptor claims {} uncompressed bytes, blob holds {}",
-                    descriptor.uncompressed_size, digests.uncompressed_size
-                ),
-            });
-        }
+        check_identity(&digests, descriptor)?;
 
         let header_len = match SeqReader::new(&content).next() {
             Some(Ok(record)) => record.len(),
@@ -428,19 +424,7 @@ impl SteleDir {
 
         let header = LayerHeader::decode(&content[..header_len])?;
 
-        if header.profile != profile.name() {
-            return Err(Error::UnknownProfile {
-                found: header.profile,
-                expected: profile.name().to_owned(),
-            });
-        }
-
-        if header.kind != descriptor.kind {
-            return Err(Error::LayerMismatch {
-                kind: descriptor.kind.clone(),
-                reason: format!("header record names kind {:?}", header.kind),
-            });
-        }
+        check_header(&header, profile, descriptor)?;
 
         // Counted by iterating rather than with `count()`: `SeqReader` reports a
         // malformed record as one `Err` item and then ends, so counting items
@@ -454,15 +438,7 @@ impl SteleDir {
             records += 1;
         }
 
-        if records != descriptor.records {
-            return Err(Error::LayerMismatch {
-                kind: descriptor.kind.clone(),
-                reason: format!(
-                    "descriptor claims {} records, blob holds {records}",
-                    descriptor.records
-                ),
-            });
-        }
+        check_record_count(records, descriptor)?;
 
         Ok(Layer {
             header,
@@ -470,5 +446,26 @@ impl SteleDir {
             header_len,
             digests,
         })
+    }
+
+    /// Stream one layer's records without holding it.
+    ///
+    /// The same verification as [`SteleDir::read_layer`] — the checks are one
+    /// implementation, called from both — but spread across the read: the
+    /// header on construction, the decompression ceiling as the stream
+    /// advances, and the identity digest, size and record count in
+    /// [`LayerReader::finish`]. Records are therefore consumable *before* the
+    /// layer is proven; see the [`crate::layer`] module documentation for the
+    /// discipline that requires of a consumer.
+    pub fn stream_layer(
+        &self,
+        index: &BlobIndex,
+        profile: &dyn Profile,
+        descriptor: &LayerDescriptor,
+        limits: Limits,
+    ) -> Result<LayerReader<fs::File>, Error> {
+        let path = self.blob_of(index, descriptor)?;
+
+        LayerReader::new(fs::File::open(&path)?, profile, descriptor, limits)
     }
 }

--- a/crates/stelae/src/frame.rs
+++ b/crates/stelae/src/frame.rs
@@ -22,8 +22,22 @@
 //! a producer that emits a non-canonical encoding would publish a diffId that
 //! no independent re-encoding can reproduce. Rejecting it at the door is what
 //! keeps "reproduce the digest" a decidable claim.
+//!
+//! ## Two readers, one validator
+//!
+//! A sequence is read either from bytes already in hand ([`SeqReader`], which
+//! borrows out of the slice it was given) or from a stream ([`RecordReader`],
+//! which refills a bounded window). They are two entry points, not two
+//! implementations: both walk items with the same scanner, so a rule can
+//! never hold on one path and lapse on the other. [`scan_item`] and
+//! [`measure_item`] are that scanner's two exits — the first for callers that
+//! hold the whole item, the second for callers that must decide whether an item
+//! is worth holding at all.
 
-use std::io::Write;
+use std::{
+    io::{Read, Write},
+    ops::Range,
+};
 
 use crate::{Error, LAYER_FORMAT_VERSION};
 
@@ -127,17 +141,92 @@ where
 /// length in bytes. Trailing bytes are left for the caller — this is what makes
 /// a CBOR *sequence* walkable.
 pub fn scan_item(bytes: &[u8]) -> Result<usize, Error> {
-    let mut scanner = Scanner { bytes, pos: 0 };
+    let mut scanner = Scanner::new(bytes);
     scanner.item(0)?;
     Ok(scanner.pos)
+}
+
+/// What scanning the start of `bytes` established about the item there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Measure {
+    /// One complete, canonical item occupying the first `len` bytes.
+    Complete { len: usize },
+    /// A canonical *prefix* of an item: nothing seen so far violates the
+    /// profile, but the item does not end within `bytes`.
+    Incomplete {
+        /// Lower bound, in bytes, on the whole item.
+        ///
+        /// Not an estimate and not a guess about what follows: it is what the
+        /// length prefixes already read oblige the encoder to deliver — the
+        /// bytes a string header claimed, plus one byte for each element of an
+        /// enclosing array or map that has not been reached. It is therefore
+        /// always greater than `bytes.len()`, which is what lets a refill loop
+        /// make progress.
+        required: u64,
+    },
+}
+
+/// Validate the start of `bytes` as a canonical CBOR item, tolerating an item
+/// that runs off the end.
+///
+/// The reason this exists rather than [`scan_item`] plus a derivation at the
+/// call site: a streaming reader has to decide *whether to hold* a record
+/// before it holds it, and [`Error::TruncatedCbor`] reports a local need — one
+/// byte for a missing head, that chunk's `n` for a string body, a `usize::MAX`
+/// sentinel for a length prefix beyond the platform's reach. Reconstructing the
+/// record's total size from those would put length arithmetic in a second
+/// place, which is exactly how two readers start disagreeing about what is
+/// canonical.
+///
+/// A violation of the deterministic profile is still an error, not an
+/// `Incomplete`: no quantity of further bytes rehabilitates a float, a tag or a
+/// non-shortest integer.
+///
+/// ```
+/// use stelae::frame::{measure_item, Measure};
+///
+/// // A byte string of four bytes, of which two arrived.
+/// assert_eq!(
+///     measure_item(&[0x44, 0x01, 0x02]).unwrap(),
+///     Measure::Incomplete { required: 5 },
+/// );
+/// // The same item, complete, with the next record's first byte behind it.
+/// assert_eq!(
+///     measure_item(&[0x44, 0x01, 0x02, 0x03, 0x04, 0x00]).unwrap(),
+///     Measure::Complete { len: 5 },
+/// );
+/// ```
+pub fn measure_item(bytes: &[u8]) -> Result<Measure, Error> {
+    let mut scanner = Scanner::new(bytes);
+
+    match scanner.item(0) {
+        Ok(()) => Ok(Measure::Complete { len: scanner.pos }),
+        // Every `TruncatedCbor` this scanner raises means "the item needs bytes
+        // that are not here", and `required` is what the raising site recorded.
+        Err(Error::TruncatedCbor { .. }) => Ok(Measure::Incomplete {
+            required: scanner.required,
+        }),
+        Err(e) => Err(e),
+    }
 }
 
 struct Scanner<'a> {
     bytes: &'a [u8],
     pos: usize,
+    /// Lower bound on the size of the item under scan. Only meaningful once a
+    /// [`Error::TruncatedCbor`] has been raised; see [`Measure::Incomplete`].
+    required: u64,
 }
 
 impl<'a> Scanner<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            pos: 0,
+            required: 0,
+        }
+    }
+
     fn non_canonical(offset: usize, reason: impl Into<String>) -> Error {
         Error::NonCanonicalCbor {
             offset,
@@ -145,11 +234,29 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    /// Report an item that runs off the end, recording what it still needs.
+    ///
+    /// The need is absolute (`offset` is measured from the start of the item),
+    /// so the recorded bound survives the unwind through enclosing containers,
+    /// which only add to it.
+    fn truncated(&mut self, offset: usize, expected: usize) -> Error {
+        self.required = (offset as u64).saturating_add(expected as u64);
+
+        Error::TruncatedCbor { offset, expected }
+    }
+
+    /// Add what an enclosing container still owes to the bound, on the way out
+    /// of a truncation. Every unread element is at least one byte.
+    fn note_pending(&mut self, e: &Error, items: u64) {
+        if matches!(e, Error::TruncatedCbor { .. }) {
+            self.required = self.required.saturating_add(items);
+        }
+    }
+
     fn byte(&mut self) -> Result<u8, Error> {
-        let b = *self.bytes.get(self.pos).ok_or(Error::TruncatedCbor {
-            offset: self.pos,
-            expected: 1,
-        })?;
+        let Some(b) = self.bytes.get(self.pos).copied() else {
+            return Err(self.truncated(self.pos, 1));
+        };
 
         self.pos += 1;
 
@@ -157,15 +264,13 @@ impl<'a> Scanner<'a> {
     }
 
     fn take(&mut self, n: usize) -> Result<&'a [u8], Error> {
-        let end = self.pos.checked_add(n).ok_or(Error::TruncatedCbor {
-            offset: self.pos,
-            expected: n,
-        })?;
+        let Some(end) = self.pos.checked_add(n) else {
+            return Err(self.truncated(self.pos, n));
+        };
 
-        let slice = self.bytes.get(self.pos..end).ok_or(Error::TruncatedCbor {
-            offset: self.pos,
-            expected: n,
-        })?;
+        let Some(slice) = self.bytes.get(self.pos..end) else {
+            return Err(self.truncated(self.pos, n));
+        };
 
         self.pos = end;
 
@@ -280,26 +385,26 @@ impl<'a> Scanner<'a> {
         match major {
             0 | 1 => Ok(()),
             2 => {
-                let len = usize::try_from(arg).map_err(|_| Error::TruncatedCbor {
-                    offset,
-                    expected: usize::MAX,
-                })?;
+                let len = self.string_len(offset, arg)?;
                 self.take(len)?;
                 Ok(())
             }
             3 => {
-                let len = usize::try_from(arg).map_err(|_| Error::TruncatedCbor {
-                    offset,
-                    expected: usize::MAX,
-                })?;
+                let len = self.string_len(offset, arg)?;
                 let raw = self.take(len)?;
                 std::str::from_utf8(raw)
                     .map_err(|e| Self::non_canonical(offset, format!("invalid utf-8: {e}")))?;
                 Ok(())
             }
             4 => {
-                for _ in 0..arg {
-                    self.item(depth + 1)?;
+                // `remaining` counts the elements *after* the one being scanned,
+                // so a truncation deep inside can be charged for the ones that
+                // never got their turn.
+                for remaining in (0..arg).rev() {
+                    if let Err(e) = self.item(depth + 1) {
+                        self.note_pending(&e, remaining);
+                        return Err(e);
+                    }
                 }
                 Ok(())
             }
@@ -308,13 +413,37 @@ impl<'a> Scanner<'a> {
         }
     }
 
+    /// Length of a byte or text string, as a `usize` this platform can address.
+    ///
+    /// A prefix beyond `usize` is reported as truncation with a sentinel
+    /// `expected`: the item is unreachable on this platform whatever follows.
+    /// The recorded bound stays exact, so a caller enforcing a ceiling refuses
+    /// it for its real size rather than for the sentinel.
+    fn string_len(&mut self, offset: usize, arg: u64) -> Result<usize, Error> {
+        usize::try_from(arg).map_err(|_| {
+            self.required = (self.pos as u64).saturating_add(arg);
+
+            Error::TruncatedCbor {
+                offset,
+                expected: usize::MAX,
+            }
+        })
+    }
+
     fn map(&mut self, entries: u64, depth: usize) -> Result<(), Error> {
         let all = self.bytes;
         let mut previous: Option<&'a [u8]> = None;
 
-        for _ in 0..entries {
+        for remaining in (0..entries).rev() {
             let key_start = self.pos;
-            self.item(depth + 1)?;
+
+            if let Err(e) = self.item(depth + 1) {
+                // Every entry left owes a key and a value; this one still owes
+                // its value.
+                self.note_pending(&e, remaining.saturating_mul(2).saturating_add(1));
+                return Err(e);
+            }
+
             let key = &all[key_start..self.pos];
 
             if let Some(previous) = previous {
@@ -333,7 +462,11 @@ impl<'a> Scanner<'a> {
             }
 
             previous = Some(key);
-            self.item(depth + 1)?;
+
+            if let Err(e) = self.item(depth + 1) {
+                self.note_pending(&e, remaining.saturating_mul(2));
+                return Err(e);
+            }
         }
 
         Ok(())
@@ -413,24 +546,307 @@ impl<'a> Iterator for SeqReader<'a> {
             }
             Err(e) => {
                 self.failed = true;
-                // Report the offset within the whole sequence, not the record.
-                Some(Err(match e {
-                    Error::NonCanonicalCbor { offset, reason } => Error::NonCanonicalCbor {
-                        offset: self.offset + offset,
-                        reason,
-                    },
-                    Error::TruncatedCbor { offset, expected } => Error::TruncatedCbor {
-                        offset: self.offset + offset,
-                        expected,
-                    },
-                    other => other,
-                }))
+                Some(Err(at_sequence_offset(e, self.offset)))
             }
         }
     }
 }
 
 impl std::iter::FusedIterator for SeqReader<'_> {}
+
+/// Restate a record-local error in the coordinates of the whole sequence.
+///
+/// Both readers report positions the same way — an offset a reader hands back
+/// is an offset into the layer, which is what a `diffId` covers and therefore
+/// the only frame of reference two implementations can agree on.
+fn at_sequence_offset(e: Error, base: usize) -> Error {
+    match e {
+        Error::NonCanonicalCbor { offset, reason } => Error::NonCanonicalCbor {
+            offset: base.saturating_add(offset),
+            reason,
+        },
+        Error::TruncatedCbor { offset, expected } => Error::TruncatedCbor {
+            offset: base.saturating_add(offset),
+            expected,
+        },
+        other => other,
+    }
+}
+
+/// Largest single record [`RecordReader`] accepts by default: 16 MiB.
+///
+/// Two orders of magnitude above the largest record any profile plans to write
+/// (a Cardano block is order 100 KB), and small enough that refusing a hostile
+/// length prefix costs a bounded allocation. A profile whose records genuinely
+/// approach this is telling its publisher something, not this crate: raise the
+/// limit deliberately through [`Limits`], with the profile's own reason.
+pub const DEFAULT_MAX_RECORD: usize = 16 * 1024 * 1024;
+
+/// Refill window [`RecordReader`] starts with: 64 KiB, matching the buffers the
+/// digest pipeline reads through.
+pub const DEFAULT_WINDOW: usize = 64 * 1024;
+
+/// What a streaming read is allowed to hold.
+///
+/// The bound the format actually needs is *one record fits in memory; a layer
+/// does not*. Both fields exist to keep that promise checkable rather than
+/// hoped for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Limits {
+    /// Largest single record accepted. Checked against what a record's length
+    /// prefixes claim *before* a buffer grows to hold it, so a corrupt or
+    /// hostile prefix costs a comparison rather than an allocation.
+    pub max_record: usize,
+    /// Size the refill window starts at. It grows — never past `max_record` —
+    /// only for a record that does not fit, and never shrinks back, so peak
+    /// memory is `max(window, the largest record actually read)`.
+    pub window: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_record: DEFAULT_MAX_RECORD,
+            window: DEFAULT_WINDOW,
+        }
+    }
+}
+
+impl Limits {
+    /// A window larger than the record ceiling would buy nothing — nothing that
+    /// large is ever yielded — so it is clamped rather than refused.
+    fn normalized(self) -> Self {
+        Self {
+            max_record: self.max_record.max(1),
+            window: self.window.clamp(1, self.max_record.max(1)),
+        }
+    }
+}
+
+/// Walks a CBOR sequence arriving over a stream, validating each record's
+/// canonical form and holding no more than one record at a time.
+///
+/// This is [`SeqReader`]'s guarantee list on a source too large to hold: every
+/// record is validated against the deterministic profile before it is yielded,
+/// and a bad record ends the walk rather than being skipped — a CBOR sequence
+/// has no frame markers, so continuing past one would hand the caller records
+/// from an arbitrary offset.
+///
+/// It adds the guarantee a stream needs and a slice does not: a record's size
+/// is checked against [`Limits::max_record`] as soon as its length prefixes
+/// claim it, and before the window grows. Nothing here trusts a length prefix
+/// far enough to allocate for it.
+///
+/// Records are borrowed out of the window, so this is not an [`Iterator`]: the
+/// borrow has to end before the window can be refilled. Callers loop on
+/// [`RecordReader::next_record`].
+///
+/// ```
+/// use stelae::frame::{encode, RecordReader, SeqWriter};
+///
+/// let mut writer = SeqWriter::new(Vec::new());
+/// for i in 0..3u64 {
+///     writer.write_record(&encode(|e| { e.u64(i)?; Ok(()) }).unwrap()).unwrap();
+/// }
+/// let sequence = writer.into_inner();
+///
+/// let mut reader = RecordReader::new(std::io::Cursor::new(&sequence));
+/// let mut seen = 0;
+/// while let Some(record) = reader.next_record() {
+///     record.unwrap();
+///     seen += 1;
+/// }
+/// assert_eq!(seen, 3);
+/// ```
+pub struct RecordReader<R> {
+    source: R,
+    /// The refill window. Its length *is* its capacity: everything from
+    /// `filled` on is scratch space for the next read.
+    window: Vec<u8>,
+    /// Bytes of `window` that hold data read from the source.
+    filled: usize,
+    /// Where the next record starts within `window`.
+    cursor: usize,
+    limits: Limits,
+    /// Offset of the next record within the sequence, for error reporting.
+    offset: usize,
+    count: u64,
+    eof: bool,
+    failed: bool,
+}
+
+impl<R: Read> RecordReader<R> {
+    /// A reader with [`Limits::default`].
+    pub fn new(source: R) -> Self {
+        Self::with_limits(source, Limits::default())
+    }
+
+    pub fn with_limits(source: R, limits: Limits) -> Self {
+        let limits = limits.normalized();
+
+        Self {
+            source,
+            window: vec![0u8; limits.window],
+            filled: 0,
+            cursor: 0,
+            limits,
+            offset: 0,
+            count: 0,
+            eof: false,
+            failed: false,
+        }
+    }
+
+    /// The next record, or `None` at the end of the sequence.
+    ///
+    /// Once a record fails validation the reader is done: every later call
+    /// returns `None`, the same way [`SeqReader`] stops.
+    pub fn next_record(&mut self) -> Option<Result<&[u8], Error>> {
+        if self.failed {
+            return None;
+        }
+
+        match self.advance() {
+            Ok(Some(record)) => {
+                self.count += 1;
+                Some(Ok(&self.window[record]))
+            }
+            Ok(None) => None,
+            Err(e) => {
+                self.failed = true;
+                Some(Err(e))
+            }
+        }
+    }
+
+    /// Number of records yielded so far.
+    ///
+    /// A record that failed validation is not counted — it is not a record.
+    /// Counting the failure instead is how a corrupt layer gets waved through
+    /// by a descriptor written to match the inflated number.
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Byte offset of the next record within the sequence.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Whether the walk ended because a record failed validation.
+    pub fn failed(&self) -> bool {
+        self.failed
+    }
+
+    /// The source, once the walk is over. [`crate::layer`] uses it to reach the
+    /// digests the pipeline underneath accumulated.
+    pub fn into_inner(self) -> R {
+        self.source
+    }
+
+    /// Locate the next record in the window, refilling until it is whole.
+    fn advance(&mut self) -> Result<Option<Range<usize>>, Error> {
+        loop {
+            let pending = &self.window[self.cursor..self.filled];
+
+            if pending.is_empty() {
+                if self.eof {
+                    return Ok(None);
+                }
+
+                self.fill(0)?;
+                continue;
+            }
+
+            match measure_item(pending) {
+                Ok(Measure::Complete { len }) => {
+                    // The window can hold more than one record, so a complete
+                    // record is still checked: the ceiling is a promise about
+                    // what a caller is handed, not only about what was
+                    // allocated to get there.
+                    self.check_ceiling(len as u64)?;
+
+                    let record = self.cursor..self.cursor + len;
+                    self.cursor += len;
+                    self.offset += len;
+
+                    return Ok(Some(record));
+                }
+                Ok(Measure::Incomplete { required }) => {
+                    // Before the window grows, not after: this is the whole
+                    // point of `measure_item` reporting a size.
+                    self.check_ceiling(required)?;
+
+                    if self.eof {
+                        // Out of bytes with an unfinished record. Re-scan
+                        // strictly so the error is the one the slice reader
+                        // would have raised on the same bytes.
+                        let e = scan_item(pending).expect_err("the item is incomplete");
+                        return Err(at_sequence_offset(e, self.offset));
+                    }
+
+                    let required = usize::try_from(required)
+                        .expect("checked against the ceiling, which is a usize");
+
+                    self.fill(required)?;
+                }
+                Err(e) => return Err(at_sequence_offset(e, self.offset)),
+            }
+        }
+    }
+
+    fn check_ceiling(&self, required: u64) -> Result<(), Error> {
+        if required > self.limits.max_record as u64 {
+            return Err(Error::RecordTooLarge {
+                offset: self.offset,
+                required,
+                limit: self.limits.max_record,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Make room for a record of at least `required` bytes and read into it.
+    ///
+    /// Compacting first is what keeps the promise in [`Limits::window`]: the
+    /// bytes of the record under construction move to the front, so the window
+    /// holds one record plus whatever of the next one came along for the ride,
+    /// never a growing tail of records already handed out.
+    fn fill(&mut self, required: usize) -> Result<(), Error> {
+        if self.cursor > 0 {
+            self.window.copy_within(self.cursor..self.filled, 0);
+            self.filled -= self.cursor;
+            self.cursor = 0;
+        }
+
+        if self.filled == self.window.len() {
+            // A full window and still no record: the record is at least one
+            // byte larger than everything held, which is the bound to check.
+            self.check_ceiling(self.filled as u64 + 1)?;
+
+            let grown = self
+                .window
+                .len()
+                .saturating_mul(2)
+                .clamp(required.max(self.filled + 1), self.limits.max_record);
+
+            self.window.resize(grown, 0);
+        } else if required > self.window.len() {
+            self.window.resize(required.min(self.limits.max_record), 0);
+        }
+
+        let read = self.source.read(&mut self.window[self.filled..])?;
+
+        if read == 0 {
+            self.eof = true;
+        } else {
+            self.filled += read;
+        }
+
+        Ok(())
+    }
+}
 
 /// The first record of every layer, defined by the protocol so a blob stays
 /// interpretable when detached from the registry that served it.
@@ -825,6 +1241,394 @@ mod tests {
             Err(Error::NonCanonicalCbor { offset: 1, .. })
         ));
         assert!(reader.next().is_none(), "iterator must not resynchronize");
+    }
+
+    /// Every input the deterministic profile refuses, in the encodings a
+    /// hostile or buggy producer would actually emit.
+    ///
+    /// The list is the crate's rejection corpus: both readers are run over it
+    /// below, and the point is not that each one refuses — it is that they
+    /// refuse *identically*. Two readers that disagree about what is canonical
+    /// are a determinism bug wearing a compatibility costume: the same bytes
+    /// would restore on one path and fail on the other, and whichever produced
+    /// the layer would have published a `diffId` nobody else reproduces.
+    const NON_CANONICAL: &[(&str, &[u8])] = &[
+        ("value 0 as uint8", &[0x18, 0x00]),
+        ("value 24 as uint16", &[0x19, 0x00, 0x18]),
+        ("value 256 as uint32", &[0x1a, 0x00, 0x00, 0x01, 0x00]),
+        ("value 65536 as uint64", &[0x1b, 0, 0, 0, 0, 0, 1, 0, 0]),
+        ("non-shortest byte-string length", &[0x58, 0x02, 0xaa, 0xbb]),
+        ("indefinite array", &[0x9f, 0x01, 0xff]),
+        ("indefinite map", &[0xbf, 0x61, b'a', 0x01, 0xff]),
+        ("indefinite byte string", &[0x5f, 0x41, 0xaa, 0xff]),
+        ("indefinite text string", &[0x7f, 0x61, b'a', 0xff]),
+        ("half-precision float", &[0xf9, 0x3c, 0x00]),
+        ("single-precision float", &[0xfa, 0x47, 0xc3, 0x50, 0x00]),
+        (
+            "double-precision float",
+            &[0xfb, 0x3f, 0xf1, 0, 0, 0, 0, 0, 0],
+        ),
+        ("tag 0", &[0xc0, 0x61, b'a']),
+        ("undefined", &[0xf7]),
+        ("simple value 255", &[0xf8, 0xff]),
+        ("break outside an indefinite item", &[0xff]),
+        ("reserved additional information", &[0x1c]),
+        (
+            "unsorted map keys",
+            &[0xa2, 0x61, b'b', 0x01, 0x61, b'a', 0x02],
+        ),
+        (
+            "duplicate map key",
+            &[0xa2, 0x61, b'a', 0x01, 0x61, b'a', 0x02],
+        ),
+        (
+            "map keys unsorted by length",
+            &[0xa2, 0x62, b'a', b'a', 0x01, 0x61, b'a', 0x02],
+        ),
+        ("invalid utf-8", &[0x61, 0xff]),
+        ("byte string cut short", &[0x44, 0x01, 0x02]),
+        ("array cut short", &[0x83, 0x01, 0x02]),
+    ];
+
+    fn good_record() -> CanonicalCbor {
+        encode(|e| {
+            e.array(2)?.u64(7)?.str("good")?;
+            Ok(())
+        })
+        .unwrap()
+    }
+
+    /// Drain a [`RecordReader`], copying records out so the result can be
+    /// compared against the slice reader's borrowed ones.
+    fn drain<R: Read>(reader: &mut RecordReader<R>) -> (Vec<Vec<u8>>, Option<Error>) {
+        let mut records = Vec::new();
+
+        while let Some(next) = reader.next_record() {
+            match next {
+                Ok(record) => records.push(record.to_vec()),
+                Err(e) => return (records, Some(e)),
+            }
+        }
+
+        (records, None)
+    }
+
+    /// The bound reported for an unfinished item is a real lower bound on the
+    /// whole item, derived from what the encoder has already committed to —
+    /// never an estimate, and never less than what is already in hand, or a
+    /// refill loop would spin.
+    #[test]
+    fn measure_reports_what_an_unfinished_item_still_needs() {
+        let cases: &[(&[u8], u64)] = &[
+            // Nothing at all: a head byte, at least.
+            (&[], 1),
+            // bytes(4) with two of them: head + 4.
+            (&[0x44, 0x01, 0x02], 5),
+            // Three-element array, nothing inside: head + one byte each.
+            (&[0x83], 4),
+            // ... and with two elements present, the third is still owed.
+            (&[0x83, 0x01, 0x02], 4),
+            // A map with one entry present owes both halves of the next.
+            (&[0xa2, 0x61, b'a', 0x01], 6),
+            // Nested: the outer array owes its second element, the inner byte
+            // string owes its body.
+            (&[0x82, 0x43, 0xaa], 6),
+            // A text string whose length prefix is larger than any layer:
+            // reported at full size, which is what a ceiling check needs.
+            (
+                &[0x7b, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00],
+                1_099_511_627_785,
+            ),
+        ];
+
+        for (bytes, required) in cases {
+            assert_eq!(
+                measure_item(bytes).unwrap(),
+                Measure::Incomplete {
+                    required: *required
+                },
+                "0x{}",
+                hex::encode(bytes)
+            );
+
+            assert!(
+                *required > bytes.len() as u64,
+                "the bound must exceed what is in hand, or a refill loop stalls"
+            );
+        }
+    }
+
+    /// A violation is a verdict, not a request for more bytes: no quantity of
+    /// further input rehabilitates a float or a tag, so `measure_item` reports
+    /// those as errors rather than as an unfinished item.
+    #[test]
+    fn measure_refuses_rather_than_waits_on_non_canonical_input() {
+        for (name, bytes) in NON_CANONICAL {
+            let measured = measure_item(bytes);
+
+            match measured {
+                // Truncation is the one honest "incomplete" in the corpus.
+                Ok(Measure::Incomplete { .. }) => assert!(
+                    name.contains("cut short"),
+                    "{name} must not be reported as merely unfinished"
+                ),
+                Ok(Measure::Complete { .. }) => panic!("{name} must not measure as complete"),
+                Err(_) => {}
+            }
+        }
+    }
+
+    /// The guarantee the whole rejection corpus exists for: one scanner, two
+    /// entry points, one verdict.
+    #[test]
+    fn both_readers_refuse_the_same_bytes_the_same_way() {
+        let good = good_record();
+
+        for (name, bad) in NON_CANONICAL {
+            let mut bytes = good.as_bytes().to_vec();
+            bytes.extend_from_slice(bad);
+
+            let mut slice = SeqReader::new(&bytes);
+            assert_eq!(slice.next().unwrap().unwrap(), good.as_bytes(), "{name}");
+            let slice_error = slice.next().unwrap().unwrap_err();
+            assert!(slice.next().is_none(), "{name}: must not resynchronize");
+
+            // Window sizes across the interesting boundaries: one byte at a
+            // time, mid-record, and comfortably larger than the whole input.
+            for window in [1, 3, 4096] {
+                let mut reader = RecordReader::with_limits(
+                    std::io::Cursor::new(&bytes),
+                    Limits {
+                        window,
+                        ..Limits::default()
+                    },
+                );
+
+                let (records, error) = drain(&mut reader);
+
+                assert_eq!(records, vec![good.as_bytes().to_vec()], "{name} @ {window}");
+                assert_eq!(
+                    reader.count(),
+                    1,
+                    "{name} @ {window}: a failure is not a record"
+                );
+
+                let error = error.unwrap_or_else(|| panic!("{name} @ {window}: expected an error"));
+
+                // Same variant, same offset, same reason — compared through the
+                // rendered message so a divergence in any of the three shows up
+                // as a diff rather than as a silently weaker assertion.
+                assert_eq!(
+                    error.to_string(),
+                    slice_error.to_string(),
+                    "{name} @ {window}"
+                );
+
+                assert!(
+                    reader.next_record().is_none(),
+                    "{name} @ {window}: must not resynchronize"
+                );
+            }
+        }
+    }
+
+    /// Nesting is bounded for both readers by the same constant — built here
+    /// rather than in the corpus because the input is generated.
+    #[test]
+    fn both_readers_bound_nesting() {
+        let mut bytes = vec![0x81; MAX_NESTING_DEPTH + 1];
+        bytes.push(0x00);
+
+        let slice_error = SeqReader::new(&bytes).next().unwrap().unwrap_err();
+        assert!(
+            matches!(slice_error, Error::CborTooDeep { .. }),
+            "{slice_error:?}"
+        );
+
+        let mut reader = RecordReader::new(std::io::Cursor::new(&bytes));
+        let error = reader.next_record().unwrap().unwrap_err();
+        assert_eq!(error.to_string(), slice_error.to_string());
+    }
+
+    /// Records that straddle every refill boundary still come back whole and in
+    /// order, whatever the window size — including a window far smaller than a
+    /// single record, which is the case the ceiling has to distinguish from a
+    /// record that is genuinely too big.
+    #[test]
+    fn records_survive_every_refill_boundary() {
+        let records: Vec<CanonicalCbor> = (0..64u64)
+            .map(|i| {
+                encode(|e| {
+                    // Sizes crossing the 24/256 encoding boundaries, so records
+                    // of several byte lengths land at every window offset.
+                    e.array(2)?.u64(i)?.bytes(&vec![i as u8; i as usize * 7])?;
+                    Ok(())
+                })
+                .unwrap()
+            })
+            .collect();
+
+        let mut writer = SeqWriter::new(Vec::new());
+        for record in &records {
+            writer.write_record(record).unwrap();
+        }
+        let sequence = writer.into_inner();
+
+        let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_bytes().to_vec()).collect();
+
+        for window in [1, 2, 3, 17, 64, 129, 4096, 1 << 20] {
+            let mut reader = RecordReader::with_limits(
+                std::io::Cursor::new(&sequence),
+                Limits {
+                    window,
+                    ..Limits::default()
+                },
+            );
+
+            let (read, error) = drain(&mut reader);
+
+            assert!(error.is_none(), "window {window}: {error:?}");
+            assert_eq!(read, expected, "window {window}");
+            assert_eq!(reader.count(), 64);
+            assert_eq!(reader.offset(), sequence.len());
+        }
+    }
+
+    /// A length prefix is a claim, not an instruction. The reader checks it
+    /// against the ceiling before the window grows, so a record claiming a
+    /// terabyte costs a comparison — the attack surface the buffered path never
+    /// had, because there the bytes had to exist before they could be claimed.
+    #[test]
+    fn an_oversized_length_prefix_is_refused_before_it_is_allocated_for() {
+        // bytes(2^40): a header that arrives in nine bytes and asks for a
+        // terabyte.
+        let bytes: &[u8] = &[0x5b, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let mut reader = RecordReader::new(std::io::Cursor::new(bytes));
+        let error = reader.next_record().unwrap().unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                Error::RecordTooLarge {
+                    offset: 0,
+                    required: 1_099_511_627_785,
+                    limit: DEFAULT_MAX_RECORD,
+                }
+            ),
+            "{error:?}"
+        );
+
+        // The window is still the window: nothing was allocated on the strength
+        // of the prefix.
+        assert!(reader.next_record().is_none());
+    }
+
+    /// The ceiling is checked against the record, not against the window, and
+    /// it is exact at the boundary — one byte either side decides it.
+    #[test]
+    fn the_record_ceiling_is_exact() {
+        let record = encode(|e| {
+            e.bytes(&[0xab; 1000])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let len = record.len();
+        assert_eq!(len, 1003, "3-byte head over a 1000-byte body");
+
+        let mut writer = SeqWriter::new(Vec::new());
+        writer.write_record(&record).unwrap();
+        let sequence = writer.into_inner();
+
+        // Exactly at the ceiling, from a window a fraction of the size.
+        let mut reader = RecordReader::with_limits(
+            std::io::Cursor::new(&sequence),
+            Limits {
+                max_record: len,
+                window: 16,
+            },
+        );
+        assert_eq!(reader.next_record().unwrap().unwrap(), record.as_bytes());
+        assert!(reader.next_record().is_none());
+
+        // One byte under it, and the same record is refused — from the length
+        // prefix, before the window ever grew to 1000 bytes.
+        let mut reader = RecordReader::with_limits(
+            std::io::Cursor::new(&sequence),
+            Limits {
+                max_record: len - 1,
+                window: 16,
+            },
+        );
+        let error = reader.next_record().unwrap().unwrap_err();
+        assert!(
+            matches!(
+                error,
+                Error::RecordTooLarge {
+                    offset: 0,
+                    required: 1003,
+                    limit: 1002
+                }
+            ),
+            "{error:?}"
+        );
+
+        // And a record that fits is not refused for the company it keeps: a
+        // window large enough to hold two of them still yields them one at a
+        // time.
+        let mut writer = SeqWriter::new(Vec::new());
+        writer.write_record(&record).unwrap();
+        writer.write_record(&record).unwrap();
+        let pair = writer.into_inner();
+
+        let mut reader = RecordReader::with_limits(
+            std::io::Cursor::new(&pair),
+            Limits {
+                max_record: len,
+                window: 4096,
+            },
+        );
+        let (read, error) = drain(&mut reader);
+        assert!(error.is_none(), "{error:?}");
+        assert_eq!(read.len(), 2);
+    }
+
+    /// A sequence that ends mid-record is truncation, not an end: the reader
+    /// says so rather than quietly reporting one record fewer.
+    #[test]
+    fn a_sequence_that_ends_mid_record_is_reported() {
+        let record = good_record();
+        let mut bytes = record.as_bytes().to_vec();
+        bytes.extend_from_slice(&record.as_bytes()[..2]);
+
+        let mut reader = RecordReader::new(std::io::Cursor::new(&bytes));
+
+        assert_eq!(reader.next_record().unwrap().unwrap(), record.as_bytes());
+
+        let error = reader.next_record().unwrap().unwrap_err();
+        assert!(matches!(error, Error::TruncatedCbor { .. }), "{error:?}");
+
+        // Reported in the coordinates of the sequence, as the slice reader
+        // would have.
+        assert_eq!(
+            error.to_string(),
+            SeqReader::new(&bytes)
+                .nth(1)
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+        );
+    }
+
+    /// An empty sequence is an empty walk, not an error.
+    #[test]
+    fn an_empty_sequence_yields_nothing() {
+        let mut reader = RecordReader::new(std::io::Cursor::new(Vec::new()));
+
+        assert!(reader.next_record().is_none());
+        assert_eq!(reader.count(), 0);
+        assert_eq!(reader.offset(), 0);
     }
 
     #[test]

--- a/crates/stelae/src/layer.rs
+++ b/crates/stelae/src/layer.rs
@@ -1,0 +1,316 @@
+//! Reading a layer without holding it.
+//!
+//! [`crate::digest::read_blob`] decompresses a whole layer into a `Vec` and
+//! hands it over. That is the right shape for a fixture and the wrong one for
+//! the sizes a profile publishes: ADR-004's worked example gives a state shard
+//! of 402,653,184 uncompressed bytes, and one mainnet epoch of blocks runs to
+//! 0.5–1.5 GB. The write path never had this problem —
+//! [`crate::digest::LayerWriter`] hashes, compresses and hashes again in one
+//! pass with nothing buffered — so the asymmetry was one-sided and easy to
+//! miss.
+//!
+//! [`LayerReader`] closes it: one pass over the compressed blob, records
+//! yielded out of a bounded window, both digests established on the way past.
+//!
+//! ## Two bounds, and why one does not subsume the other
+//!
+//! - **Per record** ([`crate::frame::Limits`]) — a record is held whole, so its
+//!   size is checked against a ceiling before the window grows for it.
+//! - **Per layer** (the descriptor's `uncompressedSize`) — the record bound
+//!   says nothing about how *many* records arrive. A blob whose descriptor
+//!   claims 400 MB can stream 400 GB one small record at a time and never trip
+//!   a per-record ceiling. `read_blob` refuses that blob with
+//!   [`Error::DecompressedTooLarge`]; so does this, at the same threshold, for
+//!   the same reason.
+//!
+//! ## Records arrive before the layer is proven
+//!
+//! A layer's `diffId` covers its whole byte string, so it cannot be confirmed
+//! until the last record has gone past. Buying earlier verification would mean
+//! a second pass over those 400 MB. This crate keeps the single pass and states
+//! the consequence instead: **records are consumable before the layer is
+//! proven, and only [`LayerReader::finish`] proves it.** A consumer must not
+//! commit a checkpoint over records it has read until `finish` returns `Ok` —
+//! which is what the Dolos restore pipeline already does, recording *completed*
+//! layer diffIds in its progress file.
+
+use std::io::{self, Read};
+
+use sha2::{Digest as _, Sha256};
+
+use crate::{
+    digest::{Digest, LayerDigests, Tap},
+    frame::{LayerHeader, Limits, RecordReader},
+    inscription::LayerDescriptor,
+    profile::Profile,
+    Error,
+};
+
+/// The compressed-blob pipeline, read end to end:
+/// file → [`Tap`] (blob digest) → zstd → [`Meter`] (diffId, ceiling) → records.
+type Pipeline<R> = Meter<zstd::stream::read::Decoder<'static, io::BufReader<Tap<R>>>>;
+
+/// A layer being read from a compressed blob, one record at a time.
+///
+/// Every claim its descriptor makes is checked, and each one as early as the
+/// bytes allow: the header record's profile and kind on construction, the
+/// decompression ceiling as the stream advances, the identity digest, the
+/// uncompressed size and the record count in [`LayerReader::finish`].
+pub struct LayerReader<R: Read> {
+    records: RecordReader<Pipeline<R>>,
+    header: LayerHeader,
+    descriptor: LayerDescriptor,
+}
+
+impl<R: Read> LayerReader<R> {
+    /// Open `source` — the compressed bytes of the layer `descriptor`
+    /// describes — and read its header record.
+    ///
+    /// Fails immediately if the blob's own header names a different profile or
+    /// kind than the document pointing at it: a layer that disagrees with its
+    /// descriptor is refused before any of its content is handed out.
+    pub fn new(
+        source: R,
+        profile: &dyn Profile,
+        descriptor: &LayerDescriptor,
+        limits: Limits,
+    ) -> Result<Self, Error> {
+        let tap = Tap::new(source);
+        let decoder = zstd::stream::read::Decoder::new(tap)?;
+        let meter = Meter::new(decoder, descriptor.uncompressed_size);
+
+        let mut records = RecordReader::with_limits(meter, limits);
+
+        let header = match records.next_record() {
+            Some(Ok(record)) => LayerHeader::decode(record)?,
+            Some(Err(e)) => return Err(lift(e)),
+            None => {
+                return Err(Error::LayerMismatch {
+                    kind: descriptor.kind.clone(),
+                    reason: "layer is empty; every layer starts with a header record".to_owned(),
+                })
+            }
+        };
+
+        check_header(&header, profile, descriptor)?;
+
+        Ok(Self {
+            records,
+            header,
+            descriptor: descriptor.clone(),
+        })
+    }
+
+    /// The layer's header record, parsed and checked against the descriptor.
+    pub fn header(&self) -> &LayerHeader {
+        &self.header
+    }
+
+    /// The next of the profile's content records, header excluded.
+    ///
+    /// Borrowed out of the reader's window, which is why this is not an
+    /// [`Iterator`]: the borrow ends before the window is refilled. The record
+    /// is canonical — that much is proven — but the *layer* is not proven until
+    /// [`LayerReader::finish`] says so.
+    pub fn next_record(&mut self) -> Option<Result<&[u8], Error>> {
+        match self.records.next_record() {
+            Some(Err(e)) => Some(Err(lift(e))),
+            other => other,
+        }
+    }
+
+    /// Finish the read: drain whatever is left, then confirm the layer.
+    ///
+    /// This is the point at which the layer becomes trustworthy. It reads to
+    /// the end of the blob — the identity digest covers every byte, so there is
+    /// no confirming it early — and checks the record count, the uncompressed
+    /// size and the `diffId` against the descriptor. Anything a caller did with
+    /// records before this returned `Ok` was done on faith.
+    pub fn finish(mut self) -> Result<LayerDigests, Error> {
+        loop {
+            match self.records.next_record() {
+                Some(Ok(_)) => {}
+                Some(Err(e)) => return Err(lift(e)),
+                None => break,
+            }
+        }
+
+        // A caller that read a bad record and carried on anyway must not be
+        // handed a confirmation. Most such layers fail the digest check below
+        // — the bytes after the bad record were never read, so they never
+        // reached the hasher — but a layer whose *last* record is malformed
+        // hashes and sizes exactly as its descriptor claims. Refusing here is
+        // what makes "`finish` confirms the layer" true rather than usually
+        // true.
+        if self.records.failed() {
+            return Err(Error::LayerMismatch {
+                kind: self.descriptor.kind.clone(),
+                reason: "a record failed validation; the layer cannot be confirmed".to_owned(),
+            });
+        }
+
+        let count = self.records.count();
+        let meter = self.records.into_inner();
+
+        let (decoder, diff_id, uncompressed_size) = meter.finish();
+
+        // The decoder ran to EOF, so the tap has already seen the whole blob;
+        // the drain is a safety net for a decoder that stops at a frame
+        // boundary instead. `BufReader` may hold bytes it read ahead, and those
+        // passed through the tap on the way in, so nothing is missed by
+        // dropping it.
+        let mut tap = decoder.finish().into_inner();
+        io::copy(&mut tap, &mut io::sink())?;
+
+        let (_, blob_digest, compressed_size) = tap.finish();
+
+        let digests = LayerDigests {
+            diff_id,
+            blob_digest,
+            uncompressed_size,
+            compressed_size,
+        };
+
+        check_identity(&digests, &self.descriptor)?;
+        check_record_count(count, &self.descriptor)?;
+
+        Ok(digests)
+    }
+}
+
+/// The layer header a blob carries has to agree with the document that points
+/// at it, and with the profile the caller implements.
+///
+/// Shared by both read paths so a header cannot be acceptable to one and not
+/// the other.
+pub(crate) fn check_header(
+    header: &LayerHeader,
+    profile: &dyn Profile,
+    descriptor: &LayerDescriptor,
+) -> Result<(), Error> {
+    if header.profile != profile.name() {
+        return Err(Error::UnknownProfile {
+            found: header.profile.clone(),
+            expected: profile.name().to_owned(),
+        });
+    }
+
+    if header.kind != descriptor.kind {
+        return Err(Error::LayerMismatch {
+            kind: descriptor.kind.clone(),
+            reason: format!("header record names kind {:?}", header.kind),
+        });
+    }
+
+    Ok(())
+}
+
+/// The identity digest and the size the descriptor claims, against what the
+/// bytes turned out to be.
+pub(crate) fn check_identity(
+    digests: &LayerDigests,
+    descriptor: &LayerDescriptor,
+) -> Result<(), Error> {
+    if digests.diff_id != descriptor.diff_id {
+        return Err(Error::DigestMismatch {
+            subject: format!("layer {:?}", descriptor.kind),
+            expected: descriptor.diff_id.to_string(),
+            actual: digests.diff_id.to_string(),
+        });
+    }
+
+    if digests.uncompressed_size != descriptor.uncompressed_size {
+        return Err(Error::LayerMismatch {
+            kind: descriptor.kind.clone(),
+            reason: format!(
+                "descriptor claims {} uncompressed bytes, blob holds {}",
+                descriptor.uncompressed_size, digests.uncompressed_size
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// The record count, header record included.
+pub(crate) fn check_record_count(records: u64, descriptor: &LayerDescriptor) -> Result<(), Error> {
+    if records != descriptor.records {
+        return Err(Error::LayerMismatch {
+            kind: descriptor.kind.clone(),
+            reason: format!(
+                "descriptor claims {} records, blob holds {records}",
+                descriptor.records
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Recover a protocol error that a pipeline stage had to smuggle through
+/// [`io::Error`].
+///
+/// [`Read`] can only fail with an `io::Error`, but a decompression ceiling is a
+/// protocol verdict, not an I/O fault. [`Meter`] boxes the real error inside
+/// one; this takes it back out, so a caller matches on
+/// [`Error::DecompressedTooLarge`] whichever path produced it.
+fn lift(e: Error) -> Error {
+    match e {
+        Error::Io(io) if io.get_ref().is_some_and(|inner| inner.is::<Error>()) => *io
+            .into_inner()
+            .expect("checked by the guard")
+            .downcast::<Error>()
+            .expect("checked by the guard"),
+        other => other,
+    }
+}
+
+/// Hashes, counts and bounds the uncompressed side of a layer stream.
+///
+/// The ceiling is checked before the bytes are handed on, so it bounds what the
+/// reader above is ever asked to hold — the same discipline
+/// [`crate::digest::read_blob`] applies to its buffer.
+struct Meter<R> {
+    inner: R,
+    hasher: Sha256,
+    total: u64,
+    limit: u64,
+}
+
+impl<R> Meter<R> {
+    fn new(inner: R, limit: u64) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+            total: 0,
+            limit,
+        }
+    }
+
+    fn finish(self) -> (R, Digest, u64) {
+        (
+            self.inner,
+            Digest::from_bytes(self.hasher.finalize().into()),
+            self.total,
+        )
+    }
+}
+
+impl<R: Read> Read for Meter<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buf)?;
+
+        self.total += read as u64;
+
+        if self.total > self.limit {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                Error::DecompressedTooLarge { limit: self.limit },
+            ));
+        }
+
+        self.hasher.update(&buf[..read]);
+
+        Ok(read)
+    }
+}

--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -23,6 +23,8 @@
 //!   §4.2.1 profile) and the protocol-owned layer header record.
 //! - [`digest`] — the streaming sha256 + zstd pipeline that yields a layer's
 //!   identity digest (`diffId`) and its transport digest in one pass.
+//! - [`layer`] — reading a layer as a stream: records out of a bounded window,
+//!   both digests on the way past, confirmation at the end.
 //! - [`inscription`] — the inscription schema, its RFC 8785 canonicalization,
 //!   its digest, and the `history` attestation invariant.
 //! - [`profile`] — the [`Profile`] trait plus the protocol's media-type,
@@ -43,13 +45,15 @@ pub mod digest;
 pub mod dir;
 pub mod frame;
 pub mod inscription;
+pub mod layer;
 pub mod profile;
 
 pub use digest::{Digest, LayerDigests, LayerWriter};
-pub use frame::{CanonicalCbor, LayerHeader, SeqReader, SeqWriter};
+pub use frame::{CanonicalCbor, LayerHeader, Limits, Measure, RecordReader, SeqReader, SeqWriter};
 pub use inscription::{
     canonical_json, Compression, HistoryEntry, Inscription, LayerDescriptor, ProfileRef,
 };
+pub use layer::LayerReader;
 pub use profile::{MediaType, Profile};
 
 /// Artifact type of a stele manifest. Generic tooling discovers stelae of every
@@ -116,6 +120,19 @@ pub enum Error {
 
     #[error("cbor nesting deeper than the protocol limit of {limit}")]
     CborTooDeep { limit: usize },
+
+    /// A record whose length prefixes claim more than the ceiling its reader
+    /// was given. Raised from the prefix, before anything is allocated to hold
+    /// the record, so a corrupt or hostile length costs a comparison.
+    #[error(
+        "record at offset {offset} needs at least {required} bytes, past the \
+         {limit}-byte ceiling set for a single record"
+    )]
+    RecordTooLarge {
+        offset: usize,
+        required: u64,
+        limit: usize,
+    },
 
     #[error("expected exactly one cbor data item, found {trailing} trailing byte(s)")]
     TrailingCbor { trailing: usize },

--- a/crates/stelae/tests/memory.rs
+++ b/crates/stelae/tests/memory.rs
@@ -1,0 +1,241 @@
+//! Peak memory during a layer read is a property, not an aspiration.
+//!
+//! The protocol's read path used to hold a whole uncompressed layer: fine for a
+//! fixture, fatal at the sizes a profile publishes (ADR-004's worked example
+//! gives a state shard of 402,653,184 bytes). These tests are what stops that
+//! from coming back. They instrument the global allocator with `stats_alloc` —
+//! the idiom the root package's `tests/memory.rs` uses for store iteration —
+//! and read a layer far larger than the reader's window while watching what the
+//! process asks for.
+//!
+//! `bytes_allocated` is cumulative over the region, which is a *stronger*
+//! statement than peak: a run that never allocates more than N bytes in total
+//! certainly never holds more than N at once. It also means a reader that
+//! allocated and freed one record per iteration would be caught here, not
+//! excused by its tidiness.
+
+use std::alloc::System;
+
+use serde_json::json;
+use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
+
+use stelae::{
+    dir::{LayerSpec, SteleDir},
+    frame::{encode, CanonicalCbor, Limits, RecordReader, SeqWriter},
+    Compression, Error, Inscription, Profile,
+};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const PROFILE_NAME: &str = "dev.example.bulk";
+const COMPRESSION_LEVEL: i32 = 3;
+
+/// Records of roughly a kilobyte, which is the order of a Dolos `indexes` or
+/// `state` record. Blocks are larger, but the point of the bound is that the
+/// layer's size does not enter it.
+const RECORD_BODY: usize = 1000;
+
+/// ~33 MB of layer against a 64 KiB window: 500 windows, so a reader that
+/// buffered even a percent of the layer would show up.
+const RECORDS: u64 = 32 * 1024;
+
+/// How many windows the layer must span for these tests to be worth running.
+const MINIMUM_WINDOWS: usize = 400;
+
+/// What the streaming path is allowed to allocate, cumulatively, to read all of
+/// it. Two orders of magnitude below the layer, and it does not move when the
+/// layer does — which is the property under test.
+///
+/// Above the 64 KiB window because the zstd bindings buffer on either side of
+/// the decoder. What this does *not* cover is libzstd's own context: that is
+/// `malloc`ed inside the C library and never reaches a Rust global allocator,
+/// so `stats_alloc` cannot see it. It is bounded by the frame's window size —
+/// a property of the compression parameters, not of the layer — so it does not
+/// weaken the claim, but the number below is the Rust side only and saying so
+/// is cheaper than someone rediscovering it.
+const STREAMING_BUDGET: usize = 1024 * 1024;
+
+struct BulkProfile;
+
+impl Profile for BulkProfile {
+    fn name(&self) -> &str {
+        PROFILE_NAME
+    }
+
+    fn version(&self) -> u64 {
+        1
+    }
+
+    fn kinds(&self) -> &[&str] {
+        &["bulk"]
+    }
+
+    fn layer_media_type(&self, kind: &str) -> Result<String, Error> {
+        Ok(format!("application/vnd.example.stele.{kind}.v1+zstd"))
+    }
+
+    fn tag_for_sequence(&self, sequence: u64) -> Result<String, Error> {
+        Ok(format!("bulk-{sequence}"))
+    }
+}
+
+fn bulk_record(i: u64) -> CanonicalCbor {
+    // Not a constant body: identical records would compress to nothing and let
+    // a decoder cheat its way through the test.
+    let body: Vec<u8> = (0..RECORD_BODY).map(|b| (b as u64 ^ i) as u8).collect();
+
+    encode(|e| {
+        e.array(2)?.u64(i)?.bytes(&body)?;
+        Ok(())
+    })
+    .unwrap()
+}
+
+fn scope() -> CanonicalCbor {
+    encode(|e| {
+        e.u64(0)?;
+        Ok(())
+    })
+    .unwrap()
+}
+
+/// The raw uncompressed sequence, as it appears inside a layer blob.
+fn sequence() -> Vec<u8> {
+    let mut writer = SeqWriter::new(Vec::new());
+
+    for i in 0..RECORDS {
+        writer.write_record(&bulk_record(i)).unwrap();
+    }
+
+    writer.into_inner()
+}
+
+/// The framing reader on its own: no compression, no digests, nothing but the
+/// refill loop. The bound here is tight enough to name — one window, plus the
+/// small change of the walk.
+#[test]
+fn framing_a_large_sequence_costs_one_window() {
+    let sequence = sequence();
+
+    let window = 64 * 1024;
+    let budget = 2 * window;
+
+    assert!(
+        sequence.len() > MINIMUM_WINDOWS * window,
+        "the layer has to dwarf the window for this to prove anything"
+    );
+
+    let region = Region::new(GLOBAL);
+
+    let mut reader = RecordReader::with_limits(
+        std::io::Cursor::new(sequence.as_slice()),
+        Limits {
+            window,
+            ..Limits::default()
+        },
+    );
+
+    let mut count = 0u64;
+    while let Some(record) = reader.next_record() {
+        // Touch the record so nothing about this loop is optimized away, but
+        // never keep it: holding records is the caller's choice to make, and
+        // this caller declines.
+        assert!(!record.unwrap().is_empty());
+        count += 1;
+    }
+
+    let allocated = region.change().bytes_allocated;
+
+    assert_eq!(count, RECORDS);
+    assert!(
+        allocated < budget,
+        "framing {} bytes should cost one {window}-byte window, not {allocated} bytes",
+        sequence.len(),
+    );
+}
+
+/// The whole path, as a restore would use it: a compressed blob on disk,
+/// verified against its descriptor, records walked without ever holding the
+/// layer.
+#[test]
+fn streaming_a_layer_does_not_scale_with_its_size() {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let records: Vec<CanonicalCbor> = (0..RECORDS).map(bulk_record).collect();
+
+    let written = stele
+        .write_layer(
+            &BulkProfile,
+            &LayerSpec::new("bulk", scope(), json!({})),
+            COMPRESSION_LEVEL,
+            &records,
+        )
+        .unwrap();
+
+    let mut inscription = Inscription::new(
+        &BulkProfile,
+        0,
+        json!({}),
+        json!({}),
+        Compression {
+            algo: "zstd".to_owned(),
+            level: COMPRESSION_LEVEL as i64,
+        },
+    );
+    inscription.layers = vec![written.descriptor.clone()];
+    stele.write_inscription(&inscription).unwrap();
+
+    let descriptor = &inscription.layers[0];
+    assert!(
+        descriptor.uncompressed_size > (MINIMUM_WINDOWS * stelae::frame::DEFAULT_WINDOW) as u64,
+        "the layer has to dwarf the window for this to prove anything"
+    );
+
+    // Everything before the region is setup: building the index is a scan of
+    // the stele, and what it costs is not what is under test.
+    drop(records);
+    let index = stele.blob_index().unwrap();
+
+    let region = Region::new(GLOBAL);
+
+    let mut reader = stele
+        .stream_layer(&index, &BulkProfile, descriptor, Limits::default())
+        .unwrap();
+
+    let mut count = 1u64; // the header record, already consumed
+    while let Some(record) = reader.next_record() {
+        assert!(!record.unwrap().is_empty());
+        count += 1;
+    }
+
+    let digests = reader.finish().unwrap();
+
+    let allocated = region.change().bytes_allocated;
+
+    assert_eq!(count, descriptor.records);
+    assert_eq!(digests.diff_id, descriptor.diff_id);
+    assert!(
+        allocated < STREAMING_BUDGET,
+        "streaming a {}-byte layer allocated {allocated} bytes; \
+         the budget is {STREAMING_BUDGET}",
+        descriptor.uncompressed_size,
+    );
+
+    // The control. Without it this test proves only that some number is small:
+    // the buffered path reads the same blob and, by design, pays the layer's
+    // size for it. If that ever stops being true the budget above has stopped
+    // measuring the difference between the two paths.
+    let region = Region::new(GLOBAL);
+    let layer = stele.read_layer(&index, &BulkProfile, descriptor).unwrap();
+    let buffered = region.change().bytes_allocated;
+
+    assert_eq!(layer.as_bytes().len() as u64, descriptor.uncompressed_size);
+    assert!(
+        buffered as u64 > descriptor.uncompressed_size,
+        "the buffered path allocated {buffered} bytes for a {}-byte layer; \
+         it is supposed to hold the whole thing",
+        descriptor.uncompressed_size,
+    );
+}

--- a/crates/stelae/tests/memory.rs
+++ b/crates/stelae/tests/memory.rs
@@ -13,8 +13,20 @@
 //! certainly never holds more than N at once. It also means a reader that
 //! allocated and freed one record per iteration would be caught here, not
 //! excused by its tidiness.
+//!
+//! ## Why these tests take a lock
+//!
+//! A `Region` reads a *process-wide* counter, and the test harness runs tests
+//! in parallel by default — so a second test's setup, which is tens of
+//! megabytes here, lands inside the first test's measurement and swamps a
+//! 64 KiB budget. It is a race, so it passes on the machine you tried it on and
+//! fails on the one you did not (this one surfaced on Windows CI). Every test
+//! in this file therefore holds [`SERIAL`] for its whole body, setup included.
 
-use std::alloc::System;
+use std::{
+    alloc::System,
+    sync::{Mutex, MutexGuard},
+};
 
 use serde_json::json;
 use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
@@ -27,6 +39,19 @@ use stelae::{
 
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+/// Held by every test in this file, so that only one is allocating at a time.
+/// A new test that forgets to take it will not fail here — it will make some
+/// *other* test flaky, which is the failure worth spending a comment on.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn exclusive() -> MutexGuard<'static, ()> {
+    // A poisoned lock means another test in this file panicked. That is its
+    // failure to report; this one still wants an uncontended allocator.
+    SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 const PROFILE_NAME: &str = "dev.example.bulk";
 const COMPRESSION_LEVEL: i32 = 3;
@@ -116,6 +141,8 @@ fn sequence() -> Vec<u8> {
 /// small change of the walk.
 #[test]
 fn framing_a_large_sequence_costs_one_window() {
+    let _serial = exclusive();
+
     let sequence = sequence();
 
     let window = 64 * 1024;
@@ -160,6 +187,8 @@ fn framing_a_large_sequence_costs_one_window() {
 /// layer.
 #[test]
 fn streaming_a_layer_does_not_scale_with_its_size() {
+    let _serial = exclusive();
+
     let temp = tempfile::tempdir().unwrap();
     let stele = SteleDir::create(temp.path()).unwrap();
 

--- a/crates/stelae/tests/toy_profile.rs
+++ b/crates/stelae/tests/toy_profile.rs
@@ -23,8 +23,8 @@ use serde_json::json;
 
 use stelae::{
     digest::read_blob,
-    dir::{LayerSpec, SteleDir},
-    frame::{encode, CanonicalCbor},
+    dir::{BlobIndex, LayerSpec, SteleDir},
+    frame::{encode, CanonicalCbor, Limits},
     Compression, Error, Inscription, LayerDescriptor, LayerWriter, Profile,
 };
 
@@ -131,6 +131,68 @@ fn index_scopes() -> (CanonicalCbor, serde_json::Value) {
     .unwrap();
 
     (header, json!({"chapter": 3}))
+}
+
+/// Read a layer both ways and insist the two paths agree.
+///
+/// Everything a consumer can observe is compared: the header, the records, the
+/// digests, and — where they fail — the failure. The two readers exist because
+/// one of them can afford to hold a layer and the other cannot; nothing else
+/// about them is allowed to differ, because a layer that restores through one
+/// and not the other is a determinism bug in the format itself.
+fn read_both_ways(
+    stele: &SteleDir,
+    index: &BlobIndex,
+    descriptor: &LayerDescriptor,
+) -> Result<Vec<Vec<u8>>, Error> {
+    let buffered = stele.read_layer(index, &ToyProfile, descriptor);
+
+    // A window far below one record, so the streaming path is exercised at its
+    // refill boundaries rather than swallowing the layer in one read.
+    let limits = Limits {
+        window: 8,
+        ..Limits::default()
+    };
+
+    let streamed = (|| {
+        let mut reader = stele.stream_layer(index, &ToyProfile, descriptor, limits)?;
+
+        let mut records = Vec::new();
+        while let Some(record) = reader.next_record() {
+            records.push(record?.to_vec());
+        }
+
+        let digests = reader.finish()?;
+
+        Ok::<_, Error>((records, digests))
+    })();
+
+    match (buffered, streamed) {
+        (Ok(layer), Ok((records, digests))) => {
+            assert_eq!(layer.digests(), &digests, "digests");
+
+            let buffered_records: Vec<Vec<u8>> = layer
+                .records()
+                .map(|r| r.unwrap().to_vec())
+                .collect::<Vec<_>>();
+
+            assert_eq!(buffered_records, records, "records");
+
+            Ok(records)
+        }
+        (Err(buffered), Err(streamed)) => {
+            assert_eq!(
+                std::mem::discriminant(&buffered),
+                std::mem::discriminant(&streamed),
+                "both paths must refuse for the same reason: \
+                 buffered {buffered:?}, streaming {streamed:?}"
+            );
+
+            Err(buffered)
+        }
+        (Ok(_), Err(streamed)) => panic!("the streaming path alone refused it: {streamed:?}"),
+        (Err(buffered), Ok(_)) => panic!("the buffered path alone refused it: {buffered:?}"),
+    }
 }
 
 /// Write a complete stele of the toy profile into `root`.
@@ -248,6 +310,88 @@ fn writes_a_stele_and_reads_it_back() {
         .unwrap();
     assert_eq!(index_layer.header().kind, "index");
     assert_eq!(index_layer.records().count(), NOTES.len());
+
+    // And both layers read back identically without ever being held.
+    for descriptor in &read.layers {
+        read_both_ways(&stele, &index, descriptor).unwrap();
+    }
+}
+
+/// The streaming reader is the one a restore uses, so the profile's records
+/// have to survive it unchanged — through a window smaller than any of them,
+/// which is the case that has to work for a 400 MB layer to be readable at all.
+#[test]
+fn a_layer_streams_back_record_for_record() {
+    let temp = tempfile::tempdir().unwrap();
+    let (inscription, _) = write_stele(temp.path());
+
+    let stele = SteleDir::open(temp.path()).unwrap();
+    let index = stele.blob_index().unwrap();
+
+    let notes_descriptor = inscription.layers_of_kind("notes").next().unwrap();
+
+    let mut reader = stele
+        .stream_layer(
+            &index,
+            &ToyProfile,
+            notes_descriptor,
+            Limits {
+                window: 4,
+                ..Limits::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(reader.header().profile, PROFILE_NAME);
+    assert_eq!(reader.header().kind, "notes");
+    assert_eq!(reader.header().scope, notes_scopes().0);
+
+    let mut notes = NOTES.iter();
+    while let Some(record) = reader.next_record() {
+        let expected = notes.next().expect("no more records were written");
+        assert_eq!(record.unwrap(), note_record(expected).as_bytes());
+    }
+    assert!(notes.next().is_none(), "every record came back");
+
+    // Only now is the layer proven. Everything above was read on the strength
+    // of the descriptor, which is the contract this reader makes explicit.
+    let digests = reader.finish().unwrap();
+    assert_eq!(digests.diff_id, notes_descriptor.diff_id);
+    assert_eq!(
+        digests.uncompressed_size,
+        notes_descriptor.uncompressed_size
+    );
+}
+
+/// `finish` is the confirmation, and it does not depend on the caller having
+/// been diligent: a reader dropped after one record proves nothing, and a
+/// reader finished without consuming anything still reads the whole layer,
+/// because the identity digest covers every byte either way.
+#[test]
+fn finish_confirms_the_layer_whether_or_not_the_records_were_read() {
+    let temp = tempfile::tempdir().unwrap();
+    let (inscription, _) = write_stele(temp.path());
+
+    let stele = SteleDir::open(temp.path()).unwrap();
+    let index = stele.blob_index().unwrap();
+    let descriptor = &inscription.layers[0];
+
+    // Not a single content record consumed.
+    let untouched = stele
+        .stream_layer(&index, &ToyProfile, descriptor, Limits::default())
+        .unwrap()
+        .finish()
+        .unwrap();
+
+    assert_eq!(untouched.diff_id, descriptor.diff_id);
+
+    // One record consumed, then finished. Same verdict, same digests.
+    let mut reader = stele
+        .stream_layer(&index, &ToyProfile, descriptor, Limits::default())
+        .unwrap();
+    reader.next_record().unwrap().unwrap();
+
+    assert_eq!(reader.finish().unwrap(), untouched);
 }
 
 /// Done criterion 2, and the property the whole protocol rests on: the same
@@ -507,7 +651,7 @@ fn tampering_is_caught_on_read() {
 }
 
 /// A descriptor that lies about its layer is refused even when the blob itself
-/// is intact.
+/// is intact — and refused identically whether the layer is held or streamed.
 #[test]
 fn a_descriptor_that_disagrees_with_its_layer_is_refused() {
     let temp = tempfile::tempdir().unwrap();
@@ -518,38 +662,42 @@ fn a_descriptor_that_disagrees_with_its_layer_is_refused() {
 
     let mut wrong_size = inscription.layers[0].clone();
     wrong_size.uncompressed_size += 1;
-    let err = stele
-        .read_layer(&index, &ToyProfile, &wrong_size)
-        .unwrap_err();
+    let err = read_both_ways(&stele, &index, &wrong_size).unwrap_err();
     assert!(matches!(err, Error::LayerMismatch { .. }), "{err:?}");
 
     let mut wrong_count = inscription.layers[0].clone();
     wrong_count.records += 1;
-    let err = stele
-        .read_layer(&index, &ToyProfile, &wrong_count)
-        .unwrap_err();
+    let err = read_both_ways(&stele, &index, &wrong_count).unwrap_err();
     assert!(matches!(err, Error::LayerMismatch { .. }), "{err:?}");
 
     let mut wrong_kind = inscription.layers[0].clone();
     wrong_kind.kind = "index".to_owned();
-    let err = stele
-        .read_layer(&index, &ToyProfile, &wrong_kind)
-        .unwrap_err();
+    let err = read_both_ways(&stele, &index, &wrong_kind).unwrap_err();
     assert!(matches!(err, Error::LayerMismatch { .. }), "{err:?}");
 
     let mut absent = inscription.layers[0].clone();
     absent.diff_id = stelae::Digest::from_bytes([0xab; 32]);
-    let err = stele.read_layer(&index, &ToyProfile, &absent).unwrap_err();
+    let err = read_both_ways(&stele, &index, &absent).unwrap_err();
     assert!(matches!(err, Error::LayerNotFound { .. }), "{err:?}");
+
+    // A descriptor claiming *less* than the layer holds is refused during
+    // decompression rather than after it, on both paths: the claim is the
+    // ceiling, and a blob that expands past its own descriptor is not read to
+    // the end just to be told so.
+    let mut too_small = inscription.layers[0].clone();
+    too_small.uncompressed_size -= 1;
+    let err = read_both_ways(&stele, &index, &too_small).unwrap_err();
+    assert!(matches!(err, Error::DecompressedTooLarge { .. }), "{err:?}");
 }
 
 /// A malformed record is not a record.
 ///
-/// `SeqReader` reports the first bad one and then ends, so *counting* the
-/// iterator's items tallies the failure itself as a record and discards the
-/// error with it. A publisher who sets `records` to match that inflated number
-/// would hand back a corrupt layer as `Ok`, in the one place whose documented
-/// job is to check everything the descriptor claims.
+/// Both readers report the first bad one and then end, so *counting* their
+/// items tallies the failure itself as a record and discards the error with it.
+/// A publisher who sets `records` to match that inflated number would hand back
+/// a corrupt layer as `Ok`, in the one place whose documented job is to check
+/// everything the descriptor claims. This is the guarantee a refill loop is
+/// most likely to lose, which is why it is checked on both paths.
 #[test]
 fn a_malformed_record_is_reported_not_counted() {
     let temp = tempfile::tempdir().unwrap();
@@ -589,9 +737,28 @@ fn a_malformed_record_is_reported_not_counted() {
     };
 
     let index = stele.blob_index().unwrap();
-    let err = stele.read_layer(&index, &ToyProfile, &corrupt).unwrap_err();
+    let err = read_both_ways(&stele, &index, &corrupt).unwrap_err();
 
     assert!(matches!(err, Error::TruncatedCbor { .. }), "{err:?}");
+
+    // And a caller that ignores the bad record does not get a confirmation out
+    // of `finish` instead. This layer is the awkward case: the malformed byte
+    // is the *last* one, so every byte still reached the hasher and the digest
+    // and size the descriptor claims both hold. Only the record count and the
+    // reader's own memory of having failed stand between a corrupt layer and an
+    // `Ok`.
+    let mut reader = stele
+        .stream_layer(&index, &ToyProfile, &corrupt, Limits::default())
+        .unwrap();
+
+    while let Some(record) = reader.next_record() {
+        if record.is_err() {
+            break;
+        }
+    }
+
+    let err = reader.finish().unwrap_err();
+    assert!(matches!(err, Error::LayerMismatch { .. }), "{err:?}");
 }
 
 /// A descriptor's media type has to be the one *this* profile defines for that


### PR DESCRIPTION
Implements the `dolos-stelae-streaming-layers` plan (automation class **core**, so this lands only through review).

Base: `main` at `174a5de6`, the PR #1147 merge.

## The gap this closes

PR #1147 left the read path holding a whole uncompressed layer while the write path held nothing. `LayerWriter` hashes, compresses and hashes again in a single pass; `SeqReader` walks a contiguous `&[u8]`, and `SteleDir::read_layer` obtained that slice by decompressing the blob into a `Vec<u8>`. That is correct for a kilobyte fixture and does not survive the sizes the Dolos profile will publish — ADR-004's worked example gives a state shard `uncompressedSize` of 402,653,184 bytes, there are 16 of them, and one mainnet epoch of `blocks` is 0.5–1.5 GB.

`dolos-stelae-snapshots` Phase 2 *assumes* a streaming reader in its restore pipeline, and no phase assigned it to anyone. This is that reader.

## What changed

**`crates/stelae/src/frame.rs`**

- `measure_item` — a second exit from the existing scanner. It tolerates an item that runs off the end and reports `Measure::Incomplete { required }`: a lower bound on the whole item, derived from the length prefixes the encoder has already committed to (a string header's claimed body, plus one byte for every element of an enclosing array or map not yet reached). Always greater than what is in hand, so a refill loop cannot stall.
  - Why not derive it at the call site from `TruncatedCbor { offset, expected }`: that error reports a *local* need — `expected: 1` from a head byte, that chunk's `n` from a `take(n)`, `usize::MAX` when a prefix exceeds `usize`. Reconstructing a total from those puts length arithmetic in a second place, which is the "two readers drift" risk arriving early.
  - A profile violation is still an error, never an `Incomplete`: no quantity of further bytes rehabilitates a float or a tag.
- `RecordReader<R: Read>` — refill-and-scan over a bounded window. Keeps both slice-reader guarantees verbatim (every record validated before it is yielded; no resynchronization after a bad one) and adds the one a stream needs: `Limits::max_record` is checked against `required` *before* the window grows.
- `Limits { max_record, window }`, `DEFAULT_MAX_RECORD` (16 MiB — two orders of magnitude above the largest record any profile plans to write) and `DEFAULT_WINDOW` (64 KiB).
- `Error::RecordTooLarge { offset, required, limit }`.
- `at_sequence_offset` — the offset remapping both readers use, so a position reported by either is a position in the layer.

`SeqReader` is unchanged: one scanner, two entry points. The rejection corpus below is what keeps them honest.

**`crates/stelae/src/layer.rs`** (new)

- `LayerReader<R: Read>` — file → `Tap` (blob digest) → zstd → `Meter` (diffId, uncompressed count, ceiling) → `RecordReader`. One pass, nothing buffered beyond the window.
- **The layer bound, which the record bound does not subsume.** A blob whose descriptor claims 400 MB can stream 400 GB one small record at a time and never trip a per-record ceiling. `Meter` checks bytes consumed against the descriptor's `uncompressedSize` as it goes and raises the same `Error::DecompressedTooLarge` that `digest::read_blob` does — both paths refuse the same blob for the same reason.
- **`finish()` confirms the layer.** A `diffId` covers the whole byte string, so it cannot be confirmed until the last record has gone past; rather than buy early verification with a second pass over 400 MB, the contract is explicit: records are consumable before the layer is proven, and a consumer must not commit a checkpoint until `finish()` returns `Ok`. It drains, then checks the identity digest, the uncompressed size and the record count — and refuses outright if a record failed validation, which is the case a caller could otherwise swallow when the malformed byte is the last one.
- `check_header`, `check_identity`, `check_record_count` — the descriptor checks, one implementation, called from both read paths.

**`crates/stelae/src/dir.rs`**

- `SteleDir::stream_layer(...)` beside `read_layer`, same verification spread across the read. `read_layer` keeps buffering (the plan left that to the implementer) and its doc now says what that costs and where to go instead.

**`crates/stelae/src/digest.rs`** — `Tap` is `pub(crate)` so the streaming path computes the blob digest from the same tap rather than a second similar-looking loop.

## Done criterion

| # | Criterion | Met |
|---|---|---|
| 1 | Record reader over `io::Read`, canonical form per record, max record size enforced against the length prefix before allocating, never more than one record plus a fixed window | ✅ `frame::RecordReader` |
| 2 | Peak-allocation test over a layer substantially larger than the buffer, `stats_alloc` + `Region` idiom, own dev-dependency; rejection test for an oversized length prefix | ✅ `crates/stelae/tests/memory.rs`; `an_oversized_length_prefix_is_refused_before_it_is_allocated_for` |
| 3 | Every slice-reader guarantee holds for the streaming one, proven by running the rejection cases through both — including `a_malformed_record_is_reported_not_counted` and the error-propagating record count in `dir.rs` | ✅ `both_readers_refuse_the_same_bytes_the_same_way` over a 23-case corpus × 3 window sizes; `read_both_ways` in `toy_profile.rs` |
| 4 | `cargo test -p stelae`, clippy, fmt, deny | ✅ see below |
| 5 | `cargo tree -p stelae -e normal` free of `dolos-*` | ✅ see below |

### Measured

```
FRAMING   allocated=65,536     budget=131,072    layer=32,997,096   (one 64 KiB window)
STREAMING allocated=197,159    budget=1,048,576  layer=32,997,121
BUFFERED  allocated=33,686,009                   (the control: read_blob pays the layer's size)
```

`bytes_allocated` is cumulative over the region, which is a stronger statement than peak. It is the Rust side only — libzstd `malloc`s its context in C, where no Rust global allocator sees it; that cost is bounded by the frame's window size (a compression parameter, not the layer), and the test says so rather than leaving it to be rediscovered.

### Verification

```
$ cargo test -p stelae
   62 passed (lib) · 2 passed (memory) · 5 passed (rfc8785) · 14 passed (toy_profile) · 3 passed (doc)
   0 failed

$ cargo clippy --all-targets --all-features -- -D warnings
   Finished — no warnings

$ cargo +nightly fmt --all -- --check
   clean

$ cargo deny check advisories
   advisories ok

$ cargo tree -p stelae -e normal | grep -cE '^dolos(-|$)'
   0
```

Also `cargo test --workspace --all-targets` → exit 0, and `cargo doc -p stelae --no-deps` → no warnings.

`cargo deny` emits three pre-existing yanked-crate warnings (`fjall`, `lsm-tree`, `spin`) and still exits 0. None is a `stelae` dependency; reported as a finding rather than worked around, same as in #1147.

### One fix on top, from CI

The first CI run failed on Windows only, in my own test: `stats_alloc`'s `Region` reads a *process-wide* counter and the harness runs tests in parallel, so the streaming test's setup — tens of megabytes of records — landed inside the framing test's measurement and blew its 64 KiB budget. A race, which is why macOS and Linux passed. `da82e877` serializes the file's tests on one lock held for the whole body, setup included.

CI on `da82e877`: fmt, clippy, deny, **Test (windows-latest)** and **Test (macos-14)** all green.

### One pre-existing failure, reported not worked around

**Test (ubuntu-latest)** fails, in the *root* package's `tests/memory.rs`:

```
---- test_fjall_shard_range_iter stdout ----
shard-range iter_entities full iteration should stay O(1).
Allocated 12531976 bytes during iteration but threshold is 10485760 bytes.
```

Not this change: `dolos` does not depend on `stelae` (`cargo tree -p dolos -e normal,dev | grep -c stelae` → 0), so that test binary does not even link this crate. The same test failed on `main` at `c7507799` on 2026-07-30 ([run 30582043059](https://github.com/txpipe/dolos/actions/runs/30582043059), Windows that time, same panic site).

It is the *same bug* this PR just fixed in its own test file, one package over: four `Region`s and four 50,000-entity setups in one binary, sharing a process-wide counter, no serialization. Whichever test the scheduler overlaps pays for its neighbour's allocations. Left alone here — fixing another package's flaky test is not this plan's scope, and raising the threshold would be the wrong repair anyway. Filed as a follow-up draft plan with the diagnosis, so whoever picks it up does not have to re-derive it.

Note on criterion 5: this stays a **manual** check. #1147 added a `stelae-boundary` CI job and dropped it before merge, so nothing enforces the boundary today; reinstating it is out of this plan's scope. If it is ever reinstated its pattern must be `^dolos(-|$)` — the root package is named `dolos`, and `^dolos-` misses it. Filed as a follow-up draft plan.

## Out of scope, deliberately

`oci.rs` and network transport, the restore pipeline, the progress file, `crates/snapshot`. This delivers the capability Phases 2 and 3 of `dolos-stelae-snapshots` consume; it does not consume it. `adrs/004_stelae_snapshots.md` is untouched — the wire format is unchanged, and its code-layout listing is forward-looking rather than a file manifest.

## For the reviewer

- **The 16 MiB record ceiling is a judgment call, not a measurement.** It comes from ADR-004 and the parent plan (largest Dolos record ≈ one block, order 100 KB), not from a synced node. If a real record ever exceeds it, that is a fact about the Dolos profile and belongs in its plan — the limit is configurable per reader precisely so nobody has to quietly raise the default.
- `Meter` returns `Error::DecompressedTooLarge` boxed inside an `io::Error` and `layer::lift` takes it back out, because `Read` can only fail with an `io::Error` but a decompression ceiling is a protocol verdict.

No escalations were opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

