### PR TITLE
feat(storage): make the archive dimension registry enforce itself

### DIFF
--- a/crates/cardano/src/indexes/delta.rs
+++ b/crates/cardano/src/indexes/delta.rs
@@ -431,6 +431,7 @@ mod tests {
     use pallas::ledger::addresses::{
         Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart,
     };
+    use std::collections::BTreeSet;
 
     fn test_shelley_address() -> Address {
         Address::Shelley(ShelleyAddress::new(
@@ -458,5 +459,110 @@ mod tests {
         assert_eq!(delta.archive[0].tx_hashes.len(), 1);
         // Shelley address produces 3 tags: full, payment, stake
         assert_eq!(delta.archive[0].tags.len(), 3);
+    }
+
+    /// Drive every tag-producing method on the builder once.
+    ///
+    /// This is the producer side of the registry: what a block turns into.
+    /// Kept as one function so the completeness check below and any future
+    /// caller see the same set.
+    fn tag_every_dimension(builder: &mut CardanoIndexDeltaBuilder) {
+        use pallas::ledger::primitives::{
+            alonzo::TransactionInput,
+            conway::{Certificate, Value},
+            StakeCredential,
+        };
+        use pallas::ledger::traverse::{MultiEraCert, MultiEraInput, MultiEraValue};
+        use std::borrow::Cow;
+        use std::collections::BTreeMap;
+
+        builder.start_block(100, vec![0; 32], Some(50));
+        builder.add_tx_hash(vec![1; 32]);
+
+        // ADDRESS, PAYMENT, STAKE
+        builder.add_address(&test_shelley_address());
+
+        // POLICY, ASSET
+        let mut names = BTreeMap::new();
+        names.insert(
+            vec![0xaa; 4].into(),
+            1u64.try_into().expect("1 is a positive coin"),
+        );
+        let mut multiasset = BTreeMap::new();
+        multiasset.insert(Hash::new([0x11; 28]), names);
+        let value = Value::Multiasset(0, multiasset);
+        builder.add_assets(&MultiEraValue::Conway(Cow::Owned(value)));
+
+        // DATUM
+        builder.add_datum_hash(vec![0x22; 32]);
+
+        // SPENT_TXO
+        let input = TransactionInput {
+            transaction_id: Hash::new([0x33; 32]),
+            index: 0,
+        };
+        builder.add_spent_input(&MultiEraInput::from_alonzo_compatible(&input));
+
+        // SCRIPT
+        builder.add_script_hash(vec![0x44; 28]);
+
+        // ACCOUNT_CERTS
+        let registration =
+            Certificate::StakeRegistration(StakeCredential::AddrKeyhash(Hash::new([0x55; 28])));
+        builder.add_cert(&MultiEraCert::Conway(Box::new(Cow::Owned(registration))));
+
+        // POOL_CERTS
+        let retirement = Certificate::PoolRetirement(Hash::new([0x66; 28]), 42);
+        builder.add_cert(&MultiEraCert::Conway(Box::new(Cow::Owned(retirement))));
+
+        // ACCOUNT_WITHDRAWALS
+        builder.add_withdrawal(&[0x77; 29]);
+
+        // METADATA
+        builder.add_metadata_label(674);
+    }
+
+    /// The dimension registry has to hold every dimension this builder emits.
+    ///
+    /// `archive::ALL` drives every bulk traversal of archive tags — index
+    /// stores keep a hash of the dimension name, not the name, so the set is
+    /// not discoverable from disk. A dimension produced here and missing there
+    /// does not fail: it silently stops being exported, and a snapshot built
+    /// from the traversal is quietly incomplete.
+    ///
+    /// The reverse direction is checked too. Without it the test could stop
+    /// covering a dimension — by a builder method losing its call above — and
+    /// still pass, which is the same blind spot one step removed.
+    #[test]
+    fn every_produced_dimension_is_registered() {
+        let mut builder =
+            CardanoIndexDeltaBuilder::new(ChainPoint::Specific(100, Hash::new([0; 32])));
+        tag_every_dimension(&mut builder);
+
+        let delta = builder.build();
+
+        let produced: BTreeSet<&str> = delta
+            .archive
+            .iter()
+            .flat_map(|block| block.tags.iter())
+            .map(|tag| tag.dimension)
+            .collect();
+
+        let registered: BTreeSet<&str> = archive::ALL.iter().copied().collect();
+
+        assert!(
+            produced.is_subset(&registered),
+            "these dimensions are produced but not in archive::ALL, so they \
+             would silently stop being exported: {:?}",
+            &produced - &registered,
+        );
+
+        assert_eq!(
+            produced,
+            registered,
+            "every registered dimension must be exercised here, otherwise this \
+             test stops covering the ones it misses: {:?} are unexercised",
+            &registered - &produced,
+        );
     }
 }

--- a/crates/cardano/src/indexes/dimensions.rs
+++ b/crates/cardano/src/indexes/dimensions.rs
@@ -26,6 +26,32 @@ pub mod utxo {
     pub const ASSET: TagDimension = "asset";
 }
 
+/// Declare a dimension registry: the constants and the `ALL` list that has to
+/// contain them, from one list.
+///
+/// Index stores keep a *hash* of the dimension name rather than the name, so
+/// the set of dimensions is not discoverable from disk: any bulk traversal of
+/// archive tags (`IndexStore::iter_archive_tags`) has to be driven by `ALL`,
+/// and a dimension missing from it silently stops being exported.
+///
+/// Writing the two out separately made that a comment's job. Here a constant
+/// cannot exist without being in `ALL`, because the same list emits both.
+macro_rules! dimension_registry {
+    (
+        $(#[$all_meta:meta])*
+        ALL;
+        $($(#[$meta:meta])* $name:ident = $value:expr;)+
+    ) => {
+        $(
+            $(#[$meta])*
+            pub const $name: TagDimension = $value;
+        )+
+
+        $(#[$all_meta])*
+        pub const ALL: [TagDimension; [$(stringify!($name)),+].len()] = [$($name),+];
+    };
+}
+
 /// Archive index dimensions.
 ///
 /// These dimensions are used for querying historical blocks by various
@@ -33,63 +59,49 @@ pub mod utxo {
 pub mod archive {
     use dolos_core::TagDimension;
 
-    /// Full address (any type: Shelley, Byron, Stake)
-    pub const ADDRESS: TagDimension = "address";
+    dimension_registry! {
+        /// Every archive dimension, in declaration order.
+        ///
+        /// Emitted from the same list as the constants above, so a dimension
+        /// that exists is a dimension that is exported.
+        ALL;
 
-    /// Payment credential (Shelley addresses only)
-    pub const PAYMENT: TagDimension = "payment";
+        /// Full address (any type: Shelley, Byron, Stake)
+        ADDRESS = "address";
 
-    /// Stake credential (Shelley addresses with delegation, or stake addresses)
-    pub const STAKE: TagDimension = "stake";
+        /// Payment credential (Shelley addresses only)
+        PAYMENT = "payment";
 
-    /// Native asset subject (policy ID + asset name)
-    pub const ASSET: TagDimension = "asset";
+        /// Stake credential (Shelley addresses with delegation, or stake addresses)
+        STAKE = "stake";
 
-    /// Native asset policy ID
-    pub const POLICY: TagDimension = "policy";
+        /// Native asset subject (policy ID + asset name)
+        ASSET = "asset";
 
-    /// Plutus datum hash
-    pub const DATUM: TagDimension = "datum";
+        /// Native asset policy ID
+        POLICY = "policy";
 
-    /// Script hash (Plutus or native)
-    pub const SCRIPT: TagDimension = "script";
+        /// Plutus datum hash
+        DATUM = "datum";
 
-    /// Spent TxO reference (tx_hash + output_index)
-    pub const SPENT_TXO: TagDimension = "spent_txo";
+        /// Script hash (Plutus or native)
+        SCRIPT = "script";
 
-    /// Account certificates (stake registration, deregistration, delegation)
-    pub const ACCOUNT_CERTS: TagDimension = "account_certs";
+        /// Spent TxO reference (tx_hash + output_index)
+        SPENT_TXO = "spent_txo";
 
-    /// Pool certificates (registration/update and retirement)
-    pub const POOL_CERTS: TagDimension = "pool_certs";
+        /// Account certificates (stake registration, deregistration, delegation)
+        ACCOUNT_CERTS = "account_certs";
 
-    /// Stake-account withdrawals by reward account bytes
-    pub const ACCOUNT_WITHDRAWALS: TagDimension = "account_withdrawals";
+        /// Pool certificates (registration/update and retirement)
+        POOL_CERTS = "pool_certs";
 
-    /// Transaction metadata labels
-    pub const METADATA: TagDimension = "metadata";
+        /// Stake-account withdrawals by reward account bytes
+        ACCOUNT_WITHDRAWALS = "account_withdrawals";
 
-    /// Every archive dimension.
-    ///
-    /// Index stores keep a hash of the dimension name rather than the name, so
-    /// the set is not discoverable from disk: any bulk traversal of archive
-    /// tags (`IndexStore::iter_archive_tags`) has to be driven by this list.
-    /// A dimension added above and not here is a dimension that silently stops
-    /// being exported.
-    pub const ALL: [TagDimension; 12] = [
-        ADDRESS,
-        PAYMENT,
-        STAKE,
-        ASSET,
-        POLICY,
-        DATUM,
-        SCRIPT,
-        SPENT_TXO,
-        ACCOUNT_CERTS,
-        POOL_CERTS,
-        ACCOUNT_WITHDRAWALS,
-        METADATA,
-    ];
+        /// Transaction metadata labels
+        METADATA = "metadata";
+    }
 }
 
 #[cfg(test)]
@@ -103,5 +115,31 @@ mod tests {
         seen.dedup();
 
         assert_eq!(seen.len(), archive::ALL.len());
+    }
+
+    /// Pins the literal strings. They are hashed into on-disk keys, so a rename
+    /// that looks cosmetic orphans every existing entry of that dimension —
+    /// the same reason `ExactKind`'s names are pinned in dolos-core. Every
+    /// other test compares a constant against itself and would survive such a
+    /// rename; this one exists to fail it.
+    #[test]
+    fn archive_dimension_names_are_storage_format() {
+        assert_eq!(
+            archive::ALL,
+            [
+                "address",
+                "payment",
+                "stake",
+                "asset",
+                "policy",
+                "datum",
+                "script",
+                "spent_txo",
+                "account_certs",
+                "pool_certs",
+                "account_withdrawals",
+                "metadata",
+            ]
+        );
     }
 }

--- a/crates/cardano/src/indexes/ext.rs
+++ b/crates/cardano/src/indexes/ext.rs
@@ -155,6 +155,26 @@ pub trait CardanoIndexExt: IndexStore {
     ) -> Result<Self::SlotIter, IndexError> {
         self.slots_by_tag(archive::METADATA, &label.to_be_bytes(), start, end)
     }
+
+    // ============ Bulk Export ============
+
+    /// Iterate every archive tag record in `slots`, across every Cardano
+    /// archive dimension.
+    ///
+    /// [`IndexStore::iter_archive_tags`] takes the dimension list because the
+    /// storage layer is chain-agnostic and cannot know it — stores keep a hash
+    /// of the dimension name, not the name. That makes `archive::ALL` the
+    /// caller's to supply, and every export call site a place the list can
+    /// drift out of.
+    ///
+    /// This is that list, once. `slots` is half-open, as it is on the method
+    /// underneath.
+    fn iter_all_archive_tags(
+        &self,
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::TagIter, IndexError> {
+        self.iter_archive_tags(&archive::ALL, slots)
+    }
 }
 
 // Blanket implementation for all IndexStore implementations

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -24,7 +24,7 @@
 use std::collections::BTreeSet;
 use std::ops::Range;
 
-use dolos_cardano::indexes::archive_dimensions;
+use dolos_cardano::indexes::{archive_dimensions, CardanoIndexExt};
 use dolos_core::{
     builtin::MemoryIndexStore, config::FjallIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint,
     ExactKind, ExactRecord, IndexDelta, IndexRecord, IndexStore as CoreIndexStore,
@@ -258,6 +258,17 @@ fn collect_tags<S: CoreIndexStore>(
         .expect("tag iteration failed")
 }
 
+/// Every dimension's tag records, the way an export call site asks for them:
+/// through the wrapper, so `archive_dimensions::ALL` is named in one place
+/// rather than at each call.
+fn collect_all_tags<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<TagRecord> {
+    store
+        .iter_all_archive_tags(slots)
+        .expect("iter_all_archive_tags failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("tag iteration failed")
+}
+
 fn collect_exacts<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
     store
         .iter_exact_records(slots)
@@ -285,7 +296,7 @@ fn export_slice<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<In
     let mut records: Vec<IndexRecord> = Vec::new();
 
     records.extend(
-        collect_tags(store, &archive_dimensions::ALL, slots.clone())
+        collect_all_tags(store, slots.clone())
             .into_iter()
             .map(IndexRecord::from),
     );
@@ -426,7 +437,7 @@ fn tag_records_are_sorted_by_dimension_key_hash_slot<B: Backend>() {
     let seeded = seed(&store);
 
     let slots = epoch_slots(EPOCHS[0]);
-    let records = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+    let records = collect_all_tags(&store, slots.clone());
 
     assert!(!records.is_empty());
 
@@ -520,7 +531,7 @@ fn tag_key_hashes_are_xxh3_except_for_metadata_labels<B: Backend>() {
     let seeded = seed(&store);
 
     let slots = epoch_slots(EPOCHS[0]);
-    let records = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+    let records = collect_all_tags(&store, slots.clone());
 
     let mut checked_hashed = 0;
     let mut checked_labels = 0;
@@ -572,7 +583,7 @@ fn undo_removes_exactly_what_apply_added<B: Backend>() {
     }
 
     let kept = epoch_slots(EPOCHS[0]);
-    let before_tags = collect_tags(&store, &archive_dimensions::ALL, kept.clone());
+    let before_tags = collect_all_tags(&store, kept.clone());
     let before_exacts = collect_exacts(&store, kept.clone());
 
     for delta in second {
@@ -583,7 +594,7 @@ fn undo_removes_exactly_what_apply_added<B: Backend>() {
 
     let rolled_back = epoch_slots(EPOCHS[1]);
     assert!(
-        !collect_tags(&store, &archive_dimensions::ALL, rolled_back.clone()).is_empty(),
+        !collect_all_tags(&store, rolled_back.clone()).is_empty(),
         "the delta about to be undone should have landed first"
     );
 
@@ -594,7 +605,7 @@ fn undo_removes_exactly_what_apply_added<B: Backend>() {
     }
 
     assert!(
-        collect_tags(&store, &archive_dimensions::ALL, rolled_back.clone()).is_empty(),
+        collect_all_tags(&store, rolled_back.clone()).is_empty(),
         "undo left archive tags behind"
     );
     assert!(
@@ -604,7 +615,7 @@ fn undo_removes_exactly_what_apply_added<B: Backend>() {
 
     assert_eq!(
         before_tags,
-        collect_tags(&store, &archive_dimensions::ALL, kept.clone()),
+        collect_all_tags(&store, kept.clone()),
         "undo removed tags it never added"
     );
     assert_eq!(
@@ -632,8 +643,8 @@ fn backends_agree_on_exported_records() {
     let slots = epoch_slots(EPOCHS[0]);
 
     assert_eq!(
-        collect_tags(&fjall, &archive_dimensions::ALL, slots.clone()),
-        collect_tags(&memory, &archive_dimensions::ALL, slots.clone()),
+        collect_all_tags(&fjall, slots.clone()),
+        collect_all_tags(&memory, slots.clone()),
         "backends disagree on the archive tag records the same deltas produce"
     );
 
@@ -812,7 +823,7 @@ fn measure_one_epoch_iteration_cost() {
     let slots = epoch_slots(target_epoch);
 
     let started = Instant::now();
-    let tags = collect_tags(&store, &archive_dimensions::ALL, slots.clone());
+    let tags = collect_all_tags(&store, slots.clone());
     let tag_elapsed = started.elapsed();
 
     let started = Instant::now();


### PR DESCRIPTION
**Plan:** `dolos-stelae-store-apis-review-cleanups`, items 3 and 8.

**Done criterion (item 3):** partially met — see the escalation at the bottom.

## What changed

`archive::ALL` warned in prose that a dimension missing from it *"silently stops being exported"*, while its only test checked for duplicates — the harmless failure. Three things now hold it up instead of the comment.

### 1. The registry emits itself (compile-time)

A `dimension_registry!` macro emits the constants **and** `ALL` from one list, so a constant cannot exist without being in `ALL`. Dropping an entry no longer quietly shortens the export set; it fails to compile at every use of the constant.

### 2. `every_produced_dimension_is_registered` (the other direction)

The macro cannot catch a dimension introduced as a bare string literal rather than through the registry. This test drives every tag-producing method on `CardanoIndexDeltaBuilder` and asserts the produced dimension set **equals** `archive::ALL`.

Equality rather than containment on purpose: a subset-only check would still pass if the test itself stopped exercising a dimension — the same blind spot one step removed.

Verified both ways:
- a stray `Tag::new("gov_action", ..)` added to an existing builder path → *"these dimensions are produced but not in archive::ALL, so they would silently stop being exported: {"gov_action"}"*
- dropping `add_metadata_label` from the driver → the equality assertion fails.

### 3. `archive_dimension_names_are_storage_format` (golden names)

Pins the literal strings. They are hashed into on-disk keys, so a rename that looks cosmetic orphans every existing entry of that dimension. Every other test compares a constant against itself and would survive one. Same role as `exact_kind_names_are_storage_format` in dolos-core.

### Item 8 — `CardanoIndexExt::iter_all_archive_tags`

`IndexStore::iter_archive_tags` takes the dimension list because the storage layer is chain-agnostic and cannot know it. That makes `archive::ALL` the caller's to supply, and every export call site a place it can drift. The one-line wrapper makes the list unmentionable at export sites; `tests/index_roundtrip.rs` goes through it everywhere except where it is deliberately testing caller-supplied lists.

## Verification

```
cargo test --workspace --all-targets      # all green
cargo clippy --all-targets --all-features -- -D warnings
cargo +nightly fmt --all -- --check
```

No on-disk, wire, or behavioural change.

## Escalation — done-criterion 3 is partially met

The criterion also says *"redb3 compiles against the same dimension definitions as fjall (or a macro emits both)"*. **This PR does not do that**, by founder decision (2026-08-04).

`dolos-redb3` depends only on `dolos-core`, not `dolos-cardano` — the workspace's storage crates are chain-agnostic by design, the same asymmetry that shaped `iter_archive_tags` taking its dimension list. Collapsing redb3's shadow `archive_dimensions` module onto the cardano constants would need a `dolos-redb3 → dolos-cardano` dependency inverting that layering, for a backend that is `#[deprecated]`, refused at store-open since #1155, and owned for deletion by the `dolos-remove-nonlive-backend-config` plan. That is reversed churn.

redb3's shadow module and its `_ => {} // Ignore unknown dimensions` arms therefore stay as they are. The parts of criterion 3 this PR does meet: the producer-side completeness test, and the registry that cannot drift from its own constants. The remaining clause — *"no backend computes an archive-tag key hash of its own"* — is item 4's, and does land in redb3, since `key_hash` lives in `dolos-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API for iterating archive tags across all Cardano archive dimensions within a slot range.
  * Centralized archive dimension definitions while preserving existing names, values, and ordering.

* **Tests**
  * Added coverage ensuring all archive-tag builders and registered dimensions are exercised.
  * Added safeguards for archive dimension ordering and storage compatibility.
  * Updated round-trip, rollback, cross-backend, and measurement tests to use the all-dimensions archive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->