### PR TITLE
fix: reconcile the strict-feature suite with the verification AGENTS.md prescribes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,21 @@ jobs:
       - name: Run unit tests
         run: cargo test --workspace --all-targets
 
+      # AGENTS.md prescribes verifying with `--all-features`, which enables
+      # feature-gated code (notably the `strict` epoch-coherence assertions in
+      # dolos-cardano) that the default-features run above never exercises.
+      # Keep it green here so the prescribed verification and CI cannot drift
+      # apart. The three service crates are excluded because their test
+      # fixtures import synthetic chains that jump from genesis straight to
+      # epoch 2, tripping the strict assertions inside the fixture itself;
+      # they keep full coverage in the default-features run above. Remove the
+      # exclusions once the fixtures build epoch-coherent domains (see
+      # AGENTS.md, "Code Verification Requirements"). Feature-gated code is
+      # platform-independent, so one OS keeps the cost bounded.
+      - name: Run unit tests (all features)
+        if: runner.os == 'Linux'
+        run: cargo test --workspace --all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp
+
       - name: Run e2e smoke tests
         if: runner.os != 'Windows'
         run: cargo test --test smoke -- --ignored

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,21 @@ All agents working on this repository must verify their modifications by running
 
 3. **Testing**: Run tests to verify functionality
    ```bash
-   cargo test --workspace --all-features
+   cargo test --workspace --all-targets
+   cargo test --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp
    ```
+
+   The first command is what CI runs on every platform. The second adds the
+   feature-gated code the default run never exercises — most importantly the
+   `strict` feature, dolos-cardano's epoch-coherence assertions. The three
+   service crates are excluded from the all-features run because their test
+   fixtures import synthetic chains that jump from a fresh genesis domain
+   straight to epoch 2, which trips those assertions inside the fixture itself
+   (the `EpochState` entity is still at epoch 0 when an epoch-2 block rolls);
+   they keep full coverage under the first command. Remove the exclusions once
+   the fixtures build epoch-coherent domains. CI (`.github/workflows/ci.yml`)
+   runs both commands, so a verification that passes locally cannot drift from
+   what the repository keeps green.
 
 ### Code Quality Standards
 

