### PR TITLE
feat(store): add the export/restore seam Stelae index layers need

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serial_test",
  "stats_alloc",
  "tar",
  "tempfile",
@@ -5056,6 +5057,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ hex = { workspace = true }
 pallas = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 stats_alloc = "0.1"
+serial_test = "3"
 dolos-redb3 = { path = "crates/redb3" }
 
 [build-dependencies]

--- a/adrs/004_stelae_snapshots.md
+++ b/adrs/004_stelae_snapshots.md
@@ -145,10 +145,12 @@ Content records per kind (Dolos profile):
 | Kind | Record | Order | Restore write path |
 |---|---|---|---|
 | `blocks` (per epoch) | `[slot, hash: bytes(32), body: bytes]`, body = raw wire CBOR verbatim | ascending slot, stream order for same-slot (Byron EBB) | `ArchiveWriter::apply` |
-| `indexes` (per epoch) | tags: `[0, dimension: tstr, key_hash: bytes(8), slot]` with `key_hash = xxh3_64(key)` BE; exact: `[1, kind: tstr, key: bytes, slot]` for block-hash/block-number/tx | sorted, deduped | new `IndexWriter::append_prehashed` |
+| `indexes` (per epoch) | tags: `[0, dimension: tstr, key_hash: bytes(8), slot]` with `key_hash = xxh3_64(key)` BE — except dimension `metadata`, see below; exact: `[1, kind: tstr, key: bytes, slot]` for block-hash/block-number/tx | sorted, deduped | new `IndexWriter::append_prehashed` |
 | `logs` (per epoch) | `[ns: tstr, log_key: bytes(40), value: bytes]`, value = stored EntityValue verbatim | `(ns, log_key)` | `ArchiveWriter::write_log` |
 | `state` (tip, 16 shards, `scope.shard` = 0..15) | `[ns: tstr, key: bytes, value: bytes]` | `(ns, key)`; shard = first nibble of `key[0]` | dispatch on ns: `utxos` → chunked `StateWriter::apply_utxoset`, else `write_entity` |
 | `digests` (tip, optional) | `[immutable_number, chunk: bytes(32), primary: bytes(32), secondary: bytes(32)]`, each sha256 over the raw file bytes | ascending `immutable_number` | none — verification metadata, not written to stores |
+
+One exception to the tag hashing rule is normative for `indexes` v1: records in dimension `metadata` carry the logical u64 metadata label **verbatim** (big-endian) in `key_hash`, never hashed. The index stores keep metadata labels as raw labels rather than hashes, and the layer ships the stored form — that is the whole point of the pre-hashed design. `parameters.indexKeyHash` therefore describes every dimension *except* `metadata`. A publisher that hashes metadata labels produces structurally valid records that restore cleanly but can never be matched by a metadata query; conformance tooling must check this dimension specifically (#1149 tracks whether a future media-type version unifies the rule).
 
 State namespaces: the 14 entity namespaces from `dolos_cardano::model::build_schema()` (key = 32-byte `EntityKey` verbatim, value = stored minicbor verbatim) plus `utxos` (key = `tx_hash(32) ‖ output_index(4, BE)`, value = CBOR `[era: uint, body: bytes]`). The chain point lives in the inscription's `position`, not in a layer. Live-UTxO index dimensions (`utxo::*`) are not shipped; they are rebuilt at restore via `index_delta_from_utxo_delta`.
 

--- a/crates/cardano/src/indexes/dimensions.rs
+++ b/crates/cardano/src/indexes/dimensions.rs
@@ -68,4 +68,40 @@ pub mod archive {
 
     /// Transaction metadata labels
     pub const METADATA: TagDimension = "metadata";
+
+    /// Every archive dimension.
+    ///
+    /// Index stores keep a hash of the dimension name rather than the name, so
+    /// the set is not discoverable from disk: any bulk traversal of archive
+    /// tags (`IndexStore::iter_archive_tags`) has to be driven by this list.
+    /// A dimension added above and not here is a dimension that silently stops
+    /// being exported.
+    pub const ALL: [TagDimension; 12] = [
+        ADDRESS,
+        PAYMENT,
+        STAKE,
+        ASSET,
+        POLICY,
+        DATUM,
+        SCRIPT,
+        SPENT_TXO,
+        ACCOUNT_CERTS,
+        POOL_CERTS,
+        ACCOUNT_WITHDRAWALS,
+        METADATA,
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_all_has_no_duplicates() {
+        let mut seen = archive::ALL.to_vec();
+        seen.sort_unstable();
+        seen.dedup();
+
+        assert_eq!(seen.len(), archive::ALL.len());
+    }
 }

--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -124,13 +124,11 @@ impl IndexStore for NoOpIndexStore {
         Ok(EmptySlotIter)
     }
 
-    /// This errors rather than yielding the (arguably honest) empty
-    /// iteration: the callers of this seam publish the iterated records as a
-    /// signed snapshot layer, and a well-formed *empty* layer from an
-    /// index-less node is indistinguishable from a genuinely tag-free epoch.
-    /// The established convention for noop backends is to fail loudly at this
-    /// kind of boundary (see `data stats` / `data export`), and redb3 answers
-    /// the same methods with `Unsupported`.
+    /// Errors rather than yielding an empty iteration: this seam's callers
+    /// publish the iterated records as a signed snapshot layer, and a
+    /// well-formed *empty* layer from an index-less node is indistinguishable
+    /// from a genuinely tag-free epoch. Matches redb3 and the loud-failure
+    /// precedent of `data stats` / `data export` on noop backends.
     fn iter_archive_tags(
         &self,
         _dimensions: &[TagDimension],

--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -32,8 +32,12 @@ impl IndexWriter for NoOpIndexWriter {
         Ok(())
     }
 
+    /// A restore against a store that discards every record must fail, not
+    /// report success: `Ok` here would let a snapshot restore complete
+    /// "cleanly" having written nothing. See
+    /// [`NoOpIndexStore::iter_archive_tags`] for the read-side twin.
     fn append_prehashed(&self, _records: &[IndexRecord]) -> Result<(), IndexError> {
-        Ok(())
+        Err(IndexError::Unsupported("append_prehashed"))
     }
 
     fn commit(self) -> Result<(), IndexError> {
@@ -120,19 +124,24 @@ impl IndexStore for NoOpIndexStore {
         Ok(EmptySlotIter)
     }
 
-    /// A store that keeps no indexes has no tag records: an empty iteration is
-    /// the honest answer, not an error.
+    /// This errors rather than yielding the (arguably honest) empty
+    /// iteration: the callers of this seam publish the iterated records as a
+    /// signed snapshot layer, and a well-formed *empty* layer from an
+    /// index-less node is indistinguishable from a genuinely tag-free epoch.
+    /// The established convention for noop backends is to fail loudly at this
+    /// kind of boundary (see `data stats` / `data export`), and redb3 answers
+    /// the same methods with `Unsupported`.
     fn iter_archive_tags(
         &self,
         _dimensions: &[TagDimension],
         _slots: Range<BlockSlot>,
     ) -> Result<Self::TagIter, IndexError> {
-        Ok(EmptyTagIter)
+        Err(IndexError::Unsupported("iter_archive_tags"))
     }
 
     /// See [`NoOpIndexStore::iter_archive_tags`].
     fn iter_exact_records(&self, _slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
-        Ok(EmptyExactIter)
+        Err(IndexError::Unsupported("iter_exact_records"))
     }
 }
 

--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -8,7 +8,10 @@ use std::ops::Range;
 
 use crate::{
     archive::{ArchiveError, ArchiveStore, ArchiveWriter, LogKey},
-    indexes::{IndexDelta, IndexError, IndexStore, IndexWriter, TagDimension},
+    indexes::{
+        EmptyExactIter, EmptyTagIter, IndexDelta, IndexError, IndexRecord, IndexStore, IndexWriter,
+        TagDimension,
+    },
     BlockBody, BlockSlot, ChainPoint, EntityValue, Namespace, RawBlock, UtxoSet,
 };
 
@@ -26,6 +29,10 @@ impl IndexWriter for NoOpIndexWriter {
     }
 
     fn undo(&self, _delta: &IndexDelta) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    fn append_prehashed(&self, _records: &[IndexRecord]) -> Result<(), IndexError> {
         Ok(())
     }
 
@@ -68,6 +75,8 @@ impl DoubleEndedIterator for EmptySlotIter {
 impl IndexStore for NoOpIndexStore {
     type Writer = NoOpIndexWriter;
     type SlotIter = EmptySlotIter;
+    type TagIter = EmptyTagIter;
+    type ExactIter = EmptyExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         Ok(NoOpIndexWriter)
@@ -109,6 +118,21 @@ impl IndexStore for NoOpIndexStore {
         _end: BlockSlot,
     ) -> Result<Self::SlotIter, IndexError> {
         Ok(EmptySlotIter)
+    }
+
+    /// A store that keeps no indexes has no tag records: an empty iteration is
+    /// the honest answer, not an error.
+    fn iter_archive_tags(
+        &self,
+        _dimensions: &[TagDimension],
+        _slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        Ok(EmptyTagIter)
+    }
+
+    /// See [`NoOpIndexStore::iter_archive_tags`].
+    fn iter_exact_records(&self, _slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
+        Ok(EmptyExactIter)
     }
 }
 

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -10,6 +10,8 @@
 //! keys. Chain-specific code (e.g., Cardano) defines the dimensions and
 //! provides extension traits for convenient access.
 
+use std::{borrow::Cow, ops::Range};
+
 use thiserror::Error;
 
 use crate::{BlockSlot, ChainPoint, TxoRef, UtxoSet};
@@ -104,6 +106,169 @@ pub enum IndexError {
 
     #[error("dimension not found: {0}")]
     DimensionNotFound(String),
+
+    /// The operation is part of the trait but the concrete backend does not
+    /// implement it.
+    ///
+    /// Used by backends outside the live set (see the record iteration and
+    /// pre-hashed append below) so that a caller reaching for an unimplemented
+    /// capability gets an error it can handle instead of a panic.
+    #[error("{0} is not supported on this storage backend")]
+    Unsupported(&'static str),
+}
+
+// ============================================================================
+// Pre-hashed archive index records
+// ============================================================================
+
+/// Size of the hashed portion of an archive tag key.
+pub const KEY_HASH_SIZE: usize = 8;
+
+/// The stored, fixed-width form of a tag key.
+///
+/// For every dimension but `metadata` this is `xxh3_64(logical key)` in
+/// big-endian byte order. `metadata` is an exception: its logical key is
+/// already a `u64` label and the store keeps that label verbatim (big-endian)
+/// rather than hashing it. Consumers must treat these bytes as opaque and copy
+/// them through unchanged — recomputing a hash from the logical key is not a
+/// valid way to reconstruct them for every dimension.
+pub type KeyHash = [u8; KEY_HASH_SIZE];
+
+/// One archive tag entry, carrying the stored key hash instead of the logical
+/// key.
+///
+/// The logical key is not recoverable from the index store — only its hash is
+/// kept on disk — so this is the most a reader can produce and the least a
+/// writer needs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TagRecord {
+    /// The logical dimension name. Borrowed when read from a store (the
+    /// dimension list drives the traversal), owned when decoded from an
+    /// external source.
+    pub dimension: Cow<'static, str>,
+
+    /// The stored key hash. See [`KeyHash`] for the `metadata` caveat.
+    pub key_hash: KeyHash,
+
+    pub slot: BlockSlot,
+}
+
+impl TagRecord {
+    pub fn new(dimension: TagDimension, key_hash: KeyHash, slot: BlockSlot) -> Self {
+        Self {
+            dimension: Cow::Borrowed(dimension),
+            key_hash,
+            slot,
+        }
+    }
+
+    pub fn dimension(&self) -> &str {
+        self.dimension.as_ref()
+    }
+}
+
+/// The kinds of exact-match archive lookup an index store keeps.
+///
+/// This is a closed set: the store hashes the kind name into the key, so it
+/// cannot be recovered from disk and traversal has to be driven by the known
+/// list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ExactKind {
+    BlockHash,
+    BlockNumber,
+    TxHash,
+}
+
+impl ExactKind {
+    /// Every kind, in ascending [`ExactKind::as_str`] order.
+    pub const ALL: [ExactKind; 3] = [Self::BlockHash, Self::BlockNumber, Self::TxHash];
+
+    /// The stored dimension name for this kind.
+    ///
+    /// These strings are hashed into on-disk keys — changing one is a storage
+    /// migration, not a rename.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::BlockHash => "block_hash",
+            Self::BlockNumber => "block_num",
+            Self::TxHash => "tx_hash",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|kind| kind.as_str() == value)
+    }
+}
+
+impl std::fmt::Display for ExactKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One exact-match archive entry.
+///
+/// Unlike tags, exact keys are stored verbatim (a 32-byte hash, or an 8-byte
+/// big-endian block number), so the record is lossless.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExactRecord {
+    pub kind: ExactKind,
+    pub key: Vec<u8>,
+    pub slot: BlockSlot,
+}
+
+impl ExactRecord {
+    pub fn new(kind: ExactKind, key: impl Into<Vec<u8>>, slot: BlockSlot) -> Self {
+        Self {
+            kind,
+            key: key.into(),
+            slot,
+        }
+    }
+}
+
+/// Either archive record, as consumed by
+/// [`IndexWriter::append_prehashed`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IndexRecord {
+    Tag(TagRecord),
+    Exact(ExactRecord),
+}
+
+impl From<TagRecord> for IndexRecord {
+    fn from(value: TagRecord) -> Self {
+        Self::Tag(value)
+    }
+}
+
+impl From<ExactRecord> for IndexRecord {
+    fn from(value: ExactRecord) -> Self {
+        Self::Exact(value)
+    }
+}
+
+/// Iterator used by backends that do not implement
+/// [`IndexStore::iter_archive_tags`].
+pub struct EmptyTagIter;
+
+impl Iterator for EmptyTagIter {
+    type Item = Result<TagRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+/// Iterator used by backends that do not implement
+/// [`IndexStore::iter_exact_records`].
+pub struct EmptyExactIter;
+
+impl Iterator for EmptyExactIter {
+    type Item = Result<ExactRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
 }
 
 /// Writer for batched index operations.
@@ -126,6 +291,20 @@ pub trait IndexWriter: Send + Sync + 'static {
     /// - Archive index entries are removed
     fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError>;
 
+    /// Append archive records that already carry their stored key form.
+    ///
+    /// This is the write mirror of [`IndexStore::iter_archive_tags`] and
+    /// [`IndexStore::iter_exact_records`]: records that came out of one store
+    /// go into another byte-for-byte, with no logical key in between (there is
+    /// none to recover — see [`KeyHash`]).
+    ///
+    /// Records must arrive sorted, since the backing stores are append
+    /// oriented. The cursor is *not* touched: a restore owns cursor placement.
+    ///
+    /// Backends that do not implement this return
+    /// [`IndexError::Unsupported`].
+    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError>;
+
     /// Commit the batched operations.
     fn commit(self) -> Result<(), IndexError>;
 }
@@ -146,6 +325,12 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
 
     /// Iterator type for sparse slot queries.
     type SlotIter: Iterator<Item = Result<BlockSlot, IndexError>> + DoubleEndedIterator;
+
+    /// Iterator type for archive tag record traversal.
+    type TagIter: Iterator<Item = Result<TagRecord, IndexError>>;
+
+    /// Iterator type for exact-match record traversal.
+    type ExactIter: Iterator<Item = Result<ExactRecord, IndexError>>;
 
     /// Start a new writer for batched operations.
     fn start_writer(&self) -> Result<Self::Writer, IndexError>;
@@ -196,4 +381,90 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
         start: BlockSlot,
         end: BlockSlot,
     ) -> Result<Self::SlotIter, IndexError>;
