### PR TITLE
refactor(storage): refuse unsupported store methods instead of panicking

### DIFF
--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -378,8 +378,13 @@ impl CoreIndexStore for IndexStore {
         Ok(())
     }
 
+    /// Whole-store copy is not implemented here (#1036).
+    ///
+    /// Refusing rather than panicking is the convention the trait's newer
+    /// methods already use: a caller reaching for a capability this backend
+    /// does not carry gets an error it can handle.
     fn copy(&self, _target: &Self) -> Result<(), IndexError> {
-        todo!("copy not implemented for fjall index store (#1036)")
+        Err(IndexError::Unsupported("copy"))
     }
 
     fn cursor(&self) -> Result<Option<ChainPoint>, IndexError> {

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -313,15 +313,18 @@ impl CoreStateStore for StateStore {
             .map_err(StateError::from)
     }
 
+    /// Multi-value namespaces have no encoding in this store: its entity
+    /// keyspace is one value per key, with no multimap to walk (#1036).
+    ///
+    /// Refusing is the convention the trait's newer methods already use, and
+    /// what the builtin memory store answers. A panic here would take down a
+    /// caller that has an error path anyway.
     fn iter_entity_values(
         &self,
         _ns: Namespace,
         _key: impl AsRef<[u8]>,
     ) -> Result<Self::EntityValueIter, StateError> {
-        // Multimap not supported - panic if called
-        unimplemented!(
-            "iter_entity_values is not supported in fjall state store (no multimap support) (#1036)"
-        )
+        Err(StateError::Unsupported("iter_entity_values"))
     }
 
     fn get_utxos(&self, refs: Vec<TxoRef>) -> Result<UtxoMap, StateError> {


### PR DESCRIPTION
**Plan:** `dolos-stelae-store-apis-review-cleanups`, item 6.

**Done criterion (item 6):** no `todo!`/`unimplemented!` remains behind `IndexStore`/`StateStore` trait methods. **Met.**

## What changed

Two fjall trait methods still panicked for a capability the backend does not carry — in the same traits where the newer methods return `Unsupported`:

- `StateStore::iter_entity_values` → `unimplemented!` (fjall's entity keyspace is one value per key; there is no multimap to walk, #1036)
- `IndexStore::copy` → `todo!` (#1036)

Both now return the error. `StateError::Unsupported` and `IndexError::Unsupported` already exist for exactly this, and the builtin memory store already answers `iter_entity_values` that way — so this is the convention catching up with the two methods that predate it.

Neither is reachable from a current caller, so nothing changes for a running node. What changes is that a future one gets an error it can handle rather than a process it cannot.

## Scope

Startup capability validation stays out — it belongs to `dolos-stelae-store-apis-followups`' config work. The `unimplemented!`s in `crates/redb3/src/wal/mod.rs` (test scaffolding) and `crates/cardano/src/forks.rs` (a version-bump path, #1033) are not behind these traits and are untouched.

## Verification

```
cargo test --workspace --all-targets      # 24 test binaries, all ok
cargo clippy --all-targets --all-features -- -D warnings
cargo +nightly fmt --all -- --check
grep -rn 'todo!\|unimplemented!' crates/fjall/ crates/core/src/ crates/redb3/src/{indexes,state}/   # no hits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)