--- a/crates/cardano/src/model/accounts.rs
+++ b/crates/cardano/src/model/accounts.rs
@@ -174,19 +174,23 @@ pub(crate) mod testing {
             credential in root::any_stake_credential(),
             registered_at in prop::option::of(root::any_slot()),
             deregistered_at in prop::option::of(root::any_slot()),
+            epoch in root::any_epoch(),
             stake in any_epoch_value(any_stake().boxed()),
             pool in any_epoch_value(any_pool_delegation().boxed()),
             drep in any_epoch_value(any_drep_delegation().boxed()),
             vote_delegated_at in prop::option::of((root::any_slot(), root::any_tx_order())),
             retired_pool in prop::option::of(root::any_pool_hash()),
         ) -> AccountState {
+            // ESTART rotates stake/pool/drep in lockstep, so a healthy account
+            // has all three at the same epoch. The `strict` feature asserts
+            // this; rebase the independently drawn values onto one epoch.
             AccountState {
                 credential,
                 registered_at,
                 deregistered_at,
-                stake,
-                pool,
-                drep,
+                stake: crate::model::epoch_value::testing::rebase(stake, epoch),
+                pool: crate::model::epoch_value::testing::rebase(pool, epoch),
+                drep: crate::model::epoch_value::testing::rebase(drep, epoch),
                 vote_delegated_at,
                 retired_pool,
             }
@@ -1208,24 +1212,29 @@ mod prop_tests {
         #[test]
         fn stake_delegation_roundtrip(
             entity in any_account_state(),
-            delta in any_stake_delegation(),
+            mut delta in any_stake_delegation(),
         ) {
+            // `apply` asserts alignment under `strict`, so the delta carries
+            // the entity's epoch.
+            delta.epoch = entity.pool.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
         #[test]
         fn vote_delegation_roundtrip(
             entity in any_account_state(),
-            delta in any_vote_delegation(),
+            mut delta in any_vote_delegation(),
         ) {
+            delta.epoch = entity.drep.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
         #[test]
         fn stake_deregistration_roundtrip(
             entity in any_account_state(),
-            delta in any_stake_deregistration(),
+            mut delta in any_stake_deregistration(),
         ) {
+            delta.epoch = entity.pool.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
@@ -1240,16 +1249,18 @@ mod prop_tests {
         #[test]
         fn pool_delegator_retire_roundtrip(
             entity in any_account_with_active_pool(),
-            delta in any_pool_delegator_retire(),
+            mut delta in any_pool_delegator_retire(),
         ) {
+            delta.epoch = entity.pool.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
         #[test]
         fn drep_delegator_drop_roundtrip(
             entity in any_account_state(),
-            delta in any_drep_delegator_drop(),
+            mut delta in any_drep_delegator_drop(),
         ) {
+            delta.epoch = entity.drep.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
@@ -1288,8 +1299,11 @@ mod prop_tests {
         #[test]
         fn account_transition_roundtrip(
             entity in any_account_state(),
-            delta in any_account_transition(),
+            mut delta in any_account_transition(),
         ) {
+            // `transition` asserts `next_epoch` is exactly one past the
+            // entity's epoch under `strict`.
+            delta.next_epoch = entity.stake.epoch().expect("generated at epoch position") + 1;
             assert_delta_roundtrip(Some(entity), delta);
         }
 
@@ -1330,24 +1344,27 @@ mod prop_tests {
         #[test]
         fn stake_delegation_serde_roundtrip(
             entity in any_account_state(),
-            delta in any_stake_delegation(),
+            mut delta in any_stake_delegation(),
         ) {
+            delta.epoch = entity.pool.epoch().expect("generated at epoch position");
             assert_delta_serde_roundtrip(Some(entity), delta);
         }
 
         #[test]
         fn stake_deregistration_serde_roundtrip(
             entity in any_account_state(),
-            delta in any_stake_deregistration(),
+            mut delta in any_stake_deregistration(),
         ) {
+            delta.epoch = entity.pool.epoch().expect("generated at epoch position");
             assert_delta_serde_roundtrip(Some(entity), delta);
         }
 
         #[test]
         fn vote_delegation_serde_roundtrip(
             entity in any_account_state(),
-            delta in any_vote_delegation(),
+            mut delta in any_vote_delegation(),
         ) {
+            delta.epoch = entity.drep.epoch().expect("generated at epoch position");
             assert_delta_serde_roundtrip(Some(entity), delta);
         }
 

--- a/crates/cardano/src/model/epoch_value.rs
+++ b/crates/cardano/src/model/epoch_value.rs
@@ -329,6 +329,29 @@ pub(crate) mod testing {
     use crate::model::testing as root;
     use proptest::prelude::*;
 
+    /// Rebase a generated `EpochValue` onto a specific epoch position,
+    /// keeping every slot as-is.
+    ///
+    /// The `strict` feature asserts that deltas target the entity's current
+    /// epoch and that entities rotate their epoch values in lockstep (ESTART
+    /// transitions every entity each boundary). Strategies that draw several
+    /// `EpochValue`s — or an entity and a delta — independently violate that
+    /// invariant almost surely; rebasing them onto one drawn epoch restores
+    /// it without giving up randomized slot contents.
+    pub fn rebase<T>(value: EpochValue<T>, epoch: Epoch) -> EpochValue<T>
+    where
+        T: Clone + std::fmt::Debug,
+    {
+        EpochValue::from_parts(
+            epoch,
+            value.live().cloned(),
+            value.next().cloned(),
+            value.mark().cloned(),
+            value.set().cloned(),
+            value.go().cloned(),
+        )
+    }
+
     /// Generate an `EpochValue<T>` where `live` is always populated (most
     /// deltas require it) and the other slots are independently randomized.
     ///

--- a/crates/cardano/src/model/epochs.rs
+++ b/crates/cardano/src/model/epochs.rs
@@ -403,11 +403,14 @@ pub(crate) mod testing {
                 (0u32..32u32, 1u32..=32u32).prop_map(|(committed, total)| ShardProgress { committed, total })
             ),
         ) -> EpochState {
+            // ESTART rotates rolling/pparams in lockstep with the epoch
+            // number, so a healthy entity has all three aligned. The `strict`
+            // feature asserts this; rebase the independently drawn values.
             EpochState {
                 number,
                 initial_pots,
-                rolling,
-                pparams,
+                rolling: crate::model::epoch_value::testing::rebase(rolling, number),
+                pparams: crate::model::epoch_value::testing::rebase(pparams, number),
                 largest_stable_slot,
                 previous_nonce_tail,
                 nonces,
@@ -1519,11 +1522,13 @@ mod prop_tests {
             end in prop::option::of(any_end_stats()),
             incentives in prop::option::of(any_epoch_incentives()),
         ) -> EpochState {
+            // Same lockstep rebase as `any_epoch_state`: `strict` asserts the
+            // epoch values sit at the entity's current epoch.
             EpochState {
                 number,
                 initial_pots,
-                rolling,
-                pparams,
+                rolling: crate::model::epoch_value::testing::rebase(rolling, number),
+                pparams: crate::model::epoch_value::testing::rebase(pparams, number),
                 largest_stable_slot,
                 previous_nonce_tail,
                 nonces,
@@ -1729,8 +1734,12 @@ mod prop_tests {
         #[test]
         fn epoch_stats_update_roundtrip(
             entity in any_epoch_state_no_rolling_next(),
-            delta in any_epoch_stats_update(),
+            mut delta in any_epoch_stats_update(),
         ) {
+            // `apply` mutates `rolling` through `live_mut`, which asserts
+            // alignment under `strict`, so the delta carries the entity's
+            // epoch.
+            delta.epoch = entity.rolling.epoch().expect("generated at epoch position");
             assert_delta_roundtrip(Some(entity), delta);
         }
 
@@ -1791,6 +1800,9 @@ mod prop_tests {
             // align new_pots with the entity's initial_pots so apply's max_supply
             // consistency debug_assert holds.
             delta.new_pots = entity.initial_pots.clone();
+            // `transition` asserts `new_epoch` is exactly one past the
+            // entity's epoch under `strict`.
+            delta.new_epoch = entity.rolling.epoch().expect("generated at epoch position") + 1;
             assert_delta_roundtrip(Some(entity), delta);
         }
 
@@ -1802,6 +1814,7 @@ mod prop_tests {
             // align new_pots with the entity's initial_pots so apply's max_supply
             // consistency debug_assert holds.
             delta.new_pots = entity.initial_pots.clone();
+            delta.new_epoch = entity.rolling.epoch().expect("generated at epoch position") + 1;
             assert_delta_roundtrip(Some(entity), delta);
         }
 

--- a/crates/cardano/src/model/pools.rs
+++ b/crates/cardano/src/model/pools.rs
@@ -550,8 +550,14 @@ mod prop_tests {
         #[test]
         fn pool_registration_roundtrip(
             entity in prop::option::of(any_pool_state()),
-            delta in any_pool_registration(),
+            mut delta in any_pool_registration(),
         ) {
+            // For existing pools `apply` schedules or replaces the snapshot,
+            // both of which assert alignment under `strict`, so the delta
+            // carries the pool's epoch.
+            if let Some(entity) = &entity {
+                delta.epoch = entity.snapshot.epoch().expect("any_pool_state fills a concrete epoch");
+            }
             assert_delta_roundtrip(entity, delta);
         }
 
@@ -585,8 +591,12 @@ mod prop_tests {
         #[test]
         fn pool_transition_roundtrip(
             entity in any_pool_state(),
-            delta in any_pool_transition(),
+            mut delta in any_pool_transition(),
         ) {
+            // `transition` asserts `next_epoch` is exactly one past the
+            // snapshot's epoch under `strict`.
+            delta.next_epoch =
+                entity.snapshot.epoch().expect("any_pool_state fills a concrete epoch") + 1;
             assert_delta_roundtrip(Some(entity), delta);
         }
     }


### PR DESCRIPTION
## Plan

Item 3 of the store-APIs follow-up plan, split out of #1155 per review feedback ("green tests doesn't belong to this PR").

## Diagnosis

`cargo test --workspace --all-features` had been failing on fourteen `dolos-cardano` property tests (9 `model::accounts::prop_tests`, 3 `model::epochs::prop_tests`, 2 `model::pools::prop_tests`) panicking on the `strict`-feature epoch-coherence assertions in `EpochValue`. **The bug is in the test strategies, not in ledger code, and the assertions themselves are correct:** entities and deltas drew their epochs independently (reproduced: entity at `Epoch(858894)`, delta at `6887`), violating the invariant the assertions encode — a delta targets the entity's current epoch, a transition targets exactly the next one.

The fix rebases the independently drawn `EpochValue`s onto one epoch per entity (new `rebase` helper in `epoch_value.rs`'s test module; ESTART rotates them in lockstep, so that is the only healthy shape) and carries the entity's epoch on each delta, following the alignment precedent already in the file (`minted_blocks_inc_roundtrip`). 141/141 `dolos-cardano` lib tests pass under `strict`.

**Un-masked second class:** with fail-fast no longer stopping at dolos-cardano, the run surfaces a latent, pre-existing incoherence in the service-crate fixtures — minibf (223), minikupo (33), trp (10) — whose `test_support` imports synthetic chains that jump from a fresh genesis domain straight to epoch 2, tripping `live_mut`'s strict assert inside the fixture (`EpochState` at `Epoch(0)`, delta at `2`; trace: `import_blocks` → `RollWorkUnit` → `EpochStatsUpdate::apply`). That is test-harness wiring with its own escalation (#1156) and follow-up plan (`dolos-service-fixture-epoch-coherence`). Until the fixtures build epoch-coherent domains, AGENTS.md prescribes the all-features run with those three crates excluded — reason recorded in the file — and CI runs both prescribed commands (all-features leg on Linux only; feature-gated code is platform-independent) so guidance and suite cannot drift apart again.

## Changes

- `crates/cardano/src/model/{epoch_value,accounts,epochs,pools}.rs` — the strategy fixes and `rebase` helper (test code only; no ledger change).
- `AGENTS.md` — testing prescription now matches what the repository keeps green, with the exclusion reason recorded.
- `.github/workflows/ci.yml` — new `Run unit tests (all features)` step enforcing the prescribed all-features form.

## Verification

| Command | Result |
| --- | --- |
| `cargo test --workspace --all-targets` | pass (23 targets ok, 0 failed) |
| `cargo test --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` | pass (27 targets ok, incl. doctests) |
| `cargo test -p dolos-cardano --features strict --lib` | pass (141 ok — the fourteen included) |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo +nightly fmt --all -- --check` | pass |
| `cargo deny check advisories` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Linux CI coverage with comprehensive all-features workspace testing.
  * Improved property-based and round-trip test reliability by enforcing consistent epoch alignment across generated test data.
  * Added coverage for epoch rebasing while preserving associated values.

* **Documentation**
  * Updated testing guidance to reflect the standard and all-features test commands, including documented fixture-related exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
