### PR TITLE
refactor(storage): let append_prehashed take an iterator

### DIFF
--- a/crates/core/src/builtin/memory/index.rs
+++ b/crates/core/src/builtin/memory/index.rs
@@ -197,13 +197,16 @@ impl IndexWriter for MemoryIndexWriter {
         Ok(())
     }
 
-    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError> {
         let mut ops = self.ops.lock().map_err(|_| poisoned())?;
 
         for record in records {
             match record {
                 IndexRecord::Tag(tag) => ops.push(Op::InsertArchiveTag((
-                    tag.dimension.clone(),
+                    tag.dimension,
                     tag.key_hash,
                     tag.slot,
                 ))),
@@ -220,7 +223,7 @@ impl IndexWriter for MemoryIndexWriter {
                         )));
                     }
 
-                    ops.push(Op::InsertExact(exact.kind, exact.key.clone(), exact.slot));
+                    ops.push(Op::InsertExact(exact.kind, exact.key, exact.slot));
                 }
             }
         }

--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -36,7 +36,10 @@ impl IndexWriter for NoOpIndexWriter {
     /// report success: `Ok` here would let a snapshot restore complete
     /// "cleanly" having written nothing. See
     /// [`NoOpIndexStore::iter_archive_tags`] for the read-side twin.
-    fn append_prehashed(&self, _records: &[IndexRecord]) -> Result<(), IndexError> {
+    fn append_prehashed(
+        &self,
+        _records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError> {
         Err(IndexError::Unsupported("append_prehashed"))
     }
 

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -338,9 +338,25 @@ pub trait IndexWriter: Send + Sync + 'static {
     /// that skips this leaves `cursor()` at `None` and bootstrap will treat the
     /// store as never indexed.
     ///
+    /// ## Chunking
+    ///
+    /// The argument is an iterator so a restore can pipe its wire decoder
+    /// straight in, rather than materializing a slice beside the write batch's
+    /// own encoded copy. It is consumed lazily and fully; a backend never
+    /// collects it.
+    ///
+    /// This call is *not* the batch boundary — the writer accumulates until
+    /// [`IndexWriter::commit`], so an unbounded iterator builds an unbounded
+    /// batch. Chunking is the caller's: feed one writer a run of records,
+    /// commit it, start the next. The sort order has to hold across the whole
+    /// restore, not merely within a chunk.
+    ///
     /// Backends that do not implement this return
     /// [`IndexError::Unsupported`].
-    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError>;
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError>;
 
     /// Commit the batched operations.
     fn commit(self) -> Result<(), IndexError>;

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -32,6 +32,7 @@
 //! All multi-byte integers are big-endian encoded for correct lexicographic
 //! ordering.
 
+use std::borrow::Cow;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -285,24 +286,27 @@ impl CoreIndexWriter for IndexStoreWriter {
         Ok(())
     }
 
-    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError> {
         let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
 
         // Records arrive sorted, hence grouped by dimension/kind: hash each
-        // group's dimension once instead of once per record.
-        let mut tag_dim: Option<(&str, [u8; DIM_HASH_SIZE])> = None;
+        // group's dimension once instead of once per record. The cached
+        // dimension is owned because a record no longer outlives its own
+        // iteration step — the clone is one per group, not one per record.
+        let mut tag_dim: Option<(Cow<'static, str>, [u8; DIM_HASH_SIZE])> = None;
         let mut exact_dim: Option<(ExactKind, [u8; DIM_HASH_SIZE])> = None;
 
         for record in records {
             match record {
                 IndexRecord::Tag(tag) => {
-                    let dimension = tag.dimension();
-
-                    let dim_hash = match tag_dim {
-                        Some((cached, hash)) if cached == dimension => hash,
+                    let dim_hash = match &tag_dim {
+                        Some((cached, hash)) if cached == &tag.dimension => *hash,
                         _ => {
-                            let hash = hash_dimension(dim_prefix::BLOCK, dimension);
-                            tag_dim = Some((dimension, hash));
+                            let hash = hash_dimension(dim_prefix::BLOCK, tag.dimension());
+                            tag_dim = Some((tag.dimension.clone(), hash));
                             hash
                         }
                     };
@@ -310,7 +314,7 @@ impl CoreIndexWriter for IndexStoreWriter {
                     archive_tags::insert_prehashed(
                         &mut batch,
                         &self.store.block_tags,
-                        tag,
+                        &tag,
                         dim_hash,
                     );
                 }
@@ -324,7 +328,7 @@ impl CoreIndexWriter for IndexStoreWriter {
                         }
                     };
 
-                    exact::insert_prehashed(&mut batch, &self.store.exact, exact, dim_hash)
+                    exact::insert_prehashed(&mut batch, &self.store.exact, &exact, dim_hash)
                         .map_err(IndexError::from)?;
                 }
             }

--- a/crates/redb3/src/indexes/mod.rs
+++ b/crates/redb3/src/indexes/mod.rs
@@ -752,7 +752,10 @@ impl CoreIndexWriter for IndexStoreWriter {
     /// against the live index backend (fjall). This store is not part of that
     /// path, so it carries the trait method without an implementation rather
     /// than a second copy of the encoding to keep in step.
-    fn append_prehashed(&self, _records: &[IndexRecord]) -> Result<(), IndexError> {
+    fn append_prehashed(
+        &self,
+        _records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError> {
         Err(IndexError::Unsupported("append_prehashed"))
     }
 

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -975,7 +975,10 @@ impl CoreIndexWriter for IndexWriterBackend {
         }
     }
 
-    fn append_prehashed(&self, records: &[IndexRecord]) -> Result<(), IndexError> {
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), IndexError> {
         match self {
             Self::Redb(w) => w.append_prehashed(records),
             Self::Fjall(w) => w.append_prehashed(records),
@@ -1386,7 +1389,7 @@ mod tests {
         indexes
             .start_writer()
             .expect("start_writer failed")
-            .append_prehashed(&[])
+            .append_prehashed([])
             .expect("append_prehashed must be supported");
     }
 

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -299,7 +299,9 @@ fn export_slice<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<In
     records
 }
 
-fn restore<S: CoreIndexStore>(store: &S, records: &[IndexRecord]) {
+/// Restore in one batch, the way a driver would restore one chunk: the writer
+/// takes the records as an iterator and accumulates them until `commit`.
+fn restore<S: CoreIndexStore>(store: &S, records: impl IntoIterator<Item = IndexRecord>) {
     let writer = store.start_writer().expect("start_writer failed");
     writer
         .append_prehashed(records)
@@ -318,7 +320,7 @@ fn epoch_slice_round_trips_through_append_prehashed<B: Backend>() {
     assert!(!records.is_empty(), "the epoch slice should not be empty");
 
     let (target, _target_guard) = B::open();
-    restore(&target, &records);
+    restore(&target, records);
 
     let mut checked_metadata = false;
 
@@ -654,8 +656,20 @@ fn records_cross_between_backends() {
     let seeded = seed(&fjall);
     let slots = epoch_slots(EPOCHS[0]);
 
-    // fjall -> memory
-    restore(&memory, &export_slice(&fjall, slots.clone()));
+    // fjall -> memory, streamed rather than collected: the writer takes an
+    // iterator so a restore driver can pipe a decoder straight into it, and
+    // nothing about that path may depend on the records sitting in a slice.
+    restore(
+        &memory,
+        collect_tags(&fjall, &archive_dimensions::ALL, slots.clone())
+            .into_iter()
+            .map(IndexRecord::from)
+            .chain(
+                collect_exacts(&fjall, slots.clone())
+                    .into_iter()
+                    .map(IndexRecord::from),
+            ),
+    );
 
     for (dimension, key, _) in seeded.tags_in(&slots) {
         let from_fjall = slots_for_tag(&fjall, dimension, key, &slots);
@@ -670,7 +684,7 @@ fn records_cross_between_backends() {
 
     // and back again, into a store that has never seen a delta
     let (restored_fjall, _guard) = Fjall::open();
-    restore(&restored_fjall, &export_slice(&memory, slots.clone()));
+    restore(&restored_fjall, export_slice(&memory, slots.clone()));
 
     for (dimension, key, _) in seeded.tags_in(&slots) {
         assert_eq!(


### PR DESCRIPTION
**Plan:** `dolos-stelae-store-apis-review-cleanups`, item 1 — the first of seven small PRs from the third bucket of the PR #1150 adversarial review.

**Done criterion (item 1):** `IndexWriter::append_prehashed` accepts an iterator; its doc states the chunking contract; `tests/index_roundtrip.rs` passes unchanged in behavior. **Met.**

## What changed

`IndexWriter::append_prehashed` took `&[IndexRecord]`, which forces a restore driver to materialize each chunk beside the write batch's own encoded copy of it. It now takes `impl IntoIterator<Item = IndexRecord>`, so a wire decoder can pipe straight into the batch. The trait is already dyn-incompatible (`fn commit(self)`), so the generic costs nothing.

Owned records also drop the per-record clones `MemoryIndexWriter` was making, and let fjall's grouped dimension cache key on a `Cow` it clones once per group rather than borrowing across iterations.

The doc gained the chunking contract, which was implicit: the call is **not** the batch boundary — the writer accumulates until `commit`, so chunking belongs to the caller, and the sort order has to hold across the whole restore rather than merely within a chunk.

`records_cross_between_backends` now restores from a chained `map` iterator rather than a slice, so nothing on that path can quietly depend on the records sitting in a collection.

Five impl sites (`fjall`, builtin `memory`, builtin `noop`, `redb3`, the adapter enum) plus the two test call sites. No on-disk or wire change.

## Verification

```
cargo test --workspace --all-targets      # all green
cargo clippy --all-targets --all-features -- -D warnings
cargo +nightly fmt --all -- --check
```

## Escalation

Item 1 is an API break for in-tree implementors only — no external consumers, and the workspace does not publish (`[workspace.metadata.release] publish = false`). No migration cost today; it grows one once the snapshots Phase 2 driver lands, which is why this goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Index and restore operations now accept any record iterator, enabling records to be streamed or provided from chained sources.
  * Record processing can consume owned data directly, reducing unnecessary copying during indexing.
  * Restoration workflows now support streaming records between storage backends.

* **Documentation**
  * Clarified iterator consumption, chunking responsibilities, accumulation behavior, and global ordering guarantees.

* **Bug Fixes**
  * Preserved existing validation and unsupported-operation error behavior while broadening input compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->