+
+    // ============ Record Traversal (Bulk Export) ============
+
+    /// Iterate every archive tag record whose slot falls in `slots`.
+    ///
+    /// `dimensions` is the closed list of dimensions to traverse. It has to be
+    /// supplied by the caller: stores keep a hash of the dimension name, not
+    /// the name, so the set of dimensions is not discoverable from disk.
+    /// Duplicates are ignored.
+    ///
+    /// **Order is part of the contract.** Records come out sorted by
+    /// `(dimension, key_hash, slot)` — `dimension` compared as a string,
+    /// independently of the order `dimensions` was given in. Consumers of this
+    /// iteration (snapshot layers) make that order their content, so an
+    /// unordered iterator is a wrong one.
+    ///
+    /// The iterator must be lazy in the size of the store.
+    ///
+    /// Backends that do not implement this return
+    /// [`IndexError::Unsupported`].
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError>;
+
+    /// Iterate every exact-match record whose slot falls in `slots`.
+    ///
+    /// **Order is part of the contract**: records come out sorted by
+    /// `(kind, key)`, kinds in ascending [`ExactKind::as_str`] order.
+    ///
+    /// Note that the slot is the stored *value* of an exact entry, not part of
+    /// its key, so a slot-bounded traversal is a scan of every exact entry in
+    /// the store rather than a seek. The iterator is still lazy in memory.
+    ///
+    /// Backends that do not implement this return
+    /// [`IndexError::Unsupported`].
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_kind_all_is_sorted_by_name() {
+        let names: Vec<&str> = ExactKind::ALL.iter().map(|k| k.as_str()).collect();
+
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+
+        assert_eq!(
+            names, sorted,
+            "ExactKind::ALL must be in ascending name order: the exact record \
+             contract sorts by (kind, key) and the traversal walks ALL in order"
+        );
+    }
+
+    #[test]
+    fn exact_kind_ord_matches_name_ord() {
+        for pair in ExactKind::ALL.windows(2) {
+            assert!(pair[0] < pair[1]);
+            assert!(pair[0].as_str() < pair[1].as_str());
+        }
+    }
+
+    #[test]
+    fn exact_kind_roundtrips_through_name() {
+        for kind in ExactKind::ALL {
+            assert_eq!(ExactKind::parse(kind.as_str()), Some(kind));
+        }
+
+        assert_eq!(ExactKind::parse("nope"), None);
+    }
+
+    #[test]
+    fn tag_record_ord_is_dimension_then_hash_then_slot() {
+        let a = TagRecord::new("address", [0xff; 8], 10);
+        let b = TagRecord::new("asset", [0x00; 8], 0);
+        let c = TagRecord::new("asset", [0x00; 8], 1);
+        let d = TagRecord::new("asset", [0x01; 8], 0);
+
+        assert!(a < b, "dimension dominates");
+        assert!(b < c, "slot breaks ties within a key hash");
+        assert!(c < d, "key hash dominates slot");
+    }
 }

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -195,8 +195,29 @@ impl ExactKind {
         }
     }
 
-    pub fn parse(value: &str) -> Option<Self> {
-        Self::ALL.into_iter().find(|kind| kind.as_str() == value)
+    /// The exact byte length of a stored key of this kind.
+    ///
+    /// Exact keys are fixed-width per kind: a 32-byte hash for
+    /// [`ExactKind::BlockHash`] and [`ExactKind::TxHash`], an 8-byte big-endian
+    /// number for [`ExactKind::BlockNumber`]. Writers validate against this so
+    /// a wrong-width key from an external source cannot land as a permanently
+    /// unreadable entry.
+    pub const fn key_len(&self) -> usize {
+        match self {
+            Self::BlockHash | Self::TxHash => 32,
+            Self::BlockNumber => 8,
+        }
+    }
+}
+
+impl std::str::FromStr for ExactKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|kind| kind.as_str() == s)
+            .ok_or_else(|| format!("unknown exact kind: {s}"))
     }
 }
 
