### PR TITLE
refactor(storage): source the stored tag key from one definition

### DIFF
--- a/crates/cardano/src/indexes/dimensions.rs
+++ b/crates/cardano/src/indexes/dimensions.rs
@@ -99,8 +99,14 @@ pub mod archive {
         /// Stake-account withdrawals by reward account bytes
         ACCOUNT_WITHDRAWALS = "account_withdrawals";
 
-        /// Transaction metadata labels
-        METADATA = "metadata";
+        /// Transaction metadata labels.
+        ///
+        /// Sourced from core rather than spelled again: it stays a
+        /// dimension-list entry like any other, but the string itself has one
+        /// definition, because this is the dimension whose logical key the
+        /// stores keep verbatim instead of hashing (see
+        /// [`dolos_core::key_hash`]).
+        METADATA = dolos_core::VERBATIM_KEY_DIMENSION;
     }
 }
 

--- a/crates/fjall/src/index/archive_tags.rs
+++ b/crates/fjall/src/index/archive_tags.rs
@@ -8,23 +8,27 @@
 //! ## Key Format
 //!
 //! ```text
-//! Key:   [dim_hash:8][xxh3(tag_key):8][slot:8]
+//! Key:   [dim_hash:8][key_hash:8][slot:8]
 //! Value: (empty)
 //! ```
 //!
-//! The `dim_hash` is computed as `xxh3("block:" + dimension)`.
+//! The `dim_hash` is computed as `xxh3("block:" + dimension)`. The `key_hash`
+//! is [`dolos_core::key_hash`] — this module does not decide it, because two
+//! backends that decided it differently would exchange records neither could
+//! then look up.
 
 use std::borrow::Cow;
 use std::ops::Range;
 
 use dolos_core::{
-    ArchiveIndexDelta, BlockSlot, IndexDelta, IndexError, KeyHash, Tag, TagDimension, TagRecord,
+    key_hash, ArchiveIndexDelta, BlockSlot, IndexDelta, IndexError, KeyHash, Tag, TagDimension,
+    TagRecord,
 };
 use fjall::{Keyspace, OwnedWriteBatch, Readable, Snapshot};
 
 use crate::index::scan::{DimensionScan, ScanTarget};
 use crate::keys::{
-    decode_slot, dim_prefix, hash_dimension, hash_key, DIM_HASH_SIZE, HASH_KEY_SIZE, SLOT_SIZE,
+    decode_slot, dim_prefix, hash_dimension, DIM_HASH_SIZE, HASH_KEY_SIZE, SLOT_SIZE,
 };
 use crate::Error;
 
@@ -32,39 +36,42 @@ use crate::Error;
 // Key Encoding
 // ============================================================================
 
-/// Fixed size of block tag key: dim_hash(8) + tag_hash(8) + slot(8) = 24 bytes
+/// Fixed size of block tag key: dim_hash(8) + key_hash(8) + slot(8) = 24 bytes
 const BLOCK_TAG_KEY_SIZE: usize = DIM_HASH_SIZE + HASH_KEY_SIZE + SLOT_SIZE;
 
