### PR TITLE
feat(storage): back in_memory state and indexes with builtin ordered-map stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "trait-variant",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ thiserror.workspace = true
 trait-variant.workspace = true
 itertools.workspace = true
 tracing.workspace = true
+xxhash-rust.workspace = true
 opentelemetry.workspace = true
 tracing-opentelemetry.workspace = true
 futures-core.workspace = true

--- a/crates/core/src/builtin/memory/index.rs
+++ b/crates/core/src/builtin/memory/index.rs
@@ -1,0 +1,475 @@
+//! In-memory index store backed by ordered maps.
+//!
+//! Same idea as the state store beside it: the disk backends encode
+//! `[dim_hash][key][slot]` triples into one flat keyspace, and an ordered map
+//! keyed on the triple itself is that keyspace without the encoding.
+//!
+//! The payoff is sharpest for archive tags. Their traversal contract is
+//! "sorted by `(dimension, key_hash, slot)`, dimension compared as a string",
+//! which the disk stores can only reach by walking a caller-supplied dimension
+//! list in name order — on disk the leading component is a *hash* of the
+//! dimension, whose order is unrelated. Keyed on the triple, that contract is
+//! the map's own ordering and holds by construction.
+//!
+//! ## Stored key form
+//!
+//! Tags are stored under [`key_hash`], not under their logical key, exactly as
+//! the disk backends store them. Keeping the logical key would be a divergence,
+//! not an improvement: [`IndexWriter::append_prehashed`] delivers records that
+//! carry only the stored form, so a store that indexed anything else could not
+//! answer a logical-key query about a restored record.
+//!
+//! ## Ephemeral by design
+//!
+//! Nothing persists, and the record iterators materialize their range into an
+//! owned buffer rather than streaming it. See the state store's module docs for
+//! what that costs and why it is the right trade here.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::ops::Range;
+use std::sync::{Arc, Mutex, RwLock};
+
+use crate::indexes::{
+    key_hash, ArchiveIndexDelta, ExactKind, ExactRecord, IndexDelta, IndexError, IndexRecord,
+    IndexStore, IndexWriter, KeyHash, TagDimension, TagRecord,
+};
+use crate::{BlockSlot, ChainPoint, TxoRef, UtxoSet};
+
+/// A stored archive tag: the traversal contract's sort key, used as the key.
+type ArchiveTag = (Cow<'static, str>, KeyHash, BlockSlot);
+
+/// The store's whole contents, guarded as one unit so a commit is atomic.
+#[derive(Default, Clone)]
+struct Tables {
+    cursor: Option<ChainPoint>,
+    /// Live UTxOs per `(dimension, logical key)`. Unlike archive tags these
+    /// keep the logical key: the query takes one, the records never leave the
+    /// store, and the set is mutable rather than append-only.
+    utxo_tags: BTreeMap<(TagDimension, Vec<u8>), HashSet<TxoRef>>,
+    archive_tags: BTreeSet<ArchiveTag>,
+    exact: BTreeMap<(ExactKind, Vec<u8>), BlockSlot>,
+}
+
+/// A single mutation, recorded by a writer and replayed at commit. See the
+/// state store's `Op` for why the writer keeps an ordered log.
+enum Op {
+    SetCursor(ChainPoint),
+    InsertUtxoTag(TagDimension, Vec<u8>, TxoRef),
+    RemoveUtxoTag(TagDimension, Vec<u8>, TxoRef),
+    InsertArchiveTag(ArchiveTag),
+    RemoveArchiveTag(ArchiveTag),
+    InsertExact(ExactKind, Vec<u8>, BlockSlot),
+    RemoveExact(ExactKind, Vec<u8>),
+}
+
+fn poisoned() -> IndexError {
+    IndexError::DbError("index store lock poisoned".into())
+}
+
+/// Index store held entirely in memory.
+///
+/// Cloning shares the underlying tables — a clone is another handle on the same
+/// store, not a copy of it.
+#[derive(Clone, Default)]
+pub struct MemoryIndexStore {
+    tables: Arc<RwLock<Tables>>,
+}
+
+impl MemoryIndexStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Present for symmetry with the disk backends. Nothing to drain.
+    pub fn shutdown(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+}
+
+/// Writer that accumulates its mutations privately and merges them under a
+/// single write lock at [`IndexWriter::commit`].
+pub struct MemoryIndexWriter {
+    store: MemoryIndexStore,
+    ops: Mutex<Vec<Op>>,
+}
+
+impl MemoryIndexWriter {
+    fn archive_tags_of(block: &ArchiveIndexDelta) -> impl Iterator<Item = ArchiveTag> + '_ {
+        block.tags.iter().filter_map(|tag| {
+            key_hash(tag.dimension, &tag.key)
+                .map(|hash| (Cow::Borrowed(tag.dimension), hash, block.slot))
+        })
+    }
+
+    fn exact_keys_of(block: &ArchiveIndexDelta) -> impl Iterator<Item = (ExactKind, Vec<u8>)> + '_ {
+        let hash = (!block.block_hash.is_empty())
+            .then(|| (ExactKind::BlockHash, block.block_hash.clone()));
+
+        let number = block
+            .block_number
+            .map(|n| (ExactKind::BlockNumber, n.to_be_bytes().to_vec()));
+
+        let txs = block
+            .tx_hashes
+            .iter()
+            .map(|hash| (ExactKind::TxHash, hash.clone()));
+
+        hash.into_iter().chain(number).chain(txs)
+    }
+}
+
+impl IndexWriter for MemoryIndexWriter {
+    fn apply(&self, delta: &IndexDelta) -> Result<(), IndexError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for (txo, tags) in &delta.utxo.produced {
+            for tag in tags {
+                ops.push(Op::InsertUtxoTag(
+                    tag.dimension,
+                    tag.key.clone(),
+                    txo.clone(),
+                ));
+            }
+        }
+
+        for (txo, tags) in &delta.utxo.consumed {
+            for tag in tags {
+                ops.push(Op::RemoveUtxoTag(
+                    tag.dimension,
+                    tag.key.clone(),
+                    txo.clone(),
+                ));
+            }
+        }
+
+        for block in &delta.archive {
+            for (kind, key) in Self::exact_keys_of(block) {
+                ops.push(Op::InsertExact(kind, key, block.slot));
+            }
+
+            for tag in Self::archive_tags_of(block) {
+                ops.push(Op::InsertArchiveTag(tag));
+            }
+        }
+
+        ops.push(Op::SetCursor(delta.cursor.clone()));
+
+        Ok(())
+    }
+
+    /// The exact inverse of [`Self::apply`], blocks walked back-to-front. The
+    /// cursor is deliberately untouched: an undo reverses index content, and
+    /// where the chain now sits is the caller's to declare.
+    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for (txo, tags) in &delta.utxo.produced {
+            for tag in tags {
+                ops.push(Op::RemoveUtxoTag(
+                    tag.dimension,
+                    tag.key.clone(),
+                    txo.clone(),
+                ));
+            }
+        }
+
+        for (txo, tags) in &delta.utxo.consumed {
+            for tag in tags {
+                ops.push(Op::InsertUtxoTag(
+                    tag.dimension,
+                    tag.key.clone(),
+                    txo.clone(),
+                ));
+            }
+        }
+
+        for block in delta.archive.iter().rev() {
+            for (kind, key) in Self::exact_keys_of(block) {
+                ops.push(Op::RemoveExact(kind, key));
+            }
+
+            for tag in Self::archive_tags_of(block) {
+                ops.push(Op::RemoveArchiveTag(tag));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for record in records {
+            match record {
+                IndexRecord::Tag(tag) => ops.push(Op::InsertArchiveTag((
+                    tag.dimension.clone(),
+                    tag.key_hash,
+                    tag.slot,
+                ))),
+                IndexRecord::Exact(exact) => {
+                    // A wrong-width key can only come from an external source —
+                    // the delta path is type-enforced — and would land as an
+                    // entry no lookup could ever reach.
+                    let expected = exact.kind.key_len();
+                    if exact.key.len() != expected {
+                        return Err(IndexError::CodecError(format!(
+                            "exact record of kind {} has a {}-byte key, expected {expected}",
+                            exact.kind,
+                            exact.key.len(),
+                        )));
+                    }
+
+                    ops.push(Op::InsertExact(exact.kind, exact.key.clone(), exact.slot));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn commit(self) -> Result<(), IndexError> {
+        let ops = self.ops.into_inner().map_err(|_| poisoned())?;
+
+        let mut tables = self.store.tables.write().map_err(|_| poisoned())?;
+
+        for op in ops {
+            match op {
+                Op::SetCursor(cursor) => tables.cursor = Some(cursor),
+                Op::InsertUtxoTag(dimension, key, txo) => {
+                    tables
+                        .utxo_tags
+                        .entry((dimension, key))
+                        .or_default()
+                        .insert(txo);
+                }
+                Op::RemoveUtxoTag(dimension, key, txo) => {
+                    if let std::collections::btree_map::Entry::Occupied(mut entry) =
+                        tables.utxo_tags.entry((dimension, key))
+                    {
+                        entry.get_mut().remove(&txo);
+                        if entry.get().is_empty() {
+                            entry.remove();
+                        }
+                    }
+                }
+                Op::InsertArchiveTag(tag) => {
+                    tables.archive_tags.insert(tag);
+                }
+                Op::RemoveArchiveTag(tag) => {
+                    tables.archive_tags.remove(&tag);
+                }
+                Op::InsertExact(kind, key, slot) => {
+                    tables.exact.insert((kind, key), slot);
+                }
+                Op::RemoveExact(kind, key) => {
+                    tables.exact.remove(&(kind, key));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Slot iterator over a materialized range.
+pub struct MemorySlotIter(std::vec::IntoIter<BlockSlot>);
+
+impl Iterator for MemorySlotIter {
+    type Item = Result<BlockSlot, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+impl DoubleEndedIterator for MemorySlotIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(Ok)
+    }
+}
+
+/// Archive tag iterator over a materialized range.
+pub struct MemoryTagIter(std::vec::IntoIter<TagRecord>);
+
+impl Iterator for MemoryTagIter {
+    type Item = Result<TagRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// Exact-match record iterator over a materialized range.
+pub struct MemoryExactIter(std::vec::IntoIter<ExactRecord>);
+
+impl Iterator for MemoryExactIter {
+    type Item = Result<ExactRecord, IndexError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// Every tag stored under `dimension`, whatever its key hash or slot.
+fn dimension_span(dimension: TagDimension) -> std::ops::RangeInclusive<ArchiveTag> {
+    let low = (Cow::Borrowed(dimension), [u8::MIN; 8], BlockSlot::MIN);
+    let high = (Cow::Borrowed(dimension), [u8::MAX; 8], BlockSlot::MAX);
+    low..=high
+}
+
+impl IndexStore for MemoryIndexStore {
+    type Writer = MemoryIndexWriter;
+    type SlotIter = MemorySlotIter;
+    type TagIter = MemoryTagIter;
+    type ExactIter = MemoryExactIter;
+
+    fn start_writer(&self) -> Result<Self::Writer, IndexError> {
+        Ok(MemoryIndexWriter {
+            store: self.clone(),
+            ops: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn initialize_schema(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    /// Merges this store's contents into `target`, the same way the disk
+    /// backends do: a copy adds, it does not replace.
+    fn copy(&self, target: &Self) -> Result<(), IndexError> {
+        // Cloned and released before touching the target, so copying a store
+        // onto itself is a no-op rather than a deadlock.
+        let source = self.tables.read().map_err(|_| poisoned())?.clone();
+
+        let mut target = target.tables.write().map_err(|_| poisoned())?;
+
+        if let Some(cursor) = source.cursor {
+            target.cursor = Some(cursor);
+        }
+
+        for (key, txos) in source.utxo_tags {
+            target.utxo_tags.entry(key).or_default().extend(txos);
+        }
+
+        target.archive_tags.extend(source.archive_tags);
+        target.exact.extend(source.exact);
+
+        Ok(())
+    }
+
+    fn cursor(&self) -> Result<Option<ChainPoint>, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables.cursor.clone())
+    }
+
+    fn utxos_by_tag(&self, dimension: TagDimension, key: &[u8]) -> Result<UtxoSet, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let found = tables
+            .utxo_tags
+            .get(&(dimension, key.to_vec()))
+            .cloned()
+            .unwrap_or_default();
+
+        Ok(found)
+    }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables
+            .exact
+            .get(&(ExactKind::BlockHash, hash.to_vec()))
+            .copied())
+    }
+
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables
+            .exact
+            .get(&(ExactKind::BlockNumber, number.to_be_bytes().to_vec()))
+            .copied())
+    }
+
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables
+            .exact
+            .get(&(ExactKind::TxHash, hash.to_vec()))
+            .copied())
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, IndexError> {
+        let Some(hash) = key_hash(dimension, key) else {
+            return Err(IndexError::CodecError(format!(
+                "{dimension} key must be 8 bytes, got {}",
+                key.len(),
+            )));
+        };
+
+        if start > end {
+            return Ok(MemorySlotIter(Vec::new().into_iter()));
+        }
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let low = (Cow::Borrowed(dimension), hash, start);
+        let high = (Cow::Borrowed(dimension), hash, end);
+
+        let slots: Vec<BlockSlot> = tables
+            .archive_tags
+            .range(low..=high)
+            .map(|(_, _, slot)| *slot)
+            .collect();
+
+        Ok(MemorySlotIter(slots.into_iter()))
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        // Sorted and deduplicated here rather than trusted from the caller, so
+        // the ordering contract holds whatever order the list arrived in.
+        let mut dimensions = dimensions.to_vec();
+        dimensions.sort_unstable();
+        dimensions.dedup();
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let records: Vec<TagRecord> = dimensions
+            .into_iter()
+            .flat_map(|dimension| {
+                tables
+                    .archive_tags
+                    .range(dimension_span(dimension))
+                    .filter(|(_, _, slot)| slots.contains(slot))
+                    .map(move |(_, hash, slot)| TagRecord::new(dimension, *hash, *slot))
+            })
+            .collect();
+
+        Ok(MemoryTagIter(records.into_iter()))
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        // `ExactKind`'s ordering is its name ordering, so the map's own order
+        // is the `(kind, key)` contract.
+        let records: Vec<ExactRecord> = tables
+            .exact
+            .iter()
+            .filter(|(_, slot)| slots.contains(slot))
+            .map(|((kind, key), slot)| ExactRecord::new(*kind, key.clone(), *slot))
+            .collect();
+
+        Ok(MemoryExactIter(records.into_iter()))
+    }
+}

--- a/crates/core/src/builtin/memory/mod.rs
+++ b/crates/core/src/builtin/memory/mod.rs
@@ -1,0 +1,21 @@
+//! Storage backed by in-process ordered maps.
+//!
+//! The persistent backends are, in bulk, composite-key encoders: they flatten
+//! tuples into a single ordered byte keyspace because that is the only shape an
+//! LSM tree or a B-tree file offers. A [`std::collections::BTreeMap`] keyed on
+//! the tuple *is* that keyspace, so these implementations are the store
+//! contracts with the encoding layer taken out — small enough to read as a
+//! specification, and useful as the reference the disk backends' conformance
+//! suites are checked against.
+//!
+//! They are ephemeral by design: nothing is written anywhere, and iteration
+//! materializes rather than streams. That suits devnets, tooling and tests, and
+//! nothing else — see each module's docs.
+
+mod index;
+mod state;
+
+pub use index::{
+    MemoryExactIter, MemoryIndexStore, MemoryIndexWriter, MemorySlotIter, MemoryTagIter,
+};
+pub use state::{MemoryEntityIter, MemoryStateStore, MemoryStateWriter, MemoryUtxoIter};

--- a/crates/core/src/builtin/memory/state.rs
+++ b/crates/core/src/builtin/memory/state.rs
@@ -1,0 +1,289 @@
+//! In-memory state store backed by ordered maps.
+//!
+//! The disk backends spend most of their code encoding composite keys into a
+//! flat, lexicographically ordered keyspace. A [`BTreeMap`] keyed on the native
+//! tuple is already that keyspace, so this implementation is the store contract
+//! with the encoding removed:
+//!
+//! - entities live in one map keyed `(namespace, entity_key)`, which makes a
+//!   namespaced range scan a plain [`BTreeMap::range`] — the same shape fjall
+//!   gets from its `[ns_hash:8][entity_key:32]` prefix;
+//! - UTxOs live in a map keyed on [`TxoRef`], whose `(tx_hash, index)` ordering
+//!   is exactly what fjall's `[tx_hash:32][index:4]` big-endian key encodes;
+//! - the cursor is one slot.
+//!
+//! ## Ephemeral by design
+//!
+//! Nothing here persists and nothing here is sized for a mainnet-shaped UTxO
+//! set: the iterators materialize their range into an owned buffer before
+//! yielding, so a full traversal transiently doubles the memory the set already
+//! occupies. That is the trade this backend makes — it exists for devnets,
+//! tooling and tests, where it is the fastest store available and the only
+//! memory-resident one that serves the snapshot export seam.
+
+use std::collections::BTreeMap;
+use std::ops::Range;
+use std::sync::{Arc, Mutex, RwLock};
+
+use crate::state::{
+    EntityKey, EntityValue, Namespace, StateError, StateStore, StateWriter, UtxoEntry,
+};
+use crate::{ChainPoint, EraCbor, TxoRef, UtxoMap, UtxoSetDelta};
+
+/// The store's whole contents, guarded as one unit so a commit is atomic.
+#[derive(Default)]
+struct Tables {
+    cursor: Option<ChainPoint>,
+    entities: BTreeMap<(Namespace, EntityKey), EntityValue>,
+    /// Values stay behind the `Arc` they arrive in, so `get_utxos` — the
+    /// hottest read on this store — hands them out without copying a CBOR body
+    /// per lookup.
+    utxos: BTreeMap<TxoRef, Arc<EraCbor>>,
+}
+
+/// A single mutation, recorded by a writer and replayed at commit.
+///
+/// Keeping the writer's work as an ordered log rather than a merged map is what
+/// makes the commit agree with a disk write batch: within one batch, a later
+/// operation on a key supersedes an earlier one, so a UTxO both produced and
+/// consumed by the same delta ends up absent rather than present.
+enum Op {
+    SetCursor(ChainPoint),
+    WriteEntity(Namespace, EntityKey, EntityValue),
+    DeleteEntity(Namespace, EntityKey),
+    PutUtxo(TxoRef, Arc<EraCbor>),
+    DeleteUtxo(TxoRef),
+}
+
+fn poisoned() -> StateError {
+    StateError::InternalStoreError("state store lock poisoned".into())
+}
+
+/// State store held entirely in memory.
+///
+/// Cloning shares the underlying tables, which is what [`StateStore`]'s `Clone`
+/// bound means everywhere else: a clone is another handle on the same store,
+/// not a copy of it.
+#[derive(Clone, Default)]
+pub struct MemoryStateStore {
+    tables: Arc<RwLock<Tables>>,
+}
+
+impl MemoryStateStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Present for symmetry with the disk backends, which need it to drain
+    /// background work before the process exits. There is nothing to drain
+    /// here.
+    pub fn shutdown(&self) -> Result<(), StateError> {
+        Ok(())
+    }
+}
+
+/// Writer that accumulates its mutations privately and merges them under a
+/// single write lock at [`StateWriter::commit`].
+///
+/// The lock is not held for the writer's lifetime: readers keep running while a
+/// writer is open, and see nothing of its work until the commit lands — the
+/// same visibility a disk transaction gives.
+pub struct MemoryStateWriter {
+    store: MemoryStateStore,
+    ops: Mutex<Vec<Op>>,
+}
+
+impl MemoryStateWriter {
+    fn push(&self, op: Op) -> Result<(), StateError> {
+        self.ops.lock().map_err(|_| poisoned())?.push(op);
+        Ok(())
+    }
+}
+
+impl StateWriter for MemoryStateWriter {
+    fn set_cursor(&self, cursor: ChainPoint) -> Result<(), StateError> {
+        self.push(Op::SetCursor(cursor))
+    }
+
+    fn write_entity(
+        &self,
+        ns: Namespace,
+        key: &EntityKey,
+        value: &EntityValue,
+    ) -> Result<(), StateError> {
+        self.push(Op::WriteEntity(ns, key.clone(), value.clone()))
+    }
+
+    fn delete_entity(&self, ns: Namespace, key: &EntityKey) -> Result<(), StateError> {
+        self.push(Op::DeleteEntity(ns, key.clone()))
+    }
+
+    /// Ordered as the disk backends order it — produced, recovered, consumed,
+    /// undone — because the order decides the outcome when a delta touches the
+    /// same ref twice.
+    fn apply_utxoset(&self, delta: &UtxoSetDelta) -> Result<(), StateError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for (txo, era_cbor) in &delta.produced_utxo {
+            ops.push(Op::PutUtxo(txo.clone(), era_cbor.clone()));
+        }
+
+        for (txo, era_cbor) in &delta.recovered_stxi {
+            ops.push(Op::PutUtxo(txo.clone(), era_cbor.clone()));
+        }
+
+        for txo in delta.consumed_utxo.keys() {
+            ops.push(Op::DeleteUtxo(txo.clone()));
+        }
+
+        for txo in delta.undone_utxo.keys() {
+            ops.push(Op::DeleteUtxo(txo.clone()));
+        }
+
+        Ok(())
+    }
+
+    fn commit(self) -> Result<(), StateError> {
+        let ops = self.ops.into_inner().map_err(|_| poisoned())?;
+
+        let mut tables = self.store.tables.write().map_err(|_| poisoned())?;
+
+        for op in ops {
+            match op {
+                Op::SetCursor(cursor) => tables.cursor = Some(cursor),
+                Op::WriteEntity(ns, key, value) => {
+                    tables.entities.insert((ns, key), value);
+                }
+                Op::DeleteEntity(ns, key) => {
+                    tables.entities.remove(&(ns, key));
+                }
+                Op::PutUtxo(txo, value) => {
+                    tables.utxos.insert(txo, value);
+                }
+                Op::DeleteUtxo(txo) => {
+                    tables.utxos.remove(&txo);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Entity iterator over a materialized range.
+pub struct MemoryEntityIter(std::vec::IntoIter<(EntityKey, EntityValue)>);
+
+impl Iterator for MemoryEntityIter {
+    type Item = Result<(EntityKey, EntityValue), StateError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// UTxO iterator over a materialized snapshot of the set.
+///
+/// Unlike the disk backends this is not lazy — see the module docs. It is still
+/// a point-in-time view: the buffer is filled under a read lock, so a
+/// concurrent writer cannot tear it.
+pub struct MemoryUtxoIter(std::vec::IntoIter<UtxoEntry>);
+
+impl Iterator for MemoryUtxoIter {
+    type Item = Result<UtxoEntry, StateError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+impl StateStore for MemoryStateStore {
+    type EntityIter = MemoryEntityIter;
+    type EntityValueIter = std::iter::Empty<Result<EntityValue, StateError>>;
+    type UtxoIter = MemoryUtxoIter;
+    type Writer = MemoryStateWriter;
+
+    fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables.cursor.clone())
+    }
+
+    fn read_entities(
+        &self,
+        ns: Namespace,
+        keys: &[&EntityKey],
+    ) -> Result<Vec<Option<EntityValue>>, StateError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let values = keys
+            .iter()
+            .map(|key| tables.entities.get(&(ns, (*key).clone())).cloned())
+            .collect();
+
+        Ok(values)
+    }
+
+    fn start_writer(&self) -> Result<Self::Writer, StateError> {
+        Ok(MemoryStateWriter {
+            store: self.clone(),
+            ops: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn iter_entities(
+        &self,
+        ns: Namespace,
+        range: Range<EntityKey>,
+    ) -> Result<Self::EntityIter, StateError> {
+        // An inverted range matches nothing on the disk backends, whose keys
+        // are bytes; `BTreeMap::range` panics on one, so it is caught here
+        // rather than turned into a difference between backends.
+        if range.start > range.end {
+            return Ok(MemoryEntityIter(Vec::new().into_iter()));
+        }
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let entries: Vec<_> = tables
+            .entities
+            .range((ns, range.start)..(ns, range.end))
+            .map(|((_, key), value)| (key.clone(), value.clone()))
+            .collect();
+
+        Ok(MemoryEntityIter(entries.into_iter()))
+    }
+
+    /// Multi-value namespaces have no definition this backend could honor: the
+    /// live persistent backend does not implement them either, so there is no
+    /// behavior to conform to. Refusing is the documented answer for a
+    /// capability a backend does not carry.
+    fn iter_entity_values(
+        &self,
+        _ns: Namespace,
+        _key: impl AsRef<[u8]>,
+    ) -> Result<Self::EntityValueIter, StateError> {
+        Err(StateError::Unsupported("iter_entity_values"))
+    }
+
+    fn get_utxos(&self, refs: Vec<TxoRef>) -> Result<UtxoMap, StateError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let found = refs
+            .into_iter()
+            .filter_map(|txo| tables.utxos.get(&txo).map(|value| (txo, value.clone())))
+            .collect();
+
+        Ok(found)
+    }
+
+    fn iter_utxos(&self) -> Result<Self::UtxoIter, StateError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let entries: Vec<UtxoEntry> = tables
+            .utxos
+            .iter()
+            .map(|(txo, value)| (txo.clone(), value.as_ref().clone()))
+            .collect();
+
+        Ok(MemoryUtxoIter(entries.into_iter()))
+    }
+}

--- a/crates/core/src/builtin/mod.rs
+++ b/crates/core/src/builtin/mod.rs
@@ -3,9 +3,11 @@
 //! This module contains implementations that don't depend on specific
 //! storage backends and can be used across different configurations.
 
+pub mod memory;
 mod mempool;
 mod noop;
 
+pub use memory::{MemoryIndexStore, MemoryIndexWriter, MemoryStateStore, MemoryStateWriter};
 pub use mempool::{EphemeralMempool, EphemeralMempoolStream};
 pub use noop::{
     EmptyBlockIter, EmptyEntityValueIter, EmptyLogIter, EmptySlotIter, NoOpArchiveStore,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -284,7 +284,9 @@ impl FjallStateConfig {
 pub enum StateStoreConfig {
     #[deprecated(note = "deprecated in favor of the supported `fjall` state backend")]
     Redb(RedbStateConfig),
-    /// In-memory backend (ephemeral, data lost on restart).
+    /// Builtin in-memory backend: serves the whole state contract, ephemeral
+    /// by design and sized for devnets, tooling and tests rather than for a
+    /// node following a public network.
     #[serde(rename = "in_memory")]
     InMemory,
     Fjall(FjallStateConfig),
@@ -456,7 +458,9 @@ impl FjallIndexConfig {
 pub enum IndexStoreConfig {
     #[deprecated(note = "deprecated in favor of the supported `fjall` index backend")]
     Redb(RedbIndexConfig),
-    /// In-memory backend (ephemeral, data lost on restart).
+    /// Builtin in-memory backend: serves the whole index contract, ephemeral
+    /// by design and sized for devnets, tooling and tests rather than for a
+    /// node following a public network.
     #[serde(rename = "in_memory")]
     InMemory,
     Fjall(FjallIndexConfig),

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -130,6 +130,32 @@ pub const KEY_HASH_SIZE: usize = 8;
 /// valid way to reconstruct them for every dimension.
 pub type KeyHash = [u8; KEY_HASH_SIZE];
 
+/// The one dimension whose logical key is kept verbatim instead of hashed.
+///
+/// Its keys are already `u64` labels, so hashing them would only lose the
+/// label. See [`KeyHash`].
+pub const VERBATIM_KEY_DIMENSION: TagDimension = "metadata";
+
+/// The stored key form of a logical tag key: the rule [`KeyHash`] describes,
+/// as code.
+///
+/// Every backend has to agree on these bytes exactly. A record crossing from
+/// one store to another carries the stored form and nothing else — the logical
+/// key is not recoverable — so a backend that derived it differently would not
+/// fail to restore, it would restore records its own queries then miss.
+///
+/// `None` means the key is not a valid one for the dimension, which today can
+/// only be a [`VERBATIM_KEY_DIMENSION`] key that is not eight bytes wide. The
+/// stores decline such a tag rather than storing something they could never
+/// look up again.
+pub fn key_hash(dimension: &str, key: &[u8]) -> Option<KeyHash> {
+    if dimension == VERBATIM_KEY_DIMENSION {
+        return key.try_into().ok();
+    }
+
+    Some(xxhash_rust::xxh3::xxh3_64(key).to_be_bytes())
+}
+
 /// One archive tag entry, carrying the stored key hash instead of the logical
 /// key.
 ///

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -188,7 +188,11 @@ impl From<TxoRef> for Vec<u8> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
+/// Ordered by `(tx_hash, index)`, which is what every backend's UTxO key
+/// encodes: fjall's `[tx_hash:32][index:4]` big-endian bytes sort this way, so
+/// a store keyed on the ref directly iterates in the same order as one keyed on
+/// the encoded form.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Serialize, Deserialize)]
 pub struct TxoRef(pub TxHash, pub TxoIdx);
 
 impl From<(TxHash, TxoIdx)> for TxoRef {

--- a/crates/testing/src/faults.rs
+++ b/crates/testing/src/faults.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use dolos_core::{
+    builtin::{MemoryIndexStore, MemoryStateStore},
     ArchiveError, ArchiveStore, BlockBody, BlockSlot, ChainPoint, Domain, DomainError, IndexError,
     IndexStore, LogEntry, LogKey, LogValue, Namespace, StateError, StateStore, TagDimension,
     TipEvent, WalError, WalStore,
@@ -56,12 +57,12 @@ impl FaultyToyDomain {
 
 #[derive(Clone)]
 pub struct FaultyStateStore {
-    inner: dolos_fjall::StateStore,
+    inner: MemoryStateStore,
     fault: TestFault,
 }
 
 impl FaultyStateStore {
-    pub fn new(inner: dolos_fjall::StateStore, fault: TestFault) -> Self {
+    pub fn new(inner: MemoryStateStore, fault: TestFault) -> Self {
         Self { inner, fault }
     }
 
@@ -79,10 +80,10 @@ impl FaultyStateStore {
 }
 
 impl StateStore for FaultyStateStore {
-    type EntityIter = <dolos_fjall::StateStore as StateStore>::EntityIter;
-    type EntityValueIter = <dolos_fjall::StateStore as StateStore>::EntityValueIter;
-    type UtxoIter = <dolos_fjall::StateStore as StateStore>::UtxoIter;
-    type Writer = <dolos_fjall::StateStore as StateStore>::Writer;
+    type EntityIter = <MemoryStateStore as StateStore>::EntityIter;
+    type EntityValueIter = <MemoryStateStore as StateStore>::EntityValueIter;
+    type UtxoIter = <MemoryStateStore as StateStore>::UtxoIter;
+    type Writer = <MemoryStateStore as StateStore>::Writer;
 
     fn read_cursor(&self) -> Result<Option<ChainPoint>, StateError> {
         if self.should_fault() {
@@ -256,12 +257,12 @@ impl ArchiveStore for FaultyArchiveStore {
 
 #[derive(Clone)]
 pub struct FaultyIndexStore {
-    inner: dolos_fjall::IndexStore,
+    inner: MemoryIndexStore,
     fault: TestFault,
 }
 
 impl FaultyIndexStore {
-    pub fn new(inner: dolos_fjall::IndexStore, fault: TestFault) -> Self {
+    pub fn new(inner: MemoryIndexStore, fault: TestFault) -> Self {
         Self { inner, fault }
     }
 
@@ -275,10 +276,10 @@ impl FaultyIndexStore {
 }
 
 impl IndexStore for FaultyIndexStore {
-    type Writer = <dolos_fjall::IndexStore as IndexStore>::Writer;
-    type SlotIter = <dolos_fjall::IndexStore as IndexStore>::SlotIter;
-    type TagIter = <dolos_fjall::IndexStore as IndexStore>::TagIter;
-    type ExactIter = <dolos_fjall::IndexStore as IndexStore>::ExactIter;
+    type Writer = <MemoryIndexStore as IndexStore>::Writer;
+    type SlotIter = <MemoryIndexStore as IndexStore>::SlotIter;
+    type TagIter = <MemoryIndexStore as IndexStore>::TagIter;
+    type ExactIter = <MemoryIndexStore as IndexStore>::ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         if self.should_fault() {

--- a/crates/testing/src/toy_domain.rs
+++ b/crates/testing/src/toy_domain.rs
@@ -1,7 +1,8 @@
 use crate::{make_custom_utxo_delta, TestAddress, UtxoGenerator};
 use dolos_cardano::indexes::index_delta_from_utxo_delta;
 use dolos_core::{
-    config::{CardanoConfig, FjallIndexConfig, FjallStateConfig, StorageConfig, SyncConfig},
+    builtin::{MemoryIndexStore, MemoryStateStore},
+    config::{CardanoConfig, StorageConfig, SyncConfig},
     sync::execute_work_unit,
     BootstrapExt, LogKey, TemporalKey, *,
 };
@@ -9,8 +10,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 pub fn seed_random_memory_store(utxo_generator: impl UtxoGenerator) -> impl StateStore {
-    let store =
-        dolos_redb3::state::StateStore::in_memory(dolos_cardano::model::build_schema()).unwrap();
+    let store = MemoryStateStore::new();
 
     let everyone = TestAddress::everyone();
     let utxos_per_address = 2..4;
@@ -127,42 +127,27 @@ impl dolos_core::MempoolStore for Mempool {
     }
 }
 
-/// Minimal `Domain` implementation bound to the live storage set: state and
-/// indexes on fjall, archive on redb. Fjall stores need a filesystem path, so
-/// each domain holds a temp directory that lives as long as the domain does.
+/// Minimal `Domain` implementation bound to the builtin memory stores for
+/// state and indexes, with the archive on redb.
+///
+/// Memory stores rather than the on-disk ones because a suite builds hundreds
+/// of these: the state and index stores serve the same contract either way —
+/// including the snapshot export seam, which is why this harness cannot go back
+/// to the redb in-memory store it used before — but these ones need no
+/// filesystem, no compaction threads and no cache, so building a domain costs
+/// about what allocating a map costs.
 #[derive(Clone)]
 pub struct ToyDomain {
     wal: dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>,
     chain: Arc<RwLock<dolos_cardano::CardanoLogic>>,
-    state: dolos_fjall::StateStore,
+    state: MemoryStateStore,
     archive: dolos_redb3::archive::ArchiveStore,
-    indexes: dolos_fjall::IndexStore,
+    indexes: MemoryIndexStore,
     mempool: Mempool,
     storage_config: StorageConfig,
     sync_config: SyncConfig,
     genesis: Arc<dolos_core::Genesis>,
     tip_broadcast: tokio::sync::broadcast::Sender<TipEvent>,
-    /// Keeps the fjall databases' directory alive for the domain's lifetime.
-    _dir: Arc<tempfile::TempDir>,
-}
-
-/// Small store footprint for test domains: one compaction worker and a tiny
-/// cache, so suites that build hundreds of domains don't pay the live
-/// defaults' thread and memory cost.
-fn test_state_config() -> FjallStateConfig {
-    FjallStateConfig {
-        cache: Some(16),
-        worker_threads: Some(1),
-        ..Default::default()
-    }
-}
-
-fn test_index_config() -> FjallIndexConfig {
-    FjallIndexConfig {
-        cache: Some(16),
-        worker_threads: Some(1),
-        ..Default::default()
-    }
 }
 
 impl ToyDomain {
@@ -191,10 +176,7 @@ impl ToyDomain {
         initial_delta: Option<UtxoSetDelta>,
         storage_config: Option<StorageConfig>,
     ) -> Self {
-        let dir = tempfile::tempdir().expect("failed to create temp dir for fjall stores");
-
-        let state =
-            dolos_fjall::StateStore::open(dir.path().join("state"), &test_state_config()).unwrap();
+        let state = MemoryStateStore::new();
 
         let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
 
@@ -202,8 +184,7 @@ impl ToyDomain {
             dolos_redb3::archive::ArchiveStore::in_memory(dolos_cardano::model::build_schema())
                 .unwrap();
 
-        let indexes =
-            dolos_fjall::IndexStore::open(dir.path().join("index"), &test_index_config()).unwrap();
+        let indexes = MemoryIndexStore::new();
 
         let chain =
             dolos_cardano::CardanoLogic::initialize::<Self>(config.clone(), &state, &genesis)
@@ -223,7 +204,6 @@ impl ToyDomain {
             sync_config: SyncConfig::default(),
             genesis: genesis.clone(),
             tip_broadcast,
-            _dir: Arc::new(dir),
         };
 
         // Apply genesis state using the work unit pattern.
@@ -313,11 +293,11 @@ impl dolos_core::Domain for ToyDomain {
     type EntityDelta = dolos_cardano::CardanoDelta;
     type Wal = dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>;
     type Archive = dolos_redb3::archive::ArchiveStore;
-    type State = dolos_fjall::StateStore;
+    type State = MemoryStateStore;
     type Chain = dolos_cardano::CardanoLogic;
     type WorkUnit = dolos_cardano::CardanoWorkUnit;
     type TipSubscription = TipSubscription;
-    type Indexes = dolos_fjall::IndexStore;
+    type Indexes = MemoryIndexStore;
     type Mempool = Mempool;
 
     fn storage_config(&self) -> &StorageConfig {

--- a/docs/content/architecture/data-layer.mdx
+++ b/docs/content/architecture/data-layer.mdx
@@ -35,7 +35,7 @@ Available backends:
 - **redb** (`dolos-redb3`) — an embedded ACID B+tree store. It backs the WAL (the only WAL implementation), and can back state, archive, and indexes.
 - **fjall** (`dolos-fjall`) — an LSM-tree engine tuned for write-heavy workloads with many hot keys, available for the state and index stores.
 - **no-op** — a store that silently discards writes, used to *disable* the archive and/or index stores.
-- **in-memory** — non-persistent variants used for testing and ephemeral nodes.
+- **in-memory** — non-persistent stores for testing and ephemeral nodes. State and indexes have builtin implementations in `dolos-core` backed by ordered maps, which serve their traits in full; the WAL, archive, and mempool use redb's memory backend instead.
 
 ## Storage modes
 

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -134,7 +134,7 @@ The `storage` section controls how Dolos stores data in the local file system. E
 | worker_threads    | integer | 4       |
 | memtable_size_mb  | integer | 64      |
 
-- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` is ephemeral — data is lost on restart. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
+- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` keeps the whole state in process memory: it is ephemeral — everything is lost on restart — and it holds the UTxO set and all entities in RAM, so it suits devnets, tooling and tests rather than a node following a public network. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
 - `path`: optional override for the state path (defaults to `<storage.path>/state`).
 - `cache`: size (MB) of the state cache.
 - `max_history`: maximum number of slots to keep before pruning.
@@ -167,7 +167,7 @@ The `storage` section controls how Dolos stores data in the local file system. E
 | worker_threads   | integer | 8       |
 | memtable_size_mb | integer | 128     |
 
-- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` is ephemeral — data is lost on restart. `no_op` disables the index layer entirely. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
+- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` keeps the whole index in process memory: ephemeral — everything is lost on restart — and RAM-resident, so it suits devnets, tooling and tests rather than a node following a public network. `no_op` disables the index layer entirely. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
 - `path`: optional override for the index path (defaults to `<storage.path>/index`).
 - `cache`: size (MB) of the index cache.
 - `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -16,8 +16,9 @@ use dolos_core::{
         ArchiveError, ArchiveStore as CoreArchiveStore, ArchiveWriter as CoreArchiveWriter, LogKey,
     },
     builtin::{
-        EmptyBlockIter, EmptyLogIter, EmptySlotIter, NoOpArchiveStore, NoOpArchiveWriter,
-        NoOpIndexStore, NoOpIndexWriter,
+        EmptyBlockIter, EmptyLogIter, EmptySlotIter, MemoryIndexStore, MemoryIndexWriter,
+        MemoryStateStore, MemoryStateWriter, NoOpArchiveStore, NoOpArchiveWriter, NoOpIndexStore,
+        NoOpIndexWriter,
     },
     config::{
         ArchiveStoreConfig, FjallIndexConfig, FjallStateConfig, IndexStoreConfig,
@@ -66,8 +67,8 @@ fn check_storage_version(config: &RootConfig) -> Result<(), Error> {
 /// chosen, so a stale configuration fails immediately with an actionable
 /// error instead of surfacing later at runtime.
 ///
-/// `in_memory` is deliberately not refused: it is ephemeral by design, and a
-/// builtin reimplementation is planned to back it.
+/// `in_memory` is not refused: it is a builtin store that serves the whole
+/// contract, ephemeral by design rather than by incapacity.
 #[allow(deprecated)]
 fn check_state_backend(config: &StateStoreConfig) -> Result<(), Error> {
     let selected = match config {
@@ -81,8 +82,8 @@ fn check_state_backend(config: &StateStoreConfig) -> Result<(), Error> {
 }
 
 /// Refuse a deprecated index backend, same rationale as
-/// [`check_state_backend`]. `in_memory` is spared pending its builtin
-/// reimplementation, and `no_op` is an explicit opt-out of the index layer.
+/// [`check_state_backend`]. `in_memory` is a builtin store that serves the
+/// whole contract, and `no_op` is an explicit opt-out of the index layer.
 #[allow(deprecated)]
 fn check_index_backend(config: &IndexStoreConfig) -> Result<(), Error> {
     let selected = match config {
@@ -371,6 +372,7 @@ where
 pub enum StateStoreBackend {
     Redb(dolos_redb3::state::StateStore),
     Fjall(dolos_fjall::StateStore),
+    Memory(MemoryStateStore),
 }
 
 impl StateStoreBackend {
@@ -394,10 +396,11 @@ impl StateStoreBackend {
     }
 
     /// Create an in-memory state store.
-    pub fn in_memory(schema: StateSchema) -> Result<Self, StateError> {
-        Ok(Self::Redb(dolos_redb3::state::StateStore::in_memory(
-            schema,
-        )?))
+    ///
+    /// Takes no schema: the builtin store discovers namespaces as they are
+    /// written, so there is no table set to declare up front.
+    pub fn in_memory() -> Result<Self, StateError> {
+        Ok(Self::Memory(MemoryStateStore::new()))
     }
 
     /// Open a state store based on the config variant.
@@ -413,7 +416,7 @@ impl StateStoreBackend {
         match config {
             StateStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
             StateStoreConfig::Fjall(cfg) => Self::open_fjall(path, cfg),
-            StateStoreConfig::InMemory => Self::in_memory(schema),
+            StateStoreConfig::InMemory => Self::in_memory(),
         }
     }
 
@@ -425,6 +428,7 @@ impl StateStoreBackend {
             Self::Fjall(s) => s
                 .shutdown()
                 .map_err(|e| StateError::InternalStoreError(e.to_string())),
+            Self::Memory(s) => s.shutdown(),
         }
     }
 }
@@ -432,6 +436,7 @@ impl StateStoreBackend {
 pub enum StateWriterBackend {
     Redb(Box<<dolos_redb3::state::StateStore as CoreStateStore>::Writer>),
     Fjall(<dolos_fjall::StateStore as CoreStateStore>::Writer),
+    Memory(MemoryStateWriter),
 }
 
 impl CoreStateWriter for StateWriterBackend {
@@ -439,6 +444,7 @@ impl CoreStateWriter for StateWriterBackend {
         match self {
             Self::Redb(w) => w.set_cursor(cursor),
             Self::Fjall(w) => w.set_cursor(cursor),
+            Self::Memory(w) => w.set_cursor(cursor),
         }
     }
 
@@ -451,6 +457,7 @@ impl CoreStateWriter for StateWriterBackend {
         match self {
             Self::Redb(w) => w.write_entity(ns, key, value),
             Self::Fjall(w) => w.write_entity(ns, key, value),
+            Self::Memory(w) => w.write_entity(ns, key, value),
         }
     }
 
@@ -458,6 +465,7 @@ impl CoreStateWriter for StateWriterBackend {
         match self {
             Self::Redb(w) => w.delete_entity(ns, key),
             Self::Fjall(w) => w.delete_entity(ns, key),
+            Self::Memory(w) => w.delete_entity(ns, key),
         }
     }
 
@@ -465,6 +473,7 @@ impl CoreStateWriter for StateWriterBackend {
         match self {
             Self::Redb(w) => w.apply_utxoset(delta),
             Self::Fjall(w) => w.apply_utxoset(delta),
+            Self::Memory(w) => w.apply_utxoset(delta),
         }
     }
 
@@ -472,6 +481,7 @@ impl CoreStateWriter for StateWriterBackend {
         match self {
             Self::Redb(w) => (*w).commit(),
             Self::Fjall(w) => w.commit(),
+            Self::Memory(w) => w.commit(),
         }
     }
 }
@@ -479,6 +489,7 @@ impl CoreStateWriter for StateWriterBackend {
 pub enum StateEntityIterBackend {
     Redb(<dolos_redb3::state::StateStore as CoreStateStore>::EntityIter),
     Fjall(<dolos_fjall::StateStore as CoreStateStore>::EntityIter),
+    Memory(<MemoryStateStore as CoreStateStore>::EntityIter),
 }
 
 impl Iterator for StateEntityIterBackend {
@@ -487,6 +498,7 @@ impl Iterator for StateEntityIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
         }
     }
 }
@@ -494,6 +506,7 @@ impl Iterator for StateEntityIterBackend {
 pub enum StateEntityValueIterBackend {
     Redb(Box<<dolos_redb3::state::StateStore as CoreStateStore>::EntityValueIter>),
     Fjall(<dolos_fjall::StateStore as CoreStateStore>::EntityValueIter),
+    Memory(<MemoryStateStore as CoreStateStore>::EntityValueIter),
 }
 
 impl Iterator for StateEntityValueIterBackend {
@@ -502,6 +515,7 @@ impl Iterator for StateEntityValueIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
         }
     }
 }
@@ -509,6 +523,7 @@ impl Iterator for StateEntityValueIterBackend {
 pub enum StateUtxoIterBackend {
     Redb(<dolos_redb3::state::StateStore as CoreStateStore>::UtxoIter),
     Fjall(<dolos_fjall::StateStore as CoreStateStore>::UtxoIter),
+    Memory(<MemoryStateStore as CoreStateStore>::UtxoIter),
 }
 
 impl Iterator for StateUtxoIterBackend {
@@ -517,6 +532,7 @@ impl Iterator for StateUtxoIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
         }
     }
 }
@@ -531,6 +547,7 @@ impl CoreStateStore for StateStoreBackend {
         match self {
             Self::Redb(s) => s.read_cursor(),
             Self::Fjall(s) => s.read_cursor(),
+            Self::Memory(s) => s.read_cursor(),
         }
     }
 
@@ -542,6 +559,7 @@ impl CoreStateStore for StateStoreBackend {
         match self {
             Self::Redb(s) => s.read_entities(ns, keys),
             Self::Fjall(s) => s.read_entities(ns, keys),
+            Self::Memory(s) => s.read_entities(ns, keys),
         }
     }
 
@@ -551,6 +569,7 @@ impl CoreStateStore for StateStoreBackend {
                 .start_writer()
                 .map(|writer| StateWriterBackend::Redb(Box::new(writer))),
             Self::Fjall(s) => s.start_writer().map(StateWriterBackend::Fjall),
+            Self::Memory(s) => s.start_writer().map(StateWriterBackend::Memory),
         }
     }
 
@@ -564,6 +583,9 @@ impl CoreStateStore for StateStoreBackend {
             Self::Fjall(s) => s
                 .iter_entities(ns, range)
                 .map(StateEntityIterBackend::Fjall),
+            Self::Memory(s) => s
+                .iter_entities(ns, range)
+                .map(StateEntityIterBackend::Memory),
         }
     }
 
@@ -579,6 +601,9 @@ impl CoreStateStore for StateStoreBackend {
             Self::Fjall(s) => s
                 .iter_entity_values(ns, key)
                 .map(StateEntityValueIterBackend::Fjall),
+            Self::Memory(s) => s
+                .iter_entity_values(ns, key)
+                .map(StateEntityValueIterBackend::Memory),
         }
     }
 
@@ -586,6 +611,7 @@ impl CoreStateStore for StateStoreBackend {
         match self {
             Self::Redb(s) => s.get_utxos(refs),
             Self::Fjall(s) => s.get_utxos(refs),
+            Self::Memory(s) => s.get_utxos(refs),
         }
     }
 
@@ -593,6 +619,7 @@ impl CoreStateStore for StateStoreBackend {
         match self {
             Self::Redb(s) => s.iter_utxos().map(StateUtxoIterBackend::Redb),
             Self::Fjall(s) => s.iter_utxos().map(StateUtxoIterBackend::Fjall),
+            Self::Memory(s) => s.iter_utxos().map(StateUtxoIterBackend::Memory),
         }
     }
 }
@@ -867,6 +894,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
 pub enum IndexStoreBackend {
     Redb(dolos_redb3::indexes::IndexStore),
     Fjall(dolos_fjall::IndexStore),
+    Memory(MemoryIndexStore),
     NoOp(NoOpIndexStore),
 }
 
@@ -893,7 +921,7 @@ impl IndexStoreBackend {
 
     /// Create an in-memory index store.
     pub fn in_memory() -> Result<Self, IndexError> {
-        Ok(Self::Redb(dolos_redb3::indexes::IndexStore::in_memory()?))
+        Ok(Self::Memory(MemoryIndexStore::new()))
     }
 
     /// Open an index store based on the config variant.
@@ -915,6 +943,7 @@ impl IndexStoreBackend {
         match self {
             Self::Redb(s) => s.shutdown().map_err(|e| IndexError::DbError(e.to_string())),
             Self::Fjall(s) => s.shutdown().map_err(|e| IndexError::DbError(e.to_string())),
+            Self::Memory(s) => s.shutdown(),
             Self::NoOp(s) => s.shutdown(),
         }
     }
@@ -923,6 +952,7 @@ impl IndexStoreBackend {
 pub enum IndexWriterBackend {
     Redb(Box<<dolos_redb3::indexes::IndexStore as CoreIndexStore>::Writer>),
     Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::Writer),
+    Memory(MemoryIndexWriter),
     NoOp(NoOpIndexWriter),
 }
 
@@ -931,6 +961,7 @@ impl CoreIndexWriter for IndexWriterBackend {
         match self {
             Self::Redb(w) => w.apply(delta),
             Self::Fjall(w) => w.apply(delta),
+            Self::Memory(w) => w.apply(delta),
             Self::NoOp(w) => w.apply(delta),
         }
     }
@@ -939,6 +970,7 @@ impl CoreIndexWriter for IndexWriterBackend {
         match self {
             Self::Redb(w) => w.undo(delta),
             Self::Fjall(w) => w.undo(delta),
+            Self::Memory(w) => w.undo(delta),
             Self::NoOp(w) => w.undo(delta),
         }
     }
@@ -947,6 +979,7 @@ impl CoreIndexWriter for IndexWriterBackend {
         match self {
             Self::Redb(w) => w.append_prehashed(records),
             Self::Fjall(w) => w.append_prehashed(records),
+            Self::Memory(w) => w.append_prehashed(records),
             Self::NoOp(w) => w.append_prehashed(records),
         }
     }
@@ -955,6 +988,7 @@ impl CoreIndexWriter for IndexWriterBackend {
         match self {
             Self::Redb(w) => (*w).commit(),
             Self::Fjall(w) => w.commit(),
+            Self::Memory(w) => w.commit(),
             Self::NoOp(w) => w.commit(),
         }
     }
@@ -963,6 +997,7 @@ impl CoreIndexWriter for IndexWriterBackend {
 pub enum IndexSlotIterBackend {
     Redb(Box<<dolos_redb3::indexes::IndexStore as CoreIndexStore>::SlotIter>),
     Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::SlotIter),
+    Memory(<MemoryIndexStore as CoreIndexStore>::SlotIter),
     NoOp(EmptySlotIter),
 }
 
@@ -972,6 +1007,7 @@ impl Iterator for IndexSlotIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -982,6 +1018,7 @@ impl DoubleEndedIterator for IndexSlotIterBackend {
         match self {
             Self::Redb(iter) => iter.next_back(),
             Self::Fjall(iter) => iter.next_back(),
+            Self::Memory(iter) => iter.next_back(),
             Self::NoOp(iter) => iter.next_back(),
         }
     }
@@ -990,6 +1027,7 @@ impl DoubleEndedIterator for IndexSlotIterBackend {
 pub enum IndexTagIterBackend {
     Redb(<dolos_redb3::indexes::IndexStore as CoreIndexStore>::TagIter),
     Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::TagIter),
+    Memory(<MemoryIndexStore as CoreIndexStore>::TagIter),
     NoOp(<NoOpIndexStore as CoreIndexStore>::TagIter),
 }
 
@@ -999,6 +1037,7 @@ impl Iterator for IndexTagIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -1007,6 +1046,7 @@ impl Iterator for IndexTagIterBackend {
 pub enum IndexExactIterBackend {
     Redb(<dolos_redb3::indexes::IndexStore as CoreIndexStore>::ExactIter),
     Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::ExactIter),
+    Memory(<MemoryIndexStore as CoreIndexStore>::ExactIter),
     NoOp(<NoOpIndexStore as CoreIndexStore>::ExactIter),
 }
 
@@ -1016,6 +1056,7 @@ impl Iterator for IndexExactIterBackend {
         match self {
             Self::Redb(iter) => iter.next(),
             Self::Fjall(iter) => iter.next(),
+            Self::Memory(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -1033,6 +1074,7 @@ impl CoreIndexStore for IndexStoreBackend {
                 .start_writer()
                 .map(|writer| IndexWriterBackend::Redb(Box::new(writer))),
             Self::Fjall(s) => s.start_writer().map(IndexWriterBackend::Fjall),
+            Self::Memory(s) => s.start_writer().map(IndexWriterBackend::Memory),
             Self::NoOp(s) => s.start_writer().map(IndexWriterBackend::NoOp),
         }
     }
@@ -1041,6 +1083,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.initialize_schema(),
             Self::Fjall(s) => s.initialize_schema(),
+            Self::Memory(s) => s.initialize_schema(),
             Self::NoOp(s) => s.initialize_schema(),
         }
     }
@@ -1049,6 +1092,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match (self, target) {
             (Self::Redb(s), Self::Redb(t)) => s.copy(t),
             (Self::Fjall(s), Self::Fjall(t)) => s.copy(t),
+            (Self::Memory(s), Self::Memory(t)) => s.copy(t),
             (Self::NoOp(s), Self::NoOp(t)) => s.copy(t),
             _ => Err(IndexError::DbError(
                 "cannot copy between different backend types".into(),
@@ -1060,6 +1104,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.cursor(),
             Self::Fjall(s) => s.cursor(),
+            Self::Memory(s) => s.cursor(),
             Self::NoOp(s) => s.cursor(),
         }
     }
@@ -1068,6 +1113,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.utxos_by_tag(dimension, key),
             Self::Fjall(s) => s.utxos_by_tag(dimension, key),
+            Self::Memory(s) => s.utxos_by_tag(dimension, key),
             Self::NoOp(s) => s.utxos_by_tag(dimension, key),
         }
     }
@@ -1076,6 +1122,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.slot_by_block_hash(hash),
             Self::Fjall(s) => s.slot_by_block_hash(hash),
+            Self::Memory(s) => s.slot_by_block_hash(hash),
             Self::NoOp(s) => s.slot_by_block_hash(hash),
         }
     }
@@ -1084,6 +1131,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.slot_by_block_number(number),
             Self::Fjall(s) => s.slot_by_block_number(number),
+            Self::Memory(s) => s.slot_by_block_number(number),
             Self::NoOp(s) => s.slot_by_block_number(number),
         }
     }
@@ -1092,6 +1140,7 @@ impl CoreIndexStore for IndexStoreBackend {
         match self {
             Self::Redb(s) => s.slot_by_tx_hash(hash),
             Self::Fjall(s) => s.slot_by_tx_hash(hash),
+            Self::Memory(s) => s.slot_by_tx_hash(hash),
             Self::NoOp(s) => s.slot_by_tx_hash(hash),
         }
     }
@@ -1110,6 +1159,9 @@ impl CoreIndexStore for IndexStoreBackend {
             Self::Fjall(s) => s
                 .slots_by_tag(dimension, key, start, end)
                 .map(IndexSlotIterBackend::Fjall),
+            Self::Memory(s) => s
+                .slots_by_tag(dimension, key, start, end)
+                .map(IndexSlotIterBackend::Memory),
             Self::NoOp(s) => s
                 .slots_by_tag(dimension, key, start, end)
                 .map(IndexSlotIterBackend::NoOp),
@@ -1128,6 +1180,9 @@ impl CoreIndexStore for IndexStoreBackend {
             Self::Fjall(s) => s
                 .iter_archive_tags(dimensions, slots)
                 .map(IndexTagIterBackend::Fjall),
+            Self::Memory(s) => s
+                .iter_archive_tags(dimensions, slots)
+                .map(IndexTagIterBackend::Memory),
             Self::NoOp(s) => s
                 .iter_archive_tags(dimensions, slots)
                 .map(IndexTagIterBackend::NoOp),
@@ -1140,6 +1195,9 @@ impl CoreIndexStore for IndexStoreBackend {
             Self::Fjall(s) => s
                 .iter_exact_records(slots)
                 .map(IndexExactIterBackend::Fjall),
+            Self::Memory(s) => s
+                .iter_exact_records(slots)
+                .map(IndexExactIterBackend::Memory),
             Self::NoOp(s) => s.iter_exact_records(slots).map(IndexExactIterBackend::NoOp),
         }
     }
@@ -1292,14 +1350,44 @@ mod tests {
         check_state_backend(&StateStoreConfig::Fjall(FjallStateConfig::default())).unwrap();
         check_index_backend(&IndexStoreConfig::Fjall(FjallIndexConfig::default())).unwrap();
 
-        // in_memory stays accepted: ephemeral by design, and a builtin
-        // reimplementation is planned to back it.
+        // in_memory stays accepted: a builtin store that serves the whole
+        // contract, ephemeral by design rather than by incapacity.
         check_state_backend(&StateStoreConfig::InMemory).unwrap();
         check_index_backend(&IndexStoreConfig::InMemory).unwrap();
 
         // no_op stays accepted too: it is an explicit opt-out of the index
         // layer.
         check_index_backend(&IndexStoreConfig::NoOp).unwrap();
+    }
+
+    /// `in_memory` has to reach the builtin stores, not a memory-mode disk
+    /// backend: that was the old wiring, and it was the reason the variant
+    /// could not serve the snapshot export seam.
+    #[test]
+    fn in_memory_selects_the_builtin_stores() {
+        let path = std::path::Path::new("/nonexistent");
+
+        let state =
+            StateStoreBackend::open(path, StateSchema::default(), &StateStoreConfig::InMemory)
+                .expect("in_memory state store should open without touching the path");
+
+        assert!(matches!(state, StateStoreBackend::Memory(_)));
+
+        let indexes = IndexStoreBackend::open(path, &IndexStoreConfig::InMemory)
+            .expect("in_memory index store should open without touching the path");
+
+        assert!(matches!(indexes, IndexStoreBackend::Memory(_)));
+
+        // And the seam the old wiring could not serve now answers.
+        state.iter_utxos().expect("iter_utxos must be supported");
+        indexes
+            .iter_archive_tags(&[], 0..1)
+            .expect("iter_archive_tags must be supported");
+        indexes
+            .start_writer()
+            .expect("start_writer failed")
+            .append_prehashed(&[])
+            .expect("append_prehashed must be supported");
     }
 
     #[test]

--- a/src/bin/dolos/data/stats.rs
+++ b/src/bin/dolos/data/stats.rs
@@ -23,14 +23,14 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
     // Stats command only works with redb backends
     let state = match &stores.state {
         StateStoreBackend::Redb(s) => s,
-        StateStoreBackend::Fjall(_) => {
+        StateStoreBackend::Fjall(_) | StateStoreBackend::Memory(_) => {
             bail!("stats command is only available for redb state backend")
         }
     };
 
     let indexes = match &stores.indexes {
         IndexStoreBackend::Redb(s) => s,
-        IndexStoreBackend::Fjall(_) => {
+        IndexStoreBackend::Fjall(_) | IndexStoreBackend::Memory(_) => {
             bail!("stats command is only available for redb index backend")
         }
         IndexStoreBackend::NoOp(_) => {

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -1,4 +1,4 @@
-//! Export/restore coverage for the pre-hashed archive index seam.
+//! Export/restore conformance for the pre-hashed archive index seam.
 //!
 //! `IndexStore::iter_archive_tags` / `iter_exact_records` and
 //! `IndexWriter::append_prehashed` are the two halves of one thing: a snapshot
@@ -15,16 +15,20 @@
 //!    sequences, so an iterator that yields the right records in the wrong
 //!    order is wrong, not slow.
 //!
-//! Both are asserted against fjall, the live index backend.
+//! The suite is written once against the [`IndexStore`] trait and run against
+//! every live backend: fjall, the persistent one, and the builtin memory store.
+//! One suite defining the semantics is the point — a backend that passed its
+//! own private tests could still disagree with its peers, and records really do
+//! cross between backends (see [`records_cross_between_backends`]).
 
 use std::collections::BTreeSet;
 use std::ops::Range;
 
 use dolos_cardano::indexes::archive_dimensions;
 use dolos_core::{
-    config::FjallIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint, ExactKind, ExactRecord,
-    IndexDelta, IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, Tag,
-    TagDimension, TagRecord,
+    builtin::MemoryIndexStore, config::FjallIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint,
+    ExactKind, ExactRecord, IndexDelta, IndexRecord, IndexStore as CoreIndexStore,
+    IndexWriter as CoreIndexWriter, Tag, TagDimension, TagRecord,
 };
 
 const EPOCH_LEN: BlockSlot = 432_000;
@@ -49,22 +53,95 @@ const SEEDED_DIMENSIONS: [TagDimension; 4] = [
 /// keeps the label verbatim rather than hashing it.
 const METADATA_LABELS: [u64; 3] = [674, 721, 1990];
 
-fn epoch_slots(epoch: u64) -> Range<BlockSlot> {
-    (epoch * EPOCH_LEN)..((epoch + 1) * EPOCH_LEN)
+/// One index backend under test.
+///
+/// The guard carries whatever the backend needs kept alive for the store to
+/// stay usable — a temp directory for the on-disk one, nothing for the
+/// in-memory one.
+trait Backend {
+    type Store: CoreIndexStore;
+    type Guard;
+
+    /// A fresh, empty store.
+    fn open() -> (Self::Store, Self::Guard);
 }
 
-fn open_store(tmpdir: &tempfile::TempDir) -> dolos_fjall::IndexStore {
-    let config = FjallIndexConfig {
-        path: None,
-        cache: Some(16),
-        max_journal_size: None,
-        flush_on_commit: Some(false),
-        l0_threshold: None,
-        worker_threads: Some(1),
-        memtable_size_mb: None,
-    };
+struct Fjall;
 
-    dolos_fjall::IndexStore::open(tmpdir.path(), &config).expect("failed to open fjall index store")
+impl Backend for Fjall {
+    type Store = dolos_fjall::IndexStore;
+    type Guard = tempfile::TempDir;
+
+    fn open() -> (Self::Store, Self::Guard) {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+
+        let config = FjallIndexConfig {
+            path: None,
+            cache: Some(16),
+            max_journal_size: None,
+            flush_on_commit: Some(false),
+            l0_threshold: None,
+            worker_threads: Some(1),
+            memtable_size_mb: None,
+        };
+
+        let store = dolos_fjall::IndexStore::open(dir.path(), &config)
+            .expect("failed to open fjall index store");
+
+        (store, dir)
+    }
+}
+
+struct Memory;
+
+impl Backend for Memory {
+    type Store = MemoryIndexStore;
+    type Guard = ();
+
+    fn open() -> (Self::Store, Self::Guard) {
+        (MemoryIndexStore::new(), ())
+    }
+}
+
+/// Declare the whole suite for one backend. Adding a backend is one line.
+macro_rules! conformance_suite {
+    ($module:ident, $backend:ty) => {
+        mod $module {
+            use super::*;
+
+            #[test]
+            fn epoch_slice_round_trips_through_append_prehashed() {
+                super::epoch_slice_round_trips_through_append_prehashed::<$backend>();
+            }
+
+            #[test]
+            fn tag_records_are_sorted_by_dimension_key_hash_slot() {
+                super::tag_records_are_sorted_by_dimension_key_hash_slot::<$backend>();
+            }
+
+            #[test]
+            fn exact_records_are_sorted_by_kind_and_key() {
+                super::exact_records_are_sorted_by_kind_and_key::<$backend>();
+            }
+
+            #[test]
+            fn tag_key_hashes_are_xxh3_except_for_metadata_labels() {
+                super::tag_key_hashes_are_xxh3_except_for_metadata_labels::<$backend>();
+            }
+
+            #[test]
+            fn undo_removes_exactly_what_apply_added() {
+                super::undo_removes_exactly_what_apply_added::<$backend>();
+            }
+        }
+    };
+}
+
+conformance_suite!(fjall, Fjall);
+conformance_suite!(memory, Memory);
+
+fn epoch_slots(epoch: u64) -> Range<BlockSlot> {
+    (epoch * EPOCH_LEN)..((epoch + 1) * EPOCH_LEN)
 }
 
 fn hash32(tag: u8, a: u64, b: u64) -> Vec<u8> {
@@ -96,11 +173,11 @@ impl Seeded {
     }
 }
 
-/// Populate a store through the regular delta path, the same one the sync
-/// pipeline uses. Nothing here knows about pre-hashed records: the export side
-/// has to cope with whatever normal indexing produced.
-fn seed(store: &dolos_fjall::IndexStore) -> Seeded {
+/// The deltas the seed applies, built independently of any store so two
+/// backends can be handed byte-identical input.
+fn seed_deltas() -> (Vec<IndexDelta>, Seeded) {
     let mut seeded = Seeded::default();
+    let mut deltas = Vec::new();
 
     for epoch in EPOCHS {
         let mut archive = Vec::new();
@@ -144,22 +221,33 @@ fn seed(store: &dolos_fjall::IndexStore) -> Seeded {
         }
 
         let cursor = ChainPoint::Slot(archive.last().unwrap().slot);
-        let delta = IndexDelta {
+        deltas.push(IndexDelta {
             cursor,
             utxo: Default::default(),
             archive,
-        };
+        });
+    }
 
+    (deltas, seeded)
+}
+
+/// Populate a store through the regular delta path, the same one the sync
+/// pipeline uses. Nothing here knows about pre-hashed records: the export side
+/// has to cope with whatever normal indexing produced.
+fn seed<S: CoreIndexStore>(store: &S) -> Seeded {
+    let (deltas, seeded) = seed_deltas();
+
+    for delta in &deltas {
         let writer = store.start_writer().expect("start_writer failed");
-        writer.apply(&delta).expect("apply failed");
+        writer.apply(delta).expect("apply failed");
         writer.commit().expect("commit failed");
     }
 
     seeded
 }
 
-fn collect_tags(
-    store: &dolos_fjall::IndexStore,
+fn collect_tags<S: CoreIndexStore>(
+    store: &S,
     dimensions: &[TagDimension],
     slots: Range<BlockSlot>,
 ) -> Vec<TagRecord> {
@@ -170,7 +258,7 @@ fn collect_tags(
         .expect("tag iteration failed")
 }
 
-fn collect_exacts(store: &dolos_fjall::IndexStore, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
+fn collect_exacts<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
     store
         .iter_exact_records(slots)
         .expect("iter_exact_records failed")
@@ -178,8 +266,8 @@ fn collect_exacts(store: &dolos_fjall::IndexStore, slots: Range<BlockSlot>) -> V
         .expect("exact iteration failed")
 }
 
-fn slots_for_tag(
-    store: &dolos_fjall::IndexStore,
+fn slots_for_tag<S: CoreIndexStore>(
+    store: &S,
     dimension: TagDimension,
     key: &[u8],
     slots: &Range<BlockSlot>,
@@ -191,37 +279,46 @@ fn slots_for_tag(
         .expect("slot iteration failed")
 }
 
-#[test]
-fn epoch_slice_round_trips_through_append_prehashed() {
-    let source_dir = tempfile::tempdir().expect("failed to create tempdir");
-    let source = open_store(&source_dir);
+/// The epoch slice a publisher would export: every tag and exact record whose
+/// slot falls in the epoch, in traversal order.
+fn export_slice<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<IndexRecord> {
+    let mut records: Vec<IndexRecord> = Vec::new();
+
+    records.extend(
+        collect_tags(store, &archive_dimensions::ALL, slots.clone())
+            .into_iter()
+            .map(IndexRecord::from),
+    );
+
+    records.extend(
+        collect_exacts(store, slots)
+            .into_iter()
+            .map(IndexRecord::from),
+    );
+
+    records
+}
+
+fn restore<S: CoreIndexStore>(store: &S, records: &[IndexRecord]) {
+    let writer = store.start_writer().expect("start_writer failed");
+    writer
+        .append_prehashed(records)
+        .expect("append_prehashed failed");
+    writer.commit().expect("commit failed");
+}
+
+fn epoch_slice_round_trips_through_append_prehashed<B: Backend>() {
+    let (source, _source_guard) = B::open();
     let seeded = seed(&source);
 
     let exported = epoch_slots(EPOCHS[0]);
     let excluded = epoch_slots(EPOCHS[1]);
 
-    let mut records: Vec<IndexRecord> = Vec::new();
-    records.extend(
-        collect_tags(&source, &archive_dimensions::ALL, exported.clone())
-            .into_iter()
-            .map(IndexRecord::from),
-    );
-    records.extend(
-        collect_exacts(&source, exported.clone())
-            .into_iter()
-            .map(IndexRecord::from),
-    );
-
+    let records = export_slice(&source, exported.clone());
     assert!(!records.is_empty(), "the epoch slice should not be empty");
 
-    let target_dir = tempfile::tempdir().expect("failed to create tempdir");
-    let target = open_store(&target_dir);
-
-    let writer = target.start_writer().expect("start_writer failed");
-    writer
-        .append_prehashed(&records)
-        .expect("append_prehashed failed");
-    writer.commit().expect("commit failed");
+    let (target, _target_guard) = B::open();
+    restore(&target, &records);
 
     let mut checked_metadata = false;
 
@@ -318,20 +415,14 @@ fn epoch_slice_round_trips_through_append_prehashed() {
     // Re-exporting the restored store must yield byte-identical records:
     // anything else means the write path re-derived something instead of
     // copying it.
-
-    let reexported_tags = collect_tags(&target, &archive_dimensions::ALL, exported.clone());
-    let source_tags = collect_tags(&source, &archive_dimensions::ALL, exported.clone());
-    assert_eq!(source_tags, reexported_tags);
-
-    let reexported_exacts = collect_exacts(&target, exported.clone());
-    let source_exacts = collect_exacts(&source, exported);
-    assert_eq!(source_exacts, reexported_exacts);
+    assert_eq!(
+        export_slice(&source, exported.clone()),
+        export_slice(&target, exported)
+    );
 }
 
-#[test]
-fn tag_records_are_sorted_by_dimension_key_hash_slot() {
-    let dir = tempfile::tempdir().expect("failed to create tempdir");
-    let store = open_store(&dir);
+fn tag_records_are_sorted_by_dimension_key_hash_slot<B: Backend>() {
+    let (store, _guard) = B::open();
     let seeded = seed(&store);
 
     let slots = epoch_slots(EPOCHS[0]);
@@ -378,10 +469,8 @@ fn tag_records_are_sorted_by_dimension_key_hash_slot() {
     assert_eq!(records, collect_tags(&store, &repeated, slots));
 }
 
-#[test]
-fn exact_records_are_sorted_by_kind_and_key() {
-    let dir = tempfile::tempdir().expect("failed to create tempdir");
-    let store = open_store(&dir);
+fn exact_records_are_sorted_by_kind_and_key<B: Backend>() {
+    let (store, _guard) = B::open();
     let seeded = seed(&store);
 
     let slots = epoch_slots(EPOCHS[0]);
@@ -424,12 +513,10 @@ fn exact_records_are_sorted_by_kind_and_key() {
 /// cross-implementation promise depends on which one a reader implements: a
 /// third-party publisher that hashes metadata labels produces records this
 /// store cannot use, and vice versa.
-#[test]
-fn tag_key_hashes_are_xxh3_except_for_metadata_labels() {
+fn tag_key_hashes_are_xxh3_except_for_metadata_labels<B: Backend>() {
     use xxhash_rust::xxh3::xxh3_64;
 
-    let dir = tempfile::tempdir().expect("failed to create tempdir");
-    let store = open_store(&dir);
+    let (store, _guard) = B::open();
     let seeded = seed(&store);
 
     let slots = epoch_slots(EPOCHS[0]);
@@ -468,6 +555,155 @@ fn tag_key_hashes_are_xxh3_except_for_metadata_labels() {
     );
 }
 
+/// A rollback has to leave the store where it started. The archive keyspaces
+/// are append-oriented, so an undo that missed an entry would be invisible
+/// until a later query returned a slot from a block that no longer exists.
+fn undo_removes_exactly_what_apply_added<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (deltas, _) = seed_deltas();
+    let (first, second) = deltas.split_at(1);
+
+    // The first epoch stays; the second is applied and then rolled back.
+    for delta in first {
+        let writer = store.start_writer().expect("start_writer failed");
+        writer.apply(delta).expect("apply failed");
+        writer.commit().expect("commit failed");
+    }
+
+    let kept = epoch_slots(EPOCHS[0]);
+    let before_tags = collect_tags(&store, &archive_dimensions::ALL, kept.clone());
+    let before_exacts = collect_exacts(&store, kept.clone());
+
+    for delta in second {
+        let writer = store.start_writer().expect("start_writer failed");
+        writer.apply(delta).expect("apply failed");
+        writer.commit().expect("commit failed");
+    }
+
+    let rolled_back = epoch_slots(EPOCHS[1]);
+    assert!(
+        !collect_tags(&store, &archive_dimensions::ALL, rolled_back.clone()).is_empty(),
+        "the delta about to be undone should have landed first"
+    );
+
+    for delta in second.iter().rev() {
+        let writer = store.start_writer().expect("start_writer failed");
+        writer.undo(delta).expect("undo failed");
+        writer.commit().expect("commit failed");
+    }
+
+    assert!(
+        collect_tags(&store, &archive_dimensions::ALL, rolled_back.clone()).is_empty(),
+        "undo left archive tags behind"
+    );
+    assert!(
+        collect_exacts(&store, rolled_back).is_empty(),
+        "undo left exact records behind"
+    );
+
+    assert_eq!(
+        before_tags,
+        collect_tags(&store, &archive_dimensions::ALL, kept.clone()),
+        "undo removed tags it never added"
+    );
+    assert_eq!(
+        before_exacts,
+        collect_exacts(&store, kept),
+        "undo removed exact records it never added"
+    );
+}
+
+/// The backends have to agree on the *stored* key form, not merely each be
+/// self-consistent.
+///
+/// A record carries the stored form and nothing else — the logical key is not
+/// recoverable — so a backend that hashed differently would still restore
+/// "successfully" and then miss every logical-key query about the restored
+/// records. Nothing inside one backend's own suite can catch that.
+#[test]
+fn backends_agree_on_exported_records() {
+    let (fjall, _guard) = Fjall::open();
+    let (memory, _) = Memory::open();
+
+    seed(&fjall);
+    seed(&memory);
+
+    let slots = epoch_slots(EPOCHS[0]);
+
+    assert_eq!(
+        collect_tags(&fjall, &archive_dimensions::ALL, slots.clone()),
+        collect_tags(&memory, &archive_dimensions::ALL, slots.clone()),
+        "backends disagree on the archive tag records the same deltas produce"
+    );
+
+    assert_eq!(
+        collect_exacts(&fjall, slots.clone()),
+        collect_exacts(&memory, slots),
+        "backends disagree on the exact records the same deltas produce"
+    );
+}
+
+/// The seam's whole purpose: records exported from one backend restore into
+/// another and answer the same questions there.
+#[test]
+fn records_cross_between_backends() {
+    let (fjall, _guard) = Fjall::open();
+    let (memory, _) = Memory::open();
+
+    let seeded = seed(&fjall);
+    let slots = epoch_slots(EPOCHS[0]);
+
+    // fjall -> memory
+    restore(&memory, &export_slice(&fjall, slots.clone()));
+
+    for (dimension, key, _) in seeded.tags_in(&slots) {
+        let from_fjall = slots_for_tag(&fjall, dimension, key, &slots);
+        let from_memory = slots_for_tag(&memory, dimension, key, &slots);
+
+        assert!(!from_fjall.is_empty());
+        assert_eq!(
+            from_fjall, from_memory,
+            "memory store restored from fjall disagrees on dimension {dimension}"
+        );
+    }
+
+    // and back again, into a store that has never seen a delta
+    let (restored_fjall, _guard) = Fjall::open();
+    restore(&restored_fjall, &export_slice(&memory, slots.clone()));
+
+    for (dimension, key, _) in seeded.tags_in(&slots) {
+        assert_eq!(
+            slots_for_tag(&fjall, dimension, key, &slots),
+            slots_for_tag(&restored_fjall, dimension, key, &slots),
+            "fjall store restored from memory disagrees on dimension {dimension}"
+        );
+    }
+
+    // Only the exported epoch crossed, so that is the range the two stores have
+    // to agree on — and outside it the restored store must stay empty rather
+    // than have picked something up along the way.
+    for (hash, number, slot) in &seeded.blocks {
+        let (expected_hash, expected_number) = if slots.contains(slot) {
+            (
+                fjall.slot_by_block_hash(hash).unwrap(),
+                fjall.slot_by_block_number(*number).unwrap(),
+            )
+        } else {
+            (None, None)
+        };
+
+        assert_eq!(
+            restored_fjall.slot_by_block_hash(hash).unwrap(),
+            expected_hash
+        );
+        assert_eq!(
+            restored_fjall.slot_by_block_number(*number).unwrap(),
+            expected_number
+        );
+    }
+}
+
 /// Mainnet-shaped epoch: ~5 days at 20s/slot.
 const COST_BLOCKS_PER_EPOCH: u64 = 21_600;
 /// Transactions per block.
@@ -488,7 +724,8 @@ fn cost_epochs() -> u64 {
 
 /// Measure the cost of slicing one epoch out of a populated index store.
 ///
-/// Not an assertion — a number. Neither traversal can seek to an epoch:
+/// Not an assertion — a number, and specific to fjall, the backend a publisher
+/// actually runs against. Neither traversal can seek to an epoch:
 ///
 /// - tag keys are `[dim_hash][key_hash][slot]`, so slot is the *last* component
 ///   and each dimension prefix is scanned in full;
@@ -507,8 +744,7 @@ fn cost_epochs() -> u64 {
 fn measure_one_epoch_iteration_cost() {
     use std::time::Instant;
 
-    let dir = tempfile::tempdir().expect("failed to create tempdir");
-    let store = open_store(&dir);
+    let (store, _guard) = Fjall::open();
 
     let epochs = cost_epochs();
     let tags_per_epoch = COST_BLOCKS_PER_EPOCH * COST_TXS_PER_BLOCK * COST_TAGS_PER_TX;

--- a/tests/state_conformance.rs
+++ b/tests/state_conformance.rs
@@ -1,0 +1,455 @@
+//! Semantic conformance for the state store contract.
+//!
+//! Written once against the [`StateStore`] trait and run against every live
+//! backend: fjall, the persistent one, and the builtin memory store. A backend
+//! that only ever ran its own tests could drift from its peers without anything
+//! failing — and the seam this pins, `iter_utxos`, feeds a snapshot layer, so a
+//! backend that iterated a slightly different set would publish one.
+//!
+//! Distinct from `tests/memory.rs`, which measures *allocation* behaviour: the
+//! disk backends promise lazy, O(1)-memory iteration, and the builtin memory
+//! store deliberately does not (it materializes). That is a documented property
+//! of each backend rather than a shared semantic, so it stays there.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dolos_core::{
+    builtin::MemoryStateStore, config::FjallStateConfig, ChainPoint, EntityKey, EraCbor, TxoRef,
+    UtxoSetDelta,
+};
+use dolos_core::{StateStore as CoreStateStore, StateWriter as CoreStateWriter};
+
+const ACCOUNTS: &str = "accounts";
+const POOLS: &str = "pools";
+
+/// One state backend under test. The guard keeps whatever the backend needs
+/// alive — a temp directory for the on-disk one, nothing for the other.
+trait Backend {
+    type Store: CoreStateStore;
+    type Guard;
+
+    fn open() -> (Self::Store, Self::Guard);
+}
+
+struct Fjall;
+
+impl Backend for Fjall {
+    type Store = dolos_fjall::StateStore;
+    type Guard = tempfile::TempDir;
+
+    fn open() -> (Self::Store, Self::Guard) {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+
+        let config = FjallStateConfig {
+            path: None,
+            cache: Some(16),
+            max_history: None,
+            max_journal_size: None,
+            flush_on_commit: Some(false),
+            l0_threshold: None,
+            worker_threads: Some(1),
+            memtable_size_mb: None,
+        };
+
+        let store = dolos_fjall::StateStore::open(dir.path(), &config)
+            .expect("failed to open fjall state store");
+
+        (store, dir)
+    }
+}
+
+struct Memory;
+
+impl Backend for Memory {
+    type Store = MemoryStateStore;
+    type Guard = ();
+
+    fn open() -> (Self::Store, Self::Guard) {
+        (MemoryStateStore::new(), ())
+    }
+}
+
+macro_rules! conformance_suite {
+    ($module:ident, $backend:ty) => {
+        mod $module {
+            use super::*;
+
+            #[test]
+            fn cursor_starts_empty_and_survives_commit() {
+                super::cursor_starts_empty_and_survives_commit::<$backend>();
+            }
+
+            #[test]
+            fn entities_are_namespaced() {
+                super::entities_are_namespaced::<$backend>();
+            }
+
+            #[test]
+            fn entity_range_is_half_open_and_ordered() {
+                super::entity_range_is_half_open_and_ordered::<$backend>();
+            }
+
+            #[test]
+            fn writes_are_invisible_until_commit() {
+                super::writes_are_invisible_until_commit::<$backend>();
+            }
+
+            #[test]
+            fn iter_utxos_yields_the_whole_set_in_ref_order() {
+                super::iter_utxos_yields_the_whole_set_in_ref_order::<$backend>();
+            }
+
+            #[test]
+            fn utxo_delta_produces_consumes_recovers_and_undoes() {
+                super::utxo_delta_produces_consumes_recovers_and_undoes::<$backend>();
+            }
+
+            #[test]
+            fn consumption_wins_within_one_delta() {
+                super::consumption_wins_within_one_delta::<$backend>();
+            }
+        }
+    };
+}
+
+conformance_suite!(fjall, Fjall);
+conformance_suite!(memory, Memory);
+
+fn key(n: u8) -> EntityKey {
+    EntityKey::from(&[n; 32])
+}
+
+fn txo(n: u8, idx: u32) -> TxoRef {
+    TxoRef([n; 32].into(), idx)
+}
+
+fn utxo(n: u8) -> Arc<EraCbor> {
+    Arc::new(EraCbor(6, vec![n; 8]))
+}
+
+fn produce(refs: &[(TxoRef, Arc<EraCbor>)]) -> UtxoSetDelta {
+    UtxoSetDelta {
+        produced_utxo: refs.iter().cloned().collect(),
+        ..Default::default()
+    }
+}
+
+fn apply_utxos<S: CoreStateStore>(store: &S, delta: &UtxoSetDelta) {
+    let writer = store.start_writer().expect("start_writer failed");
+    writer.apply_utxoset(delta).expect("apply_utxoset failed");
+    writer.commit().expect("commit failed");
+}
+
+fn all_utxos<S: CoreStateStore>(store: &S) -> Vec<(TxoRef, EraCbor)> {
+    store
+        .iter_utxos()
+        .expect("iter_utxos failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("utxo iteration failed")
+}
+
+fn cursor_starts_empty_and_survives_commit<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    assert_eq!(store.read_cursor().expect("read_cursor failed"), None);
+
+    let writer = store.start_writer().expect("start_writer failed");
+    writer
+        .set_cursor(ChainPoint::Slot(42))
+        .expect("set_cursor failed");
+    writer.commit().expect("commit failed");
+
+    assert_eq!(
+        store.read_cursor().expect("read_cursor failed"),
+        Some(ChainPoint::Slot(42))
+    );
+}
+
+fn entities_are_namespaced<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().expect("start_writer failed");
+    writer
+        .write_entity(ACCOUNTS, &key(1), &vec![0xaa])
+        .expect("write_entity failed");
+    writer
+        .write_entity(POOLS, &key(1), &vec![0xbb])
+        .expect("write_entity failed");
+    writer.commit().expect("commit failed");
+
+    // The same key in two namespaces is two entities.
+    assert_eq!(
+        store.read_entities(ACCOUNTS, &[&key(1)]).unwrap(),
+        vec![Some(vec![0xaa])]
+    );
+    assert_eq!(
+        store.read_entities(POOLS, &[&key(1)]).unwrap(),
+        vec![Some(vec![0xbb])]
+    );
+
+    // A missing key reads as a hole in the right position, not a short vector.
+    assert_eq!(
+        store
+            .read_entities(ACCOUNTS, &[&key(0), &key(1), &key(2)])
+            .unwrap(),
+        vec![None, Some(vec![0xaa]), None]
+    );
+
+    // Deleting one namespace's entry leaves the other alone.
+    let writer = store.start_writer().expect("start_writer failed");
+    writer
+        .delete_entity(ACCOUNTS, &key(1))
+        .expect("delete_entity failed");
+    writer.commit().expect("commit failed");
+
+    assert_eq!(
+        store.read_entities(ACCOUNTS, &[&key(1)]).unwrap(),
+        vec![None]
+    );
+    assert_eq!(
+        store.read_entities(POOLS, &[&key(1)]).unwrap(),
+        vec![Some(vec![0xbb])]
+    );
+}
+
+fn entity_range_is_half_open_and_ordered<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().expect("start_writer failed");
+    for n in [1u8, 2, 3, 4] {
+        writer
+            .write_entity(ACCOUNTS, &key(n), &vec![n])
+            .expect("write_entity failed");
+    }
+    // A neighbouring namespace whose keys must not show up in the scan.
+    writer
+        .write_entity(POOLS, &key(2), &vec![0xff])
+        .expect("write_entity failed");
+    writer.commit().expect("commit failed");
+
+    let collect = |range| {
+        store
+            .iter_entities(ACCOUNTS, range)
+            .expect("iter_entities failed")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("entity iteration failed")
+    };
+
+    let all = collect(EntityKey::full_range());
+    assert_eq!(
+        all.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+        vec![key(1), key(2), key(3), key(4)],
+        "entities come out in key order, and only from the requested namespace"
+    );
+
+    // Half-open: the start is included, the end is not.
+    let middle = collect(key(2)..key(4));
+    assert_eq!(
+        middle.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+        vec![key(2), key(3)]
+    );
+
+    assert!(
+        collect(key(2)..key(2)).is_empty(),
+        "an empty range is empty"
+    );
+
+    // An inverted range matches nothing rather than blowing up: the disk
+    // backends compare encoded bytes and simply find none, so an ordered-map
+    // backend has to reach the same answer instead of panicking on the bound.
+    assert!(
+        collect(key(4)..key(2)).is_empty(),
+        "an inverted range is empty"
+    );
+}
+
+fn writes_are_invisible_until_commit<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    apply_utxos(&store, &produce(&[(txo(1, 0), utxo(1))]));
+
+    let writer = store.start_writer().expect("start_writer failed");
+    writer
+        .write_entity(ACCOUNTS, &key(9), &vec![0x09])
+        .expect("write_entity failed");
+    writer
+        .apply_utxoset(&produce(&[(txo(2, 0), utxo(2))]))
+        .expect("apply_utxoset failed");
+    writer
+        .set_cursor(ChainPoint::Slot(7))
+        .expect("set_cursor failed");
+
+    // Everything above is still pending: a reader sees the store as it was.
+    assert_eq!(
+        store.read_entities(ACCOUNTS, &[&key(9)]).unwrap(),
+        vec![None]
+    );
+    assert_eq!(all_utxos(&store).len(), 1);
+    assert_eq!(store.read_cursor().unwrap(), None);
+
+    writer.commit().expect("commit failed");
+
+    assert_eq!(
+        store.read_entities(ACCOUNTS, &[&key(9)]).unwrap(),
+        vec![Some(vec![0x09])]
+    );
+    assert_eq!(all_utxos(&store).len(), 2);
+    assert_eq!(store.read_cursor().unwrap(), Some(ChainPoint::Slot(7)));
+}
+
+fn iter_utxos_yields_the_whole_set_in_ref_order<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    // Written out of order, and with more than one index per tx hash, so the
+    // ordering claim has something to bite on.
+    let refs = [
+        (txo(3, 1), utxo(31)),
+        (txo(1, 2), utxo(12)),
+        (txo(3, 0), utxo(30)),
+        (txo(1, 0), utxo(10)),
+        (txo(2, 0), utxo(20)),
+    ];
+    apply_utxos(&store, &produce(&refs));
+
+    let iterated = all_utxos(&store);
+
+    assert_eq!(
+        iterated.len(),
+        refs.len(),
+        "iter_utxos yields the whole set"
+    );
+
+    let expected: HashMap<TxoRef, EraCbor> = refs
+        .iter()
+        .map(|(txo, value)| (txo.clone(), value.as_ref().clone()))
+        .collect();
+    assert_eq!(
+        iterated.iter().cloned().collect::<HashMap<_, _>>(),
+        expected,
+        "iter_utxos yields exactly what was written, values included"
+    );
+
+    let order: Vec<TxoRef> = iterated.iter().map(|(txo, _)| txo.clone()).collect();
+    let mut sorted = order.clone();
+    sorted.sort();
+    assert_eq!(
+        order, sorted,
+        "iter_utxos yields refs in (tx_hash, index) order — what every backend's \
+         key encoding sorts by"
+    );
+
+    // The same set, asked for by ref.
+    let by_ref = store
+        .get_utxos(refs.iter().map(|(txo, _)| txo.clone()).collect())
+        .expect("get_utxos failed");
+    assert_eq!(by_ref.len(), refs.len());
+    for (txo, value) in &refs {
+        assert_eq!(by_ref.get(txo).map(|v| v.as_ref()), Some(value.as_ref()));
+    }
+
+    // A ref that was never produced is absent rather than an error.
+    let missing = store
+        .get_utxos(vec![txo(9, 9)])
+        .expect("get_utxos failed for an unknown ref");
+    assert!(missing.is_empty());
+}
+
+fn utxo_delta_produces_consumes_recovers_and_undoes<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    apply_utxos(
+        &store,
+        &produce(&[(txo(1, 0), utxo(1)), (txo(2, 0), utxo(2))]),
+    );
+
+    // Consume one: it leaves the set.
+    apply_utxos(
+        &store,
+        &UtxoSetDelta {
+            consumed_utxo: [(txo(1, 0), utxo(1))].into_iter().collect(),
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        all_utxos(&store)
+            .into_iter()
+            .map(|(txo, _)| txo)
+            .collect::<Vec<_>>(),
+        vec![txo(2, 0)]
+    );
+
+    // Roll that back: `recovered_stxi` puts a consumed UTxO back, value and
+    // all, and `undone_utxo` takes a produced one away again.
+    apply_utxos(
+        &store,
+        &UtxoSetDelta {
+            recovered_stxi: [(txo(1, 0), utxo(1))].into_iter().collect(),
+            undone_utxo: [(txo(2, 0), utxo(2))].into_iter().collect(),
+            ..Default::default()
+        },
+    );
+
+    let remaining = all_utxos(&store);
+    assert_eq!(
+        remaining,
+        vec![(txo(1, 0), utxo(1).as_ref().clone())],
+        "recovered UTxOs come back whole; undone ones are gone"
+    );
+}
+
+/// A delta that both produces and consumes the same ref leaves it absent.
+///
+/// The backends order their write batches differently — fjall removes consumed
+/// then undone, redb3 the other way round — but every one of them applies both
+/// removal sets after both insertion sets, so the outcome is a property of the
+/// delta rather than of the backend. Pinning it here keeps it that way.
+fn consumption_wins_within_one_delta<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    apply_utxos(
+        &store,
+        &UtxoSetDelta {
+            produced_utxo: [(txo(1, 0), utxo(1)), (txo(2, 0), utxo(2))]
+                .into_iter()
+                .collect(),
+            consumed_utxo: [(txo(1, 0), utxo(1))].into_iter().collect(),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(
+        all_utxos(&store)
+            .into_iter()
+            .map(|(txo, _)| txo)
+            .collect::<Vec<_>>(),
+        vec![txo(2, 0)]
+    );
+}
+
+/// The two live backends have to agree on the UTxO set the same delta produces,
+/// and on the order they hand it over: `iter_utxos` feeds a snapshot layer, so
+/// the sequence is the published content.
+#[test]
+fn backends_agree_on_the_iterated_utxo_set() {
+    let (fjall, _guard) = Fjall::open();
+    let (memory, _) = Memory::open();
+
+    let delta = UtxoSetDelta {
+        produced_utxo: [
+            (txo(7, 3), utxo(73)),
+            (txo(1, 0), utxo(10)),
+            (txo(7, 0), utxo(70)),
+            (txo(4, 9), utxo(49)),
+        ]
+        .into_iter()
+        .collect(),
+        consumed_utxo: [(txo(4, 9), utxo(49))].into_iter().collect(),
+        ..Default::default()
+    };
+
+    apply_utxos(&fjall, &delta);
+    apply_utxos(&memory, &delta);
+
+    assert_eq!(all_utxos(&fjall), all_utxos(&memory));
+}


### PR DESCRIPTION
## What

`in_memory` state and indexes were the redb3 stores running on redb's `InMemoryBackend` (`crates/redb3/src/state/mod.rs:104`), so they inherited redb's inability to serve the export/restore seam #1150 added: `iter_utxos` returned `Unsupported` (`crates/redb3/src/state/mod.rs:335`), and the index side had no `iter_archive_tags` or `append_prehashed`. That was an accident of implementation, not a property of being in memory.

This implements both directly, on ordered maps, in `dolos_core::builtin::memory`.

The disk backends are, in bulk, composite-key encoders: they flatten tuples into one ordered byte keyspace because that is the only shape an LSM tree or a B-tree file offers. A `BTreeMap` keyed on the tuple *is* that keyspace, so:

- `iter_utxos`, `iter_archive_tags` and `iter_exact_records` are `.range()` calls;
- the archive-tag ordering contract — `(dimension, key_hash, slot)`, dimension compared as a string — is the map's own ordering. On disk the leading key component is a *hash* of the dimension, whose order is unrelated, which is why fjall has to walk a caller-supplied dimension list in name order to get there;
- entities are one map keyed `(namespace, entity_key)`, so a namespaced range scan needs no prefix encoding.

Writers accumulate their mutations privately as an ordered op log and merge them under a single write lock at `commit`. That gives the same atomicity and visibility as a disk transaction — readers keep running while a writer is open and see nothing of its work until it lands — without holding a lock for the writer's lifetime. The log stays ordered rather than merged so that a later operation on a key supersedes an earlier one, which is how a write batch behaves and is what decides the outcome when one delta both produces and consumes a ref.

### One definition of a tag record's stored key

A tag record carries only its stored `key_hash`; the logical key is not on disk and cannot be recovered. A backend that derived those bytes differently would not fail to restore — it would restore successfully and then miss every logical-key query about the restored records.

The rule (`xxh3_64` big-endian, except `metadata`, whose `u64` label is stored verbatim) had been prose in `KeyHash`'s doc comment since #1150. It is now code beside it, as `dolos_core::indexes::key_hash`, returning `None` for a key that is not valid for its dimension — which is exactly the behaviour both call sites already had: drop on write, refuse on query.

`crates/fjall` still derives its own; the two are held together by test here (see below) rather than by construction. Folding fjall onto the shared definition is a separate change — it touches the live backend's write path and belongs on its own.

### `ToyDomain`

`State` and `Indexes` rebind to the new stores; archive stays on redb, WAL untouched. They serve the same contract as fjall — including the seam, which is why this could not go back to the redb in-memory store — but need no filesystem, no compaction threads and no cache, so building a domain costs about what allocating a map costs. The temp directory the domain held is gone.

`crates/testing/src/harness/cardano.rs` stays on disk-backed fjall deliberately: it replays a real Mithril immutable DB from a caller-provided directory.

## Test suites

Both store-level suites are now written once against the traits and run against every live backend, so one suite defines the semantics rather than each backend testing itself:

- `tests/index_roundtrip.rs` — reworked from fjall-only into a parameterized suite (5 tests × 2 backends): the epoch-slice round trip through `append_prehashed`, the two ordering contracts, the `metadata` verbatim-label exception, and a new `undo_removes_exactly_what_apply_added`.
- `tests/state_conformance.rs` — new (7 tests × 2 backends): `iter_utxos` over the whole set in `(tx_hash, index)` order, cursor, namespaced entities, half-open and inverted ranges, the four `UtxoSetDelta` cases, and commit visibility.

Two tests hold the backends to each other rather than to themselves — nothing inside one backend's own suite can catch a divergence here:

- `backends_agree_on_exported_records` — identical deltas must export identical records.
- `records_cross_between_backends` — a slice exported from fjall restores into the memory store and answers the same logical-key queries; exported back out, it restores into a fresh fjall store that answers them too.

`tests/memory.rs` is unchanged and still fjall/redb3-only: it measures *allocation*, and the builtin stores deliberately materialize their ranges instead of streaming (see below).

## Not a mainnet-shaped backend

Iteration materializes into an owned buffer, so a full traversal transiently doubles the memory the set already occupies, and nothing persists. That suits devnets, tooling and tests; the docs say so plainly, in both `configuration/schema.mdx` and `architecture/data-layer.mdx`.

## Verification

| Command | Result |
| --- | --- |
| `cargo test --workspace --all-targets` (what CI runs) | pass — 24 suites ok, 0 failed |
| `cargo test --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` (per `AGENTS.md`) | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo +nightly fmt --all -- --check` | pass |
| `cargo deny check advisories` | pass |

Suite wall time, before and after the `ToyDomain` rebinding:

| suite | before (fjall) | after | |
| --- | --- | --- | --- |
| `dolos-minibf` (242 tests) | 111.18 s | 2.90 s | 38× |
| `dolos-minikupo` (41) | 18.55 s | 0.49 s | 38× |
| `dolos-trp` (10) | 5.53 s | 0.19 s | 29× |

## Notes for review

- **`dolos-core` gains a dependency on `xxhash-rust`.** Already a workspace dependency and already in the lockfile, so nothing new enters the tree, but the edge is new. It is what `key_hash` needs.
- **`TxoRef` gains `Ord`/`PartialOrd`.** Derived, so `(tx_hash, index)` — which is what every backend's UTxO key encoding already sorts by.
- **`StateStoreBackend::in_memory` no longer takes a `StateSchema`.** The builtin store discovers namespaces as they are written, so there is no table set to declare up front.
- **`iter_entity_values` returns `Unsupported` on the memory store.** Multi-value namespaces have no definition it could conform to — fjall does not implement them either (#1036) — so it declines rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full in-memory state and index storage backends for development, tooling, and testing.
  * In-memory backends now support ordered queries, UTxO operations, archive tags, cursors, commits, rollbacks, and round-trip workflows.
  * Added metadata key hashing and improved deterministic UTxO ordering.
* **Documentation**
  * Clarified that in-memory storage is ephemeral, lost on restart, and unsuitable for public-network nodes.
* **Tests**
  * Added comprehensive conformance and cross-backend compatibility coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->