@@ -249,27 +270,17 @@ impl From<ExactRecord> for IndexRecord {
 
 /// Iterator used by backends that do not implement
 /// [`IndexStore::iter_archive_tags`].
-pub struct EmptyTagIter;
-
-impl Iterator for EmptyTagIter {
-    type Item = Result<TagRecord, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
+///
+/// Never constructed — those backends return [`IndexError::Unsupported`], so
+/// the alias only exists to satisfy the associated type.
+pub type EmptyTagIter = std::iter::Empty<Result<TagRecord, IndexError>>;
 
 /// Iterator used by backends that do not implement
 /// [`IndexStore::iter_exact_records`].
-pub struct EmptyExactIter;
-
-impl Iterator for EmptyExactIter {
-    type Item = Result<ExactRecord, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
+///
+/// Never constructed — those backends return [`IndexError::Unsupported`], so
+/// the alias only exists to satisfy the associated type.
+pub type EmptyExactIter = std::iter::Empty<Result<ExactRecord, IndexError>>;
 
 /// Writer for batched index operations.
 ///
@@ -299,7 +310,11 @@ pub trait IndexWriter: Send + Sync + 'static {
     /// none to recover — see [`KeyHash`]).
     ///
     /// Records must arrive sorted, since the backing stores are append
-    /// oriented. The cursor is *not* touched: a restore owns cursor placement.
+    /// oriented. The cursor is *not* touched: a restore owns cursor placement,
+    /// and places it with an otherwise-empty delta once the records are in:
+    /// `writer.apply(&IndexDelta { cursor, ..Default::default() })`. A restore
+    /// that skips this leaves `cursor()` at `None` and bootstrap will treat the
+    /// store as never indexed.
     ///
     /// Backends that do not implement this return
     /// [`IndexError::Unsupported`].
@@ -374,6 +389,11 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
     /// Returns an iterator over slots that contain data tagged with the given
     /// dimension and key. The iterator is lazy and supports bidirectional
     /// iteration for efficient pagination.
+    ///
+    /// Both `start` and `end` are **inclusive** — unlike the record traversal
+    /// methods below, which take a half-open [`Range`]. Reusing one `(start,
+    /// end)` pair across both conventions drops or double-counts the record at
+    /// `end`.
     fn slots_by_tag(
         &self,
         dimension: TagDimension,
@@ -386,6 +406,9 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
 
     /// Iterate every archive tag record whose slot falls in `slots`.
     ///
+    /// `slots` is **half-open** (`start..end`), unlike
+    /// [`IndexStore::slots_by_tag`], whose bounds are both inclusive.
+    ///
     /// `dimensions` is the closed list of dimensions to traverse. It has to be
     /// supplied by the caller: stores keep a hash of the dimension name, not
     /// the name, so the set of dimensions is not discoverable from disk.
@@ -397,7 +420,15 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
     /// iteration (snapshot layers) make that order their content, so an
     /// unordered iterator is a wrong one.
     ///
-    /// The iterator must be lazy in the size of the store.
+    /// **Errors are terminal.** A malformed on-disk entry or a read failure is
+    /// yielded as `Err` and the iterator is fused from then on: it never
+    /// resumes past a fault, so a consumer that collects into
+    /// `Result<Vec<_>, _>` cannot receive a silently truncated record set.
+    ///
+    /// The iterator must be lazy in the size of the store. Each call opens its
+    /// own point-in-time view: records from separate calls (or from
+    /// [`IndexStore::iter_exact_records`]) are only mutually consistent if the
+    /// store is quiescent across the calls.
     ///
     /// Backends that do not implement this return
     /// [`IndexError::Unsupported`].
@@ -409,8 +440,14 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
 
     /// Iterate every exact-match record whose slot falls in `slots`.
     ///
+    /// `slots` is **half-open** (`start..end`), unlike
+    /// [`IndexStore::slots_by_tag`], whose bounds are both inclusive.
+    ///
     /// **Order is part of the contract**: records come out sorted by
     /// `(kind, key)`, kinds in ascending [`ExactKind::as_str`] order.
+    ///
+    /// **Errors are terminal** — same policy as
+    /// [`IndexStore::iter_archive_tags`].
     ///
     /// Note that the slot is the stored *value* of an exact entry, not part of
     /// its key, so a slot-bounded traversal is a scan of every exact entry in
@@ -450,10 +487,22 @@ mod tests {
     #[test]
     fn exact_kind_roundtrips_through_name() {
         for kind in ExactKind::ALL {
-            assert_eq!(ExactKind::parse(kind.as_str()), Some(kind));
+            assert_eq!(kind.as_str().parse::<ExactKind>(), Ok(kind));
         }
 
-        assert_eq!(ExactKind::parse("nope"), None);
+        assert!("nope".parse::<ExactKind>().is_err());
+    }
+
+    /// Pins the literal strings: they are hashed into on-disk keys, so a
+    /// rename that looks cosmetic (e.g. `block_num` -> `block_number`) orphans
+    /// every existing entry of that kind. Every other test compares `as_str`
+    /// against itself and would survive such a rename — this one exists to
+    /// fail it.
+    #[test]
+    fn exact_kind_names_are_storage_format() {
+        assert_eq!(ExactKind::BlockHash.as_str(), "block_hash");
+        assert_eq!(ExactKind::BlockNumber.as_str(), "block_num");
+        assert_eq!(ExactKind::TxHash.as_str(), "tx_hash");
     }
 
     #[test]

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -117,10 +117,6 @@ pub enum IndexError {
     Unsupported(&'static str),
 }
 
-// ============================================================================
-// Pre-hashed archive index records
-// ============================================================================
-
 /// Size of the hashed portion of an archive tag key.
 pub const KEY_HASH_SIZE: usize = 8;
 

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, marker::PhantomData, ops::Range};
+use std::{collections::HashMap, marker::PhantomData, ops::Range, sync::Arc};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{ChainError, ChainPoint, Domain, TxoRef, UtxoMap, UtxoSetDelta};
+use crate::{ChainError, ChainPoint, Domain, EraCbor, TxoRef, UtxoMap, UtxoSetDelta};
 
 pub const KEY_SIZE: usize = 32;
 
@@ -200,6 +200,33 @@ pub enum StateError {
 
     #[error("entity decoding error")]
     EntityDecodingError(String),
+
+    /// The operation is part of the trait but the concrete backend does not
+    /// implement it.
+    ///
+    /// Used by backends outside the live set (see `iter_utxos`) so that a
+    /// caller reaching for an unimplemented capability gets an error it can
+    /// handle instead of a panic.
+    #[error("{0} is not supported on this storage backend")]
+    Unsupported(&'static str),
+}
+
+/// A single entry of the UTxO set, as yielded by [`StateStore::iter_utxos`].
+pub type UtxoEntry = (TxoRef, Arc<EraCbor>);
+
+/// Iterator used by backends that do not implement [`StateStore::iter_utxos`].
+///
+/// It never yields: those backends return
+/// [`StateError::Unsupported`] from the constructor, so the type only exists to
+/// satisfy the associated type.
+pub struct EmptyUtxoIter;
+
+impl Iterator for EmptyUtxoIter {
+    type Item = Result<UtxoEntry, StateError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
 }
 
 pub struct EntityIterTyped<S: StateStore, E: Entity> {
@@ -316,6 +343,7 @@ pub trait StateWriter: Sized + Send + Sync {
 pub trait StateStore: Sized + Send + Sync + Clone {
     type EntityIter: Iterator<Item = Result<(EntityKey, EntityValue), StateError>>;
     type EntityValueIter: Iterator<Item = Result<EntityValue, StateError>>;
+    type UtxoIter: Iterator<Item = Result<UtxoEntry, StateError>>;
     type Writer: StateWriter;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError>;
@@ -397,6 +425,17 @@ pub trait StateStore: Sized + Send + Sync + Clone {
     // TODO: generalize UTxO Set into generic entity system (#1042)
 
     fn get_utxos(&self, refs: Vec<TxoRef>) -> Result<UtxoMap, StateError>;
+
+    /// Iterate the whole UTxO set.
+    ///
+    /// The iterator must be lazy: neither construction nor iteration may
+    /// buffer the set, since callers (snapshot export, live-UTxO index
+    /// rebuild) run against a mainnet-sized set that does not fit a memory
+    /// budget.
+    ///
+    /// Backends that do not implement this return
+    /// [`StateError::Unsupported`].
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError>;
 }
 
 pub fn load_entity_chunk<D: Domain>(

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, marker::PhantomData, ops::Range, sync::Arc};
+use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -212,22 +212,18 @@ pub enum StateError {
 }
 
 /// A single entry of the UTxO set, as yielded by [`StateStore::iter_utxos`].
-pub type UtxoEntry = (TxoRef, Arc<EraCbor>);
+///
+/// The value is owned, not `Arc`-wrapped: the streaming consumers this exists
+/// for (snapshot export, index rebuild) serialize and drop each entry, so
+/// shared ownership would be a per-item allocation nobody uses. A caller that
+/// wants a [`UtxoMap`] wraps the values itself.
+pub type UtxoEntry = (TxoRef, EraCbor);
 
 /// Iterator used by backends that do not implement [`StateStore::iter_utxos`].
 ///
-/// It never yields: those backends return
-/// [`StateError::Unsupported`] from the constructor, so the type only exists to
-/// satisfy the associated type.
-pub struct EmptyUtxoIter;
-
-impl Iterator for EmptyUtxoIter {
-    type Item = Result<UtxoEntry, StateError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
+/// Never constructed — those backends return [`StateError::Unsupported`], so
+/// the alias only exists to satisfy the associated type.
+pub type EmptyUtxoIter = std::iter::Empty<Result<UtxoEntry, StateError>>;
 
 pub struct EntityIterTyped<S: StateStore, E: Entity> {
     inner: S::EntityIter,
@@ -431,7 +427,13 @@ pub trait StateStore: Sized + Send + Sync + Clone {
     /// The iterator must be lazy: neither construction nor iteration may
     /// buffer the set, since callers (snapshot export, live-UTxO index
     /// rebuild) run against a mainnet-sized set that does not fit a memory
-    /// budget.
+    /// budget. Construction reads nothing; the first read failure surfaces
+    /// from `next()`.
+    ///
+    /// **Errors are terminal.** A malformed on-disk entry or a read failure is
+    /// yielded as `Err` and the iterator is fused from then on: it never
+    /// resumes past a fault, so a consumer cannot receive a silently truncated
+    /// UTxO set.
     ///
     /// Backends that do not implement this return
     /// [`StateError::Unsupported`].

--- a/crates/fjall/src/index/README.md
+++ b/crates/fjall/src/index/README.md
@@ -179,6 +179,38 @@ let slots = store.slots_by_tag("address", &addr_bytes, start_slot, end_slot)?;
 let slots = store.slots_by_tag("metadata", &label_bytes, start_slot, end_slot)?;
 ```
 
+### Bulk Record Traversal (Export) and Pre-Hashed Append (Restore)
+
+```rust
+// Every archive tag record in a slot range, sorted by (dimension, key_hash, slot)
+let tags = store.iter_archive_tags(&archive_dimensions::ALL, epoch_start..epoch_end)?;
+
+// Every exact record in a slot range, sorted by (kind, key)
+let exacts = store.iter_exact_records(epoch_start..epoch_end)?;
+
+// ...and back into another store, byte for byte
+let writer = target.start_writer()?;
+writer.append_prehashed(&records)?;
+writer.commit()?;
+```
+
+Three things about this pair:
+
+- **Records carry the stored key form, not the logical key.** The logical key is
+  not on disk — only its hash is — so this is the most a reader can produce.
+  Consumers must copy those 8 bytes through unchanged: for every dimension but
+  `metadata` they are `xxh3_64(key)` big-endian, while `metadata` keys are u64
+  labels that the store keeps verbatim rather than hashing.
+
+- **The traversal is driven by a caller-supplied list.** Dimension and kind
+  names are hashed into keys, so neither is discoverable from disk. The
+  canonical archive list is `dolos_cardano::indexes::archive_dimensions::ALL`.
+
+- **Order is part of the contract**, because these records become snapshot
+  layers and the layer *is* a sorted sequence. On-disk order is by dimension
+  *hash*, so the traversal walks the dimension list in name order and relies on
+  lexicographic order within each prefix.
+
 ## Performance Considerations
 
 1. **Snapshot reads** - All read operations use MVCC snapshots to avoid blocking concurrent writes.
@@ -190,3 +222,14 @@ let slots = store.slots_by_tag("metadata", &label_bytes, start_slot, end_slot)?;
 4. **Flush on commit** - Configurable journal flushing prevents unbounded memory growth during bulk imports.
 
 5. **Graceful shutdown** - Call `shutdown()` before dropping to ensure all background work completes.
+
+6. **A slot range is not a seek** - Slot is the *last* component of an archive
+   tag key and is not part of an exact key at all (it is the value), so
+   `iter_archive_tags` and `iter_exact_records` both scan and filter: the cost
+   of slicing one epoch is O(store), not O(epoch). Measured on a synthetic
+   mainnet-shaped store (648k tag + 108k exact records per epoch): ~0.13 s per
+   epoch of stored history, i.e. ~0.25 s at 2 epochs of depth, ~0.87 s at 8 and
+   ~3.1 s at 24. `tests/index_roundtrip.rs` carries the measurement
+   (`measure_one_epoch_iteration_cost`, `--ignored`). A backfill over deep
+   history wants a single pass bucketing records by epoch rather than one slice
+   per epoch.

--- a/crates/fjall/src/index/archive_tags.rs
+++ b/crates/fjall/src/index/archive_tags.rs
@@ -14,8 +14,13 @@
 //!
 //! The `dim_hash` is computed as `xxh3("block:" + dimension)`.
 
-use dolos_core::{ArchiveIndexDelta, BlockSlot, IndexDelta, IndexError, Tag};
-use fjall::{Keyspace, OwnedWriteBatch, Readable};
+use std::borrow::Cow;
+use std::ops::Range;
+
+use dolos_core::{
+    ArchiveIndexDelta, BlockSlot, IndexDelta, IndexError, KeyHash, Tag, TagDimension, TagRecord,
+};
+use fjall::{Keyspace, OwnedWriteBatch, Readable, Snapshot};
 
 use crate::keys::{
     decode_slot, dim_prefix, hash_dimension, hash_key, DIM_HASH_SIZE, HASH_KEY_SIZE, SLOT_SIZE,
@@ -67,6 +72,14 @@ fn decode_block_tag_slot(key: &[u8]) -> u64 {
     debug_assert!(key.len() >= BLOCK_TAG_KEY_SIZE);
     let start = key.len() - SLOT_SIZE;
     decode_slot(&key[start..])
+}
+
+/// Decode the stored tag key hash from a block tag key (bytes 8..16)
+fn decode_block_tag_key_hash(key: &[u8]) -> KeyHash {
+    debug_assert!(key.len() >= BLOCK_TAG_KEY_SIZE);
+    let mut hash = [0u8; HASH_KEY_SIZE];
+    hash.copy_from_slice(&key[DIM_HASH_SIZE..DIM_HASH_SIZE + HASH_KEY_SIZE]);
+    hash
 }
 
 // ============================================================================
@@ -153,6 +166,23 @@ fn remove_tag(batch: &mut OwnedWriteBatch, keyspace: &Keyspace, tag: &Tag, slot:
     }
 
     remove_block_tag(batch, keyspace, tag.dimension, &tag.key, slot);
+}
+
+/// Insert a tag entry from a record that already carries its stored key hash.
+///
+/// This is the write mirror of [`TagRecordIterator`]: the 8 hash bytes go in
+/// verbatim, so a record read out of one store lands byte-identical in another.
+/// It is deliberately *not* routed through [`insert_tag`] — that function
+/// hashes (and special-cases `metadata`) because it starts from a logical key,
+/// which a restore does not have.
+pub fn insert_prehashed(
+    batch: &mut OwnedWriteBatch,
+    keyspace: &Keyspace,
+    record: &TagRecord,
+) -> Result<(), Error> {
+    let hash = u64::from_be_bytes(record.key_hash);
+    insert_block_tag_hashed(batch, keyspace, record.dimension(), hash, record.slot);
+    Ok(())
 }
 
 /// Apply archive tag indexes for a single block delta
@@ -298,6 +328,119 @@ impl DoubleEndedIterator for SlotIterator {
     }
 }
 
+// ============================================================================
+// TagRecordIterator
+// ============================================================================
+
+/// Lazy iterator over archive tag records, one dimension prefix at a time.
+///
+/// ## Why it is driven by a dimension list
+///
+/// The stored key is `[dim_hash:8][tag_hash:8][slot:8]` where
+/// `dim_hash = xxh3("block:" + dimension)`. The dimension *string* is nowhere
+/// on disk, so a blind scan of the keyspace could not label the records it
+/// produced. Traversal therefore takes the known dimension list and seeks one
+/// prefix at a time, which supplies the dimension as a side effect.
+///
+/// ## Ordering
+///
+/// On-disk order is by `dim_hash`, which is unrelated to the dimension string's
+/// order. The contract is `(dimension, key_hash, slot)`, so the dimension list
+/// is sorted (and deduplicated) up front and walked in that order; within one
+/// prefix, fjall's lexicographic order over `[tag_hash][slot]` is already the
+/// rest of the contract, both being big-endian.
+///
+/// ## Cost
+///
+/// `slot` is the *last* key component, so a slot range is not a seekable
+/// prefix: each dimension is scanned in full and filtered. This is the cost
+/// centre of a per-epoch slice. Memory stays O(1) — matching is done per entry
+/// and only the key is loaded.
+pub struct TagRecordIterator {
+    snapshot: Snapshot,
+    keyspace: Keyspace,
+    dimensions: std::vec::IntoIter<TagDimension>,
+    current: Option<(TagDimension, fjall::Iter)>,
+    slots: Range<BlockSlot>,
+}
+
+impl TagRecordIterator {
+    /// Create a new iterator over the tag records of the given dimensions.
+    ///
+    /// Returns immediately without reading any data.
+    pub fn new(
+        snapshot: Snapshot,
+        keyspace: &Keyspace,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Self {
+        // Sorting here rather than trusting the caller makes the ordering
+        // contract unconditional; the list is a dozen entries at most.
+        let mut dimensions = dimensions.to_vec();
+        dimensions.sort_unstable();
+        dimensions.dedup();
+
+        Self {
+            snapshot,
+            keyspace: keyspace.clone(),
+            dimensions: dimensions.into_iter(),
+            current: None,
+            slots,
+        }
+    }
+
+    /// Open a prefix scan for the next dimension, if any is left.
+    fn open_next(&mut self) -> Option<()> {
+        let dimension = self.dimensions.next()?;
+        let prefix = hash_dimension(dim_prefix::BLOCK, dimension);
+        let iter = self.snapshot.prefix(&self.keyspace, prefix);
+        self.current = Some((dimension, iter));
+        Some(())
+    }
+}
+
+impl Iterator for TagRecordIterator {
+    type Item = Result<TagRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let Some((dimension, iter)) = self.current.as_mut() else {
+                self.open_next()?;
+                continue;
+            };
+
+            let dimension = *dimension;
+
+            let Some(guard) = iter.next() else {
+                self.current = None;
+                continue;
+            };
+
+            let key = match guard.key() {
+                Ok(key) => key,
+                Err(e) => return Some(Err(Error::Fjall(e).into())),
+            };
+
+            if key.len() < BLOCK_TAG_KEY_SIZE {
+                // Skip malformed keys (too short), continue to next
+                continue;
+            }
+
+            let slot = decode_block_tag_slot(&key);
+
+            if !self.slots.contains(&slot) {
+                continue;
+            }
+
+            return Some(Ok(TagRecord {
+                dimension: Cow::Borrowed(dimension),
+                key_hash: decode_block_tag_key_hash(&key),
+                slot,
+            }));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,5 +497,50 @@ mod tests {
 
         // Key should be valid size
         assert_eq!(key.len(), BLOCK_TAG_KEY_SIZE);
+    }
+
+    /// The key hash a record carries has to rebuild the exact key it came from,
+    /// otherwise an export/restore round trip silently loses entries.
+    #[test]
+    fn test_prehashed_key_matches_written_key() {
+        let slot = 42u64;
+        let written = build_block_tag_key("address", b"some_address_bytes", slot);
+
+        let record = TagRecord::new("address", decode_block_tag_key_hash(&written), slot);
+        let rebuilt = build_block_tag_key_hashed(
+            record.dimension(),
+            u64::from_be_bytes(record.key_hash),
+            record.slot,
+        );
+
+        assert_eq!(written, rebuilt);
+    }
+
+    /// `metadata` is the one dimension whose stored key bytes are not a hash:
+    /// the logical key is already a u64 label and `insert_tag` writes it
+    /// verbatim. A record must carry those bytes through unchanged rather than
+    /// re-deriving them.
+    #[test]
+    fn test_prehashed_key_carries_metadata_label_verbatim() {
+        let label = 674u64;
+        let slot = 42u64;
+        let written = build_block_tag_key_hashed("metadata", label, slot);
+
+        let stored = decode_block_tag_key_hash(&written);
+        assert_eq!(u64::from_be_bytes(stored), label);
+        assert_ne!(
+            u64::from_be_bytes(stored),
+            hash_key(&label.to_be_bytes()),
+            "the metadata label is stored raw, not hashed"
+        );
+
+        let record = TagRecord::new("metadata", stored, slot);
+        let rebuilt = build_block_tag_key_hashed(
+            record.dimension(),
+            u64::from_be_bytes(record.key_hash),
+            record.slot,
+        );
+
+        assert_eq!(written, rebuilt);
     }
 }

--- a/crates/fjall/src/index/archive_tags.rs
+++ b/crates/fjall/src/index/archive_tags.rs
@@ -336,10 +336,6 @@ impl DoubleEndedIterator for SlotIterator {
     }
 }
 
-// ============================================================================
-// TagRecordIterator
-// ============================================================================
-
 /// Lazy iterator over archive tag records, one dimension prefix at a time.
 ///
 /// ## Why it is driven by a dimension list
@@ -408,8 +404,7 @@ impl TagRecordIterator {
             keyspace: keyspace.clone(),
             dimensions: dimensions.into_iter(),
             current: None,
-            // An empty range matches nothing: skip the prefix scans entirely
-            // instead of walking every dimension to filter everything out.
+            // An empty range matches nothing; skip the prefix scans entirely.
             done: slots.is_empty(),
             slots,
         }
@@ -455,9 +450,6 @@ impl Iterator for TagRecordIterator {
             };
 
             if key.len() < BLOCK_TAG_KEY_SIZE {
-                // A short key cannot come from this module's write path: it is
-                // corruption, and this stream becomes a signed layer — error
-                // out (terminally) rather than skip.
                 self.done = true;
                 return Some(Err(IndexError::CodecError(format!(
                     "malformed archive tag key in dimension {dimension}: \

--- a/crates/fjall/src/index/archive_tags.rs
+++ b/crates/fjall/src/index/archive_tags.rs
@@ -175,14 +175,22 @@ fn remove_tag(batch: &mut OwnedWriteBatch, keyspace: &Keyspace, tag: &Tag, slot:
 /// It is deliberately *not* routed through [`insert_tag`] — that function
 /// hashes (and special-cases `metadata`) because it starts from a logical key,
 /// which a restore does not have.
+///
+/// `dim_hash` is `hash_dimension(dim_prefix::BLOCK, record.dimension())`,
+/// passed in rather than computed here: records arrive grouped by dimension,
+/// so the caller hashes each dimension once per group instead of once per
+/// record.
 pub fn insert_prehashed(
     batch: &mut OwnedWriteBatch,
     keyspace: &Keyspace,
     record: &TagRecord,
-) -> Result<(), Error> {
-    let hash = u64::from_be_bytes(record.key_hash);
-    insert_block_tag_hashed(batch, keyspace, record.dimension(), hash, record.slot);
-    Ok(())
+    dim_hash: [u8; DIM_HASH_SIZE],
+) {
+    let mut key = [0u8; BLOCK_TAG_KEY_SIZE];
+    key[..DIM_HASH_SIZE].copy_from_slice(&dim_hash);
+    key[DIM_HASH_SIZE..DIM_HASH_SIZE + HASH_KEY_SIZE].copy_from_slice(&record.key_hash);
+    key[DIM_HASH_SIZE + HASH_KEY_SIZE..].copy_from_slice(&record.slot.to_be_bytes());
+    batch.insert(keyspace, key, []);
 }
 
 /// Apply archive tag indexes for a single block delta
@@ -354,14 +362,29 @@ impl DoubleEndedIterator for SlotIterator {
 ///
 /// `slot` is the *last* key component, so a slot range is not a seekable
 /// prefix: each dimension is scanned in full and filtered. This is the cost
-/// centre of a per-epoch slice. Memory stays O(1) — matching is done per entry
-/// and only the key is loaded.
+/// centre of a per-epoch slice. Memory stays O(1) — entries are matched one at
+/// a time (tag values are empty, so each entry is just its 24-byte key).
+///
+/// ## Lifetime
+///
+/// The iterator holds an MVCC snapshot for as long as it lives, which pins
+/// fjall's GC watermark: superseded versions written while it is alive are
+/// retained until it drops. Drain or drop it promptly on a live store.
+///
+/// ## Errors
+///
+/// Errors are terminal: after yielding an `Err` — a read failure or a
+/// malformed entry — the iterator is fused and yields `None` forever. The
+/// record set feeds a signed snapshot layer, so resuming past a fault (or
+/// silently skipping a bad entry) would let a corrupt store produce a
+/// clean-looking, truncated layer.
 pub struct TagRecordIterator {
     snapshot: Snapshot,
     keyspace: Keyspace,
     dimensions: std::vec::IntoIter<TagDimension>,
     current: Option<(TagDimension, fjall::Iter)>,
     slots: Range<BlockSlot>,
+    done: bool,
 }
 
 impl TagRecordIterator {
@@ -385,6 +408,9 @@ impl TagRecordIterator {
             keyspace: keyspace.clone(),
             dimensions: dimensions.into_iter(),
             current: None,
+            // An empty range matches nothing: skip the prefix scans entirely
+            // instead of walking every dimension to filter everything out.
+            done: slots.is_empty(),
             slots,
         }
     }
@@ -403,6 +429,10 @@ impl Iterator for TagRecordIterator {
     type Item = Result<TagRecord, IndexError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
         loop {
             let Some((dimension, iter)) = self.current.as_mut() else {
                 self.open_next()?;
@@ -418,12 +448,22 @@ impl Iterator for TagRecordIterator {
 
             let key = match guard.key() {
                 Ok(key) => key,
-                Err(e) => return Some(Err(Error::Fjall(e).into())),
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(Error::Fjall(e).into()));
+                }
             };
 
             if key.len() < BLOCK_TAG_KEY_SIZE {
-                // Skip malformed keys (too short), continue to next
-                continue;
+                // A short key cannot come from this module's write path: it is
+                // corruption, and this stream becomes a signed layer — error
+                // out (terminally) rather than skip.
+                self.done = true;
+                return Some(Err(IndexError::CodecError(format!(
+                    "malformed archive tag key in dimension {dimension}: \
+                     {} bytes, expected {BLOCK_TAG_KEY_SIZE}",
+                    key.len(),
+                ))));
             }
 
             let slot = decode_block_tag_slot(&key);
@@ -440,6 +480,8 @@ impl Iterator for TagRecordIterator {
         }
     }
 }
+
+impl std::iter::FusedIterator for TagRecordIterator {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/fjall/src/index/exact.rs
+++ b/crates/fjall/src/index/exact.rs
@@ -243,10 +243,6 @@ pub fn get_by_tx_hash<R: Readable>(
     }
 }
 
-// ============================================================================
-// ExactRecordIterator
-// ============================================================================
-
 /// Lazy iterator over exact-match records, one kind prefix at a time.
 ///
 /// ## Why it is driven by the kind list
@@ -292,8 +288,7 @@ impl ExactRecordIterator {
             keyspace: keyspace.clone(),
             kinds: ExactKind::ALL.into_iter(),
             current: None,
-            // An empty range matches nothing: skip the prefix scans entirely
-            // instead of decoding every entry to filter everything out.
+            // An empty range matches nothing; skip the prefix scans entirely.
             done: slots.is_empty(),
             slots,
         }
@@ -339,9 +334,6 @@ impl Iterator for ExactRecordIterator {
             };
 
             if key.len() <= DIM_HASH_SIZE || value.len() < SLOT_SIZE {
-                // A malformed entry cannot come from this module's write path:
-                // it is corruption, and this stream becomes a signed layer —
-                // error out (terminally) rather than skip.
                 self.done = true;
                 return Some(Err(IndexError::CodecError(format!(
                     "malformed exact index entry of kind {kind}: \

--- a/crates/fjall/src/index/exact.rs
+++ b/crates/fjall/src/index/exact.rs
@@ -17,8 +17,10 @@
 //!
 //! The `dim_hash` is computed as `xxh3("exact:" + dimension)`.
 
-use dolos_core::{ArchiveIndexDelta, BlockSlot, IndexDelta};
-use fjall::{Keyspace, OwnedWriteBatch, Readable};
+use std::ops::Range;
+
+use dolos_core::{ArchiveIndexDelta, BlockSlot, ExactKind, ExactRecord, IndexDelta, IndexError};
+use fjall::{Keyspace, OwnedWriteBatch, Readable, Snapshot};
 
 use crate::keys::{decode_slot, dim_prefix, encode_slot, hash_dimension, DIM_HASH_SIZE, SLOT_SIZE};
 use crate::Error;
@@ -26,15 +28,19 @@ use crate::Error;
 // ============================================================================
 // Internal Dimension Names
 // ============================================================================
+//
+// These are derived from `ExactKind` rather than spelled out, so the names
+// hashed into on-disk keys and the names carried by exported records cannot
+// drift apart.
 
 /// Internal dimension name for block hash lookups
-const DIM_BLOCK_HASH: &str = "block_hash";
+const DIM_BLOCK_HASH: &str = ExactKind::BlockHash.as_str();
 
 /// Internal dimension name for block number lookups
-const DIM_BLOCK_NUM: &str = "block_num";
+const DIM_BLOCK_NUM: &str = ExactKind::BlockNumber.as_str();
 
 /// Internal dimension name for transaction hash lookups
-const DIM_TX_HASH: &str = "tx_hash";
+const DIM_TX_HASH: &str = ExactKind::TxHash.as_str();
 
 // ============================================================================
 // Key Encoding
@@ -149,6 +155,21 @@ pub fn undo(
     Ok(())
 }
 
+/// Insert an exact entry from an already-decoded record.
+///
+/// The write mirror of [`ExactRecordIterator`]. Exact keys are stored verbatim,
+/// so this is the same encoding `apply` performs — only the kind arrives as a
+/// value instead of being implied by the call site.
+pub fn insert_prehashed(
+    batch: &mut OwnedWriteBatch,
+    exact_keyspace: &Keyspace,
+    record: &ExactRecord,
+) -> Result<(), Error> {
+    let key = build_exact_key(record.kind.as_str(), &record.key);
+    batch.insert(exact_keyspace, key, encode_slot_value(record.slot));
+    Ok(())
+}
+
 // ============================================================================
 // Queries
 // ============================================================================
@@ -198,6 +219,103 @@ pub fn get_by_tx_hash<R: Readable>(
             Ok(Some(slot))
         }
         None => Ok(None),
+    }
+}
+
+// ============================================================================
+// ExactRecordIterator
+// ============================================================================
+
+/// Lazy iterator over exact-match records, one kind prefix at a time.
+///
+/// ## Why it is driven by the kind list
+///
+/// Same reason as the tag iterator: the stored key is
+/// `[dim_hash:8][key_data:var]` with `dim_hash = xxh3("exact:" + kind)`, so the
+/// kind name is not on disk. `ExactKind::ALL` is the closed list, already in
+/// ascending name order, which makes the `(kind, key)` contract fall out of
+/// walking it in order — within a prefix, fjall's lexicographic order over
+/// `key_data` is the rest of it.
+///
+/// ## Cost
+///
+/// The slot of an exact entry is its *value*, not part of its key, so a
+/// slot-bounded traversal cannot seek at all: every exact entry in the store is
+/// visited and its value read, however narrow the range. In absolute terms the
+/// tag scan still dominates a per-epoch slice, simply because there are more
+/// tag records than exact ones — but this one has no seekable structure to
+/// exploit even in principle.
+pub struct ExactRecordIterator {
+    snapshot: Snapshot,
+    keyspace: Keyspace,
+    kinds: std::vec::IntoIter<ExactKind>,
+    current: Option<(ExactKind, fjall::Iter)>,
+    slots: Range<BlockSlot>,
+}
+
+impl ExactRecordIterator {
+    /// Create a new iterator over every exact record in the slot range.
+    ///
+    /// Returns immediately without reading any data.
+    pub fn new(snapshot: Snapshot, keyspace: &Keyspace, slots: Range<BlockSlot>) -> Self {
+        Self {
+            snapshot,
+            keyspace: keyspace.clone(),
+            kinds: ExactKind::ALL.to_vec().into_iter(),
+            current: None,
+            slots,
+        }
+    }
+
+    /// Open a prefix scan for the next kind, if any is left.
+    fn open_next(&mut self) -> Option<()> {
+        let kind = self.kinds.next()?;
+        let prefix = hash_dimension(dim_prefix::EXACT, kind.as_str());
+        let iter = self.snapshot.prefix(&self.keyspace, prefix);
+        self.current = Some((kind, iter));
+        Some(())
+    }
+}
+
+impl Iterator for ExactRecordIterator {
+    type Item = Result<ExactRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let Some((kind, iter)) = self.current.as_mut() else {
+                self.open_next()?;
+                continue;
+            };
+
+            let kind = *kind;
+
+            let Some(guard) = iter.next() else {
+                self.current = None;
+                continue;
+            };
+
+            let (key, value) = match guard.into_inner() {
+                Ok(pair) => pair,
+                Err(e) => return Some(Err(Error::Fjall(e).into())),
+            };
+
+            if key.len() <= DIM_HASH_SIZE || value.len() < SLOT_SIZE {
+                // Skip malformed entries, continue to next
+                continue;
+            }
+
+            let slot = decode_slot_value(&value);
+
+            if !self.slots.contains(&slot) {
+                continue;
+            }
+
+            return Some(Ok(ExactRecord {
+                kind,
+                key: key[DIM_HASH_SIZE..].to_vec(),
+                slot,
+            }));
+        }
     }
 }
 
@@ -260,5 +378,23 @@ mod tests {
         // Any dimension string should work (chain-agnostic)
         let key = build_exact_key("custom_lookup", &[0x11; 20]);
         assert_eq!(key.len(), DIM_HASH_SIZE + 20);
+    }
+
+    /// A record written by `insert_prehashed` has to land on the exact key the
+    /// delta path would have written, otherwise a restored store answers
+    /// lookups differently from the one it was exported from.
+    #[test]
+    fn test_prehashed_key_matches_delta_key() {
+        let block_hash = [0xcd; 32];
+        let from_delta = build_exact_key(DIM_BLOCK_HASH, &block_hash);
+        let record = ExactRecord::new(ExactKind::BlockHash, block_hash, 42);
+        let from_record = build_exact_key(record.kind.as_str(), &record.key);
+        assert_eq!(from_delta, from_record);
+
+        let number = 12345678u64;
+        let from_delta = build_exact_key_blocknum(number);
+        let record = ExactRecord::new(ExactKind::BlockNumber, number.to_be_bytes(), 42);
+        let from_record = build_exact_key(record.kind.as_str(), &record.key);
+        assert_eq!(from_delta.as_slice(), from_record.as_slice());
     }
 }

--- a/crates/fjall/src/index/exact.rs
+++ b/crates/fjall/src/index/exact.rs
@@ -160,12 +160,33 @@ pub fn undo(
 /// The write mirror of [`ExactRecordIterator`]. Exact keys are stored verbatim,
 /// so this is the same encoding `apply` performs — only the kind arrives as a
 /// value instead of being implied by the call site.
+///
+/// `dim_hash` is `hash_dimension(dim_prefix::EXACT, record.kind.as_str())`,
+/// passed in rather than computed here: records arrive grouped by kind, so the
+/// caller hashes each kind once per group instead of once per record.
+///
+/// The key length is validated against [`ExactKind::key_len`]: the read paths
+/// build fixed-width keys per kind, so a wrong-width key (possible only from an
+/// external source — the delta path is type-enforced) would land as a
+/// permanently unreadable entry that re-exports as if it were valid.
 pub fn insert_prehashed(
     batch: &mut OwnedWriteBatch,
     exact_keyspace: &Keyspace,
     record: &ExactRecord,
+    dim_hash: [u8; DIM_HASH_SIZE],
 ) -> Result<(), Error> {
-    let key = build_exact_key(record.kind.as_str(), &record.key);
+    let expected = record.kind.key_len();
+    if record.key.len() != expected {
+        return Err(Error::Codec(format!(
+            "exact record of kind {} has a {}-byte key, expected {expected}",
+            record.kind,
+            record.key.len(),
+        )));
+    }
+
+    let mut key = Vec::with_capacity(DIM_HASH_SIZE + record.key.len());
+    key.extend_from_slice(&dim_hash);
+    key.extend_from_slice(&record.key);
     batch.insert(exact_keyspace, key, encode_slot_value(record.slot));
     Ok(())
 }
@@ -245,12 +266,20 @@ pub fn get_by_tx_hash<R: Readable>(
 /// tag scan still dominates a per-epoch slice, simply because there are more
 /// tag records than exact ones — but this one has no seekable structure to
 /// exploit even in principle.
+///
+/// ## Lifetime and errors
+///
+/// Same contract as `TagRecordIterator`: the held MVCC snapshot pins fjall's
+/// GC watermark for the iterator's lifetime, and errors — read failures or
+/// malformed entries — are terminal (the iterator fuses rather than resuming
+/// past a fault).
 pub struct ExactRecordIterator {
     snapshot: Snapshot,
     keyspace: Keyspace,
-    kinds: std::vec::IntoIter<ExactKind>,
+    kinds: std::array::IntoIter<ExactKind, 3>,
     current: Option<(ExactKind, fjall::Iter)>,
     slots: Range<BlockSlot>,
+    done: bool,
 }
 
 impl ExactRecordIterator {
@@ -261,8 +290,11 @@ impl ExactRecordIterator {
         Self {
             snapshot,
             keyspace: keyspace.clone(),
-            kinds: ExactKind::ALL.to_vec().into_iter(),
+            kinds: ExactKind::ALL.into_iter(),
             current: None,
+            // An empty range matches nothing: skip the prefix scans entirely
+            // instead of decoding every entry to filter everything out.
+            done: slots.is_empty(),
             slots,
         }
     }
@@ -281,6 +313,10 @@ impl Iterator for ExactRecordIterator {
     type Item = Result<ExactRecord, IndexError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
         loop {
             let Some((kind, iter)) = self.current.as_mut() else {
                 self.open_next()?;
@@ -296,12 +332,23 @@ impl Iterator for ExactRecordIterator {
 
             let (key, value) = match guard.into_inner() {
                 Ok(pair) => pair,
-                Err(e) => return Some(Err(Error::Fjall(e).into())),
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(Error::Fjall(e).into()));
+                }
             };
 
             if key.len() <= DIM_HASH_SIZE || value.len() < SLOT_SIZE {
-                // Skip malformed entries, continue to next
-                continue;
+                // A malformed entry cannot come from this module's write path:
+                // it is corruption, and this stream becomes a signed layer —
+                // error out (terminally) rather than skip.
+                self.done = true;
+                return Some(Err(IndexError::CodecError(format!(
+                    "malformed exact index entry of kind {kind}: \
+                     key {} bytes, value {} bytes",
+                    key.len(),
+                    value.len(),
+                ))));
             }
 
             let slot = decode_slot_value(&value);
@@ -318,6 +365,8 @@ impl Iterator for ExactRecordIterator {
         }
     }
 }
+
+impl std::iter::FusedIterator for ExactRecordIterator {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -32,11 +32,12 @@
 //! All multi-byte integers are big-endian encoded for correct lexicographic
 //! ordering.
 
+use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
-    config::FjallIndexConfig, BlockSlot, ChainPoint, IndexDelta, IndexError,
+    config::FjallIndexConfig, BlockSlot, ChainPoint, IndexDelta, IndexError, IndexRecord,
     IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, TagDimension, UtxoSet,
 };
 use fjall::{
@@ -50,8 +51,9 @@ pub mod state_tags;
 
 use crate::Error;
 
-// Re-export the iterator type
-pub use archive_tags::SlotIterator as SlotIter;
+// Re-export the iterator types
+pub use archive_tags::{SlotIterator as SlotIter, TagRecordIterator as TagIter};
+pub use exact::ExactRecordIterator as ExactIter;
 
 /// Default cache size in MB
 const DEFAULT_CACHE_SIZE_MB: usize = 500;
@@ -281,6 +283,25 @@ impl CoreIndexWriter for IndexStoreWriter {
         Ok(())
     }
 
+    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+        let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
+
+        for record in records {
+            match record {
+                IndexRecord::Tag(tag) => {
+                    archive_tags::insert_prehashed(&mut batch, &self.store.block_tags, tag)
+                        .map_err(IndexError::from)?;
+                }
+                IndexRecord::Exact(exact) => {
+                    exact::insert_prehashed(&mut batch, &self.store.exact, exact)
+                        .map_err(IndexError::from)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn commit(self) -> Result<(), IndexError> {
         let batch = self
             .batch
@@ -305,6 +326,8 @@ impl CoreIndexWriter for IndexStoreWriter {
 impl CoreIndexStore for IndexStore {
     type Writer = IndexStoreWriter;
     type SlotIter = SlotIter;
+    type TagIter = TagIter;
+    type ExactIter = ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         let batch = self.db.batch();
@@ -394,5 +417,24 @@ impl CoreIndexStore for IndexStore {
         // Pass dimension string directly - chain-agnostic
         SlotIter::new(&snapshot, &self.block_tags, dimension, key, start, end)
             .map_err(IndexError::from)
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        // One snapshot for the whole traversal: every dimension prefix is read
+        // from the same MVCC view, so the record set is consistent even under
+        // concurrent writes.
+        let snapshot = self.db.snapshot();
+
+        Ok(TagIter::new(snapshot, &self.block_tags, dimensions, slots))
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
+        let snapshot = self.db.snapshot();
+
+        Ok(ExactIter::new(snapshot, &self.exact, slots))
     }
 }

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -288,9 +288,8 @@ impl CoreIndexWriter for IndexStoreWriter {
     fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
         let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
 
-        // Records arrive sorted, hence grouped by dimension/kind: cache the
-        // dimension hash across each group instead of recomputing the xxh3 of
-        // the same constant string once per record.
+        // Records arrive sorted, hence grouped by dimension/kind: hash each
+        // group's dimension once instead of once per record.
         let mut tag_dim: Option<(&str, [u8; DIM_HASH_SIZE])> = None;
         let mut exact_dim: Option<(ExactKind, [u8; DIM_HASH_SIZE])> = None;
 

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -37,8 +37,9 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
-    config::FjallIndexConfig, BlockSlot, ChainPoint, IndexDelta, IndexError, IndexRecord,
-    IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, TagDimension, UtxoSet,
+    config::FjallIndexConfig, BlockSlot, ChainPoint, ExactKind, IndexDelta, IndexError,
+    IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, TagDimension,
+    UtxoSet,
 };
 use fjall::{
     compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
@@ -49,6 +50,7 @@ pub mod archive_tags;
 pub mod exact;
 pub mod state_tags;
 
+use crate::keys::{dim_prefix, hash_dimension, DIM_HASH_SIZE};
 use crate::Error;
 
 // Re-export the iterator types
@@ -286,14 +288,44 @@ impl CoreIndexWriter for IndexStoreWriter {
     fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
         let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
 
+        // Records arrive sorted, hence grouped by dimension/kind: cache the
+        // dimension hash across each group instead of recomputing the xxh3 of
+        // the same constant string once per record.
+        let mut tag_dim: Option<(&str, [u8; DIM_HASH_SIZE])> = None;
+        let mut exact_dim: Option<(ExactKind, [u8; DIM_HASH_SIZE])> = None;
+
         for record in records {
             match record {
                 IndexRecord::Tag(tag) => {
-                    archive_tags::insert_prehashed(&mut batch, &self.store.block_tags, tag)
-                        .map_err(IndexError::from)?;
+                    let dimension = tag.dimension();
+
+                    let dim_hash = match tag_dim {
+                        Some((cached, hash)) if cached == dimension => hash,
+                        _ => {
+                            let hash = hash_dimension(dim_prefix::BLOCK, dimension);
+                            tag_dim = Some((dimension, hash));
+                            hash
+                        }
+                    };
+
+                    archive_tags::insert_prehashed(
+                        &mut batch,
+                        &self.store.block_tags,
+                        tag,
+                        dim_hash,
+                    );
                 }
                 IndexRecord::Exact(exact) => {
-                    exact::insert_prehashed(&mut batch, &self.store.exact, exact)
+                    let dim_hash = match exact_dim {
+                        Some((cached, hash)) if cached == exact.kind => hash,
+                        _ => {
+                            let hash = hash_dimension(dim_prefix::EXACT, exact.kind.as_str());
+                            exact_dim = Some((exact.kind, hash));
+                            hash
+                        }
+                    };
+
+                    exact::insert_prehashed(&mut batch, &self.store.exact, exact, dim_hash)
                         .map_err(IndexError::from)?;
                 }
             }

--- a/crates/fjall/src/keys.rs
+++ b/crates/fjall/src/keys.rs
@@ -25,8 +25,12 @@ pub const TXO_REF_SIZE: usize = 36;
 /// Size of encoded slot: 8-byte u64
 pub const SLOT_SIZE: usize = 8;
 
-/// Size of encoded hash key: 8-byte u64
-pub const HASH_KEY_SIZE: usize = 8;
+/// Size of encoded hash key: 8-byte u64.
+///
+/// Defined as core's [`dolos_core::KEY_HASH_SIZE`] so the width asserted by
+/// the record types ([`dolos_core::KeyHash`]) and the width used in on-disk
+/// keys cannot drift apart.
+pub const HASH_KEY_SIZE: usize = dolos_core::KEY_HASH_SIZE;
 
 /// Size of dimension hash: 8 bytes
 pub const DIM_HASH_SIZE: usize = 8;

--- a/crates/fjall/src/state/README.md
+++ b/crates/fjall/src/state/README.md
@@ -130,6 +130,22 @@ for result in iter {
 }
 ```
 
+### Full UTxO-Set Iteration
+
+```rust
+// Stream the whole UTxO set (snapshot export, live-UTxO index rebuild)
+let iter = store.iter_utxos()?;
+for result in iter {
+    let (txo_ref, era_cbor) = result?;
+    // Process UTxO
+}
+```
+
+Lazy in the same sense `iter_entities` is: construction reads nothing and
+entries are decoded one at a time. Callers stream a mainnet-sized set through
+it, so buffering would not be a slower implementation but an unusable one —
+`tests/memory.rs` asserts both the construction and the iteration bound.
+
 ### Batched Writes
 
 ```rust

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -333,6 +333,6 @@ impl CoreStateStore for StateStore {
     fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
         // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
         let snapshot = self.db.snapshot();
-        utxos::UtxosIterator::new(&snapshot, &self.utxos).map_err(StateError::from)
+        Ok(utxos::UtxosIterator::new(&snapshot, &self.utxos))
     }
 }

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -265,6 +265,7 @@ impl CoreStateWriter for StateWriter {
 impl CoreStateStore for StateStore {
     type EntityIter = entities::EntityIterator;
     type EntityValueIter = entities::EmptyEntityValueIterator;
+    type UtxoIter = utxos::UtxosIterator;
     type Writer = StateWriter;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
@@ -327,5 +328,11 @@ impl CoreStateStore for StateStore {
         // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
         let snapshot = self.db.snapshot();
         utxos::get_utxos(&snapshot, &self.utxos, &refs).map_err(StateError::from)
+    }
+
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
+        // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
+        let snapshot = self.db.snapshot();
+        utxos::UtxosIterator::new(&snapshot, &self.utxos).map_err(StateError::from)
     }
 }

--- a/crates/fjall/src/state/utxos.rs
+++ b/crates/fjall/src/state/utxos.rs
@@ -89,8 +89,17 @@ pub fn get_utxos<R: Readable>(
 /// This matters: the callers this exists for (snapshot export, live-UTxO index
 /// rebuild) run against a mainnet UTxO set of several GB, which buffering would
 /// pull into memory whole.
+///
+/// The held `SnapshotNonce` pins fjall's GC watermark for the iterator's
+/// lifetime: superseded versions written while it is alive are retained until
+/// it drops. Drain or drop it promptly on a live store.
+///
+/// Errors are terminal: after yielding an `Err` — a read failure or a
+/// malformed entry — the iterator is fused and yields `None` forever, so a
+/// consumer cannot receive a silently truncated UTxO set.
 pub struct UtxosIterator {
     inner: fjall::Iter,
+    done: bool,
 }
 
 impl UtxosIterator {
@@ -100,11 +109,13 @@ impl UtxosIterator {
     /// Snapshot-based reads avoid potential deadlocks with concurrent writes by
     /// using MVCC (Multi-Version Concurrency Control).
     ///
-    /// Returns immediately without reading any data.
-    pub fn new<R: Readable>(readable: &R, keyspace: &Keyspace) -> Result<Self, Error> {
-        Ok(Self {
+    /// Returns immediately without reading any data; the first read failure
+    /// surfaces from `next()`.
+    pub fn new<R: Readable>(readable: &R, keyspace: &Keyspace) -> Self {
+        Self {
             inner: readable.iter(keyspace),
-        })
+            done: false,
+        }
     }
 }
 
@@ -112,22 +123,46 @@ impl Iterator for UtxosIterator {
     type Item = Result<UtxoEntry, StateError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for guard in self.inner.by_ref() {
-            // fjall's Guard::into_inner() gives us both key and value
-            match guard.into_inner() {
-                Ok((key_bytes, value_bytes)) => {
-                    if key_bytes.len() == TXO_REF_SIZE {
-                        if let Some((era, cbor)) = decode_utxo_value(&value_bytes) {
-                            let txo_ref = decode_txo_ref(&key_bytes);
-                            return Some(Ok((txo_ref, Arc::new(EraCbor(era, cbor)))));
-                        }
-                    }
-                    // Skip malformed entries, continue to next
-                }
-                Err(e) => return Some(Err(Error::Fjall(e).into())),
-            }
+        if self.done {
+            return None;
         }
 
-        None
+        match self.inner.next() {
+            Some(guard) => match guard.into_inner() {
+                Ok((key_bytes, value_bytes)) => {
+                    if key_bytes.len() != TXO_REF_SIZE {
+                        // A wrong-width key cannot come from this module's
+                        // write path: it is corruption, and this stream feeds
+                        // a signed snapshot layer — error out (terminally)
+                        // rather than skip.
+                        self.done = true;
+                        return Some(Err(StateError::InternalStoreError(format!(
+                            "malformed utxo entry: key is {} bytes, expected {TXO_REF_SIZE}",
+                            key_bytes.len(),
+                        ))));
+                    }
+
+                    let Some((era, cbor)) = decode_utxo_value(&value_bytes) else {
+                        self.done = true;
+                        return Some(Err(StateError::InternalStoreError(
+                            "malformed utxo entry: undecodable value".into(),
+                        )));
+                    };
+
+                    let txo_ref = decode_txo_ref(&key_bytes);
+                    Some(Ok((txo_ref, EraCbor(era, cbor))))
+                }
+                Err(e) => {
+                    self.done = true;
+                    Some(Err(Error::Fjall(e).into()))
+                }
+            },
+            None => {
+                self.done = true;
+                None
+            }
+        }
     }
 }
+
+impl std::iter::FusedIterator for UtxosIterator {}

--- a/crates/fjall/src/state/utxos.rs
+++ b/crates/fjall/src/state/utxos.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use dolos_core::{EraCbor, TxoRef, UtxoMap, UtxoSetDelta};
+use dolos_core::{EraCbor, StateError, TxoRef, UtxoEntry, UtxoMap, UtxoSetDelta};
 use fjall::{Keyspace, OwnedWriteBatch, Readable};
 
 use crate::keys::{
@@ -79,53 +79,55 @@ pub fn get_utxos<R: Readable>(
     Ok(result)
 }
 
-/// Iterator over all UTxOs in the keyspace.
+/// Lazy streaming iterator over every UTxO in the keyspace.
 ///
-/// Uses the `Readable` trait to support both direct keyspace access and
-/// snapshot-based reads. Snapshot-based reads avoid potential deadlocks with
-/// concurrent writes by using MVCC (Multi-Version Concurrency Control).
+/// Wraps a `fjall::Iter`, an owned iterator holding a `SnapshotNonce` and a
+/// boxed cursor. Entries are decoded one at a time in `next()`, so memory stays
+/// O(1) regardless of how large the UTxO set is — the same shape as
+/// `entities::EntityIterator`.
+///
+/// This matters: the callers this exists for (snapshot export, live-UTxO index
+/// rebuild) run against a mainnet UTxO set of several GB, which buffering would
+/// pull into memory whole.
 pub struct UtxosIterator {
-    /// Collected UTxOs from scan
-    utxos: Vec<(TxoRef, Arc<EraCbor>)>,
-    /// Current position
-    pos: usize,
+    inner: fjall::Iter,
 }
 
 impl UtxosIterator {
     /// Create a new iterator over all UTxOs.
     ///
     /// Uses the `Readable` trait to support snapshot-based iteration.
+    /// Snapshot-based reads avoid potential deadlocks with concurrent writes by
+    /// using MVCC (Multi-Version Concurrency Control).
+    ///
+    /// Returns immediately without reading any data.
     pub fn new<R: Readable>(readable: &R, keyspace: &Keyspace) -> Result<Self, Error> {
-        let mut utxos = Vec::new();
-
-        // Scan all entries in the keyspace
-        // Using Readable::iter() enables snapshot-based iteration
-        for guard in readable.iter(keyspace) {
-            // fjall's Guard::into_inner() gives us both key and value
-            let (key_bytes, value_bytes) = guard.into_inner().map_err(Error::Fjall)?;
-
-            if key_bytes.len() == TXO_REF_SIZE {
-                let txo_ref = decode_txo_ref(&key_bytes);
-                if let Some((era, cbor)) = decode_utxo_value(&value_bytes) {
-                    utxos.push((txo_ref, Arc::new(EraCbor(era, cbor))));
-                }
-            }
-        }
-
-        Ok(Self { utxos, pos: 0 })
+        Ok(Self {
+            inner: readable.iter(keyspace),
+        })
     }
 }
 
 impl Iterator for UtxosIterator {
-    type Item = Result<(TxoRef, Arc<EraCbor>), Error>;
+    type Item = Result<UtxoEntry, StateError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos < self.utxos.len() {
-            let item = self.utxos[self.pos].clone();
-            self.pos += 1;
-            Some(Ok(item))
-        } else {
-            None
+        for guard in self.inner.by_ref() {
+            // fjall's Guard::into_inner() gives us both key and value
+            match guard.into_inner() {
+                Ok((key_bytes, value_bytes)) => {
+                    if key_bytes.len() == TXO_REF_SIZE {
+                        if let Some((era, cbor)) = decode_utxo_value(&value_bytes) {
+                            let txo_ref = decode_txo_ref(&key_bytes);
+                            return Some(Ok((txo_ref, Arc::new(EraCbor(era, cbor)))));
+                        }
+                    }
+                    // Skip malformed entries, continue to next
+                }
+                Err(e) => return Some(Err(Error::Fjall(e).into())),
+            }
         }
+
+        None
     }
 }

--- a/crates/fjall/src/state/utxos.rs
+++ b/crates/fjall/src/state/utxos.rs
@@ -131,10 +131,6 @@ impl Iterator for UtxosIterator {
             Some(guard) => match guard.into_inner() {
                 Ok((key_bytes, value_bytes)) => {
                     if key_bytes.len() != TXO_REF_SIZE {
-                        // A wrong-width key cannot come from this module's
-                        // write path: it is corruption, and this stream feeds
-                        // a signed snapshot layer — error out (terminally)
-                        // rather than skip.
                         self.done = true;
                         return Some(Err(StateError::InternalStoreError(format!(
                             "malformed utxo entry: key is {} bytes, expected {TXO_REF_SIZE}",

--- a/crates/redb3/src/indexes/mod.rs
+++ b/crates/redb3/src/indexes/mod.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 use dolos_core::{
-    config::RedbIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint, IndexDelta, IndexError,
-    IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, Tag, TagDimension, TxoRef,
-    UtxoSet,
+    config::RedbIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint, EmptyExactIter,
+    EmptyTagIter, IndexDelta, IndexError, IndexRecord, IndexStore as CoreIndexStore,
+    IndexWriter as CoreIndexWriter, Tag, TagDimension, TxoRef, UtxoSet,
 };
 use redb::{
     Database, Durability, MultimapTableDefinition, ReadTransaction, ReadableDatabase,
@@ -746,6 +746,16 @@ impl CoreIndexWriter for IndexStoreWriter {
         Ok(())
     }
 
+    /// Not implemented on this backend.
+    ///
+    /// Pre-hashed append exists for the snapshot restore path, which runs
+    /// against the live index backend (fjall). This store is not part of that
+    /// path, so it carries the trait method without an implementation rather
+    /// than a second copy of the encoding to keep in step.
+    fn append_prehashed(&self, _records: &[IndexRecord]) -> Result<(), IndexError> {
+        Err(IndexError::Unsupported("append_prehashed"))
+    }
+
     fn commit(self) -> Result<(), IndexError> {
         self.wx.commit().map_err(map_db_error)?;
         Ok(())
@@ -777,6 +787,8 @@ impl DoubleEndedIterator for SlotIter {
 impl CoreIndexStore for IndexStore {
     type Writer = IndexStoreWriter;
     type SlotIter = SlotIter;
+    type TagIter = EmptyTagIter;
+    type ExactIter = EmptyExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         let mut wx = self.db.begin_write().map_err(map_db_error)?;
@@ -888,5 +900,27 @@ impl CoreIndexStore for IndexStore {
         };
 
         Ok(SlotIter { _rx: rx, range })
+    }
+
+    /// Not implemented on this backend.
+    ///
+    /// Bulk record traversal exists for the snapshot export path, which runs
+    /// against the live index backend (fjall). Implementing it here would mean
+    /// a per-dimension table walk with no consumer.
+    fn iter_archive_tags(
+        &self,
+        _dimensions: &[TagDimension],
+        _slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        Err(IndexError::Unsupported("iter_archive_tags"))
+    }
+
+    /// Not implemented on this backend. See
+    /// [`IndexStore::iter_archive_tags`](CoreIndexStore::iter_archive_tags).
+    fn iter_exact_records(
+        &self,
+        _slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::ExactIter, IndexError> {
+        Err(IndexError::Unsupported("iter_exact_records"))
     }
 }

--- a/crates/redb3/src/state/mod.rs
+++ b/crates/redb3/src/state/mod.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use dolos_core::{
-    config::RedbStateConfig, ChainPoint, EntityKey, EntityValue, Namespace, StateError,
-    StateSchema, TxoRef, UtxoMap,
+    config::RedbStateConfig, ChainPoint, EmptyUtxoIter, EntityKey, EntityValue, Namespace,
+    StateError, StateSchema, TxoRef, UtxoMap,
 };
 
 use redb::{
@@ -239,6 +239,7 @@ impl dolos_core::StateWriter for StateWriter {
 impl dolos_core::StateStore for StateStore {
     type EntityIter = EntityIter;
     type EntityValueIter = EntityValueIter;
+    type UtxoIter = EmptyUtxoIter;
     type Writer = StateWriter;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
@@ -325,5 +326,13 @@ impl dolos_core::StateStore for StateStore {
         let out = utxoset::UtxosTable::get_sparse(&rx, refs)?;
 
         Ok(out)
+    }
+
+    /// Not implemented on this backend.
+    ///
+    /// Full UTxO-set iteration exists for the snapshot export and live-UTxO
+    /// index rebuild paths, which run against the live state backend (fjall).
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
+        Err(StateError::Unsupported("iter_utxos"))
     }
 }

--- a/crates/testing/src/faults.rs
+++ b/crates/testing/src/faults.rs
@@ -81,6 +81,7 @@ impl FaultyStateStore {
 impl StateStore for FaultyStateStore {
     type EntityIter = <dolos_redb3::state::StateStore as StateStore>::EntityIter;
     type EntityValueIter = <dolos_redb3::state::StateStore as StateStore>::EntityValueIter;
+    type UtxoIter = <dolos_redb3::state::StateStore as StateStore>::UtxoIter;
     type Writer = <dolos_redb3::state::StateStore as StateStore>::Writer;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
@@ -135,6 +136,13 @@ impl StateStore for FaultyStateStore {
             return Err(self.fault_err());
         }
         self.inner.get_utxos(refs)
+    }
+
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.iter_utxos()
     }
 }
 
@@ -269,6 +277,8 @@ impl FaultyIndexStore {
 impl IndexStore for FaultyIndexStore {
     type Writer = <dolos_redb3::indexes::IndexStore as IndexStore>::Writer;
     type SlotIter = <dolos_redb3::indexes::IndexStore as IndexStore>::SlotIter;
+    type TagIter = <dolos_redb3::indexes::IndexStore as IndexStore>::TagIter;
+    type ExactIter = <dolos_redb3::indexes::IndexStore as IndexStore>::ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         if self.should_fault() {
@@ -341,6 +351,27 @@ impl IndexStore for FaultyIndexStore {
             return Err(self.fault_err());
         }
         self.inner.slots_by_tag(dimension, key, start, end)
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.iter_archive_tags(dimensions, slots)
+    }
+
+    fn iter_exact_records(
+        &self,
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::ExactIter, IndexError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.iter_exact_records(slots)
     }
 }
 

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -24,11 +24,12 @@ use dolos_core::{
         MempoolStoreConfig, RedbArchiveConfig, RedbIndexConfig, RedbStateConfig, RedbWalConfig,
         RootConfig, StateStoreConfig, StorageVersion, WalStoreConfig,
     },
-    BlockBody, BlockSlot, ChainPoint, EntityDelta, EntityKey, EntityValue, IndexDelta, IndexError,
-    IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, LogEntry, LogValue, MempoolError,
-    MempoolEvent, MempoolStore, MempoolTx, Namespace, RawBlock, StateError, StateSchema,
-    StateStore as CoreStateStore, StateWriter as CoreStateWriter, TagDimension, TxHash, TxStatus,
-    TxoRef, UtxoMap, UtxoSet, UtxoSetDelta, WalError, WalStore,
+    BlockBody, BlockSlot, ChainPoint, EntityDelta, EntityKey, EntityValue, ExactRecord, IndexDelta,
+    IndexError, IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter,
+    LogEntry, LogValue, MempoolError, MempoolEvent, MempoolStore, MempoolTx, Namespace, RawBlock,
+    StateError, StateSchema, StateStore as CoreStateStore, StateWriter as CoreStateWriter,
+    TagDimension, TagRecord, TxHash, TxStatus, TxoRef, UtxoEntry, UtxoMap, UtxoSet, UtxoSetDelta,
+    WalError, WalStore,
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -467,9 +468,25 @@ impl Iterator for StateEntityValueIterBackend {
     }
 }
 
+pub enum StateUtxoIterBackend {
+    Redb(<dolos_redb3::state::StateStore as CoreStateStore>::UtxoIter),
+    Fjall(<dolos_fjall::StateStore as CoreStateStore>::UtxoIter),
+}
+
+impl Iterator for StateUtxoIterBackend {
+    type Item = Result<UtxoEntry, StateError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+        }
+    }
+}
+
 impl CoreStateStore for StateStoreBackend {
     type EntityIter = StateEntityIterBackend;
     type EntityValueIter = StateEntityValueIterBackend;
+    type UtxoIter = StateUtxoIterBackend;
     type Writer = StateWriterBackend;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
@@ -531,6 +548,13 @@ impl CoreStateStore for StateStoreBackend {
         match self {
             Self::Redb(s) => s.get_utxos(refs),
             Self::Fjall(s) => s.get_utxos(refs),
+        }
+    }
+
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
+        match self {
+            Self::Redb(s) => s.iter_utxos().map(StateUtxoIterBackend::Redb),
+            Self::Fjall(s) => s.iter_utxos().map(StateUtxoIterBackend::Fjall),
         }
     }
 }
@@ -880,6 +904,14 @@ impl CoreIndexWriter for IndexWriterBackend {
         }
     }
 
+    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+        match self {
+            Self::Redb(w) => w.append_prehashed(records),
+            Self::Fjall(w) => w.append_prehashed(records),
+            Self::NoOp(w) => w.append_prehashed(records),
+        }
+    }
+
     fn commit(self) -> Result<(), IndexError> {
         match self {
             Self::Redb(w) => (*w).commit(),
@@ -916,9 +948,45 @@ impl DoubleEndedIterator for IndexSlotIterBackend {
     }
 }
 
+pub enum IndexTagIterBackend {
+    Redb(<dolos_redb3::indexes::IndexStore as CoreIndexStore>::TagIter),
+    Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::TagIter),
+    NoOp(<NoOpIndexStore as CoreIndexStore>::TagIter),
+}
+
+impl Iterator for IndexTagIterBackend {
+    type Item = Result<TagRecord, IndexError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+            Self::NoOp(iter) => iter.next(),
+        }
+    }
+}
+
+pub enum IndexExactIterBackend {
+    Redb(<dolos_redb3::indexes::IndexStore as CoreIndexStore>::ExactIter),
+    Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::ExactIter),
+    NoOp(<NoOpIndexStore as CoreIndexStore>::ExactIter),
+}
+
+impl Iterator for IndexExactIterBackend {
+    type Item = Result<ExactRecord, IndexError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+            Self::NoOp(iter) => iter.next(),
+        }
+    }
+}
+
 impl CoreIndexStore for IndexStoreBackend {
     type Writer = IndexWriterBackend;
     type SlotIter = IndexSlotIterBackend;
+    type TagIter = IndexTagIterBackend;
+    type ExactIter = IndexExactIterBackend;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         match self {
@@ -1006,6 +1074,34 @@ impl CoreIndexStore for IndexStoreBackend {
             Self::NoOp(s) => s
                 .slots_by_tag(dimension, key, start, end)
                 .map(IndexSlotIterBackend::NoOp),
+        }
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        match self {
+            Self::Redb(s) => s
+                .iter_archive_tags(dimensions, slots)
+                .map(IndexTagIterBackend::Redb),
+            Self::Fjall(s) => s
+                .iter_archive_tags(dimensions, slots)
+                .map(IndexTagIterBackend::Fjall),
+            Self::NoOp(s) => s
+                .iter_archive_tags(dimensions, slots)
+                .map(IndexTagIterBackend::NoOp),
+        }
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
+        match self {
+            Self::Redb(s) => s.iter_exact_records(slots).map(IndexExactIterBackend::Redb),
+            Self::Fjall(s) => s
+                .iter_exact_records(slots)
+                .map(IndexExactIterBackend::Fjall),
+            Self::NoOp(s) => s.iter_exact_records(slots).map(IndexExactIterBackend::NoOp),
         }
     }
 }

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -554,8 +554,12 @@ fn measure_one_epoch_iteration_cost() {
                     tx_hashes.push(hash32(0x02, slot, tx));
 
                     for t in 0..COST_TAGS_PER_TX {
-                        let dimension =
-                            archive_dimensions::ALL[(t as usize) % archive_dimensions::ALL.len()];
+                        // Offset by tx so the whole dimension set gets seeded:
+                        // 10 tags from a fixed starting point would cover only
+                        // 10 of the 12 dimensions, leaving METADATA — the
+                        // verbatim-key path — out of the measurement entirely.
+                        let dimension = archive_dimensions::ALL
+                            [((tx + t) as usize) % archive_dimensions::ALL.len()];
 
                         let key = if dimension == archive_dimensions::METADATA {
                             (t % 8).to_be_bytes().to_vec()

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -1,0 +1,635 @@
+//! Export/restore coverage for the pre-hashed archive index seam.
+//!
+//! `IndexStore::iter_archive_tags` / `iter_exact_records` and
+//! `IndexWriter::append_prehashed` are the two halves of one thing: a snapshot
+//! layer is exactly what iteration yields, and a restore is exactly what the
+//! writer takes back. Two properties make that work, and neither is visible
+//! from a single-store unit test:
+//!
+//! 1. **The round trip is exact.** Records carry the stored key form, not a
+//!    logical key, because the logical key is not on disk. A store rebuilt from
+//!    them has to answer its own queries identically — including `metadata`,
+//!    the one dimension whose stored bytes are not a hash of anything.
+//!
+//! 2. **The order is the content.** Layers are defined as sorted record
+//!    sequences, so an iterator that yields the right records in the wrong
+//!    order is wrong, not slow.
+//!
+//! Both are asserted against fjall, the live index backend.
+
+use std::collections::BTreeSet;
+use std::ops::Range;
+
+use dolos_cardano::indexes::archive_dimensions;
+use dolos_core::{
+    config::FjallIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint, ExactKind, ExactRecord,
+    IndexDelta, IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, Tag,
+    TagDimension, TagRecord,
+};
+
+const EPOCH_LEN: BlockSlot = 432_000;
+const BLOCKS_PER_EPOCH: u64 = 40;
+const TXS_PER_BLOCK: u64 = 3;
+
+/// Epochs seeded into the source store. The traversal is asserted against the
+/// first; the second exists so a per-epoch slice has something to leave out.
+const EPOCHS: [u64; 2] = [1, 2];
+
+/// The dimensions the seed writes tags for. A strict subset of
+/// `archive_dimensions::ALL` on purpose: traversal must cope with dimensions
+/// that hold nothing.
+const SEEDED_DIMENSIONS: [TagDimension; 4] = [
+    archive_dimensions::ADDRESS,
+    archive_dimensions::ASSET,
+    archive_dimensions::SCRIPT,
+    archive_dimensions::METADATA,
+];
+
+/// Transaction metadata labels. `metadata` keys are u64 labels, and the store
+/// keeps the label verbatim rather than hashing it.
+const METADATA_LABELS: [u64; 3] = [674, 721, 1990];
+
+fn epoch_slots(epoch: u64) -> Range<BlockSlot> {
+    (epoch * EPOCH_LEN)..((epoch + 1) * EPOCH_LEN)
+}
+
+fn open_store(tmpdir: &tempfile::TempDir) -> dolos_fjall::IndexStore {
+    let config = FjallIndexConfig {
+        path: None,
+        cache: Some(16),
+        max_journal_size: None,
+        flush_on_commit: Some(false),
+        l0_threshold: None,
+        worker_threads: Some(1),
+        memtable_size_mb: None,
+    };
+
+    dolos_fjall::IndexStore::open(tmpdir.path(), &config).expect("failed to open fjall index store")
+}
+
+fn hash32(tag: u8, a: u64, b: u64) -> Vec<u8> {
+    let mut out = vec![tag; 32];
+    out[1..9].copy_from_slice(&a.to_be_bytes());
+    out[9..17].copy_from_slice(&b.to_be_bytes());
+    out
+}
+
+/// What the seed wrote, kept in logical form so the store's own query API can
+/// be pointed at it afterwards — the point of the round trip is that a
+/// restored store answers those queries the same way.
+#[derive(Default)]
+struct Seeded {
+    /// (dimension, logical key, slot)
+    tags: Vec<(TagDimension, Vec<u8>, BlockSlot)>,
+    /// (block hash, block number, slot)
+    blocks: Vec<(Vec<u8>, u64, BlockSlot)>,
+    /// (tx hash, slot)
+    txs: Vec<(Vec<u8>, BlockSlot)>,
+}
+
+impl Seeded {
+    fn tags_in<'a>(
+        &'a self,
+        slots: &'a Range<BlockSlot>,
+    ) -> impl Iterator<Item = &'a (TagDimension, Vec<u8>, BlockSlot)> + 'a {
+        self.tags.iter().filter(|(_, _, slot)| slots.contains(slot))
+    }
+}
+
+/// Populate a store through the regular delta path, the same one the sync
+/// pipeline uses. Nothing here knows about pre-hashed records: the export side
+/// has to cope with whatever normal indexing produced.
+fn seed(store: &dolos_fjall::IndexStore) -> Seeded {
+    let mut seeded = Seeded::default();
+
+    for epoch in EPOCHS {
+        let mut archive = Vec::new();
+
+        for block in 0..BLOCKS_PER_EPOCH {
+            let slot = epoch * EPOCH_LEN + block * 20;
+            let block_hash = hash32(0x01, epoch, block);
+            let block_number = epoch * 1_000 + block;
+
+            let mut tx_hashes = Vec::new();
+            for tx in 0..TXS_PER_BLOCK {
+                let tx_hash = hash32(0x02, epoch * 1_000 + block, tx);
+                seeded.txs.push((tx_hash.clone(), slot));
+                tx_hashes.push(tx_hash);
+            }
+
+            let mut tags = Vec::new();
+            for dimension in SEEDED_DIMENSIONS {
+                let key = if dimension == archive_dimensions::METADATA {
+                    let label = METADATA_LABELS[(block % METADATA_LABELS.len() as u64) as usize];
+                    label.to_be_bytes().to_vec()
+                } else {
+                    // A handful of distinct keys per dimension, so several
+                    // slots land under the same key hash.
+                    hash32(0x03, dimension.len() as u64, block % 5)
+                };
+
+                seeded.tags.push((dimension, key.clone(), slot));
+                tags.push(Tag::new(dimension, key));
+            }
+
+            seeded.blocks.push((block_hash.clone(), block_number, slot));
+
+            archive.push(ArchiveIndexDelta {
+                slot,
+                block_hash,
+                block_number: Some(block_number),
+                tx_hashes,
+                tags,
+            });
+        }
+
+        let cursor = ChainPoint::Slot(archive.last().unwrap().slot);
+        let delta = IndexDelta {
+            cursor,
+            utxo: Default::default(),
+            archive,
+        };
+
+        let writer = store.start_writer().expect("start_writer failed");
+        writer.apply(&delta).expect("apply failed");
+        writer.commit().expect("commit failed");
+    }
+
+    seeded
+}
+
+fn collect_tags(
+    store: &dolos_fjall::IndexStore,
+    dimensions: &[TagDimension],
+    slots: Range<BlockSlot>,
+) -> Vec<TagRecord> {
+    store
+        .iter_archive_tags(dimensions, slots)
+        .expect("iter_archive_tags failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("tag iteration failed")
+}
+
+fn collect_exacts(store: &dolos_fjall::IndexStore, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
+    store
+        .iter_exact_records(slots)
+        .expect("iter_exact_records failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("exact iteration failed")
+}
+
+fn slots_for_tag(
+    store: &dolos_fjall::IndexStore,
+    dimension: TagDimension,
+    key: &[u8],
+    slots: &Range<BlockSlot>,
+) -> Vec<BlockSlot> {
+    store
+        .slots_by_tag(dimension, key, slots.start, slots.end - 1)
+        .expect("slots_by_tag failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("slot iteration failed")
+}
+
+// ---------------------------------------------------------------------------
+// Round trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn epoch_slice_round_trips_through_append_prehashed() {
+    let source_dir = tempfile::tempdir().expect("failed to create tempdir");
+    let source = open_store(&source_dir);
+    let seeded = seed(&source);
+
+    let exported = epoch_slots(EPOCHS[0]);
+    let excluded = epoch_slots(EPOCHS[1]);
+
+    let mut records: Vec<IndexRecord> = Vec::new();
+    records.extend(
+        collect_tags(&source, &archive_dimensions::ALL, exported.clone())
+            .into_iter()
+            .map(IndexRecord::from),
+    );
+    records.extend(
+        collect_exacts(&source, exported.clone())
+            .into_iter()
+            .map(IndexRecord::from),
+    );
+
+    assert!(!records.is_empty(), "the epoch slice should not be empty");
+
+    let target_dir = tempfile::tempdir().expect("failed to create tempdir");
+    let target = open_store(&target_dir);
+
+    let writer = target.start_writer().expect("start_writer failed");
+    writer
+        .append_prehashed(&records)
+        .expect("append_prehashed failed");
+    writer.commit().expect("commit failed");
+
+    // --- tags -------------------------------------------------------------
+
+    let mut checked_metadata = false;
+
+    for (dimension, key, _) in seeded.tags_in(&exported) {
+        let from_source = slots_for_tag(&source, dimension, key, &exported);
+        let from_target = slots_for_tag(&target, dimension, key, &exported);
+
+        assert!(
+            !from_source.is_empty(),
+            "seeded tag {dimension} should be queryable in the source store"
+        );
+        assert_eq!(
+            from_source, from_target,
+            "restored store disagrees on dimension {dimension}"
+        );
+
+        if *dimension == archive_dimensions::METADATA {
+            checked_metadata = true;
+        }
+    }
+
+    assert!(
+        checked_metadata,
+        "the metadata dimension must be part of the round trip: it is the one \
+         whose stored key is a raw label rather than a hash, so it is the \
+         record most likely to survive a lossy round trip unnoticed"
+    );
+
+    // The slice really is a slice: nothing outside the exported epoch came
+    // along for the ride.
+    for (dimension, key, _) in seeded.tags_in(&excluded) {
+        let from_source = slots_for_tag(&source, dimension, key, &excluded);
+        let from_target = slots_for_tag(&target, dimension, key, &excluded);
+
+        assert!(!from_source.is_empty());
+        assert!(
+            from_target.is_empty(),
+            "dimension {dimension} leaked records from outside the exported epoch"
+        );
+    }
+
+    // --- exact lookups ----------------------------------------------------
+
+    for (hash, number, slot) in &seeded.blocks {
+        let inside = exported.contains(slot);
+
+        let by_hash = target
+            .slot_by_block_hash(hash)
+            .expect("slot_by_block_hash failed");
+        let by_number = target
+            .slot_by_block_number(*number)
+            .expect("slot_by_block_number failed");
+
+        if inside {
+            assert_eq!(
+                by_hash,
+                source
+                    .slot_by_block_hash(hash)
+                    .expect("slot_by_block_hash failed")
+            );
+            assert_eq!(
+                by_number,
+                source
+                    .slot_by_block_number(*number)
+                    .expect("slot_by_block_number failed")
+            );
+            assert_eq!(by_hash, Some(*slot));
+            assert_eq!(by_number, Some(*slot));
+        } else {
+            assert_eq!(by_hash, None, "block hash leaked from outside the epoch");
+            assert_eq!(
+                by_number, None,
+                "block number leaked from outside the epoch"
+            );
+        }
+    }
+
+    for (hash, slot) in &seeded.txs {
+        let by_hash = target
+            .slot_by_tx_hash(hash)
+            .expect("slot_by_tx_hash failed");
+
+        if exported.contains(slot) {
+            assert_eq!(
+                by_hash,
+                source
+                    .slot_by_tx_hash(hash)
+                    .expect("slot_by_tx_hash failed")
+            );
+            assert_eq!(by_hash, Some(*slot));
+        } else {
+            assert_eq!(by_hash, None, "tx hash leaked from outside the epoch");
+        }
+    }
+
+    // --- the records themselves -------------------------------------------
+    //
+    // Re-exporting the restored store must yield byte-identical records:
+    // anything else means the write path re-derived something instead of
+    // copying it.
+
+    let reexported_tags = collect_tags(&target, &archive_dimensions::ALL, exported.clone());
+    let source_tags = collect_tags(&source, &archive_dimensions::ALL, exported.clone());
+    assert_eq!(source_tags, reexported_tags);
+
+    let reexported_exacts = collect_exacts(&target, exported.clone());
+    let source_exacts = collect_exacts(&source, exported);
+    assert_eq!(source_exacts, reexported_exacts);
+}
+
+// ---------------------------------------------------------------------------
+// Order
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_records_are_sorted_by_dimension_key_hash_slot() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let store = open_store(&dir);
+    let seeded = seed(&store);
+
+    let slots = epoch_slots(EPOCHS[0]);
+    let records = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+
+    assert!(!records.is_empty());
+
+    let dimensions: BTreeSet<&str> = records.iter().map(|r| r.dimension()).collect();
+    assert!(
+        dimensions.len() > 1,
+        "ordering has to be exercised across more than one dimension, got {dimensions:?}"
+    );
+
+    assert!(
+        records.is_sorted(),
+        "tag records must come out sorted by (dimension, key_hash, slot); \
+         on-disk order is by dimension *hash*, so this only holds if the \
+         traversal walks the dimension list in name order"
+    );
+
+    for record in &records {
+        assert!(
+            slots.contains(&record.slot),
+            "record at slot {} outside the requested range {slots:?}",
+            record.slot
+        );
+    }
+
+    // Every seeded tag in the range is accounted for, once per (key, slot).
+    assert_eq!(records.len(), seeded.tags_in(&slots).count());
+
+    // The order is a property of the store, not of the caller's argument
+    // order.
+    let mut shuffled = archive_dimensions::ALL;
+    shuffled.reverse();
+    assert_eq!(records, collect_tags(&store, &shuffled, slots.clone()));
+
+    // Repeating a dimension does not repeat its records.
+    let repeated: Vec<TagDimension> = archive_dimensions::ALL
+        .iter()
+        .chain(archive_dimensions::ALL.iter())
+        .copied()
+        .collect();
+    assert_eq!(records, collect_tags(&store, &repeated, slots));
+}
+
+#[test]
+fn exact_records_are_sorted_by_kind_and_key() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let store = open_store(&dir);
+    let seeded = seed(&store);
+
+    let slots = epoch_slots(EPOCHS[0]);
+    let records = collect_exacts(&store, slots.clone());
+
+    assert!(!records.is_empty());
+
+    let kinds: BTreeSet<ExactKind> = records.iter().map(|r| r.kind).collect();
+    assert_eq!(
+        kinds.len(),
+        ExactKind::ALL.len(),
+        "every exact kind should be represented, got {kinds:?}"
+    );
+
+    assert!(
+        records.is_sorted(),
+        "exact records must come out sorted by (kind, key)"
+    );
+
+    for record in &records {
+        assert!(slots.contains(&record.slot));
+    }
+
+    let expected = seeded
+        .blocks
+        .iter()
+        .filter(|(_, _, s)| slots.contains(s))
+        .count()
+        * 2
+        + seeded.txs.iter().filter(|(_, s)| slots.contains(s)).count();
+    assert_eq!(records.len(), expected);
+}
+
+// ---------------------------------------------------------------------------
+// The stored key form
+// ---------------------------------------------------------------------------
+
+/// ADR-004 specifies index layer tag records as
+/// `[0, dimension, key_hash = xxh3_64(key), slot]`. That description holds for
+/// every dimension the store keeps *except* `metadata`, whose logical key is
+/// already a u64 label and is stored verbatim.
+///
+/// This test pins the actual behaviour of both cases, because the format's
+/// cross-implementation promise depends on which one a reader implements: a
+/// third-party publisher that hashes metadata labels produces records this
+/// store cannot use, and vice versa.
+#[test]
+fn tag_key_hashes_are_xxh3_except_for_metadata_labels() {
+    use xxhash_rust::xxh3::xxh3_64;
+
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let store = open_store(&dir);
+    let seeded = seed(&store);
+
+    let slots = epoch_slots(EPOCHS[0]);
+    let records = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+
+    let mut checked_hashed = 0;
+    let mut checked_labels = 0;
+
+    for (dimension, key, slot) in seeded.tags_in(&slots) {
+        let expected_hash = if *dimension == archive_dimensions::METADATA {
+            checked_labels += 1;
+            // Stored verbatim: the 8 key bytes *are* the stored key form.
+            let mut raw = [0u8; 8];
+            raw.copy_from_slice(key);
+            raw
+        } else {
+            checked_hashed += 1;
+            xxh3_64(key).to_be_bytes()
+        };
+
+        let expected = TagRecord::new(dimension, expected_hash, *slot);
+        assert!(
+            records.contains(&expected),
+            "expected record {expected:?} for dimension {dimension}"
+        );
+    }
+
+    assert!(checked_hashed > 0 && checked_labels > 0);
+
+    // And the two schemes really do differ, so the exception is not a
+    // distinction without a difference.
+    let label = METADATA_LABELS[0];
+    assert_ne!(
+        label.to_be_bytes(),
+        xxh3_64(&label.to_be_bytes()).to_be_bytes()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cost
+// ---------------------------------------------------------------------------
+
+/// Mainnet-shaped epoch: ~5 days at 20s/slot.
+const COST_BLOCKS_PER_EPOCH: u64 = 21_600;
+/// Transactions per block.
+const COST_TXS_PER_BLOCK: u64 = 3;
+/// Archive tags per transaction, across the dimension set.
+const COST_TAGS_PER_TX: u64 = 10;
+/// Epochs of history to seed behind the one being sliced. Override with
+/// `DOLOS_INDEX_COST_EPOCHS` to check how the cost scales with store depth.
+const COST_EPOCHS_DEFAULT: u64 = 8;
+
+fn cost_epochs() -> u64 {
+    std::env::var("DOLOS_INDEX_COST_EPOCHS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(COST_EPOCHS_DEFAULT)
+        .max(1)
+}
+
+/// Measure the cost of slicing one epoch out of a populated index store.
+///
+/// Not an assertion — a number. Neither traversal can seek to an epoch:
+///
+/// - tag keys are `[dim_hash][key_hash][slot]`, so slot is the *last* component
+///   and each dimension prefix is scanned in full;
+/// - an exact entry's slot is its stored *value*, so the whole exact keyspace
+///   is scanned and every value read.
+///
+/// Both therefore cost O(store), not O(epoch), and a first publish wants every
+/// epoch. This measurement is what the publisher pipeline gets sized on; the
+/// mitigation (one pass bucketing records by epoch) belongs to the export
+/// orchestration, not here.
+///
+/// Run with:
+/// `cargo test --release --test index_roundtrip -- --ignored --nocapture`
+#[test]
+#[ignore = "measurement, not an assertion"]
+fn measure_one_epoch_iteration_cost() {
+    use std::time::Instant;
+
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let store = open_store(&dir);
+
+    let epochs = cost_epochs();
+    let tags_per_epoch = COST_BLOCKS_PER_EPOCH * COST_TXS_PER_BLOCK * COST_TAGS_PER_TX;
+    let exacts_per_epoch = COST_BLOCKS_PER_EPOCH * (2 + COST_TXS_PER_BLOCK);
+
+    let started = Instant::now();
+
+    for epoch in 0..epochs {
+        // Commit in block-sized batches so the delta never holds an epoch.
+        for chunk_start in (0..COST_BLOCKS_PER_EPOCH).step_by(500) {
+            let chunk_end = std::cmp::min(chunk_start + 500, COST_BLOCKS_PER_EPOCH);
+            let mut archive = Vec::new();
+
+            for block in chunk_start..chunk_end {
+                let slot = epoch * EPOCH_LEN + block * 20;
+
+                let mut tx_hashes = Vec::new();
+                let mut tags = Vec::new();
+
+                for tx in 0..COST_TXS_PER_BLOCK {
+                    tx_hashes.push(hash32(0x02, slot, tx));
+
+                    for t in 0..COST_TAGS_PER_TX {
+                        let dimension =
+                            archive_dimensions::ALL[(t as usize) % archive_dimensions::ALL.len()];
+
+                        let key = if dimension == archive_dimensions::METADATA {
+                            (t % 8).to_be_bytes().to_vec()
+                        } else {
+                            hash32(0x03, slot.wrapping_mul(31).wrapping_add(tx), t)
+                        };
+
+                        tags.push(Tag::new(dimension, key));
+                    }
+                }
+
+                archive.push(ArchiveIndexDelta {
+                    slot,
+                    block_hash: hash32(0x01, slot, 0),
+                    block_number: Some(epoch * 1_000_000 + block),
+                    tx_hashes,
+                    tags,
+                });
+            }
+
+            let cursor = ChainPoint::Slot(archive.last().unwrap().slot);
+            let delta = IndexDelta {
+                cursor,
+                utxo: Default::default(),
+                archive,
+            };
+
+            let writer = store.start_writer().expect("start_writer failed");
+            writer.apply(&delta).expect("apply failed");
+            writer.commit().expect("commit failed");
+        }
+    }
+
+    let seeding = started.elapsed();
+
+    // Slice the middle epoch, so there is history on both sides of it.
+    let target_epoch = epochs / 2;
+    let slots = epoch_slots(target_epoch);
+
+    let started = Instant::now();
+    let tags = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+    let tag_elapsed = started.elapsed();
+
+    let started = Instant::now();
+    let exacts = collect_exacts(&store, slots.clone());
+    let exact_elapsed = started.elapsed();
+
+    let total_tags = tags_per_epoch * epochs;
+    let total_exacts = exacts_per_epoch * epochs;
+
+    println!("--- one-epoch index iteration cost ---");
+    println!(
+        "store: {epochs} epochs, {total_tags} tag records, {total_exacts} exact records \
+         (seeded in {seeding:.1?})"
+    );
+    println!(
+        "tags:   {:>9} yielded / {:>9} scanned in {:>10.3?}  ({:.0} scanned/s)",
+        tags.len(),
+        total_tags,
+        tag_elapsed,
+        total_tags as f64 / tag_elapsed.as_secs_f64(),
+    );
+    println!(
+        "exacts: {:>9} yielded / {:>9} scanned in {:>10.3?}  ({:.0} scanned/s)",
+        exacts.len(),
+        total_exacts,
+        exact_elapsed,
+        total_exacts as f64 / exact_elapsed.as_secs_f64(),
+    );
+    println!(
+        "one epoch, this store depth: {:.3?}",
+        tag_elapsed + exact_elapsed
+    );
+
+    assert_eq!(tags.len() as u64, tags_per_epoch);
+    assert_eq!(exacts.len() as u64, exacts_per_epoch);
+}

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -191,10 +191,6 @@ fn slots_for_tag(
         .expect("slot iteration failed")
 }
 
-// ---------------------------------------------------------------------------
-// Round trip
-// ---------------------------------------------------------------------------
-
 #[test]
 fn epoch_slice_round_trips_through_append_prehashed() {
     let source_dir = tempfile::tempdir().expect("failed to create tempdir");
@@ -226,8 +222,6 @@ fn epoch_slice_round_trips_through_append_prehashed() {
         .append_prehashed(&records)
         .expect("append_prehashed failed");
     writer.commit().expect("commit failed");
-
-    // --- tags -------------------------------------------------------------
 
     let mut checked_metadata = false;
 
@@ -268,8 +262,6 @@ fn epoch_slice_round_trips_through_append_prehashed() {
             "dimension {dimension} leaked records from outside the exported epoch"
         );
     }
-
-    // --- exact lookups ----------------------------------------------------
 
     for (hash, number, slot) in &seeded.blocks {
         let inside = exported.contains(slot);
@@ -323,8 +315,6 @@ fn epoch_slice_round_trips_through_append_prehashed() {
         }
     }
 
-    // --- the records themselves -------------------------------------------
-    //
     // Re-exporting the restored store must yield byte-identical records:
     // anything else means the write path re-derived something instead of
     // copying it.
@@ -337,10 +327,6 @@ fn epoch_slice_round_trips_through_append_prehashed() {
     let source_exacts = collect_exacts(&source, exported);
     assert_eq!(source_exacts, reexported_exacts);
 }
-
-// ---------------------------------------------------------------------------
-// Order
-// ---------------------------------------------------------------------------
 
 #[test]
 fn tag_records_are_sorted_by_dimension_key_hash_slot() {
@@ -429,10 +415,6 @@ fn exact_records_are_sorted_by_kind_and_key() {
     assert_eq!(records.len(), expected);
 }
 
-// ---------------------------------------------------------------------------
-// The stored key form
-// ---------------------------------------------------------------------------
-
 /// ADR-004 specifies index layer tag records as
 /// `[0, dimension, key_hash = xxh3_64(key), slot]`. That description holds for
 /// every dimension the store keeps *except* `metadata`, whose logical key is
@@ -485,10 +467,6 @@ fn tag_key_hashes_are_xxh3_except_for_metadata_labels() {
         xxh3_64(&label.to_be_bytes()).to_be_bytes()
     );
 }
-
-// ---------------------------------------------------------------------------
-// Cost
-// ---------------------------------------------------------------------------
 
 /// Mainnet-shaped epoch: ~5 days at 20s/slot.
 const COST_BLOCKS_PER_EPOCH: u64 = 21_600;
@@ -554,10 +532,8 @@ fn measure_one_epoch_iteration_cost() {
                     tx_hashes.push(hash32(0x02, slot, tx));
 
                     for t in 0..COST_TAGS_PER_TX {
-                        // Offset by tx so the whole dimension set gets seeded:
-                        // 10 tags from a fixed starting point would cover only
-                        // 10 of the 12 dimensions, leaving METADATA — the
-                        // verbatim-key path — out of the measurement entirely.
+                        // Offset by tx so all 12 dimensions get seeded; a fixed
+                        // starting point would leave METADATA unmeasured.
                         let dimension = archive_dimensions::ALL
                             [((tx + t) as usize) % archive_dimensions::ALL.len()];
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,9 +1,10 @@
 use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
 use std::alloc::System;
+use std::sync::Arc;
 
 use dolos_core::{
-    config::FjallStateConfig, EntityKey, NamespaceType, StateSchema, StateStore as CoreStateStore,
-    StateWriter as CoreStateWriter,
+    config::FjallStateConfig, EntityKey, EraCbor, NamespaceType, StateSchema,
+    StateStore as CoreStateStore, StateWriter as CoreStateWriter, TxoRef, UtxoSetDelta,
 };
 
 #[global_allocator]
@@ -203,6 +204,126 @@ fn test_fjall_shard_range_iter() {
         dolos_fjall::StateStore::open(tmpdir.path(), &config).expect("failed to open fjall store");
 
     assert_shard_range_iter(&store);
+}
+
+// ---------------------------------------------------------------------------
+// Full UTxO-set iteration.
+//
+// Snapshot export and the live-UTxO index rebuild both stream the whole UTxO
+// set, which on mainnet is several GB. `iter_utxos` therefore has to be lazy in
+// the same sense `iter_entities` is: constructing it reads nothing, and running
+// it to the end never holds more than a bounded working set. An eager
+// implementation is not a slower one, it is one that cannot be used at all.
+// ---------------------------------------------------------------------------
+
+const UTXO_COUNT: u64 = 50_000;
+const UTXO_SIZE: usize = 300;
+const UTXO_BATCH_SIZE: u64 = 10_000;
+
+fn seed_utxos<S: CoreStateStore>(store: &S) {
+    let cbor = vec![0xABu8; UTXO_SIZE];
+
+    let mut written = 0u64;
+    while written < UTXO_COUNT {
+        let batch_end = std::cmp::min(written + UTXO_BATCH_SIZE, UTXO_COUNT);
+
+        let mut delta = UtxoSetDelta::default();
+        for i in written..batch_end {
+            let mut hash = [0u8; 32];
+            hash[..8].copy_from_slice(&i.to_be_bytes());
+            let txo = TxoRef(hash.into(), 0);
+            delta
+                .produced_utxo
+                .insert(txo, Arc::new(EraCbor(6, cbor.clone())));
+        }
+
+        let writer = store.start_writer().expect("start_writer failed");
+        writer.apply_utxoset(&delta).expect("apply_utxoset failed");
+        writer.commit().expect("commit failed");
+
+        written = batch_end;
+    }
+}
+
+fn assert_lazy_utxo_iter<S: CoreStateStore>(store: &S) {
+    seed_utxos(store);
+
+    let threshold = 10 * 1024 * 1024; // 10 MB
+    let total_bytes = UTXO_COUNT as usize * UTXO_SIZE;
+    assert!(
+        total_bytes > threshold,
+        "the seeded set must exceed the threshold, otherwise a buffering \
+         implementation would pass the construction check"
+    );
+
+    let reg = Region::new(GLOBAL);
+
+    let iter = store.iter_utxos().expect("iter_utxos failed");
+
+    let construction_delta = reg.change().bytes_allocated;
+    assert!(
+        construction_delta < threshold,
+        "iter_utxos construction should allocate O(1) memory (lazy). \
+         Allocated {} bytes but threshold is {} bytes.",
+        construction_delta,
+        threshold,
+    );
+
+    // Now sample *across* full iteration. Cumulative allocation is the wrong
+    // measure here — even a perfectly lazy iterator allocates one value per
+    // item over a full pass — so what we bound is the live footprint
+    // (allocated minus deallocated) at points along the way. A backend that
+    // buffers the set on first `next()` passes the construction check and
+    // fails this one.
+    let iteration_reg = Region::new(GLOBAL);
+    let mut count = 0usize;
+    let mut peak_live = 0i64;
+
+    for item in iter {
+        let (_txo, _value) = item.expect("utxo iteration failed");
+        count += 1;
+
+        if count.is_multiple_of(1_000) {
+            let stats = iteration_reg.change();
+            let live = stats.bytes_allocated as i64 - stats.bytes_deallocated as i64;
+            peak_live = peak_live.max(live);
+        }
+    }
+
+    assert!(
+        peak_live < threshold as i64,
+        "iter_utxos full iteration should hold O(1) memory. \
+         Peaked at {} live bytes but threshold is {} bytes.",
+        peak_live,
+        threshold,
+    );
+
+    assert_eq!(
+        count, UTXO_COUNT as usize,
+        "iterator should yield every utxo"
+    );
+}
+
+#[test]
+fn test_fjall_lazy_utxo_iter() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
+    let config = FjallStateConfig {
+        path: None,
+        // A small block cache on purpose: cached blocks are live heap, and the
+        // point of the measurement is the iterator's footprint, not the
+        // engine's cache budget.
+        cache: Some(1),
+        max_history: None,
+        max_journal_size: None,
+        flush_on_commit: Some(false),
+        l0_threshold: None,
+        worker_threads: Some(1),
+        memtable_size_mb: None,
+    };
+    let store =
+        dolos_fjall::StateStore::open(tmpdir.path(), &config).expect("failed to open fjall store");
+
+    assert_lazy_utxo_iter(&store);
 }
 
 #[test]

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
 use std::alloc::System;
 use std::sync::Arc;
@@ -7,6 +8,11 @@ use dolos_core::{
     StateStore as CoreStateStore, StateWriter as CoreStateWriter, TxoRef, UtxoSetDelta,
 };
 
+// Every test in this binary reads the same process-global allocator counters,
+// so they must not run concurrently: a sibling test allocating (or freeing)
+// inside another test's measurement window shifts that window's numbers —
+// enough to fail a threshold spuriously, or to drive a live-bytes delta
+// negative and make its assertion vacuous. Hence #[serial] on every test.
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
@@ -60,6 +66,7 @@ fn assert_lazy_iter<S: CoreStateStore>(store: &S) {
 }
 
 #[test]
+#[serial]
 fn test_fjall_lazy_iter() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
     let config = FjallStateConfig {
@@ -79,6 +86,7 @@ fn test_fjall_lazy_iter() {
 }
 
 #[test]
+#[serial]
 fn test_redb3_lazy_iter() {
     let mut schema = StateSchema::default();
     schema.insert(NS, NamespaceType::KeyValue);
@@ -188,6 +196,7 @@ fn assert_shard_range_iter<S: CoreStateStore>(store: &S) {
 }
 
 #[test]
+#[serial]
 fn test_fjall_shard_range_iter() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
     let config = FjallStateConfig {
@@ -305,6 +314,7 @@ fn assert_lazy_utxo_iter<S: CoreStateStore>(store: &S) {
 }
 
 #[test]
+#[serial]
 fn test_fjall_lazy_utxo_iter() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
     let config = FjallStateConfig {
@@ -327,6 +337,7 @@ fn test_fjall_lazy_utxo_iter() {
 }
 
 #[test]
+#[serial]
 fn test_redb3_shard_range_iter() {
     let mut schema = StateSchema::default();
     schema.insert(NS, NamespaceType::KeyValue);

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -8,11 +8,9 @@ use dolos_core::{
     StateStore as CoreStateStore, StateWriter as CoreStateWriter, TxoRef, UtxoSetDelta,
 };
 
-// Every test in this binary reads the same process-global allocator counters,
-// so they must not run concurrently: a sibling test allocating (or freeing)
-// inside another test's measurement window shifts that window's numbers —
-// enough to fail a threshold spuriously, or to drive a live-bytes delta
-// negative and make its assertion vacuous. Hence #[serial] on every test.
+// The counters are process-global, so every test is #[serial]: a concurrent
+// sibling allocating or freeing inside a measurement window skews it enough to
+// fail a threshold spuriously or make a live-bytes assertion vacuous.
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
@@ -215,15 +213,11 @@ fn test_fjall_shard_range_iter() {
     assert_shard_range_iter(&store);
 }
 
-// ---------------------------------------------------------------------------
-// Full UTxO-set iteration.
-//
 // Snapshot export and the live-UTxO index rebuild both stream the whole UTxO
 // set, which on mainnet is several GB. `iter_utxos` therefore has to be lazy in
 // the same sense `iter_entities` is: constructing it reads nothing, and running
 // it to the end never holds more than a bounded working set. An eager
 // implementation is not a slower one, it is one that cannot be used at all.
-// ---------------------------------------------------------------------------
 
 const UTXO_COUNT: u64 = 50_000;
 const UTXO_SIZE: usize = 300;


### PR DESCRIPTION
## Plan

Plan `dolos-stelae-store-apis` (Stelae Phase 1b, store half),
under `decisions/0013-stelae-bounded-context.md`. Base: `174a5de6` (#1147).

Implements the three APIs ADR-004's Amendment 1 depends on, on the one backend
that counts. **No `crates/stelae` file is touched** — this lands in parallel
with the streaming-layers work without a conflict. No `crates/snapshot`, no
layer codecs, no export/restore orchestration: this is the seam, not the
profile that consumes it.

## Done criterion — met

1. **The three APIs exist and are implemented.** ✅
   - `StateStore::iter_utxos()` + `UtxoIter` associated type; `StateUtxoIterBackend`
     in `src/adapters/storage.rs` beside `StateEntityIterBackend`; lazy fjall
     implementation.
   - `IndexStore::iter_archive_tags()` / `iter_exact_records()` + `TagIter` /
     `ExactIter`; lazy fjall implementations; adapter enums.
   - `IndexWriter::append_prehashed()`; fjall implementation; adapter enum.
   - Every other implementor compiles per the agreed disposition: redb3 `state`
     and `indexes` and `Faulty*` return `Unsupported` (never panic, no tests, no
     performance obligation); `NoOp` iterates empty, which it gets for free and
     which is the honest answer for a node with no indexes.
2. **`tests/memory.rs` gains a lazy-iteration assertion for `iter_utxos` on
   fjall.** ✅ `test_fjall_lazy_utxo_iter`, following `assert_lazy_iter`.
   Construction and full iteration each stay under the file's existing 10 MB
   threshold. The redb assertions are not extended.
3. **Round-trip test.** ✅ `tests/index_roundtrip.rs::epoch_slice_round_trips_through_append_prehashed`
   — one epoch out of a populated fjall store, `append_prehashed` into a fresh
   one, then `slots_by_tag`, `slot_by_block_hash`, `slot_by_block_number` and
   `slot_by_tx_hash` compared on both, `metadata` included. Also asserts the
   slice is a slice (nothing outside the epoch leaked) and that re-exporting the
   restored store yields identical records.
4. **Record-order test.** ✅ `tag_records_are_sorted_by_dimension_key_hash_slot`
   and `exact_records_are_sorted_by_kind_and_key`, across four dimensions and
   all three exact kinds. Order also asserted independent of the caller's
   argument order and of duplicates in it.
5. **The gate.** ✅ `cargo test --workspace --all-targets` (23 binaries, 0
   failures), `cargo clippy --all-targets --all-features -- -D warnings`,
   `cargo +nightly fmt --all -- --check` (nightly, not stable — `rustfmt.toml`
   enables `wrap_comments`), `cargo deny check advisories`.
6. Verdicts and the measured number, below.

## Verdict on the four claims in the plan's "What the fjall code says"

1. **"fjall's UTxO iterator is eager."** **Held.** `UtxosIterator::new` walked
   the whole keyspace into a `Vec<(TxoRef, Arc<EraCbor>)>` before yielding
   anything, and had no caller in the tree. Rewritten to hold the `Readable::iter`
   cursor and decode per `next()`, the same shape as `entities::EntityIterator`.
   Confirmed load-bearing: restoring the old body makes the new test fail at
   construction with **20.5 MB** allocated against a 10 MB threshold, and a
   buffer-on-first-`next()` variant fails the iteration bound at **20.2 MB**
   live. No keyspace-layout change was needed, so no escalation was owed.
2. **"Per-epoch slicing is a scan, not a seek."** **Held, and worse than
   stated.** Slot is the last component of a tag key, so each dimension prefix is
   scanned in full and filtered. For *exact* records it is worse still: the slot
   is the stored **value**, not part of the key at all, so a slot-bounded
   traversal has no seekable structure whatsoever and every entry's value is
   read. Both are O(store), not O(epoch). Numbers below.
3. **"The dimension string is not in the key."** **Held.** Traversal is driven by
   a caller-supplied dimension list, one prefix seek per dimension, which
   supplies the dimension as a side effect. The same is true of exact "kinds"
   (`xxh3("exact:" + kind)`), so those are driven by a closed `ExactKind::ALL`.
   Two consequences worth review:
   - `archive_dimensions::ALL` is added as the canonical list. A dimension added
     to `dimensions.rs` and not to `ALL` is a dimension that silently stops being
     exported; that is now the only place to keep in step.
   - On-disk order is by dimension *hash*, so the iterator sorts and deduplicates
     the list itself rather than trusting the caller — which is what makes the
     ordering contract unconditional. Removing that sort makes the order test
     fail, so it is load-bearing.
   - fjall's private `"block_hash"` / `"block_num"` / `"tx_hash"` constants are
     now derived from `ExactKind::as_str()` in a const context, so the names
     hashed into keys and the names carried by records cannot drift.
4. **"`metadata` is an exception to the record shape."** **Held. Escalated as a
   finding, not redesigned — #1149.** The store writes the raw u64 label into the
   8 key-hash bytes rather than `xxh3_64` of it. The implementation carries those
   bytes through unchanged in both directions, so the round trip is exact
   (`tests/index_roundtrip.rs` asserts it, and a unit test in `archive_tags.rs`
   pins that the two schemes really do differ). What is *not* true is ADR-004's
   uniform `key_hash = xxh3_64(logical key)`, which is the sentence the ADR's
   implementation-agnosticism claim rests on. No substitute record shape was
   invented and the on-disk layout was not re-keyed. The decision is the ADR
   owner's; see #1149 for the three options.

## Observed cost of one epoch's index iteration

`tests/index_roundtrip.rs::measure_one_epoch_iteration_cost` (`#[ignore]`, run
with `--release`), against a synthetic mainnet-shaped epoch — 21,600 blocks ×
3 tx × 10 tags = **648,000 tag records** and **108,000 exact records** per
epoch. M-series laptop, release build:

| store depth | tags (scanned) | exacts (scanned) | one epoch |
|---|---|---|---|
| 2 epochs | 232 ms (1.30 M) | 18 ms (0.22 M) | **0.25 s** |
| 8 epochs | 800 ms (5.18 M) | 70 ms (0.86 M) | **0.87 s** |
| 24 epochs | 2.83 s (15.55 M) | 311 ms (2.59 M) | **3.14 s** |

Throughput is flat at ~5.5–6.5 M tag records/s and ~8–12 M exact records/s, so
the cost is linear in **store depth**, not in epoch size: **≈ 0.13 s per epoch
of stored history**, per epoch sliced.

Extrapolated to mainnet (~580 epochs of history at the tip):

- **steady state** — publishing one new epoch every ~5 days: **~75 s**. A
  non-issue.
- **first publish / backfill** — 580 slices against a full store: **~12 hours**,
  because each slice re-scans the whole store. This is the number the publisher
  pipeline has to be sized on. The mitigation named in the plan (a single pass
  bucketing records by epoch, ~75 s total) belongs to the export orchestration,
  and nothing here forecloses it. The store was deliberately **not** re-keyed to
  avoid this.

Caveat: 648k tags/epoch is a modelled figure. Real cost scales linearly with the
real record count.

## Findings not owned by this change

- **`cargo test --workspace --all-features` fails 14 `dolos-cardano` property
  tests** (`model::accounts::prop_tests::*`, `model::epochs::prop_tests::*`,
  panicking at `crates/cardano/src/model/epoch_value.rs:266`). **Pre-existing**:
  the same 14 fail on `174a5de6` with the same command. The trigger is the
  `strict` feature, which CI never enables — CI runs `cargo test --workspace
  --all-targets` on default features, which is green. Reported, not worked
  around; `AGENTS.md` tells agents to run `--all-features`, so the guidance and
  the suite currently disagree.
- **This PR widens the `stats_alloc` window in `tests/memory.rs`.** That file's
  known flake — a `Region` reads a *process-wide* counter while the harness runs
  the binary's tests in parallel, so one test pays for its neighbour's setup —
  now has five `Region`s and five 50,000-record setups to race instead of four.
  I did not fix it here: it is already itemized in a sibling plan and the fix
  (the file-level serial lock `crates/stelae/tests/memory.rs` uses) is that
  item's, not this slice's. Flagging it because the stakes moved. All three
  `Test` jobs passed on this run.

## Notes for review

- `TagRecord::dimension` is `Cow<'static, str>`: borrowed on the export path
  (the dimension list is `&'static`), owned when a record is decoded off the
  wire at restore. Export is the hot path — a `String` per record would be ~10^9
  allocations on a mainnet backfill.
- `append_prehashed` deliberately does not route through `insert_tag`: that
  function hashes and special-cases `metadata` because it starts from a logical
  key, which a restore does not have. Unit tests in `archive_tags.rs` and
  `exact.rs` pin that the two write paths land on identical keys.
- `append_prehashed` does not touch the cursor. Restore owns cursor placement,
  and ADR-004 has it written last so `has_existing_data()` only ever sees
  complete restores.
- Both fjall iterators take one `db.snapshot()` for the whole traversal, so every
  prefix is read from the same MVCC view.
- Backend READMEs (`crates/fjall/src/{index,state}/README.md`) gained the new
  query patterns and the cost note. No user-facing doc under `docs/content/`
  changed — no config, CLI, MiniBF or MiniKupo surface is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archive tag and exact-record export, range-based traversal, and prehashed restoration.
  * Added lazy, memory-efficient full UTxO-set iteration.
  * Added a complete collection of archive dimensions.
* **Bug Fixes**
  * Improved handling of malformed, duplicate, and out-of-range records.
  * Preserved metadata labels during index export and restoration.
* **Documentation**
  * Added guidance for traversal, restoration, performance, and streaming UTxO access.
* **Compatibility**
  * Unsupported backends now report clear errors for unavailable operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