-/// Build a block tag key: `[dim_hash:8][xxh3(tag_key):8][slot:8]`
-fn build_block_tag_key(dimension: &str, tag_key: &[u8], slot: u64) -> [u8; BLOCK_TAG_KEY_SIZE] {
-    let tag_hash = hash_key(tag_key);
-    build_block_tag_key_hashed(dimension, tag_hash, slot)
-}
-
-/// Build a block tag key with pre-computed tag hash:
-/// `[dim_hash:8][tag_hash:8][slot:8]`
-fn build_block_tag_key_hashed(
-    dimension: &str,
-    tag_hash: u64,
+/// Build a block tag key from an already-hashed dimension:
+/// `[dim_hash:8][key_hash:8][slot:8]`
+///
+/// The one place this layout is written. Callers that hold the dimension
+/// *string* go through [`build_block_tag_key`]; callers restoring a batch of
+/// records hash the dimension once per group and come here directly.
+fn build_block_tag_key_for_dim(
+    dim_hash: [u8; DIM_HASH_SIZE],
+    key_hash: KeyHash,
     slot: u64,
 ) -> [u8; BLOCK_TAG_KEY_SIZE] {
-    let dim_hash = hash_dimension(dim_prefix::BLOCK, dimension);
     let mut key = [0u8; BLOCK_TAG_KEY_SIZE];
     key[..DIM_HASH_SIZE].copy_from_slice(&dim_hash);
-    key[DIM_HASH_SIZE..DIM_HASH_SIZE + HASH_KEY_SIZE].copy_from_slice(&tag_hash.to_be_bytes());
+    key[DIM_HASH_SIZE..DIM_HASH_SIZE + HASH_KEY_SIZE].copy_from_slice(&key_hash);
     key[DIM_HASH_SIZE + HASH_KEY_SIZE..].copy_from_slice(&slot.to_be_bytes());
     key
 }
 
-/// Build prefix for block tag queries: `[dim_hash:8][tag_hash:8]`
-fn build_block_tag_prefix_hashed(
+/// Build a block tag key: `[dim_hash:8][key_hash:8][slot:8]`
+fn build_block_tag_key(dimension: &str, key_hash: KeyHash, slot: u64) -> [u8; BLOCK_TAG_KEY_SIZE] {
+    let dim_hash = hash_dimension(dim_prefix::BLOCK, dimension);
+    build_block_tag_key_for_dim(dim_hash, key_hash, slot)
+}
+
+/// Build prefix for block tag queries: `[dim_hash:8][key_hash:8]`
+fn build_block_tag_prefix(
     dimension: &str,
-    tag_hash: u64,
+    key_hash: KeyHash,
 ) -> [u8; DIM_HASH_SIZE + HASH_KEY_SIZE] {
     let dim_hash = hash_dimension(dim_prefix::BLOCK, dimension);
     let mut prefix = [0u8; DIM_HASH_SIZE + HASH_KEY_SIZE];
     prefix[..DIM_HASH_SIZE].copy_from_slice(&dim_hash);
-    prefix[DIM_HASH_SIZE..].copy_from_slice(&tag_hash.to_be_bytes());
+    prefix[DIM_HASH_SIZE..].copy_from_slice(&key_hash);
     prefix
 }
 
@@ -87,86 +94,34 @@ fn decode_block_tag_key_hash(key: &[u8]) -> KeyHash {
 // Operations
 // ============================================================================
 
-/// Insert a block tag entry (multimap style)
-fn insert_block_tag(
-    batch: &mut OwnedWriteBatch,
-    keyspace: &Keyspace,
-    dimension: &str,
-    data: &[u8],
-    slot: BlockSlot,
-) {
-    let key = build_block_tag_key(dimension, data, slot);
-    batch.insert(keyspace, key, []);
-}
-
-/// Insert a block tag entry with pre-hashed key
-fn insert_block_tag_hashed(
-    batch: &mut OwnedWriteBatch,
-    keyspace: &Keyspace,
-    dimension: &str,
-    hash: u64,
-    slot: BlockSlot,
-) {
-    let key = build_block_tag_key_hashed(dimension, hash, slot);
-    batch.insert(keyspace, key, []);
-}
-
-/// Remove a block tag entry (multimap style)
-fn remove_block_tag(
-    batch: &mut OwnedWriteBatch,
-    keyspace: &Keyspace,
-    dimension: &str,
-    data: &[u8],
-    slot: BlockSlot,
-) {
-    let key = build_block_tag_key(dimension, data, slot);
-    batch.remove(keyspace, key);
-}
-
-/// Remove a block tag entry with pre-hashed key
-fn remove_block_tag_hashed(
-    batch: &mut OwnedWriteBatch,
-    keyspace: &Keyspace,
-    dimension: &str,
-    hash: u64,
-    slot: BlockSlot,
-) {
-    let key = build_block_tag_key_hashed(dimension, hash, slot);
-    batch.remove(keyspace, key);
-}
-
 /// Insert a tag into the archive-tags keyspace.
 ///
-/// For "metadata" dimension, the key is already the u64 hash value (8 bytes).
-/// For all other dimensions, the key is hashed internally.
+/// The stored key form comes from [`dolos_core::key_hash`], which is also
+/// where the `metadata` exception lives — this module knows only that a tag key
+/// has a stored form, not how it is derived.
+///
+/// A key with no valid stored form is dropped rather than stored: `key_hash`
+/// declines it precisely because nothing could look it up again.
 fn insert_tag(batch: &mut OwnedWriteBatch, keyspace: &Keyspace, tag: &Tag, slot: BlockSlot) {
-    // Metadata is special - the key is already the u64 hash value
-    if tag.dimension == "metadata" {
-        if let Ok(hash_bytes) = tag.key.as_slice().try_into() {
-            let hash = u64::from_be_bytes(hash_bytes);
-            insert_block_tag_hashed(batch, keyspace, tag.dimension, hash, slot);
-        }
+    let Some(hash) = key_hash(tag.dimension, &tag.key) else {
         return;
-    }
+    };
 
-    insert_block_tag(batch, keyspace, tag.dimension, &tag.key, slot);
+    let key = build_block_tag_key(tag.dimension, hash, slot);
+    batch.insert(keyspace, key, []);
 }
 
 /// Remove a tag from the archive-tags keyspace.
 ///
-/// For "metadata" dimension, the key is already the u64 hash value (8 bytes).
-/// For all other dimensions, the key is hashed internally.
+/// The exact inverse of [`insert_tag`], including which keys it declines: a tag
+/// that was never stored has nothing to remove.
 fn remove_tag(batch: &mut OwnedWriteBatch, keyspace: &Keyspace, tag: &Tag, slot: BlockSlot) {
-    // Metadata is special - the key is already the u64 hash value
-    if tag.dimension == "metadata" {
-        if let Ok(hash_bytes) = tag.key.as_slice().try_into() {
-            let hash = u64::from_be_bytes(hash_bytes);
-            remove_block_tag_hashed(batch, keyspace, tag.dimension, hash, slot);
-        }
+    let Some(hash) = key_hash(tag.dimension, &tag.key) else {
         return;
-    }
+    };
 
-    remove_block_tag(batch, keyspace, tag.dimension, &tag.key, slot);
+    let key = build_block_tag_key(tag.dimension, hash, slot);
+    batch.remove(keyspace, key);
 }
 
 /// Insert a tag entry from a record that already carries its stored key hash.
@@ -174,8 +129,8 @@ fn remove_tag(batch: &mut OwnedWriteBatch, keyspace: &Keyspace, tag: &Tag, slot:
 /// This is the write mirror of [`TagRecordIterator`]: the 8 hash bytes go in
 /// verbatim, so a record read out of one store lands byte-identical in another.
 /// It is deliberately *not* routed through [`insert_tag`] — that function
-/// hashes (and special-cases `metadata`) because it starts from a logical key,
-/// which a restore does not have.
+/// derives the stored form from a logical key, which a restore does not have
+/// and cannot recover.
 ///
 /// `dim_hash` is `hash_dimension(dim_prefix::BLOCK, record.dimension())`,
 /// passed in rather than computed here: records arrive grouped by dimension,
@@ -187,10 +142,7 @@ pub fn insert_prehashed(
     record: &TagRecord,
     dim_hash: [u8; DIM_HASH_SIZE],
 ) {
-    let mut key = [0u8; BLOCK_TAG_KEY_SIZE];
-    key[..DIM_HASH_SIZE].copy_from_slice(&dim_hash);
-    key[DIM_HASH_SIZE..DIM_HASH_SIZE + HASH_KEY_SIZE].copy_from_slice(&record.key_hash);
-    key[DIM_HASH_SIZE + HASH_KEY_SIZE..].copy_from_slice(&record.slot.to_be_bytes());
+    let key = build_block_tag_key_for_dim(dim_hash, record.key_hash, record.slot);
     batch.insert(keyspace, key, []);
 }
 
@@ -260,31 +212,19 @@ pub struct SlotIterator {
 impl SlotIterator {
     /// Create a new slot iterator from an archive-tags keyspace prefix scan.
     ///
-    /// The dimension string is passed directly (chain-agnostic).
+    /// The dimension string is passed directly (chain-agnostic), and the key
+    /// arrives already in its stored form: the caller derives it with
+    /// [`dolos_core::key_hash`], the same function the write path uses, so a
+    /// query cannot look under bytes an insert would not have written.
     pub fn new<R: Readable>(
         readable: &R,
         keyspace: &Keyspace,
         dimension: &str,
-        data: &[u8],
+        key_hash: KeyHash,
         start_slot: BlockSlot,
         end_slot: BlockSlot,
     ) -> Result<Self, Error> {
-        let hash = hash_key(data);
-        Self::from_hash(readable, keyspace, dimension, hash, start_slot, end_slot)
-    }
-
-    /// Create from a pre-computed hash (for metadata labels).
-    ///
-    /// The dimension string is passed directly (chain-agnostic).
-    pub fn from_hash<R: Readable>(
-        readable: &R,
-        keyspace: &Keyspace,
-        dimension: &str,
-        hash: u64,
-        start_slot: BlockSlot,
-        end_slot: BlockSlot,
-    ) -> Result<Self, Error> {
-        let prefix = build_block_tag_prefix_hashed(dimension, hash);
+        let prefix = build_block_tag_prefix(dimension, key_hash);
         let mut slots = Vec::new();
 
         // Using Readable::prefix() enables snapshot-based iteration
@@ -456,11 +396,17 @@ impl std::iter::FusedIterator for TagRecordIterator {}
 mod tests {
     use super::*;
 
+    /// The stored form of a logical key, for tests that start from one.
+    /// Production code never unwraps this — see [`insert_tag`].
+    fn stored(dimension: &str, key: &[u8]) -> KeyHash {
+        key_hash(dimension, key).expect("test keys are valid for their dimension")
+    }
+
     #[test]
     fn test_block_tag_key_roundtrip() {
         let tag_key = b"some_address_bytes";
         let slot = 141868807u64;
-        let key = build_block_tag_key("address", tag_key, slot);
+        let key = build_block_tag_key("address", stored("address", tag_key), slot);
 
         assert_eq!(key.len(), BLOCK_TAG_KEY_SIZE);
 
@@ -470,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_block_tag_ordering() {
-        let tag_key = b"test_address";
+        let tag_key = stored("address", b"test_address");
         let key1 = build_block_tag_key("address", tag_key, 100);
         let key2 = build_block_tag_key("address", tag_key, 200);
         let key3 = build_block_tag_key("address", tag_key, 50);
@@ -482,10 +428,9 @@ mod tests {
 
     #[test]
     fn test_block_tag_prefix() {
-        let tag_key = b"test_address";
+        let tag_key = stored("address", b"test_address");
         let key = build_block_tag_key("address", tag_key, 12345);
-        let tag_hash = hash_key(tag_key);
-        let prefix = build_block_tag_prefix_hashed("address", tag_hash);
+        let prefix = build_block_tag_prefix("address", tag_key);
 
         // Key should start with prefix
         assert!(key.starts_with(&prefix));
@@ -495,7 +440,7 @@ mod tests {
     fn test_utxo_block_separation() {
         // UTxO and block tags with same dimension name should have different prefixes
         let utxo_dim_hash = hash_dimension(dim_prefix::UTXO, "address");
-        let block_key = build_block_tag_key("address", b"addr", 0);
+        let block_key = build_block_tag_key("address", stored("address", b"addr"), 0);
 
         // dim_hash for utxo vs block should be different
         assert_ne!(&utxo_dim_hash, &block_key[..DIM_HASH_SIZE]);
@@ -504,7 +449,11 @@ mod tests {
     #[test]
     fn test_any_dimension_works() {
         // Any dimension string should work (chain-agnostic)
-        let key = build_block_tag_key("another_dimension", b"data", 12345);
+        let key = build_block_tag_key(
+            "another_dimension",
+            stored("another_dimension", b"data"),
+            12345,
+        );
 
         // Key should be valid size
         assert_eq!(key.len(), BLOCK_TAG_KEY_SIZE);
@@ -515,43 +464,51 @@ mod tests {
     #[test]
     fn test_prehashed_key_matches_written_key() {
         let slot = 42u64;
-        let written = build_block_tag_key("address", b"some_address_bytes", slot);
+        let written =
+            build_block_tag_key("address", stored("address", b"some_address_bytes"), slot);
 
         let record = TagRecord::new("address", decode_block_tag_key_hash(&written), slot);
-        let rebuilt = build_block_tag_key_hashed(
-            record.dimension(),
-            u64::from_be_bytes(record.key_hash),
-            record.slot,
-        );
+        let rebuilt = build_block_tag_key(record.dimension(), record.key_hash, record.slot);
 
         assert_eq!(written, rebuilt);
     }
 
     /// `metadata` is the one dimension whose stored key bytes are not a hash:
-    /// the logical key is already a u64 label and `insert_tag` writes it
-    /// verbatim. A record must carry those bytes through unchanged rather than
+    /// the logical key is already a u64 label and the store keeps it verbatim.
+    /// A record must carry those bytes through unchanged rather than
     /// re-deriving them.
+    ///
+    /// This module no longer decides that — [`dolos_core::key_hash`] does — so
+    /// what is pinned here is that the decision reaches the on-disk key.
     #[test]
     fn test_prehashed_key_carries_metadata_label_verbatim() {
         let label = 674u64;
         let slot = 42u64;
-        let written = build_block_tag_key_hashed("metadata", label, slot);
+        let stored_label = stored("metadata", &label.to_be_bytes());
+        let written = build_block_tag_key("metadata", stored_label, slot);
 
-        let stored = decode_block_tag_key_hash(&written);
-        assert_eq!(u64::from_be_bytes(stored), label);
+        assert_eq!(u64::from_be_bytes(stored_label), label);
         assert_ne!(
-            u64::from_be_bytes(stored),
-            hash_key(&label.to_be_bytes()),
+            stored_label,
+            xxhash_rust::xxh3::xxh3_64(&label.to_be_bytes()).to_be_bytes(),
             "the metadata label is stored raw, not hashed"
         );
 
-        let record = TagRecord::new("metadata", stored, slot);
-        let rebuilt = build_block_tag_key_hashed(
-            record.dimension(),
-            u64::from_be_bytes(record.key_hash),
-            record.slot,
-        );
+        let record = TagRecord::new("metadata", decode_block_tag_key_hash(&written), slot);
+        let rebuilt = build_block_tag_key(record.dimension(), record.key_hash, record.slot);
 
         assert_eq!(written, rebuilt);
+    }
+
+    /// A `metadata` key that is not eight bytes has no stored form: it would
+    /// land under bytes no query could reconstruct. Both write paths drop it
+    /// rather than store it.
+    #[test]
+    fn test_malformed_metadata_key_has_no_stored_form() {
+        assert!(key_hash("metadata", b"seven!!").is_none());
+        assert!(key_hash("metadata", &674u64.to_be_bytes()).is_some());
+
+        // Every other dimension takes a key of any width.
+        assert!(key_hash("address", b"seven!!").is_some());
     }
 }

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -38,9 +38,9 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
-    config::FjallIndexConfig, BlockSlot, ChainPoint, ExactKind, IndexDelta, IndexError,
+    config::FjallIndexConfig, key_hash, BlockSlot, ChainPoint, ExactKind, IndexDelta, IndexError,
     IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, TagDimension,
-    UtxoSet,
+    UtxoSet, KEY_HASH_SIZE,
 };
 use fjall::{
     compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
@@ -430,28 +430,23 @@ impl CoreIndexStore for IndexStore {
         start: BlockSlot,
         end: BlockSlot,
     ) -> Result<Self::SlotIter, IndexError> {
+        // The stored key form is the write path's, not this method's: the same
+        // `key_hash` an insert used, so a query cannot look under bytes an
+        // insert would not have written. `None` is a key with no valid stored
+        // form — today only a `metadata` label that is not eight bytes wide —
+        // which is a malformed query rather than an empty result.
+        let Some(hash) = key_hash(dimension, key) else {
+            return Err(IndexError::CodecError(format!(
+                "{dimension} key must be {KEY_HASH_SIZE} bytes, got {}",
+                key.len(),
+            )));
+        };
+
         // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
         let snapshot = self.db.snapshot();
 
-        // For metadata, key is already the u64 encoded as bytes
-        if dimension == "metadata" {
-            let metadata =
-                u64::from_be_bytes(key.try_into().map_err(|_| {
-                    IndexError::CodecError("metadata key must be 8 bytes".to_string())
-                })?);
-            return SlotIter::from_hash(
-                &snapshot,
-                &self.block_tags,
-                dimension,
-                metadata,
-                start,
-                end,
-            )
-            .map_err(IndexError::from);
-        }
-
         // Pass dimension string directly - chain-agnostic
-        SlotIter::new(&snapshot, &self.block_tags, dimension, key, start, end)
+        SlotIter::new(&snapshot, &self.block_tags, dimension, hash, start, end)
             .map_err(IndexError::from)
     }
 

--- a/crates/redb3/src/indexes/mod.rs
+++ b/crates/redb3/src/indexes/mod.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 use dolos_core::{
-    config::RedbIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint, EmptyExactIter,
+    config::RedbIndexConfig, key_hash, ArchiveIndexDelta, BlockSlot, ChainPoint, EmptyExactIter,
     EmptyTagIter, IndexDelta, IndexError, IndexRecord, IndexStore as CoreIndexStore,
-    IndexWriter as CoreIndexWriter, Tag, TagDimension, TxoRef, UtxoSet,
+    IndexWriter as CoreIndexWriter, Tag, TagDimension, TxoRef, UtxoSet, KEY_HASH_SIZE,
 };
 use redb::{
     Database, Durability, MultimapTableDefinition, ReadTransaction, ReadableDatabase,
@@ -69,7 +69,10 @@ pub mod archive_dimensions {
     pub const ACCOUNT_CERTS: &str = "account_certs";
     pub const POOL_CERTS: &str = "pool_certs";
     pub const ACCOUNT_WITHDRAWALS: &str = "account_withdrawals";
-    pub const METADATA: &str = "metadata";
+    /// Sourced from core: this is the one dimension whose logical key is kept
+    /// verbatim instead of hashed, and that fact belongs to the stored-key
+    /// rule rather than to this backend.
+    pub const METADATA: &str = dolos_core::VERBATIM_KEY_DIMENSION;
     pub const SCRIPT: &str = "script";
 }
 
@@ -440,23 +443,36 @@ fn undo_archive_delta(wx: &WriteTransaction, block: &ArchiveIndexDelta) -> Resul
     Ok(())
 }
 
+/// The stored form of a tag key, as the `u64` this backend's bucketed keys
+/// take.
+///
+/// The derivation is [`dolos_core::key_hash`]'s, not this module's — including
+/// the `metadata` exception, whose logical key is already a `u64` label and is
+/// kept verbatim rather than hashed. A backend that decided those bytes for
+/// itself could disagree with another and neither would fail: records would
+/// cross, restore cleanly, and then miss every logical-key query about
+/// themselves.
+///
+/// `None` from `key_hash` is a key with no valid stored form — today only a
+/// `metadata` label that is not eight bytes wide. This backend refuses it,
+/// which is the behaviour these call sites already had.
+fn stored_tag_key(tag: &Tag) -> Result<u64, Error> {
+    let hash = key_hash(tag.dimension, &tag.key).ok_or_else(|| {
+        Error::ArchiveError(format!(
+            "{} key must be {KEY_HASH_SIZE} bytes",
+            tag.dimension
+        ))
+    })?;
+
+    Ok(u64::from_be_bytes(hash))
+}
+
 /// Insert a single archive tag.
 fn insert_archive_tag(wx: &WriteTransaction, tag: &Tag, slot: BlockSlot) -> Result<(), Error> {
     use archive::indexes::*;
-    use xxhash_rust::xxh3::xxh3_64;
 
     let key_builder = archive::indexes::key_builder();
-    let bucketed_key =
-        if tag.dimension == archive_dimensions::METADATA {
-            let metadata =
-                u64::from_be_bytes(tag.key.as_slice().try_into().map_err(|_| {
-                    Error::ArchiveError("metadata key must be 8 bytes".to_string())
-                })?);
-            key_builder.bucketed_key(metadata, slot)
-        } else {
-            let key = xxh3_64(&tag.key);
-            key_builder.bucketed_key(key, slot)
-        };
+    let bucketed_key = key_builder.bucketed_key(stored_tag_key(tag)?, slot);
 
     match tag.dimension {
         archive_dimensions::ADDRESS => {
@@ -516,20 +532,9 @@ fn insert_archive_tag(wx: &WriteTransaction, tag: &Tag, slot: BlockSlot) -> Resu
 /// Remove a single archive tag.
 fn remove_archive_tag(wx: &WriteTransaction, tag: &Tag, slot: BlockSlot) -> Result<(), Error> {
     use archive::indexes::*;
-    use xxhash_rust::xxh3::xxh3_64;
 
     let key_builder = archive::indexes::key_builder();
-    let bucketed_key =
-        if tag.dimension == archive_dimensions::METADATA {
-            let metadata =
-                u64::from_be_bytes(tag.key.as_slice().try_into().map_err(|_| {
-                    Error::ArchiveError("metadata key must be 8 bytes".to_string())
-                })?);
-            key_builder.bucketed_key(metadata, slot)
-        } else {
-            let key = xxh3_64(&tag.key);
-            key_builder.bucketed_key(key, slot)
-        };
+    let bucketed_key = key_builder.bucketed_key(stored_tag_key(tag)?, slot);
 
     match tag.dimension {
         archive_dimensions::ADDRESS => {
@@ -888,9 +893,13 @@ impl CoreIndexStore for IndexStore {
                 archive::indexes::Indexes::iter_by_account_withdrawals(&rx, key, start, end)?
             }
             archive_dimensions::METADATA => {
-                // Metadata is keyed by u64, need to parse the bytes
-                let metadata = u64::from_be_bytes(key.try_into().map_err(|_| {
-                    IndexError::CodecError("metadata key must be 8 bytes".to_string())
+                // The label is stored verbatim rather than hashed, and
+                // `key_hash` is where that exception lives.
+                let metadata = u64::from_be_bytes(key_hash(dimension, key).ok_or_else(|| {
+                    IndexError::CodecError(format!(
+                        "{dimension} key must be {KEY_HASH_SIZE} bytes, got {}",
+                        key.len()
+                    ))
                 })?);
                 archive::indexes::Indexes::iter_by_metadata(&rx, &metadata, start, end)?
             }


### PR DESCRIPTION
**Plan:** `dolos-stelae-store-apis-review-cleanups`, item 4.

**Done criterion:** *"no backend computes an archive-tag key hash of its own — every write and query path goes through `dolos_core::indexes::key_hash`, including the `metadata` exception — and `grep -rn '"metadata"' crates/` finds definitions, not scattered comparisons."* Met for every live path; one exception reported below.

## Why this matters more than it looks

A tag record carries only its stored `key_hash`. The logical key is not on disk and cannot be recovered. So two backends that derived those eight bytes differently **would not fail to restore** — they would restore successfully and then miss every logical-key query about the restored records.

#1158 wrote the rule down for the first time, as `dolos_core::key_hash`, because the builtin memory stores needed it. But only that store used it: both disk backends still derived their own, each with its own bare `== "metadata"` literal. The agreement between them was pinned empirically by `backends_agree_on_exported_records` and `records_cross_between_backends` — which catch a divergence but do not prevent one.

## What changed

**fjall** — all three sites: `insert_tag`, `remove_tag`, `IndexStore::slots_by_tag`.
- `build_block_tag_key` now takes the stored form rather than deriving one, and the `_hashed` twins collapse into it — one place writes the `[dim_hash][key_hash][slot]` layout, shared with `insert_prehashed`.
- `SlotIterator::from_hash`, which existed only for the metadata path, goes away with the special case that needed it.

**redb3** — write path (`insert_archive_tag` / `remove_archive_tag`, via a shared `stored_tag_key`) and the metadata query arm. `archive_dimensions::METADATA` is now `dolos_core::VERBATIM_KEY_DIMENSION` rather than a second spelling.

**dolos-cardano** — `archive::METADATA` stays a dimension-list entry (that is what it is) but is sourced from the same constant, so the string has one definition.

## Behaviour is unchanged, by construction

`key_hash`'s non-verbatim branch is `xxh3_64(key).to_be_bytes()` — exactly what both backends computed. Its `None` is the malformed-`metadata`-key case each already handled: **dropped** on write in fjall, **refused** in redb3. Those two differ from each other; they are deliberately left differing, since this is not the PR to reconcile them.

The proof that fjall's on-disk bytes did not move is in tests that were already there:
- `tag_key_hashes_are_xxh3_except_for_metadata_labels` computes the expected hashes independently in the test and asserts fjall's exports match — passes unchanged.
- `backends_agree_on_exported_records` and `records_cross_between_backends` compare fjall against the memory store, which was already using `key_hash` before this PR — passes unchanged.

## Verification

```
cargo test --workspace --all-targets      # all green
cargo test --test index_roundtrip -- backends_agree_on_exported_records records_cross_between_backends
cargo clippy --all-targets --all-features -- -D warnings
cargo +nightly fmt --all -- --check
```

`grep -rn '"metadata"' crates/` now finds: the core definition, a README example, and tests. No behavioural comparisons.

## Finding — 12 more copies in redb3, not touched

The plan named three redb3 sites. Exploration turned up a fourth nest it did not know about: `crates/redb3/src/archive/indexes.rs` has **12 per-table `compute_key` functions**, each its own `xxh3_64`, serving the non-metadata arms of `slots_by_tag`.

Left alone, for three reasons:
1. Those tables are written **only** by redb3's `IndexStore`, which is `#[deprecated]` and refused at store-open since #1155 — so this is unreachable code in a running node.
2. Routing them through `key_hash` needs the dimension name at each table, which is the shadow-registry problem the founder already waived for this plan (see #1161).
3. No drift is introduced by leaving them: redb3's write path now computes `u64::from_be_bytes(xxh3_64(key).to_be_bytes())`, which is bit-identical to `compute_key`'s `xxh3_64(key)`.

They should go with the backend, in `dolos-remove-nonlive-backend-config`.

## Note for the merge queue

This touches one line of `crates/cardano/src/indexes/dimensions.rs` that #1161 also rewrites (the `METADATA` entry). Whichever lands second takes a one-line conflict: keep `dolos_core::VERBATIM_KEY_DIMENSION` as the value, in whichever form (`const` or macro entry) that branch uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive tag indexing and retrieval for metadata and other key types.
  * Preserved verbatim metadata labels during archive operations.
  * Added validation to handle malformed or incorrectly sized keys more reliably.
  * Standardized archive tag handling across supported storage backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->