### PR TITLE
feat(snapshot): define the io.txpipe.dolos.cardano stelae profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dolos-snapshot"
+version = "1.6.0"
+dependencies = [
+ "dolos-cardano",
+ "dolos-core",
+ "hex",
+ "minicbor 0.26.4",
+ "serde_json",
+ "stelae",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dolos-testing"
 version = "1.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ members = [
     "crates/cardano",
     "crates/core",
     "crates/fjall",
+    "crates/snapshot",
     "crates/stelae",
     "crates/testing",
     "crates/minibf",

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dolos-snapshot"
+description = "The io.txpipe.dolos.cardano Stelae profile"
+version.workspace = true
+edition.workspace = true
+
+# This crate is the *profile* half of the Stelae boundary: it may depend on
+# `stelae` and on `dolos-*`, never the other way around. See
+# adrs/004_stelae_snapshots.md, "Code layout".
+[dependencies]
+stelae = { path = "../stelae" }
+dolos-core = { path = "../core" }
+dolos-cardano = { path = "../cardano" }
+
+hex.workspace = true
+minicbor.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile = "3.20.0"

--- a/crates/snapshot/src/layers/blocks.rs
+++ b/crates/snapshot/src/layers/blocks.rs
@@ -1,0 +1,170 @@
+//! The `blocks` layer: raw block data, one record per block.
+//!
+//! `[slot, hash: bytes(32), body: bytes]`, ascending slot, stream order
+//! preserved within a slot.
+//!
+//! ## The hash is an input, not a derivation
+//!
+//! [`dolos_core::ArchiveStore::get_range`] yields `(slot, body)` — the block
+//! hash is not stored alongside the block, it is computed by decoding the
+//! header. This codec therefore takes the hash from its caller and neither
+//! derives nor checks it: deriving it means Cardano block decoding, which
+//! belongs to the export driver that already holds a decoded block, not to a
+//! format description. The consequence is explicit rather than implicit — a
+//! publisher that supplies a wrong hash produces a layer that restores cleanly
+//! and answers block-hash lookups wrongly, so the derivation site is the one
+//! place that has to be right.
+//!
+//! ## Why the order rule is not a sort key
+//!
+//! Byron end-of-epoch boundary blocks share a slot with the block that follows
+//! them, and the two are distinguishable only by the order they arrived in.
+//! "Ascending slot, stream order within a slot" is therefore a property of a
+//! *sequence*, not a function of a record, and no comparator expresses it. The
+//! validator enforces the half that is checkable — slots never go backwards —
+//! and the export driver is responsible for feeding blocks in chain order.
+
+use dolos_core::{BlockHash, BlockSlot};
+use stelae::frame::{self, CanonicalCbor};
+
+use super::{blob, close, fixed, open, uint};
+use crate::{Error, BLOCKS};
+
+/// One block, as the layer carries it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockRecord {
+    pub slot: BlockSlot,
+    pub hash: BlockHash,
+    /// Raw wire CBOR, verbatim. Never re-encoded — a block's bytes are its
+    /// identity on the chain, and this layer is not the place to reinterpret
+    /// them.
+    pub body: Vec<u8>,
+}
+
+impl BlockRecord {
+    pub fn new(slot: BlockSlot, hash: BlockHash, body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            slot,
+            hash,
+            body: body.into(),
+        }
+    }
+}
+
+pub fn encode(record: &BlockRecord) -> Result<CanonicalCbor, Error> {
+    Ok(frame::encode(|e| {
+        e.array(3)?
+            .u64(record.slot)?
+            .bytes(record.hash.as_ref())?
+            .bytes(&record.body)?;
+        Ok(())
+    })?)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<BlockRecord, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(BLOCKS, &mut decoder, 3)?;
+
+    let slot = uint(BLOCKS, "slot", &mut decoder)?;
+    let hash = fixed::<32>(BLOCKS, "hash", &mut decoder)?;
+    let body = blob(BLOCKS, "body", &mut decoder)?.to_vec();
+
+    close(BLOCKS, &decoder, bytes)?;
+
+    Ok(BlockRecord {
+        slot,
+        hash: BlockHash::new(hash),
+        body,
+    })
+}
+
+/// Ascending slot, with same-slot runs left alone.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OrderCheck {
+    last: Option<BlockSlot>,
+}
+
+impl OrderCheck {
+    pub fn check(&mut self, record: &BlockRecord) -> Result<(), Error> {
+        if let Some(last) = self.last {
+            if record.slot < last {
+                return Err(Error::out_of_order(
+                    BLOCKS,
+                    format!("slot {} follows slot {last}", record.slot),
+                ));
+            }
+        }
+
+        self.last = Some(record.slot);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(slot: BlockSlot, byte: u8) -> BlockRecord {
+        BlockRecord::new(slot, BlockHash::new([byte; 32]), vec![byte; 4])
+    }
+
+    #[test]
+    fn round_trips() {
+        for original in [record(0, 0), record(u32::MAX as u64 + 1, 0xff)] {
+            let encoded = encode(&original).unwrap();
+            assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+        }
+    }
+
+    #[test]
+    fn an_empty_body_is_a_shape_error_nowhere() {
+        // A zero-length body is structurally fine; refusing it would be this
+        // crate inventing a chain rule it has no business having.
+        let original = BlockRecord::new(7, BlockHash::new([0; 32]), Vec::new());
+        let encoded = encode(&original).unwrap();
+        assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+    }
+
+    #[test]
+    fn a_wrong_width_hash_is_refused() {
+        let bad = frame::encode(|e| {
+            e.array(3)?.u64(1)?.bytes(&[0u8; 28])?.bytes(&[])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(bad.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_trailing_byte_is_refused() {
+        let mut bytes = encode(&record(1, 1)).unwrap().into_bytes();
+        bytes.push(0x00);
+
+        let err = decode(&bytes).unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+
+    /// The Byron case: two blocks at one slot, in the order they arrived.
+    #[test]
+    fn same_slot_blocks_are_accepted_in_stream_order() {
+        let mut order = OrderCheck::default();
+
+        for record in [record(10, 1), record(10, 2), record(11, 3)] {
+            order.check(&record).unwrap();
+        }
+    }
+
+    #[test]
+    fn a_slot_going_backwards_is_refused() {
+        let mut order = OrderCheck::default();
+
+        order.check(&record(11, 1)).unwrap();
+
+        let err = order.check(&record(10, 2)).unwrap_err();
+        assert!(matches!(err, Error::OutOfOrder { .. }), "{err:?}");
+    }
+}

--- a/crates/snapshot/src/layers/digests.rs
+++ b/crates/snapshot/src/layers/digests.rs
@@ -1,0 +1,156 @@
+//! The `digests` layer: sha256 of every Cardano immutable-DB file the stele
+//! covers.
+//!
+//! `[immutable_number, chunk: bytes(32), primary: bytes(32), secondary:
+//! bytes(32)]`, ascending `immutable_number`.
+//!
+//! ## Carries no restorable data
+//!
+//! Nothing here is written to a store. The layer exists so that block data
+//! obtained from *somewhere else* — a Mithril aggregator, a mirror, a relay
+//! replay — can be checked against the stele's signed inscription before it is
+//! imported. It is also the enabler for a future Mithril-sourced restore mode,
+//! which is why the digests are exactly Mithril Cardano DB v2's merkle leaves:
+//! sha256 over the raw `.chunk`/`.primary`/`.secondary` file bytes, so a
+//! certificate whose beacon covers `lastImmutable` verifies them by merkle
+//! proof.
+//!
+//! The certificate itself is deliberately *not* part of a stele. Certificates
+//! are produced on the aggregator's cadence, so two publishers at the same
+//! boundary would reference different ones and stop reproducing each other's
+//! inscription; the digest values, by contrast, are byte-stable properties of
+//! the chain.
+//!
+//! The layer is optional — a network without a Mithril aggregator simply has no
+//! `digests` layer, and the inscription says so.
+
+use stelae::{
+    frame::{self, CanonicalCbor},
+    Digest,
+};
+
+use super::{close, fixed, open, uint};
+use crate::{Error, DIGESTS};
+
+/// The three files of one immutable chunk, by content.
+///
+/// Uses [`stelae::Digest`] rather than a fourth thirty-two-byte newtype: these
+/// are sha256 over bytes, which is what that type is, and it already prints and
+/// parses in the `sha256:…` form the rest of a stele uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImmutableDigests {
+    pub immutable_number: u64,
+    pub chunk: Digest,
+    pub primary: Digest,
+    pub secondary: Digest,
+}
+
+pub fn encode(record: &ImmutableDigests) -> Result<CanonicalCbor, Error> {
+    Ok(frame::encode(|e| {
+        e.array(4)?
+            .u64(record.immutable_number)?
+            .bytes(record.chunk.as_bytes())?
+            .bytes(record.primary.as_bytes())?
+            .bytes(record.secondary.as_bytes())?;
+        Ok(())
+    })?)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<ImmutableDigests, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(DIGESTS, &mut decoder, 4)?;
+
+    let immutable_number = uint(DIGESTS, "immutable_number", &mut decoder)?;
+    let chunk = fixed::<32>(DIGESTS, "chunk", &mut decoder)?;
+    let primary = fixed::<32>(DIGESTS, "primary", &mut decoder)?;
+    let secondary = fixed::<32>(DIGESTS, "secondary", &mut decoder)?;
+
+    close(DIGESTS, &decoder, bytes)?;
+
+    Ok(ImmutableDigests {
+        immutable_number,
+        chunk: Digest::from_bytes(chunk),
+        primary: Digest::from_bytes(primary),
+        secondary: Digest::from_bytes(secondary),
+    })
+}
+
+/// Strictly ascending `immutable_number` — one record per immutable file set.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OrderCheck {
+    last: Option<u64>,
+}
+
+impl OrderCheck {
+    pub fn check(&mut self, record: &ImmutableDigests) -> Result<(), Error> {
+        if let Some(last) = self.last {
+            if record.immutable_number <= last {
+                return Err(Error::out_of_order(
+                    DIGESTS,
+                    format!(
+                        "immutable {} follows immutable {last}",
+                        record.immutable_number
+                    ),
+                ));
+            }
+        }
+
+        self.last = Some(record.immutable_number);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(number: u64) -> ImmutableDigests {
+        ImmutableDigests {
+            immutable_number: number,
+            chunk: Digest::from_bytes([0x11; 32]),
+            primary: Digest::from_bytes([0x22; 32]),
+            secondary: Digest::from_bytes([0x33; 32]),
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        for number in [0u64, 6187, u32::MAX as u64 + 1] {
+            let original = record(number);
+            let encoded = encode(&original).unwrap();
+
+            assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+        }
+    }
+
+    #[test]
+    fn a_wrong_width_digest_is_refused() {
+        let wire = frame::encode(|e| {
+            e.array(4)?
+                .u64(1)?
+                .bytes(&[0u8; 32])?
+                .bytes(&[0u8; 20])?
+                .bytes(&[0u8; 32])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn ordering_is_strictly_ascending() {
+        let mut order = OrderCheck::default();
+
+        order.check(&record(0)).unwrap();
+        order.check(&record(1)).unwrap();
+
+        for backwards in [record(1), record(0)] {
+            let err = OrderCheck { last: Some(1) }.check(&backwards).unwrap_err();
+            assert!(matches!(err, Error::OutOfOrder { .. }), "{err:?}");
+        }
+    }
+}

--- a/crates/snapshot/src/layers/indexes.rs
+++ b/crates/snapshot/src/layers/indexes.rs
@@ -288,20 +288,31 @@ mod tests {
         assert!(matches!(err, Error::UnknownDimension(_)), "{err:?}");
     }
 
+    /// `"block_number"` is the deliberate one: it is the plausible spelling of
+    /// a kind that really exists, and `dolos-core` pins `block_num`
+    /// precisely because that rename looks cosmetic and orphans every
+    /// stored entry. If `ExactKind::as_str` ever moves to it, this case is
+    /// *supposed* to fail — the wire literal is the stored form, and the
+    /// goldens would move with it.
     #[test]
     fn an_unknown_exact_kind_is_refused() {
-        let wire = frame::encode(|e| {
-            e.array(4)?
-                .u64(EXACT_DISCRIMINANT)?
-                .str("block_number")?
-                .bytes(&[0u8; 8])?
-                .u64(1)?;
-            Ok(())
-        })
-        .unwrap();
+        for name in ["block_number", "not_an_exact_kind", "", "TxHash"] {
+            let wire = frame::encode(|e| {
+                e.array(4)?
+                    .u64(EXACT_DISCRIMINANT)?
+                    .str(name)?
+                    .bytes(&[0u8; 8])?
+                    .u64(1)?;
+                Ok(())
+            })
+            .unwrap();
 
-        let err = decode(wire.as_bytes()).unwrap_err();
-        assert!(matches!(err, Error::UnknownExactKind(_)), "{err:?}");
+            let err = decode(wire.as_bytes()).unwrap_err();
+            assert!(
+                matches!(err, Error::UnknownExactKind(_)),
+                "{name:?}: {err:?}"
+            );
+        }
     }
 
     /// A key wider than any kind's — and wider than the inline buffer — is

--- a/crates/snapshot/src/layers/indexes.rs
+++ b/crates/snapshot/src/layers/indexes.rs
@@ -1,0 +1,417 @@
+//! The `indexes` layer: pre-hashed archive index records.
+//!
+//! Two record shapes share the layer, told apart by a leading discriminant:
+//!
+//! - tags — `[0, dimension: tstr, key_hash: bytes(8), slot]`
+//! - exact — `[1, kind: tstr, key: bytes, slot]`
+//!
+//! ## Pre-hashed, and why that is the whole point
+//!
+//! The index stores keep only `xxh3_64` of a tag's logical key, so the logical
+//! key is not recoverable from disk. Rather than resolve historical transaction
+//! inputs to rebuild it at publish time — the most expensive machinery in the
+//! original design — the hashing scheme is promoted into the profile and the
+//! stored form travels. This codec therefore *never hashes anything*: it copies
+//! [`dolos_core::KeyHash`] bytes through in both directions. The one dimension
+//! whose stored form is not a hash ([`dolos_core::VERBATIM_KEY_DIMENSION`],
+//! whose keys are already `u64` labels) needs no special case here for exactly
+//! that reason — it is opaque bytes like every other dimension, and
+//! [`dolos_core::key_hash`] remains the only place in the tree that knows the
+//! difference.
+//!
+//! ## Order: tags, then exact
+//!
+//! ADR-004 gives the two shapes separate orders — `(dimension, key_hash, slot)`
+//! and `(kind, key)` — and a leading discriminant that sorts `0` before `1`.
+//! The layer therefore carries every tag record first, then every exact record,
+//! which is also the shape the two source iterators hand over
+//! ([`dolos_core::IndexStore::iter_archive_tags`] then
+//! [`dolos_core::IndexStore::iter_exact_records`]). Both runs are strictly
+//! ascending, so "sorted, deduped" is one rule rather than two.
+//!
+//! Exact records dedupe on `(kind, key)` and not on the slot behind it: a block
+//! hash names one slot, so two records sharing a key are a contradiction, not a
+//! pair.
+
+use dolos_cardano::indexes::archive_dimensions;
+use dolos_core::{
+    BlockSlot, ExactKind, ExactRecord, IndexRecord, KeyHash, TagDimension, TagRecord,
+};
+use stelae::frame::{self, CanonicalCbor};
+
+use super::{blob, close, fixed, open, text, uint};
+use crate::{Error, INDEXES};
+
+/// Leading discriminant of a tag record.
+pub const TAG_DISCRIMINANT: u64 = 0;
+
+/// Leading discriminant of an exact-match record.
+pub const EXACT_DISCRIMINANT: u64 = 1;
+
+/// Resolve a dimension read off the wire to the `&'static str` the stores use.
+///
+/// Fails closed against `dolos_cardano`'s archive registry, which is the only
+/// list of dimensions there is: stores keep a hash of the name rather than the
+/// name, so an unrecognised dimension cannot be looked up, restored or even
+/// traversed later.
+pub fn resolve_dimension(name: &str) -> Result<TagDimension, Error> {
+    archive_dimensions::ALL
+        .into_iter()
+        .find(|known| *known == name)
+        .ok_or_else(|| Error::UnknownDimension(name.to_owned()))
+}
+
+/// Resolve an exact-record kind read off the wire.
+///
+/// The wire string is the stored one — [`ExactKind::as_str`] — so this is that
+/// type's own [`std::str::FromStr`] and not a mapping table beside it.
+pub fn resolve_exact_kind(name: &str) -> Result<ExactKind, Error> {
+    name.parse()
+        .map_err(|_| Error::UnknownExactKind(name.to_owned()))
+}
+
+pub fn encode(record: &IndexRecord) -> Result<CanonicalCbor, Error> {
+    match record {
+        IndexRecord::Tag(tag) => encode_tag(tag),
+        IndexRecord::Exact(exact) => encode_exact(exact),
+    }
+}
+
+fn encode_tag(record: &TagRecord) -> Result<CanonicalCbor, Error> {
+    // Resolved rather than trusted: a `TagRecord` decoded from an outside source
+    // carries an owned dimension string, and shipping one no store has a table
+    // for would produce a layer that restores cleanly and can never be queried.
+    let dimension = resolve_dimension(record.dimension())?;
+
+    Ok(frame::encode(|e| {
+        e.array(4)?
+            .u64(TAG_DISCRIMINANT)?
+            .str(dimension)?
+            .bytes(&record.key_hash)?
+            .u64(record.slot)?;
+        Ok(())
+    })?)
+}
+
+fn encode_exact(record: &ExactRecord) -> Result<CanonicalCbor, Error> {
+    Ok(frame::encode(|e| {
+        e.array(4)?
+            .u64(EXACT_DISCRIMINANT)?
+            .str(record.kind.as_str())?
+            .bytes(record.key())?
+            .u64(record.slot)?;
+        Ok(())
+    })?)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<IndexRecord, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(INDEXES, &mut decoder, 4)?;
+
+    let discriminant = uint(INDEXES, "discriminant", &mut decoder)?;
+
+    let record = match discriminant {
+        TAG_DISCRIMINANT => {
+            let dimension = resolve_dimension(text(INDEXES, "dimension", &mut decoder)?)?;
+            let key_hash: KeyHash = fixed(INDEXES, "key_hash", &mut decoder)?;
+            let slot = uint(INDEXES, "slot", &mut decoder)?;
+
+            IndexRecord::Tag(TagRecord::new(dimension, key_hash, slot))
+        }
+        EXACT_DISCRIMINANT => {
+            let kind = resolve_exact_kind(text(INDEXES, "kind", &mut decoder)?)?;
+            let key = blob(INDEXES, "key", &mut decoder)?;
+            let slot = uint(INDEXES, "slot", &mut decoder)?;
+
+            // The width rule belongs to `ExactRecord`, which is where the delta
+            // path already enforces it. Surfacing its refusal keeps one
+            // validation site: a second one here could disagree, and the entry
+            // it let through would be one no lookup could ever reach.
+            IndexRecord::Exact(ExactRecord::new(kind, key, slot)?)
+        }
+        other => {
+            return Err(Error::malformed(
+                INDEXES,
+                format!("unknown record discriminant {other}"),
+            ))
+        }
+    };
+
+    close(INDEXES, &decoder, bytes)?;
+
+    Ok(record)
+}
+
+/// Every tag record, strictly ascending; then every exact record, likewise.
+#[derive(Debug, Default, Clone)]
+pub struct OrderCheck {
+    last_tag: Option<TagRecord>,
+    last_exact: Option<ExactRecord>,
+}
+
+impl OrderCheck {
+    pub fn check(&mut self, record: &IndexRecord) -> Result<(), Error> {
+        match record {
+            IndexRecord::Tag(tag) => self.check_tag(tag),
+            IndexRecord::Exact(exact) => self.check_exact(exact),
+        }
+    }
+
+    fn check_tag(&mut self, record: &TagRecord) -> Result<(), Error> {
+        if self.last_exact.is_some() {
+            return Err(Error::out_of_order(
+                INDEXES,
+                "a tag record after an exact record; every tag record comes first",
+            ));
+        }
+
+        if let Some(previous) = &self.last_tag {
+            // `TagRecord`'s own ordering is `(dimension, key_hash, slot)`, so
+            // "strictly ascending" is both the sort rule and the dedup rule.
+            if record <= previous {
+                return Err(Error::out_of_order(
+                    INDEXES,
+                    format!("tag {record:?} follows {previous:?}"),
+                ));
+            }
+        }
+
+        self.last_tag = Some(record.clone());
+
+        Ok(())
+    }
+
+    fn check_exact(&mut self, record: &ExactRecord) -> Result<(), Error> {
+        if let Some(previous) = &self.last_exact {
+            if (record.kind, record.key()) <= (previous.kind, previous.key()) {
+                return Err(Error::out_of_order(
+                    INDEXES,
+                    format!("exact {record:?} follows {previous:?}"),
+                ));
+            }
+        }
+
+        self.last_exact = Some(*record);
+
+        Ok(())
+    }
+}
+
+/// The slot of either record shape, for callers planning an epoch range.
+pub fn slot_of(record: &IndexRecord) -> BlockSlot {
+    match record {
+        IndexRecord::Tag(tag) => tag.slot,
+        IndexRecord::Exact(exact) => exact.slot,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_core::{key_hash, MAX_EXACT_KEY_LEN, VERBATIM_KEY_DIMENSION};
+
+    use super::*;
+
+    fn tag(dimension: TagDimension, hash: u8, slot: BlockSlot) -> IndexRecord {
+        TagRecord::new(dimension, [hash; 8], slot).into()
+    }
+
+    fn exact(kind: ExactKind, byte: u8, slot: BlockSlot) -> IndexRecord {
+        ExactRecord::new(kind, &vec![byte; kind.key_len()], slot)
+            .unwrap()
+            .into()
+    }
+
+    #[test]
+    fn every_dimension_round_trips() {
+        for dimension in archive_dimensions::ALL {
+            let original = tag(dimension, 0x7f, 42);
+            let encoded = encode(&original).unwrap();
+
+            assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+        }
+    }
+
+    #[test]
+    fn every_exact_kind_round_trips() {
+        for kind in ExactKind::ALL {
+            let original = exact(kind, 0x11, 7);
+            let encoded = encode(&original).unwrap();
+
+            assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+        }
+    }
+
+    /// The dimension whose stored key is a verbatim `u64` label rather than a
+    /// hash. Nothing in this codec treats it specially — that is the property
+    /// under test.
+    #[test]
+    fn the_verbatim_dimension_carries_its_label_unchanged() {
+        let label = 674u64;
+        let stored = key_hash(VERBATIM_KEY_DIMENSION, &label.to_be_bytes()).unwrap();
+
+        assert_eq!(stored, label.to_be_bytes(), "the label is kept, not hashed");
+
+        let original: IndexRecord = TagRecord::new(VERBATIM_KEY_DIMENSION, stored, 900).into();
+        let encoded = encode(&original).unwrap();
+        let decoded = decode(encoded.as_bytes()).unwrap();
+
+        assert_eq!(decoded, original);
+
+        let IndexRecord::Tag(tag) = decoded else {
+            panic!("expected a tag record");
+        };
+        assert_eq!(u64::from_be_bytes(tag.key_hash), label);
+    }
+
+    #[test]
+    fn an_unknown_dimension_is_refused_in_both_directions() {
+        let wire = frame::encode(|e| {
+            e.array(4)?
+                .u64(TAG_DISCRIMINANT)?
+                .str("not_a_dimension")?
+                .bytes(&[0u8; 8])?
+                .u64(1)?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::UnknownDimension(_)), "{err:?}");
+
+        let smuggled = TagRecord {
+            dimension: std::borrow::Cow::Owned("not_a_dimension".to_owned()),
+            key_hash: [0u8; 8],
+            slot: 1,
+        };
+        let err = encode(&smuggled.into()).unwrap_err();
+        assert!(matches!(err, Error::UnknownDimension(_)), "{err:?}");
+    }
+
+    #[test]
+    fn an_unknown_exact_kind_is_refused() {
+        let wire = frame::encode(|e| {
+            e.array(4)?
+                .u64(EXACT_DISCRIMINANT)?
+                .str("block_number")?
+                .bytes(&[0u8; 8])?
+                .u64(1)?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::UnknownExactKind(_)), "{err:?}");
+    }
+
+    /// A key wider than any kind's — and wider than the inline buffer — is
+    /// refused by `ExactRecord::new`, whose verdict this codec surfaces rather
+    /// than duplicating.
+    #[test]
+    fn an_over_wide_exact_key_is_refused_by_the_store_type() {
+        for width in [MAX_EXACT_KEY_LEN + 1, 64, 0] {
+            let wire = frame::encode(|e| {
+                e.array(4)?
+                    .u64(EXACT_DISCRIMINANT)?
+                    .str(ExactKind::TxHash.as_str())?
+                    .bytes(&vec![0u8; width])?
+                    .u64(1)?;
+                Ok(())
+            })
+            .unwrap();
+
+            let err = decode(wire.as_bytes()).unwrap_err();
+            assert!(matches!(err, Error::Index(_)), "{width}: {err:?}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_discriminant_is_refused() {
+        let wire = frame::encode(|e| {
+            e.array(4)?
+                .u64(2)?
+                .str("address")?
+                .bytes(&[0u8; 8])?
+                .u64(1)?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn tags_then_exact_is_accepted() {
+        let mut order = OrderCheck::default();
+
+        for record in [
+            tag(archive_dimensions::ADDRESS, 0x00, 1),
+            tag(archive_dimensions::ADDRESS, 0x00, 2),
+            tag(archive_dimensions::ADDRESS, 0x01, 0),
+            tag(archive_dimensions::ASSET, 0x00, 0),
+            exact(ExactKind::BlockHash, 0x00, 5),
+            exact(ExactKind::BlockHash, 0x01, 4),
+            exact(ExactKind::BlockNumber, 0x00, 3),
+            exact(ExactKind::TxHash, 0x00, 2),
+        ] {
+            order.check(&record).unwrap();
+        }
+    }
+
+    #[test]
+    fn out_of_order_and_duplicate_records_are_refused() {
+        let cases: [(&str, Vec<IndexRecord>); 5] = [
+            (
+                "a tag after an exact",
+                vec![
+                    exact(ExactKind::BlockHash, 0x00, 1),
+                    tag(archive_dimensions::ADDRESS, 0x00, 1),
+                ],
+            ),
+            (
+                "a repeated tag",
+                vec![
+                    tag(archive_dimensions::ADDRESS, 0x00, 1),
+                    tag(archive_dimensions::ADDRESS, 0x00, 1),
+                ],
+            ),
+            (
+                "a tag slot going backwards",
+                vec![
+                    tag(archive_dimensions::ADDRESS, 0x00, 2),
+                    tag(archive_dimensions::ADDRESS, 0x00, 1),
+                ],
+            ),
+            (
+                "a dimension going backwards",
+                vec![
+                    tag(archive_dimensions::ASSET, 0x00, 1),
+                    tag(archive_dimensions::ADDRESS, 0x00, 1),
+                ],
+            ),
+            (
+                "an exact key repeated under a different slot",
+                vec![
+                    exact(ExactKind::BlockHash, 0x00, 1),
+                    exact(ExactKind::BlockHash, 0x00, 2),
+                ],
+            ),
+        ];
+
+        for (why, records) in cases {
+            let mut order = OrderCheck::default();
+            let mut refused = None;
+
+            for record in &records {
+                if let Err(e) = order.check(record) {
+                    refused = Some(e);
+                    break;
+                }
+            }
+
+            let err = refused.unwrap_or_else(|| panic!("{why} was accepted"));
+            assert!(matches!(err, Error::OutOfOrder { .. }), "{why}: {err:?}");
+        }
+    }
+}

--- a/crates/snapshot/src/layers/logs.rs
+++ b/crates/snapshot/src/layers/logs.rs
@@ -1,0 +1,200 @@
+//! The `logs` layer: epoch-boundary ledger logs.
+//!
+//! `[ns: tstr, log_key: bytes(40), value: bytes]`, ordered by `(ns, log_key)`.
+//!
+//! ## Why these are shipped rather than derived
+//!
+//! Reward and stake logs are products of ledger computation over a whole epoch.
+//! Deriving them at restore time means replaying the ledger, which is the thing
+//! a snapshot exists to avoid — so they travel, and the value is the stored
+//! minicbor of the entity, byte for byte. This codec never decodes an entity: a
+//! log value is an opaque byte string here, which is also why an entity holding
+//! a float (`StakeLog::relative_size`) does not collide with the layer's
+//! no-floats encoding rule. The rule governs the record's own CBOR, and the
+//! value is a byte string within it.
+//!
+//! Determinism therefore rests on the entity encoders being deterministic — an
+//! ADR-004 limitation, and an audit that belongs to the export slice, not here.
+
+use dolos_core::{EntityValue, LogKey, Namespace};
+use stelae::frame::{self, CanonicalCbor};
+
+use super::{blob, close, fixed, open, text};
+use crate::{namespaces, Error, LOGS};
+
+/// Width of a [`LogKey`]: an 8-byte big-endian slot followed by a 32-byte
+/// entity key.
+///
+/// Spelled out because `dolos-core` keeps the two halves private, and pinned
+/// against the type by `log_key_len_matches_the_store_type` — a `LogKey` built
+/// from a slice zero-pads or truncates to fit, so a decoder that took the wire
+/// length on trust would turn a short key into a plausible, unreachable one.
+pub const LOG_KEY_LEN: usize = 40;
+
+/// One epoch-boundary log entry, as the layer carries it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogRecord {
+    pub ns: Namespace,
+    pub key: LogKey,
+    /// The stored `EntityValue`, verbatim.
+    pub value: EntityValue,
+}
+
+impl LogRecord {
+    pub fn new(ns: Namespace, key: LogKey, value: impl Into<EntityValue>) -> Self {
+        Self {
+            ns,
+            key,
+            value: value.into(),
+        }
+    }
+}
+
+pub fn encode(record: &LogRecord) -> Result<CanonicalCbor, Error> {
+    let ns = namespaces::resolve(record.ns)?;
+
+    Ok(frame::encode(|e| {
+        e.array(3)?
+            .str(ns)?
+            .bytes(record.key.as_ref())?
+            .bytes(&record.value)?;
+        Ok(())
+    })?)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<LogRecord, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(LOGS, &mut decoder, 3)?;
+
+    let ns = namespaces::resolve(text(LOGS, "ns", &mut decoder)?)?;
+    let key: [u8; LOG_KEY_LEN] = fixed(LOGS, "log_key", &mut decoder)?;
+    let value = blob(LOGS, "value", &mut decoder)?.to_vec();
+
+    close(LOGS, &decoder, bytes)?;
+
+    Ok(LogRecord {
+        ns,
+        key: LogKey::from(key.as_slice()),
+        value,
+    })
+}
+
+/// Strictly ascending `(ns, log_key)`.
+#[derive(Debug, Default, Clone)]
+pub struct OrderCheck {
+    last: Option<(Namespace, LogKey)>,
+}
+
+impl OrderCheck {
+    pub fn check(&mut self, record: &LogRecord) -> Result<(), Error> {
+        let current = (record.ns, record.key.clone());
+
+        if let Some(previous) = &self.last {
+            if current <= *previous {
+                return Err(Error::out_of_order(
+                    LOGS,
+                    format!(
+                        "{}/{} follows {}/{}",
+                        current.0,
+                        hex::encode(current.1.as_ref()),
+                        previous.0,
+                        hex::encode(previous.1.as_ref()),
+                    ),
+                ));
+            }
+        }
+
+        self.last = Some(current);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_cardano::model::{FixedNamespace, LeaderRewardLog, StakeLog};
+
+    use super::*;
+
+    fn key(slot: u64, entity: u8) -> LogKey {
+        let mut raw = [0u8; LOG_KEY_LEN];
+        raw[..8].copy_from_slice(&slot.to_be_bytes());
+        raw[8..].fill(entity);
+        LogKey::from(raw.as_slice())
+    }
+
+    #[test]
+    fn log_key_len_matches_the_store_type() {
+        assert_eq!(LOG_KEY_LEN, LogKey::full_range().start.as_ref().len());
+    }
+
+    #[test]
+    fn round_trips() {
+        let original = LogRecord::new(LeaderRewardLog::NS, key(432_000, 0xab), vec![0x82, 0x01]);
+        let encoded = encode(&original).unwrap();
+
+        assert_eq!(decode(encoded.as_bytes()).unwrap(), original);
+    }
+
+    #[test]
+    fn an_unknown_namespace_is_refused_in_both_directions() {
+        let wire = frame::encode(|e| {
+            e.array(3)?
+                .str("not_a_namespace")?
+                .bytes(&[0u8; LOG_KEY_LEN])?
+                .bytes(&[])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let err = decode(wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::UnknownNamespace(_)), "{err:?}");
+
+        let smuggled = LogRecord::new("not_a_namespace", key(1, 0), Vec::new());
+        let err = encode(&smuggled).unwrap_err();
+        assert!(matches!(err, Error::UnknownNamespace(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_wrong_width_log_key_is_refused() {
+        for width in [8, 32, 39, 41] {
+            let wire = frame::encode(|e| {
+                e.array(3)?
+                    .str(StakeLog::NS)?
+                    .bytes(&vec![0u8; width])?
+                    .bytes(&[])?;
+                Ok(())
+            })
+            .unwrap();
+
+            let err = decode(wire.as_bytes()).unwrap_err();
+            assert!(
+                matches!(err, Error::MalformedRecord { .. }),
+                "{width}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordering_is_namespace_then_key() {
+        let mut order = OrderCheck::default();
+
+        for record in [
+            LogRecord::new(LeaderRewardLog::NS, key(0, 0x00), Vec::new()),
+            LogRecord::new(LeaderRewardLog::NS, key(0, 0x01), Vec::new()),
+            LogRecord::new(LeaderRewardLog::NS, key(1, 0x00), Vec::new()),
+            LogRecord::new(StakeLog::NS, key(0, 0x00), Vec::new()),
+        ] {
+            order.check(&record).unwrap();
+        }
+
+        for backwards in [
+            LogRecord::new(StakeLog::NS, key(0, 0x00), Vec::new()),
+            LogRecord::new(LeaderRewardLog::NS, key(9, 0x00), Vec::new()),
+        ] {
+            let err = order.check(&backwards).unwrap_err();
+            assert!(matches!(err, Error::OutOfOrder { .. }), "{err:?}");
+        }
+    }
+}

--- a/crates/snapshot/src/layers/mod.rs
+++ b/crates/snapshot/src/layers/mod.rs
@@ -1,0 +1,131 @@
+//! One codec per layer kind.
+//!
+//! Every module here exposes the same three things, so a caller meets one shape
+//! five times:
+//!
+//! - `encode(&Record) -> Result<CanonicalCbor, Error>` — through
+//!   [`stelae::frame::encode`], so the deterministic-encoding profile is
+//!   enforced by construction rather than by review.
+//! - `decode(&[u8]) -> Result<Record, Error>` — fail-closed, and total: a
+//!   record that decodes is a record the restore path can write.
+//! - `OrderCheck` — the kind's ordering contract as a streaming validator,
+//!   because ordering *is* content here. A restore ingests these records
+//!   append-only into sorted stores; records arriving out of order do not fail
+//!   loudly, they land in a store whose own queries then miss them.
+//!
+//! The ordering rules are ADR-004's, and three of the five are exactly the
+//! iteration order the source stores already promise
+//! ([`dolos_core::IndexStore::iter_archive_tags`],
+//! [`dolos_core::IndexStore::iter_exact_records`]). The validator is not a
+//! substitute for that promise; it is what catches a driver that merges,
+//! chunks or parallelizes those iterators and loses it.
+//!
+//! ## Why decoding does not re-validate canonical form
+//!
+//! Records reach `decode` from [`stelae::dir::Layer::records`] or
+//! [`stelae::LayerReader::next_record`], both of which have already validated
+//! every byte against the deterministic profile — that is the framing layer's
+//! job and it is not repeated here. What `decode` does check is *shape*: the
+//! field count, each field's type and width, and that nothing trails the
+//! record.
+
+pub mod blocks;
+pub mod digests;
+pub mod indexes;
+pub mod logs;
+pub mod state;
+
+use minicbor::Decoder;
+
+use crate::Error;
+
+/// Open a record's outer array, insisting on a definite length of `expected`.
+pub(crate) fn open(
+    kind: &'static str,
+    decoder: &mut Decoder<'_>,
+    expected: u64,
+) -> Result<(), Error> {
+    let fields = decoder
+        .array()
+        .map_err(|e| Error::malformed(kind, format!("expected an array: {e}")))?
+        .ok_or_else(|| Error::malformed(kind, "indefinite-length array"))?;
+
+    if fields != expected {
+        return Err(Error::malformed(
+            kind,
+            format!("expected {expected} fields, found {fields}"),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Insist the record ended where the array did.
+///
+/// A CBOR sequence has no frame markers, so a record with a tail would be read
+/// as one item by the framing layer and as a different, shorter item here — two
+/// readers disagreeing about the same bytes, which is how a diffId stops
+/// meaning anything.
+pub(crate) fn close(kind: &'static str, decoder: &Decoder<'_>, bytes: &[u8]) -> Result<(), Error> {
+    let read = decoder.position();
+
+    if read != bytes.len() {
+        return Err(Error::malformed(
+            kind,
+            format!("{} trailing byte(s) after the record", bytes.len() - read),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn uint(
+    kind: &'static str,
+    field: &str,
+    decoder: &mut Decoder<'_>,
+) -> Result<u64, Error> {
+    decoder
+        .u64()
+        .map_err(|e| Error::malformed(kind, format!("{field}: {e}")))
+}
+
+pub(crate) fn text<'b>(
+    kind: &'static str,
+    field: &str,
+    decoder: &mut Decoder<'b>,
+) -> Result<&'b str, Error> {
+    decoder
+        .str()
+        .map_err(|e| Error::malformed(kind, format!("{field}: {e}")))
+}
+
+pub(crate) fn blob<'b>(
+    kind: &'static str,
+    field: &str,
+    decoder: &mut Decoder<'b>,
+) -> Result<&'b [u8], Error> {
+    decoder
+        .bytes()
+        .map_err(|e| Error::malformed(kind, format!("{field}: {e}")))
+}
+
+/// A byte string of exactly `N` bytes.
+///
+/// Width is checked here rather than by a lossy conversion downstream: every
+/// fixed-width key type in `dolos-core` (`EntityKey`, `LogKey`, `KeyHash`)
+/// converts from a slice by zero-padding or truncating, so a wrong-width field
+/// would become a valid-looking key that no lookup can ever reach.
+pub(crate) fn fixed<const N: usize>(
+    kind: &'static str,
+    field: &str,
+    decoder: &mut Decoder<'_>,
+) -> Result<[u8; N], Error> {
+    let raw = blob(kind, field, decoder)?;
+
+    raw.try_into().map_err(|_| {
+        Error::malformed(
+            kind,
+            format!("{field}: expected {N} bytes, found {}", raw.len()),
+        )
+    })
+}

--- a/crates/snapshot/src/layers/state.rs
+++ b/crates/snapshot/src/layers/state.rs
@@ -1,0 +1,443 @@
+//! The `state` layer: the ledger tip, as sixteen uniform key-value shards.
+//!
+//! `[ns: tstr, key: bytes, value: bytes]`, ordered by `(ns, key)`, with the
+//! shard given by the first nibble of `key[0]`.
+//!
+//! ## One record shape, including for UTxOs
+//!
+//! ADR-004 treats the UTxO set as namespace [`crate::UTXOS`] beside the
+//! fourteen entity namespaces, rather than as a special layer kind. That is
+//! what keeps the format's state vocabulary to a single record, and it makes
+//! the planned refactor folding UTxOs into the entity system (#1042) invisible
+//! from outside: the day `utxos` becomes an ordinary namespace, nothing in this
+//! file changes.
+//!
+//! ## The one place bytes are built rather than carried
+//!
+//! Entity values are the stored minicbor, verbatim. UTxO values are not: the
+//! state store holds an [`EraCbor`], which is a Rust value rather than a byte
+//! string, so this codec composes `[era, body]` itself. It composes it through
+//! [`stelae::frame::encode`] — the same validator every record goes through —
+//! so the one transformed field in the whole profile is canonical by
+//! construction rather than by inspection.
+//!
+//! ## Sharding
+//!
+//! The first nibble of the first key byte, so sixteen shards. Keys are
+//! hash-derived (transaction hashes, credentials, script hashes), so the split
+//! is uniform without a hash of its own; shards can be fetched in parallel and
+//! stay far from registry size limits as state grows.
+
+use dolos_core::{state::KEY_SIZE, EntityKey, EntityValue, Era, EraCbor, Namespace, TxoRef};
+use stelae::frame::{self, CanonicalCbor};
+
+use super::{blob, close, open, text, uint};
+use crate::{namespaces, Error, STATE, UTXOS};
+
+/// Number of state shards. Reported to readers as `parameters.stateShards`.
+pub const STATE_SHARDS: u64 = 16;
+
+/// Width of an entity key — every namespace but [`crate::UTXOS`].
+pub const ENTITY_KEY_LEN: usize = KEY_SIZE;
+
+/// Width of a UTxO key: `tx_hash(32) ‖ output_index(4, BE)`.
+pub const UTXO_KEY_LEN: usize = KEY_SIZE + 4;
+
+/// The shard a state key belongs to: the first nibble of its first byte.
+///
+/// Total by construction — [`decode`] refuses a record whose key is not the
+/// width its namespace requires, and both widths are non-zero — so the fallback
+/// for an empty key is unreachable rather than a policy.
+pub fn shard_of(key: &[u8]) -> u8 {
+    key.first().copied().unwrap_or(0) >> 4
+}
+
+/// One state entry, as the layer carries it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StateRecord {
+    pub ns: Namespace,
+    /// [`ENTITY_KEY_LEN`] bytes, or [`UTXO_KEY_LEN`] under [`crate::UTXOS`].
+    pub key: Vec<u8>,
+    /// The stored `EntityValue` verbatim, or CBOR `[era, body]` under
+    /// [`crate::UTXOS`].
+    pub value: EntityValue,
+}
+
+impl StateRecord {
+    /// The shard this record belongs in.
+    pub fn shard(&self) -> u8 {
+        shard_of(&self.key)
+    }
+}
+
+/// A record for an entity, whose value is carried verbatim.
+///
+/// Refuses [`crate::UTXOS`]: that namespace's value has a shape this function
+/// would not build, and a raw byte string smuggled in under it would restore as
+/// an unreadable UTxO.
+pub fn entity(ns: Namespace, key: &EntityKey, value: &EntityValue) -> Result<StateRecord, Error> {
+    if ns == UTXOS {
+        return Err(Error::malformed(
+            STATE,
+            format!("namespace {UTXOS:?} is built by `utxo`, not by `entity`"),
+        ));
+    }
+
+    Ok(StateRecord {
+        ns: namespaces::resolve(ns)?,
+        key: key.as_ref().to_vec(),
+        value: value.clone(),
+    })
+}
+
+/// A record for one UTxO, composing the `[era, body]` value.
+pub fn utxo(txo: &TxoRef, value: &EraCbor) -> Result<StateRecord, Error> {
+    let mut key = Vec::with_capacity(UTXO_KEY_LEN);
+    key.extend_from_slice(txo.0.as_ref());
+    key.extend_from_slice(&txo.1.to_be_bytes());
+
+    Ok(StateRecord {
+        ns: UTXOS,
+        key,
+        value: encode_utxo_value(value)?.into_bytes(),
+    })
+}
+
+/// Read a record back as an entity. Refuses a [`crate::UTXOS`] record.
+pub fn as_entity(record: &StateRecord) -> Result<(Namespace, EntityKey), Error> {
+    if record.ns == UTXOS {
+        return Err(Error::malformed(
+            STATE,
+            format!("namespace {UTXOS:?} is read by `as_utxo`, not by `as_entity`"),
+        ));
+    }
+
+    let key: [u8; ENTITY_KEY_LEN] = record.key.as_slice().try_into().map_err(|_| {
+        Error::malformed(
+            STATE,
+            format!(
+                "{}: expected a {ENTITY_KEY_LEN}-byte key, found {}",
+                record.ns,
+                record.key.len()
+            ),
+        )
+    })?;
+
+    Ok((record.ns, EntityKey::from(&key)))
+}
+
+/// Read a record back as a UTxO. Refuses any namespace but [`crate::UTXOS`].
+pub fn as_utxo(record: &StateRecord) -> Result<(TxoRef, EraCbor), Error> {
+    if record.ns != UTXOS {
+        return Err(Error::malformed(
+            STATE,
+            format!("namespace {:?} is not the utxo set", record.ns),
+        ));
+    }
+
+    let key: [u8; UTXO_KEY_LEN] = record.key.as_slice().try_into().map_err(|_| {
+        Error::malformed(
+            STATE,
+            format!(
+                "utxo key: expected {UTXO_KEY_LEN} bytes, found {}",
+                record.key.len()
+            ),
+        )
+    })?;
+
+    let (hash, index) = key.split_at(KEY_SIZE);
+    let hash: [u8; KEY_SIZE] = hash.try_into().expect("split at KEY_SIZE");
+    let index = u32::from_be_bytes(index.try_into().expect("the remaining four bytes"));
+
+    Ok((
+        TxoRef(hash.into(), index),
+        decode_utxo_value(&record.value)?,
+    ))
+}
+
+/// The `utxos` value: `[era: uint, body: bytes]`.
+pub fn encode_utxo_value(value: &EraCbor) -> Result<CanonicalCbor, Error> {
+    Ok(frame::encode(|e| {
+        e.array(2)?.u64(u64::from(value.0))?.bytes(&value.1)?;
+        Ok(())
+    })?)
+}
+
+pub fn decode_utxo_value(bytes: &[u8]) -> Result<EraCbor, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(STATE, &mut decoder, 2)?;
+
+    let era = uint(STATE, "era", &mut decoder)?;
+    let era = Era::try_from(era)
+        .map_err(|_| Error::malformed(STATE, format!("era {era} does not fit a u16")))?;
+    let body = blob(STATE, "body", &mut decoder)?.to_vec();
+
+    close(STATE, &decoder, bytes)?;
+
+    Ok(EraCbor(era, body))
+}
+
+pub fn encode(record: &StateRecord) -> Result<CanonicalCbor, Error> {
+    let ns = namespaces::resolve(record.ns)?;
+
+    check_key_width(ns, record.key.len())?;
+
+    Ok(frame::encode(|e| {
+        e.array(3)?
+            .str(ns)?
+            .bytes(&record.key)?
+            .bytes(&record.value)?;
+        Ok(())
+    })?)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<StateRecord, Error> {
+    let mut decoder = minicbor::Decoder::new(bytes);
+
+    open(STATE, &mut decoder, 3)?;
+
+    let ns = namespaces::resolve(text(STATE, "ns", &mut decoder)?)?;
+    let key = blob(STATE, "key", &mut decoder)?.to_vec();
+    let value = blob(STATE, "value", &mut decoder)?.to_vec();
+
+    close(STATE, &decoder, bytes)?;
+
+    check_key_width(ns, key.len())?;
+
+    Ok(StateRecord { ns, key, value })
+}
+
+/// Both key widths are fixed by their namespace, and both `EntityKey` and a
+/// UTxO ref convert from a slice by padding or truncating — so a wrong width
+/// that got through would become a well-formed key pointing at nothing.
+fn check_key_width(ns: Namespace, len: usize) -> Result<(), Error> {
+    let expected = if ns == UTXOS {
+        UTXO_KEY_LEN
+    } else {
+        ENTITY_KEY_LEN
+    };
+
+    if len != expected {
+        return Err(Error::malformed(
+            STATE,
+            format!("{ns}: expected a {expected}-byte key, found {len}"),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Strictly ascending `(ns, key)`, optionally within one shard.
+#[derive(Debug, Default, Clone)]
+pub struct OrderCheck {
+    shard: Option<u8>,
+    last: Option<(Namespace, Vec<u8>)>,
+}
+
+impl OrderCheck {
+    /// A check that also insists every record belongs to `shard`.
+    ///
+    /// Worth having beside the ordering rule: a record in the wrong shard layer
+    /// still restores — the write path dispatches on the namespace, not on the
+    /// shard — so nothing downstream would ever notice, and a client fetching
+    /// shards selectively would silently miss it.
+    pub fn for_shard(shard: u8) -> Self {
+        Self {
+            shard: Some(shard),
+            last: None,
+        }
+    }
+
+    pub fn check(&mut self, record: &StateRecord) -> Result<(), Error> {
+        if let Some(shard) = self.shard {
+            if record.shard() != shard {
+                return Err(Error::malformed(
+                    STATE,
+                    format!(
+                        "{}/{} belongs to shard {}, not shard {shard}",
+                        record.ns,
+                        hex::encode(&record.key),
+                        record.shard(),
+                    ),
+                ));
+            }
+        }
+
+        let current = (record.ns, record.key.clone());
+
+        if let Some(previous) = &self.last {
+            if current <= *previous {
+                return Err(Error::out_of_order(
+                    STATE,
+                    format!(
+                        "{}/{} follows {}/{}",
+                        current.0,
+                        hex::encode(&current.1),
+                        previous.0,
+                        hex::encode(&previous.1),
+                    ),
+                ));
+            }
+        }
+
+        self.last = Some(current);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_cardano::model::{AccountState, FixedNamespace, PoolState};
+
+    use super::*;
+
+    fn entity_key(byte: u8) -> EntityKey {
+        EntityKey::from(&[byte; ENTITY_KEY_LEN])
+    }
+
+    fn txo(byte: u8, index: u32) -> TxoRef {
+        TxoRef([byte; KEY_SIZE].into(), index)
+    }
+
+    #[test]
+    fn an_entity_record_round_trips() {
+        let original =
+            entity(AccountState::NS, &entity_key(0x5a), &vec![0x82, 0x01, 0x02]).unwrap();
+
+        let encoded = encode(&original).unwrap();
+        let decoded = decode(encoded.as_bytes()).unwrap();
+
+        assert_eq!(decoded, original);
+        assert_eq!(
+            as_entity(&decoded).unwrap(),
+            (AccountState::NS, entity_key(0x5a))
+        );
+    }
+
+    #[test]
+    fn a_utxo_record_round_trips() {
+        let ref_ = txo(0x30, 7);
+        let value = EraCbor(6, vec![0xa0, 0x01]);
+
+        let original = utxo(&ref_, &value).unwrap();
+
+        assert_eq!(original.ns, UTXOS);
+        assert_eq!(original.key.len(), UTXO_KEY_LEN);
+
+        let encoded = encode(&original).unwrap();
+        let decoded = decode(encoded.as_bytes()).unwrap();
+
+        assert_eq!(decoded, original);
+        assert_eq!(as_utxo(&decoded).unwrap(), (ref_, value));
+    }
+
+    /// The composed field, checked against the encoding profile it has to obey
+    /// rather than against itself.
+    #[test]
+    fn the_utxo_value_is_canonical_by_construction() {
+        for era in [0u16, 23, 24, 255, 256, u16::MAX] {
+            let value = EraCbor(era, vec![0xff; 3]);
+            let composed = encode_utxo_value(&value).unwrap();
+
+            // `CanonicalCbor::new` is the validator; re-running it over the
+            // bytes proves the composition did not merely happen to pass once.
+            CanonicalCbor::new(composed.as_bytes().to_vec()).unwrap();
+            assert_eq!(decode_utxo_value(composed.as_bytes()).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn the_two_readers_refuse_each_others_records() {
+        let entity_record = entity(PoolState::NS, &entity_key(1), &Vec::new()).unwrap();
+        let utxo_record = utxo(&txo(1, 0), &EraCbor(1, Vec::new())).unwrap();
+
+        assert!(as_utxo(&entity_record).is_err());
+        assert!(as_entity(&utxo_record).is_err());
+        assert!(entity(UTXOS, &entity_key(1), &Vec::new()).is_err());
+    }
+
+    #[test]
+    fn a_wrong_width_key_is_refused() {
+        for (ns, width) in [
+            (AccountState::NS, UTXO_KEY_LEN),
+            (AccountState::NS, 0),
+            (UTXOS, ENTITY_KEY_LEN),
+            (UTXOS, UTXO_KEY_LEN + 1),
+        ] {
+            let wire = frame::encode(|e| {
+                e.array(3)?.str(ns)?.bytes(&vec![0u8; width])?.bytes(&[])?;
+                Ok(())
+            })
+            .unwrap();
+
+            let err = decode(wire.as_bytes()).unwrap_err();
+            assert!(
+                matches!(err, Error::MalformedRecord { .. }),
+                "{ns}/{width}: {err:?}"
+            );
+        }
+    }
+
+    /// Hash-derived keys spread evenly over the sixteen shards, which is the
+    /// premise the shard split rests on.
+    #[test]
+    fn sharding_is_the_first_nibble_and_covers_every_shard() {
+        assert_eq!(shard_of(&[0x00]), 0);
+        assert_eq!(shard_of(&[0x0f]), 0);
+        assert_eq!(shard_of(&[0x10]), 1);
+        assert_eq!(shard_of(&[0xff]), 15);
+
+        let mut counts = [0usize; STATE_SHARDS as usize];
+        for byte in 0u8..=255 {
+            counts[shard_of(&[byte]) as usize] += 1;
+        }
+
+        assert!(counts.iter().all(|c| *c == 16), "{counts:?}");
+    }
+
+    /// The two key widths shard the same way, so one rule covers the whole
+    /// layer kind.
+    #[test]
+    fn both_key_widths_shard_identically() {
+        let entity_record = entity(PoolState::NS, &entity_key(0xc3), &Vec::new()).unwrap();
+        let utxo_record = utxo(&txo(0xc3, 0), &EraCbor(1, Vec::new())).unwrap();
+
+        assert_eq!(entity_record.shard(), 12);
+        assert_eq!(utxo_record.shard(), 12);
+    }
+
+    #[test]
+    fn ordering_is_namespace_then_key() {
+        let mut order = OrderCheck::default();
+
+        for record in [
+            entity(AccountState::NS, &entity_key(0x00), &Vec::new()).unwrap(),
+            entity(AccountState::NS, &entity_key(0x01), &Vec::new()).unwrap(),
+            entity(PoolState::NS, &entity_key(0x00), &Vec::new()).unwrap(),
+            utxo(&txo(0x00, 0), &EraCbor(1, Vec::new())).unwrap(),
+        ] {
+            order.check(&record).unwrap();
+        }
+
+        let err = order
+            .check(&entity(AccountState::NS, &entity_key(0x09), &Vec::new()).unwrap())
+            .unwrap_err();
+        assert!(matches!(err, Error::OutOfOrder { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_record_from_another_shard_is_refused() {
+        let mut order = OrderCheck::for_shard(0);
+
+        order
+            .check(&entity(AccountState::NS, &entity_key(0x0a), &Vec::new()).unwrap())
+            .unwrap();
+
+        let err = order
+            .check(&entity(AccountState::NS, &entity_key(0xa0), &Vec::new()).unwrap())
+            .unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+}

--- a/crates/snapshot/src/layers/state.rs
+++ b/crates/snapshot/src/layers/state.rs
@@ -348,6 +348,28 @@ mod tests {
         }
     }
 
+    /// The era is a `u16` in the stores and a CBOR uint on the wire, so the
+    /// widths disagree and the decoder narrows. `encode_utxo_value` cannot
+    /// reach the refusal — an `EraCbor` already holds a `u16` — so the wire
+    /// bytes are built directly, which is the only way an out-of-range era
+    /// arrives at all.
+    #[test]
+    fn an_out_of_range_era_is_refused() {
+        for era in [u64::from(u16::MAX) + 1, u64::MAX] {
+            let wire = frame::encode(|e| {
+                e.array(2)?.u64(era)?.bytes(&[])?;
+                Ok(())
+            })
+            .unwrap();
+
+            let err = decode_utxo_value(wire.as_bytes()).unwrap_err();
+            assert!(
+                matches!(err, Error::MalformedRecord { .. }),
+                "{era}: {err:?}"
+            );
+        }
+    }
+
     #[test]
     fn the_two_readers_refuse_each_others_records() {
         let entity_record = entity(PoolState::NS, &entity_key(1), &Vec::new()).unwrap();

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -1,0 +1,561 @@
+//! # The `io.txpipe.dolos.cardano` profile
+//!
+//! [`stelae`] is the protocol: framing, canonicalization, digests and the
+//! naming rules that let vendors coexist in one registry. It knows nothing
+//! about Cardano. This crate is the other half — the *profile* — and it says
+//! what a Dolos stele actually contains: five layer kinds, their media types,
+//! the tag a sequence renders as, what goes in `position`, `parameters` and
+//! each layer's `scope`, and the byte-exact codec for every record shape.
+//!
+//! The normative specification is `adrs/004_stelae_snapshots.md`; this crate is
+//! that document's record table (§"Layer formats") made executable.
+//!
+//! ## What is here, and what is deliberately not
+//!
+//! Everything in this crate is a *description* of the format: pure functions
+//! over records already in hand. There is no export, no restore, no store
+//! iteration and no CLI — those are orchestration and land on top of this. The
+//! split exists so that the byte shapes, the ordering rules and the vocabulary
+//! are frozen by golden digests *before* anything drives a store through them,
+//! because a codec that drifts silently republishes a different identity under
+//! the same name.
+//!
+//! ## The rules this crate keeps
+//!
+//! - **Stored bytes are carried, never recomputed.** Index records ship the
+//!   stored key form (see [`dolos_core::key_hash`]); entity and log values ship
+//!   their stored minicbor verbatim. The single exception is the `utxos`
+//!   namespace, whose value this crate builds — and builds through
+//!   [`stelae::frame::encode`], so it is canonical by construction.
+//! - **Vocabulary has one definition.** Dimension names come from
+//!   `dolos_cardano::indexes::archive_dimensions::ALL`, exact-record kind names
+//!   from [`dolos_core::ExactKind::as_str`], state namespaces from the entity
+//!   types' own `FixedNamespace::NS`. This crate spells none of them again.
+//! - **Decoding fails closed.** A dimension, namespace or exact kind this
+//!   profile does not define is an error, never a record passed through on the
+//!   assumption that someone downstream will notice.
+//!
+//! ## Module map
+//!
+//! - [`layers`] — one codec per layer kind, each with `encode`, `decode` and an
+//!   `OrderCheck` that enforces the kind's ordering contract.
+//! - [`namespaces`] — the closed set of state namespaces.
+
+pub mod layers;
+pub mod namespaces;
+
+use dolos_core::ChainPoint;
+use serde_json::json;
+use stelae::{
+    dir::LayerSpec,
+    frame::{self, CanonicalCbor},
+    Compression, Profile,
+};
+
+pub use layers::state::{shard_of, STATE_SHARDS};
+pub use namespaces::{NAMESPACES, UTXOS};
+
+/// Reverse-DNS name of this profile. Vendor-owned; the protocol validates the
+/// shape and never composes it.
+pub const PROFILE_NAME: &str = "io.txpipe.dolos.cardano";
+
+/// Major version of the profile. A client refuses an inscription above this.
+pub const PROFILE_VERSION: u64 = 1;
+
+pub const BLOCKS: &str = "blocks";
+pub const INDEXES: &str = "indexes";
+pub const LOGS: &str = "logs";
+pub const STATE: &str = "state";
+pub const DIGESTS: &str = "digests";
+
+/// The five layer kinds, in the order the inscription lists them.
+pub const KINDS: [&str; 5] = [BLOCKS, INDEXES, LOGS, STATE, DIGESTS];
+
+/// The kinds whose scope is an epoch range. The remaining two are tip layers
+/// and carry their own scope shapes.
+pub const EPOCH_KINDS: [&str; 3] = [BLOCKS, INDEXES, LOGS];
+
+/// IANA `vnd.` vendor token for this profile's payload media types. Shorter
+/// than the profile name by custom, and the slot the coexistence rules require
+/// a publisher to control.
+pub const MEDIA_TYPE_VENDOR: &str = "dolos";
+
+/// Payload media-type version. Moves with the record shapes, independently of
+/// the protocol's own schema version.
+pub const MEDIA_TYPE_VERSION: u64 = 1;
+
+/// Payload media-type codec token. Compression is transport, so this is not
+/// part of a stele's identity — see [`stelae::inscription`].
+pub const MEDIA_TYPE_CODEC: &str = "zstd";
+
+/// The key-hashing scheme index layers ship under, as reported in
+/// `parameters.indexKeyHash`.
+///
+/// Describes every dimension *except* [`dolos_core::VERBATIM_KEY_DIMENSION`],
+/// whose logical key is a `u64` label the stores keep verbatim. That exception
+/// is normative for `indexes` v1 (ADR-004) and lives in
+/// [`dolos_core::key_hash`], which is the only place in the tree that decides
+/// it.
+pub const INDEX_KEY_HASH: &str = "xxh3-64";
+
+/// Compression algorithm, pinned so blobs dedupe across publishers in practice.
+/// Correctness never depends on it: identity is the uncompressed digest.
+pub const COMPRESSION_ALGO: &str = "zstd";
+
+/// Compression level, pinned for the same reason as [`COMPRESSION_ALGO`].
+pub const COMPRESSION_LEVEL: i32 = 9;
+
+/// Errors raised by this profile.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("stelae error: {0}")]
+    Stelae(#[from] stelae::Error),
+
+    /// Raised where a record's validity is the index store's judgement rather
+    /// than this crate's — exact-key widths, above all. Surfacing the store's
+    /// refusal keeps one validation site instead of two that can disagree.
+    #[error("index store error: {0}")]
+    Index(#[from] dolos_core::IndexError),
+
+    #[error("malformed {kind} record: {reason}")]
+    MalformedRecord { kind: &'static str, reason: String },
+
+    #[error("{kind} records are out of order: {reason}")]
+    OutOfOrder { kind: &'static str, reason: String },
+
+    #[error("{0:?} is not an archive dimension this profile defines")]
+    UnknownDimension(String),
+
+    #[error("{0:?} is not a state namespace this profile defines")]
+    UnknownNamespace(String),
+
+    #[error("{0:?} is not an exact-record kind this profile defines")]
+    UnknownExactKind(String),
+
+    #[error("layer kind {kind:?} does not take {scope}")]
+    ScopeMismatch { kind: String, scope: &'static str },
+
+    /// A stele stands at a specific block, so its `position` needs that block's
+    /// hash. A cursor that has only a slot cannot anchor one.
+    #[error("a stele's position needs a block hash, but the chain point is {0}")]
+    UnanchoredPoint(String),
+}
+
+impl Error {
+    pub(crate) fn malformed(kind: &'static str, reason: impl Into<String>) -> Self {
+        Self::MalformedRecord {
+            kind,
+            reason: reason.into(),
+        }
+    }
+
+    pub(crate) fn out_of_order(kind: &'static str, reason: impl Into<String>) -> Self {
+        Self::OutOfOrder {
+            kind,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// The Dolos profile.
+///
+/// Stateless by design: the [`Profile`] trait answers questions about naming
+/// and kinds, and nothing here needs a chain, a store or a configuration to
+/// answer them. Everything that *does* — `position`, `parameters`, the
+/// per-layer scopes — is a free function or a scope type below, because the
+/// trait deliberately has no hook for anything dataset-shaped.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DolosProfile;
+
+impl Profile for DolosProfile {
+    fn name(&self) -> &str {
+        PROFILE_NAME
+    }
+
+    fn version(&self) -> u64 {
+        PROFILE_VERSION
+    }
+
+    fn kinds(&self) -> &[&str] {
+        &KINDS
+    }
+
+    fn layer_media_type(&self, kind: &str) -> Result<String, stelae::Error> {
+        if !KINDS.contains(&kind) {
+            return Err(stelae::Error::UnknownLayerKind {
+                profile: PROFILE_NAME.to_owned(),
+                kind: kind.to_owned(),
+            });
+        }
+
+        Ok(format!(
+            "application/vnd.{MEDIA_TYPE_VENDOR}.stele.{kind}.v{MEDIA_TYPE_VERSION}+{MEDIA_TYPE_CODEC}"
+        ))
+    }
+
+    /// The profile sets the protocol's `sequence` to the Cardano epoch, so the
+    /// immutable tag names it.
+    fn tag_for_sequence(&self, sequence: u64) -> Result<String, stelae::Error> {
+        Ok(format!("epoch-{sequence}"))
+    }
+}
+
+/// The network a stele belongs to, as `position.network` records it.
+///
+/// The magic is the identity a restoring node checks against its own
+/// configuration; the name is for humans reading the inscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Network {
+    pub magic: u64,
+    pub name: String,
+}
+
+impl Network {
+    pub fn new(magic: u64, name: impl Into<String>) -> Self {
+        Self {
+            magic,
+            name: name.into(),
+        }
+    }
+}
+
+/// Build the profile's `position`: where in the Cardano chain this stele
+/// stands.
+///
+/// `point` is the boundary the stele was cut at — in practice the state store's
+/// cursor after a `stop_epoch` sync. It must carry a hash: a stele that names
+/// only a slot cannot be verified against a chain.
+pub fn position(
+    network: &Network,
+    point: &ChainPoint,
+    epoch: u64,
+) -> Result<serde_json::Value, Error> {
+    let hash = point
+        .hash()
+        .ok_or_else(|| Error::UnanchoredPoint(point.to_string()))?;
+
+    Ok(json!({
+        "network": {"magic": network.magic, "name": network.name},
+        "point": {"slot": point.slot(), "hash": hex::encode(hash)},
+        "epoch": epoch,
+    }))
+}
+
+/// Build the profile's `parameters`: what a reader needs in order to interpret
+/// the layers.
+///
+/// Both values are consequences of code in this workspace rather than free
+/// choices, so both are sourced rather than spelled: the shard count is
+/// [`STATE_SHARDS`], which [`shard_of`] divides by, and the hash scheme is
+/// [`INDEX_KEY_HASH`], which describes [`dolos_core::key_hash`].
+pub fn parameters() -> serde_json::Value {
+    json!({"stateShards": STATE_SHARDS, "indexKeyHash": INDEX_KEY_HASH})
+}
+
+/// The compression this profile publishes under.
+pub fn compression() -> Compression {
+    Compression {
+        algo: COMPRESSION_ALGO.to_owned(),
+        level: COMPRESSION_LEVEL as i64,
+    }
+}
+
+/// Scope of a per-epoch layer: `blocks`, `indexes` and `logs`.
+///
+/// The slot bounds are inclusive and describe the blocks the layer covers, not
+/// a half-open range — they are what a reader prints, not what it iterates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochScope {
+    pub network_magic: u64,
+    pub epoch: u64,
+    pub start_slot: u64,
+    pub end_slot: u64,
+}
+
+/// Scope of one shard of the state tip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateScope {
+    pub network_magic: u64,
+    pub epoch: u64,
+    pub shard: u8,
+}
+
+/// Scope of the optional `digests` layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DigestsScope {
+    pub network_magic: u64,
+    pub epoch: u64,
+    pub last_immutable: u64,
+}
+
+/// A layer's scope, in the two encodings the protocol carries.
+///
+/// The header scope rides in the layer's own first record, so a blob detached
+/// from its registry is still interpretable; the descriptor scope rides in the
+/// inscription, so a client can plan without fetching a blob. They are two
+/// encodings of one profile-owned idea, and the protocol reads neither.
+pub trait Scope {
+    /// The CBOR form, for the layer header record.
+    fn header(&self) -> Result<CanonicalCbor, Error>;
+
+    /// The JSON form, for the inscription's layer descriptor.
+    fn descriptor(&self) -> serde_json::Value;
+
+    /// The layer kinds this scope shape belongs to.
+    fn kinds(&self) -> &'static [&'static str];
+
+    /// A short name for the shape, used when refusing a mismatched kind.
+    fn shape(&self) -> &'static str;
+
+    /// Both encodings plus the kind, ready for
+    /// [`stelae::dir::SteleDir::write_layer`].
+    ///
+    /// Refuses a kind that does not take this scope shape: a state layer
+    /// carrying an epoch scope would be structurally valid CBOR and permanently
+    /// wrong, which is exactly the class of mistake a scope type exists to make
+    /// unrepresentable.
+    fn layer_spec(&self, kind: &str) -> Result<LayerSpec, Error> {
+        if !self.kinds().contains(&kind) {
+            return Err(Error::ScopeMismatch {
+                kind: kind.to_owned(),
+                scope: self.shape(),
+            });
+        }
+
+        Ok(LayerSpec::new(kind, self.header()?, self.descriptor()))
+    }
+}
+
+impl Scope for EpochScope {
+    fn header(&self) -> Result<CanonicalCbor, Error> {
+        Ok(frame::encode(|e| {
+            e.array(4)?
+                .u64(self.network_magic)?
+                .u64(self.epoch)?
+                .u64(self.start_slot)?
+                .u64(self.end_slot)?;
+            Ok(())
+        })?)
+    }
+
+    fn descriptor(&self) -> serde_json::Value {
+        json!({"epoch": self.epoch, "startSlot": self.start_slot, "endSlot": self.end_slot})
+    }
+
+    fn kinds(&self) -> &'static [&'static str] {
+        &EPOCH_KINDS
+    }
+
+    fn shape(&self) -> &'static str {
+        "an epoch scope"
+    }
+}
+
+impl Scope for StateScope {
+    fn header(&self) -> Result<CanonicalCbor, Error> {
+        Ok(frame::encode(|e| {
+            e.array(3)?
+                .u64(self.network_magic)?
+                .u64(self.epoch)?
+                .u64(u64::from(self.shard))?;
+            Ok(())
+        })?)
+    }
+
+    fn descriptor(&self) -> serde_json::Value {
+        json!({"shard": self.shard})
+    }
+
+    fn kinds(&self) -> &'static [&'static str] {
+        &[STATE]
+    }
+
+    fn shape(&self) -> &'static str {
+        "a state scope"
+    }
+}
+
+impl Scope for DigestsScope {
+    fn header(&self) -> Result<CanonicalCbor, Error> {
+        Ok(frame::encode(|e| {
+            e.array(3)?
+                .u64(self.network_magic)?
+                .u64(self.epoch)?
+                .u64(self.last_immutable)?;
+            Ok(())
+        })?)
+    }
+
+    fn descriptor(&self) -> serde_json::Value {
+        json!({"lastImmutable": self.last_immutable})
+    }
+
+    fn kinds(&self) -> &'static [&'static str] {
+        &[DIGESTS]
+    }
+
+    fn shape(&self) -> &'static str {
+        "a digests scope"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_core::BlockHash;
+    use stelae::profile::{checked_layer_media_type, checked_tag_for_sequence, MediaType};
+
+    use super::*;
+
+    /// Done criterion 1: every kind's name survives the protocol's naming
+    /// rules, and so does the tag.
+    #[test]
+    fn every_kind_passes_the_protocols_naming_rules() {
+        for kind in KINDS {
+            let media_type = checked_layer_media_type(&DolosProfile, kind).unwrap();
+            let parsed = MediaType::parse(&media_type).unwrap();
+
+            assert_eq!(parsed.vendor, MEDIA_TYPE_VENDOR);
+            assert_eq!(parsed.kind, kind);
+            assert_eq!(parsed.version, MEDIA_TYPE_VERSION);
+            assert_eq!(parsed.codec, MEDIA_TYPE_CODEC);
+        }
+
+        assert_eq!(
+            checked_tag_for_sequence(&DolosProfile, 550).unwrap(),
+            "epoch-550"
+        );
+        assert_eq!(
+            checked_tag_for_sequence(&DolosProfile, 0).unwrap(),
+            "epoch-0"
+        );
+        assert_eq!(DolosProfile.moving_tag(), "latest");
+    }
+
+    #[test]
+    fn an_undefined_kind_is_refused() {
+        for kind in ["utxos", "receipts", "", "Blocks"] {
+            assert!(DolosProfile.layer_media_type(kind).is_err(), "{kind:?}");
+            assert!(
+                checked_layer_media_type(&DolosProfile, kind).is_err(),
+                "{kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_profile_name_is_reverse_dns() {
+        stelae::profile::validate_profile_name(PROFILE_NAME).unwrap();
+    }
+
+    #[test]
+    fn position_needs_an_anchored_point() {
+        let network = Network::new(764824073, "mainnet");
+        let point = ChainPoint::Specific(133660800, BlockHash::from([0xab; 32]));
+
+        let built = position(&network, &point, 550).unwrap();
+        assert_eq!(built["network"]["magic"], 764824073u64);
+        assert_eq!(built["network"]["name"], "mainnet");
+        assert_eq!(built["point"]["slot"], 133660800u64);
+        assert_eq!(built["point"]["hash"], "ab".repeat(32));
+        assert_eq!(built["epoch"], 550u64);
+
+        for unanchored in [ChainPoint::Origin, ChainPoint::Slot(133660800)] {
+            let err = position(&network, &unanchored, 550).unwrap_err();
+            assert!(matches!(err, Error::UnanchoredPoint(_)), "{err:?}");
+        }
+    }
+
+    /// The two parameters are claims about code elsewhere in this workspace, so
+    /// they are compared against that code rather than against themselves.
+    #[test]
+    fn parameters_report_what_the_code_does() {
+        let parameters = parameters();
+
+        assert_eq!(parameters["stateShards"], STATE_SHARDS);
+        assert_eq!(parameters["indexKeyHash"], INDEX_KEY_HASH);
+
+        let shards: Vec<u8> = (0u8..=255).map(|b| shard_of(&[b])).collect();
+        let distinct: std::collections::BTreeSet<u8> = shards.iter().copied().collect();
+        assert_eq!(distinct.len() as u64, STATE_SHARDS);
+    }
+
+    /// A scope belongs to the kinds whose shape it is, and to no others.
+    #[test]
+    fn a_scope_refuses_a_kind_it_does_not_describe() {
+        let epoch = EpochScope {
+            network_magic: 2,
+            epoch: 7,
+            start_slot: 100,
+            end_slot: 199,
+        };
+        let state = StateScope {
+            network_magic: 2,
+            epoch: 7,
+            shard: 3,
+        };
+        let digests = DigestsScope {
+            network_magic: 2,
+            epoch: 7,
+            last_immutable: 42,
+        };
+
+        for kind in EPOCH_KINDS {
+            epoch.layer_spec(kind).unwrap();
+        }
+        state.layer_spec(STATE).unwrap();
+        digests.layer_spec(DIGESTS).unwrap();
+
+        for (spec, kind) in [
+            (epoch.layer_spec(STATE), STATE),
+            (epoch.layer_spec(DIGESTS), DIGESTS),
+            (state.layer_spec(BLOCKS), BLOCKS),
+            (digests.layer_spec(LOGS), LOGS),
+        ] {
+            let err = spec.unwrap_err();
+            assert!(
+                matches!(err, Error::ScopeMismatch { .. }),
+                "{kind}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn scopes_encode_the_shapes_the_adr_pins() {
+        let epoch = EpochScope {
+            network_magic: 1,
+            epoch: 2,
+            start_slot: 3,
+            end_slot: 4,
+        };
+        assert_eq!(
+            epoch.header().unwrap().as_bytes(),
+            &[0x84, 0x01, 0x02, 0x03, 0x04]
+        );
+        assert_eq!(
+            epoch.descriptor(),
+            json!({"epoch": 2, "startSlot": 3, "endSlot": 4})
+        );
+
+        let state = StateScope {
+            network_magic: 1,
+            epoch: 2,
+            shard: 15,
+        };
+        assert_eq!(
+            state.header().unwrap().as_bytes(),
+            &[0x83, 0x01, 0x02, 0x0f]
+        );
+        assert_eq!(state.descriptor(), json!({"shard": 15}));
+
+        let digests = DigestsScope {
+            network_magic: 1,
+            epoch: 2,
+            last_immutable: 6187,
+        };
+        assert_eq!(
+            digests.header().unwrap().as_bytes(),
+            &[0x83, 0x01, 0x02, 0x19, 0x18, 0x2b]
+        );
+        assert_eq!(digests.descriptor(), json!({"lastImmutable": 6187}));
+    }
+}

--- a/crates/snapshot/src/namespaces.rs
+++ b/crates/snapshot/src/namespaces.rs
@@ -1,0 +1,95 @@
+//! The closed set of state namespaces a Dolos stele carries.
+//!
+//! ADR-004 defines state as one uniform key-value space: the fourteen entity
+//! namespaces of `dolos_cardano::model::build_schema()` plus [`UTXOS`], which
+//! is the UTxO set wearing the same shape as everything else. That uniformity
+//! is deliberate — it means the format has one state record, and the planned
+//! refactor folding UTxOs into the entity system (#1042) is invisible to it.
+//!
+//! The names are not spelled here. Fourteen of them are read off the entity
+//! types' own `FixedNamespace::NS`, and `utxos` is defined here because nothing
+//! else in the tree defines it. A namespace that exists in `build_schema` and
+//! not in [`NAMESPACES`] would be silently dropped from every published stele,
+//! so `namespace_coverage_matches_build_schema` in `tests/coverage.rs` makes
+//! that a build failure instead.
+
+use dolos_cardano::model::{
+    AccountState, AssetState, DRepState, DatumState, EpochState, EraSummary, FixedNamespace,
+    LeaderRewardLog, MemberRewardLog, PendingMirState, PendingRewardState, PoolDepositRefundLog,
+    PoolState, ProposalState, StakeLog,
+};
+use dolos_core::Namespace;
+
+use crate::Error;
+
+/// The UTxO set as a state namespace.
+///
+/// The one namespace with no entity type behind it, so the one string this
+/// crate owns outright. Its key is `tx_hash(32) ‖ output_index(4, BE)` and its
+/// value is CBOR `[era, body]` — see [`crate::layers::state`].
+pub const UTXOS: Namespace = "utxos";
+
+/// Every state namespace, in ascending byte order.
+///
+/// Sorted because a state layer's records are ordered by `(ns, key)` and the
+/// coverage test compares this list against `build_schema()` directly;
+/// `namespaces_are_sorted` keeps it that way.
+pub const NAMESPACES: [Namespace; 15] = [
+    AccountState::NS,
+    AssetState::NS,
+    DatumState::NS,
+    DRepState::NS,
+    EpochState::NS,
+    EraSummary::NS,
+    LeaderRewardLog::NS,
+    MemberRewardLog::NS,
+    PendingMirState::NS,
+    PendingRewardState::NS,
+    PoolDepositRefundLog::NS,
+    PoolState::NS,
+    ProposalState::NS,
+    StakeLog::NS,
+    UTXOS,
+];
+
+/// Resolve a namespace read off the wire to the `&'static str` the stores use.
+///
+/// Fails closed. A namespace this profile does not define cannot be restored —
+/// no store has a table for it — so decoding it into an owned string and hoping
+/// a later stage notices would only move the failure somewhere less
+/// informative.
+pub fn resolve(name: &str) -> Result<Namespace, Error> {
+    NAMESPACES
+        .into_iter()
+        .find(|known| *known == name)
+        .ok_or_else(|| Error::UnknownNamespace(name.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespaces_are_sorted_and_distinct() {
+        let mut sorted = NAMESPACES;
+        sorted.sort_unstable();
+
+        assert_eq!(NAMESPACES, sorted, "NAMESPACES must be in byte order");
+
+        let mut deduped = sorted.to_vec();
+        deduped.dedup();
+        assert_eq!(deduped.len(), NAMESPACES.len(), "duplicate namespace");
+    }
+
+    #[test]
+    fn resolve_round_trips_every_namespace_and_refuses_the_rest() {
+        for ns in NAMESPACES {
+            assert_eq!(resolve(ns).unwrap(), ns);
+        }
+
+        for unknown in ["", "utxo", "Accounts", "blocks", "metadata"] {
+            let err = resolve(unknown).unwrap_err();
+            assert!(matches!(err, Error::UnknownNamespace(_)), "{unknown:?}");
+        }
+    }
+}

--- a/crates/snapshot/tests/common/mod.rs
+++ b/crates/snapshot/tests/common/mod.rs
@@ -1,0 +1,340 @@
+//! One small, hand-pinned Dolos stele, shared by the roundtrip and golden
+//! tests.
+//!
+//! Every value here is a literal. Nothing is drawn from `dolos-testing`'s
+//! seeder, and nothing is derived from a store: a golden digest whose input can
+//! move when an unrelated fixture is edited is not a golden, and the drift it
+//! was there to catch would be re-pinned as a matter of routine.
+//!
+//! The records are synthetic — synthetic block bodies, synthetic hashes,
+//! synthetic key hashes. That is deliberate and sufficient: this crate's job is
+//! the *shape* of a record, and no part of it interprets a block, a hash or a
+//! stored key. What the fixture does have to be is *complete*, because the
+//! golden digests are what freeze the vocabulary: every archive dimension,
+//! every exact-record kind, every state namespace and every log namespace
+//! appears at least once.
+
+// Each integration test binary compiles this module in full, so the parts one
+// binary does not reach look dead to it. They are not.
+#![allow(dead_code)]
+
+use dolos_cardano::{
+    indexes::archive_dimensions,
+    model::{
+        EpochState, FixedNamespace, LeaderRewardLog, MemberRewardLog, PoolDepositRefundLog,
+        StakeLog,
+    },
+};
+use dolos_core::{
+    key_hash, BlockHash, EntityKey, EraCbor, ExactKind, ExactRecord, IndexRecord, LogKey,
+    TagRecord, TxoRef, VERBATIM_KEY_DIMENSION,
+};
+use dolos_snapshot::{
+    layers::{
+        blocks::BlockRecord,
+        digests::ImmutableDigests,
+        logs::{LogRecord, LOG_KEY_LEN},
+        state::{self, StateRecord, ENTITY_KEY_LEN},
+    },
+    DigestsScope, DolosProfile, EpochScope, Error, Network, Scope, StateScope, BLOCKS, DIGESTS,
+    INDEXES, LOGS, NAMESPACES, STATE, UTXOS,
+};
+use stelae::{
+    dir::{BlobIndex, SteleDir, WrittenLayer},
+    frame::{CanonicalCbor, LayerHeader, Limits},
+    inscription::LayerDescriptor,
+    Digest, Profile,
+};
+
+pub const NETWORK_MAGIC: u64 = 764824073;
+pub const NETWORK_NAME: &str = "mainnet";
+
+/// The stele's sequence, which for this profile is the epoch.
+pub const EPOCH: u64 = 7;
+pub const START_SLOT: u64 = 100;
+pub const END_SLOT: u64 = 101;
+pub const LAST_IMMUTABLE: u64 = 3;
+
+/// The boundary block this stele stands at.
+pub const POINT_HASH: [u8; 32] = [0x0b; 32];
+
+/// A transaction-metadata label, carried verbatim rather than hashed.
+pub const METADATA_LABEL: u64 = 674;
+
+/// The two state shards the fixture populates. Sixteen exist; a fixture that
+/// wrote all of them would say nothing more than two do about the split.
+pub const SHARDS: [u8; 2] = [0, 1];
+
+pub fn network() -> Network {
+    Network::new(NETWORK_MAGIC, NETWORK_NAME)
+}
+
+pub fn epoch_scope() -> EpochScope {
+    EpochScope {
+        network_magic: NETWORK_MAGIC,
+        epoch: EPOCH,
+        start_slot: START_SLOT,
+        end_slot: END_SLOT,
+    }
+}
+
+pub fn state_scope(shard: u8) -> StateScope {
+    StateScope {
+        network_magic: NETWORK_MAGIC,
+        epoch: EPOCH,
+        shard,
+    }
+}
+
+pub fn digests_scope() -> DigestsScope {
+    DigestsScope {
+        network_magic: NETWORK_MAGIC,
+        epoch: EPOCH,
+        last_immutable: LAST_IMMUTABLE,
+    }
+}
+
+/// Three blocks, two of which share a slot — the Byron end-of-epoch boundary
+/// case, whose order no comparator recovers.
+pub fn blocks() -> Vec<BlockRecord> {
+    vec![
+        BlockRecord::new(
+            START_SLOT,
+            BlockHash::new([0x41; 32]),
+            vec![0x82, 0x00, 0x00],
+        ),
+        BlockRecord::new(
+            START_SLOT,
+            BlockHash::new([0x42; 32]),
+            vec![0x82, 0x00, 0x01],
+        ),
+        BlockRecord::new(END_SLOT, BlockHash::new([0x43; 32]), vec![0x82, 0x01, 0x00]),
+    ]
+}
+
+/// One tag record per archive dimension, then one exact record per kind.
+///
+/// The tag run is sorted by dimension name, which is not the order the registry
+/// declares them in — the layer's order is the contract, the registry's is
+/// documentation.
+pub fn indexes() -> Vec<IndexRecord> {
+    let mut dimensions = archive_dimensions::ALL;
+    dimensions.sort_unstable();
+
+    let mut records: Vec<IndexRecord> = dimensions
+        .into_iter()
+        .enumerate()
+        .map(|(i, dimension)| {
+            let stored = if dimension == VERBATIM_KEY_DIMENSION {
+                // The exception, and the only place the fixture derives a stored
+                // key rather than pinning one: the point of this record is that
+                // the label survives untouched.
+                key_hash(dimension, &METADATA_LABEL.to_be_bytes()).unwrap()
+            } else {
+                [0x10 + i as u8; 8]
+            };
+
+            TagRecord::new(dimension, stored, START_SLOT).into()
+        })
+        .collect();
+
+    records.extend([
+        IndexRecord::Exact(
+            ExactRecord::new(ExactKind::BlockHash, &[0x21; 32], START_SLOT).unwrap(),
+        ),
+        IndexRecord::Exact(
+            ExactRecord::new(ExactKind::BlockNumber, &4242u64.to_be_bytes(), END_SLOT).unwrap(),
+        ),
+        IndexRecord::Exact(ExactRecord::new(ExactKind::TxHash, &[0x23; 32], END_SLOT).unwrap()),
+    ]);
+
+    records
+}
+
+/// One log per namespace the ledger actually writes logs under.
+pub fn logs() -> Vec<LogRecord> {
+    [
+        EpochState::NS,
+        LeaderRewardLog::NS,
+        MemberRewardLog::NS,
+        PoolDepositRefundLog::NS,
+        StakeLog::NS,
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(i, ns)| LogRecord::new(ns, log_key(START_SLOT, 0x30 + i as u8), vec![0x81, i as u8]))
+    .collect()
+}
+
+/// One record per state namespace, in the requested shard.
+///
+/// Every namespace appears in every shard, which no real stele would do — real
+/// keys are hash-derived and land where they land. It is what makes the golden
+/// freeze all fifteen namespace strings twice over.
+pub fn state(shard: u8) -> Vec<StateRecord> {
+    NAMESPACES
+        .into_iter()
+        .enumerate()
+        .map(|(i, ns)| {
+            let byte = (shard << 4) | (i as u8 & 0x0f);
+
+            if ns == UTXOS {
+                state::utxo(
+                    &TxoRef([byte; ENTITY_KEY_LEN].into(), 3),
+                    &EraCbor(6, vec![0xa0, byte]),
+                )
+                .unwrap()
+            } else {
+                state::entity(
+                    ns,
+                    &EntityKey::from(&[byte; ENTITY_KEY_LEN]),
+                    &vec![byte, 0xff],
+                )
+                .unwrap()
+            }
+        })
+        .collect()
+}
+
+pub fn digests() -> Vec<ImmutableDigests> {
+    (0..2u64)
+        .map(|n| ImmutableDigests {
+            immutable_number: n,
+            chunk: Digest::from_bytes([0x50 | n as u8; 32]),
+            primary: Digest::from_bytes([0x60 | n as u8; 32]),
+            secondary: Digest::from_bytes([0x70 | n as u8; 32]),
+        })
+        .collect()
+}
+
+pub fn log_key(slot: u64, entity: u8) -> LogKey {
+    let mut raw = [0u8; LOG_KEY_LEN];
+    raw[..8].copy_from_slice(&slot.to_be_bytes());
+    raw[8..].fill(entity);
+
+    LogKey::from(raw.as_slice())
+}
+
+pub fn encode_all<T>(
+    records: &[T],
+    encode: impl Fn(&T) -> Result<CanonicalCbor, Error>,
+) -> Vec<CanonicalCbor> {
+    records.iter().map(|r| encode(r).unwrap()).collect()
+}
+
+/// The uncompressed byte string of a layer: its header record, then its
+/// content.
+///
+/// This is exactly what a `diffId` covers, so a golden computed from it is the
+/// same number `SteleDir::write_layer` puts in a descriptor —
+/// `descriptors_match_the_per_kind_goldens` holds the two against each other.
+pub fn sequence(kind: &str, scope: &dyn Scope, records: &[CanonicalCbor]) -> Vec<u8> {
+    let header = LayerHeader::new(DolosProfile.name(), kind, scope.header().unwrap())
+        .encode()
+        .unwrap();
+
+    let mut bytes = header.into_bytes();
+
+    for record in records {
+        bytes.extend_from_slice(record.as_bytes());
+    }
+
+    bytes
+}
+
+pub fn write_layer(
+    stele: &SteleDir,
+    kind: &str,
+    scope: &dyn Scope,
+    records: &[CanonicalCbor],
+) -> WrittenLayer {
+    stele
+        .write_layer(
+            &DolosProfile,
+            &scope.layer_spec(kind).unwrap(),
+            dolos_snapshot::COMPRESSION_LEVEL,
+            records,
+        )
+        .unwrap()
+}
+
+/// The fixture's five kinds, encoded, in inscription order.
+///
+/// `state` appears twice — one layer per populated shard — which is the normal
+/// case for this profile rather than an edge one.
+pub fn all_layers() -> Vec<(&'static str, Box<dyn Scope>, Vec<CanonicalCbor>)> {
+    use dolos_snapshot::layers::{
+        blocks, digests as digests_layer, indexes as indexes_layer, logs,
+    };
+
+    let mut layers: Vec<(&'static str, Box<dyn Scope>, Vec<CanonicalCbor>)> = vec![
+        (
+            BLOCKS,
+            Box::new(epoch_scope()),
+            encode_all(&self::blocks(), blocks::encode),
+        ),
+        (
+            INDEXES,
+            Box::new(epoch_scope()),
+            encode_all(&self::indexes(), indexes_layer::encode),
+        ),
+        (
+            LOGS,
+            Box::new(epoch_scope()),
+            encode_all(&self::logs(), logs::encode),
+        ),
+    ];
+
+    for shard in SHARDS {
+        layers.push((
+            STATE,
+            Box::new(state_scope(shard)),
+            encode_all(&state(shard), state::encode),
+        ));
+    }
+
+    layers.push((
+        DIGESTS,
+        Box::new(digests_scope()),
+        encode_all(&self::digests(), digests_layer::encode),
+    ));
+
+    layers
+}
+
+/// Read a layer both ways and insist the two paths agree.
+///
+/// The same discipline `crates/stelae/tests/toy_profile.rs` applies to the toy
+/// profile: a layer that reads back through one path and not the other is a
+/// determinism bug in the format, and this profile is the first real one to put
+/// that to the test.
+pub fn read_both_ways(
+    stele: &SteleDir,
+    index: &BlobIndex,
+    descriptor: &LayerDescriptor,
+) -> Vec<Vec<u8>> {
+    let buffered = stele.read_layer(index, &DolosProfile, descriptor).unwrap();
+
+    // A window far below one record, so the refill path is exercised rather
+    // than swallowing the layer in a single read.
+    let limits = Limits {
+        window: 8,
+        ..Limits::default()
+    };
+
+    let mut reader = stele
+        .stream_layer(index, &DolosProfile, descriptor, limits)
+        .unwrap();
+
+    let mut streamed = Vec::new();
+    while let Some(record) = reader.next_record() {
+        streamed.push(record.unwrap().to_vec());
+    }
+
+    assert_eq!(&reader.finish().unwrap(), buffered.digests(), "digests");
+
+    let held: Vec<Vec<u8>> = buffered.records().map(|r| r.unwrap().to_vec()).collect();
+    assert_eq!(held, streamed, "records, layer {:?}", descriptor.kind);
+
+    streamed
+}

--- a/crates/snapshot/tests/coverage.rs
+++ b/crates/snapshot/tests/coverage.rs
@@ -1,0 +1,156 @@
+//! Done criterion 4: the vocabulary this profile ships is the vocabulary the
+//! rest of the workspace has.
+//!
+//! Three closed sets feed the format — the archive dimensions, the exact-record
+//! kinds and the state namespaces — and all three are defined elsewhere. Adding
+//! to any of them is a routine change in `dolos-core` or `dolos-cardano` that
+//! has nothing to do with snapshots, and the failure mode is silent: a new
+//! dimension is simply never exported, or a new namespace is exported but never
+//! frozen by a golden, and the first anyone hears of it is a restored node
+//! missing data.
+//!
+//! So the sets are checked in both directions, and the *fixture* is checked
+//! against them too: a golden digest only freezes what its input contains, and
+//! an addition upstream has to break a test here rather than quietly widen what
+//! a stele may hold.
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use common::*;
+use dolos_cardano::{indexes::archive_dimensions, model::build_schema};
+use dolos_core::{ExactKind, IndexRecord, Namespace};
+use dolos_snapshot::{layers::indexes, namespaces, NAMESPACES, UTXOS};
+
+/// The state namespaces this profile carries are exactly `build_schema`'s, plus
+/// the UTxO set.
+#[test]
+fn namespace_registry_matches_build_schema() {
+    let schema: BTreeSet<Namespace> = build_schema().keys().copied().collect();
+    let registry: BTreeSet<Namespace> = NAMESPACES.into_iter().collect();
+
+    assert!(
+        registry.contains(UTXOS),
+        "the utxo set is a state namespace"
+    );
+
+    let entities: BTreeSet<Namespace> =
+        registry.iter().copied().filter(|ns| *ns != UTXOS).collect();
+
+    assert_eq!(
+        entities, schema,
+        "the profile's state namespaces have drifted from build_schema()"
+    );
+
+    // ADR-004 says fourteen entity namespaces plus `utxos`. If that count moves,
+    // the sentence in the ADR moves with it.
+    assert_eq!(entities.len(), 14);
+    assert_eq!(NAMESPACES.len(), 15);
+}
+
+#[test]
+fn every_namespace_resolves_and_nothing_else_does() {
+    for ns in NAMESPACES {
+        assert_eq!(namespaces::resolve(ns).unwrap(), ns);
+    }
+
+    for absent in ["utxo", "accounts ", "UTXOS", "", "blocks", "wal"] {
+        assert!(namespaces::resolve(absent).is_err(), "{absent:?}");
+    }
+}
+
+#[test]
+fn every_dimension_resolves_and_nothing_else_does() {
+    for dimension in archive_dimensions::ALL {
+        assert_eq!(indexes::resolve_dimension(dimension).unwrap(), dimension);
+    }
+
+    // The UTxO filter dimensions are live-state indexes, rebuilt at restore from
+    // the UTxO set rather than shipped — so they are deliberately not archive
+    // dimensions, and `spent_txo` is the archive one whose name is nearest.
+    for absent in ["utxo::address", "spent-txo", "", "Address"] {
+        assert!(indexes::resolve_dimension(absent).is_err(), "{absent:?}");
+    }
+}
+
+#[test]
+fn every_exact_kind_resolves_and_nothing_else_does() {
+    for kind in ExactKind::ALL {
+        assert_eq!(indexes::resolve_exact_kind(kind.as_str()).unwrap(), kind);
+    }
+
+    for absent in ["block_number", "tx", "", "BlockHash"] {
+        assert!(indexes::resolve_exact_kind(absent).is_err(), "{absent:?}");
+    }
+}
+
+/// Every archive dimension appears in the golden `indexes` layer, so every
+/// dimension name is a string some published digest depends on.
+#[test]
+fn the_golden_indexes_layer_covers_every_dimension_and_kind() {
+    let records = common::indexes();
+
+    let dimensions: BTreeSet<String> = records
+        .iter()
+        .filter_map(|record| match record {
+            IndexRecord::Tag(tag) => Some(tag.dimension().to_owned()),
+            IndexRecord::Exact(_) => None,
+        })
+        .collect();
+
+    let expected: BTreeSet<String> = archive_dimensions::ALL
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+
+    assert_eq!(
+        dimensions, expected,
+        "the golden indexes layer no longer freezes every dimension name"
+    );
+
+    let kinds: BTreeSet<ExactKind> = records
+        .iter()
+        .filter_map(|record| match record {
+            IndexRecord::Exact(exact) => Some(exact.kind),
+            IndexRecord::Tag(_) => None,
+        })
+        .collect();
+
+    assert_eq!(
+        kinds,
+        ExactKind::ALL.into_iter().collect::<BTreeSet<_>>(),
+        "the golden indexes layer no longer freezes every exact-record kind"
+    );
+}
+
+/// Every state namespace appears in the golden `state` layers.
+#[test]
+fn the_golden_state_layers_cover_every_namespace() {
+    let expected: BTreeSet<Namespace> = NAMESPACES.into_iter().collect();
+
+    for shard in SHARDS {
+        let present: BTreeSet<Namespace> = common::state(shard)
+            .iter()
+            .map(|record| record.ns)
+            .collect();
+
+        assert_eq!(
+            present, expected,
+            "shard {shard}: the golden state layer no longer freezes every namespace"
+        );
+    }
+}
+
+/// The `logs` layer draws from the same namespace registry, so a log written
+/// under a namespace no state layer knows would be refused rather than shipped.
+#[test]
+fn the_golden_logs_layer_draws_from_the_namespace_registry() {
+    let registry: BTreeSet<Namespace> = NAMESPACES.into_iter().collect();
+
+    let present: BTreeSet<Namespace> = common::logs().iter().map(|record| record.ns).collect();
+
+    assert!(present.is_subset(&registry));
+    assert!(!present.is_empty());
+    assert!(!present.contains(UTXOS), "the utxo set is not a log");
+}

--- a/crates/snapshot/tests/coverage.rs
+++ b/crates/snapshot/tests/coverage.rs
@@ -109,6 +109,10 @@ fn the_golden_indexes_layer_covers_every_dimension_and_kind() {
         "the golden indexes layer no longer freezes every dimension name"
     );
 
+    // Twelve, as the module documentation of `tests/goldens.rs` states. Pinned
+    // here so that prose cannot go stale while every other test still passes.
+    assert_eq!(expected.len(), 12);
+
     let kinds: BTreeSet<ExactKind> = records
         .iter()
         .filter_map(|record| match record {

--- a/crates/snapshot/tests/goldens.rs
+++ b/crates/snapshot/tests/goldens.rs
@@ -126,8 +126,19 @@ fn write_stele(root: &std::path::Path) -> (Inscription, Digest) {
 /// without a directory in the way.
 #[test]
 fn per_kind_diff_ids_are_pinned() {
+    let layers = all_layers();
+
+    // Before the zip, not after: `zip` stops at the shorter side, so a dropped
+    // layer would quietly shorten the loop rather than fail it — in the one test
+    // whose whole job is to notice a layer changing.
+    assert_eq!(
+        layers.len(),
+        GOLDEN_LAYERS.len(),
+        "the stele no longer has the layers the goldens pin"
+    );
+
     for ((kind, scope, records), (expected_kind, diff_id, count, size)) in
-        all_layers().into_iter().zip(GOLDEN_LAYERS)
+        layers.into_iter().zip(GOLDEN_LAYERS)
     {
         assert_eq!(kind, expected_kind);
 
@@ -226,6 +237,12 @@ fn a_complete_stele_reads_back_and_reproduces_its_digest() {
 fn descriptors_match_the_per_kind_goldens() {
     let temp = tempfile::tempdir().unwrap();
     let (inscription, _) = write_stele(temp.path());
+
+    assert_eq!(
+        inscription.layers.len(),
+        GOLDEN_LAYERS.len(),
+        "the stele no longer has the layers the goldens pin"
+    );
 
     for (descriptor, (kind, diff_id, records, size)) in inscription.layers.iter().zip(GOLDEN_LAYERS)
     {

--- a/crates/snapshot/tests/goldens.rs
+++ b/crates/snapshot/tests/goldens.rs
@@ -1,0 +1,311 @@
+//! Done criterion 3: the golden digests.
+//!
+//! Every value pinned here is a sha256 over bytes this profile and ADR-004
+//! together fully determine — the deterministic CBOR sequence of each layer,
+//! and the RFC 8785 canonical JSON of the inscription. Nothing platform-,
+//! timing- or compression-dependent enters them, so they hold across machines
+//! and across zstd versions.
+//!
+//! That makes this file the drift alarm for the whole profile. These digests
+//! *are* published identity: a change to a record shape, a scope key spelling,
+//! a media type, a namespace string or an exact-kind literal moves one, and
+//! moving one silently is precisely the failure Stelae exists to prevent. A
+//! deliberate format change updates these in the same commit that changes the
+//! ADR. An accidental one shows up here first — and a value that disagrees with
+//! a re-run on unchanged code is encoding nondeterminism, which is a finding,
+//! never a re-pin.
+//!
+//! Between them these freeze: the five media types, the tag string, the twelve
+//! archive dimension names, the three exact-record kind literals, the fifteen
+//! state namespace strings, the five log namespace strings, the layer header
+//! and scope shapes, and the `position`/`parameters` key spellings.
+
+mod common;
+
+use common::*;
+use dolos_core::{BlockHash, ChainPoint};
+use dolos_snapshot::{
+    layers::{blocks, digests, indexes, logs, state},
+    DolosProfile, BLOCKS, DIGESTS, INDEXES, LOGS, STATE,
+};
+use stelae::{
+    dir::SteleDir,
+    frame::Limits,
+    inscription::{HistoryEntry, Inscription},
+    Digest,
+};
+
+/// `(kind, diffId, records, uncompressedSize)`, in inscription order.
+///
+/// `records` counts the protocol's header record, as a descriptor does.
+const GOLDEN_LAYERS: [(&str, &str, u64, u64); 6] = [
+    (
+        BLOCKS,
+        "sha256:14a05418723da3c0b4117b5f30ef07d96887b3e12eae114988ff299a654ff106",
+        4,
+        167,
+    ),
+    (
+        INDEXES,
+        "sha256:557948cad9dec8605fbde96912db9b6421b47f2ded4c00886ed59f1638b4678c",
+        16,
+        431,
+    ),
+    (
+        LOGS,
+        "sha256:bbe98e028f2842eafdf570035ec3b27b9f6c8f465e827da31339217ed184d042",
+        6,
+        337,
+    ),
+    (
+        STATE,
+        "sha256:24782c03c7d1e11045425cedad200a2759991f767869f409e05cefaf6743d816",
+        16,
+        767,
+    ),
+    (
+        STATE,
+        "sha256:f9e9f22a50f267cda7a0c31d879a8bae9e77fddc335dbb4ae8ca4d24be7c52ea",
+        16,
+        767,
+    ),
+    (
+        DIGESTS,
+        "sha256:13f9bbdf676ac47ad7238a52fa525f4413a88335c23d2d567c888abd8dedec80",
+        3,
+        250,
+    ),
+];
+
+/// The stele's identity: sha256 of the canonical inscription.
+const GOLDEN_INSCRIPTION: &str =
+    "sha256:811c29403a58a0984fc8e576feedbf24c79120733bbc95c9731f255fd6322d9e";
+
+fn history() -> Vec<HistoryEntry> {
+    vec![
+        HistoryEntry {
+            sequence: EPOCH - 2,
+            inscription_digest: Digest::from_bytes([0x55; 32]),
+        },
+        HistoryEntry {
+            sequence: EPOCH - 1,
+            inscription_digest: Digest::from_bytes([0x66; 32]),
+        },
+    ]
+}
+
+/// Write the whole fixture stele into `root`: six layers and an inscription.
+fn write_stele(root: &std::path::Path) -> (Inscription, Digest) {
+    let stele = SteleDir::create(root).unwrap();
+
+    let point = ChainPoint::Specific(END_SLOT, BlockHash::new(POINT_HASH));
+
+    let mut inscription = Inscription::new(
+        &DolosProfile,
+        EPOCH,
+        dolos_snapshot::position(&network(), &point, EPOCH).unwrap(),
+        dolos_snapshot::parameters(),
+        dolos_snapshot::compression(),
+    );
+
+    inscription.history = history();
+
+    inscription.layers = all_layers()
+        .into_iter()
+        .map(|(kind, scope, records)| {
+            write_layer(&stele, kind, scope.as_ref(), &records).descriptor
+        })
+        .collect();
+
+    let digest = stele.write_inscription(&inscription).unwrap();
+
+    (inscription, digest)
+}
+
+/// Each layer's identity, computed from the byte string a `diffId` covers,
+/// without a directory in the way.
+#[test]
+fn per_kind_diff_ids_are_pinned() {
+    for ((kind, scope, records), (expected_kind, diff_id, count, size)) in
+        all_layers().into_iter().zip(GOLDEN_LAYERS)
+    {
+        assert_eq!(kind, expected_kind);
+
+        let bytes = sequence(kind, scope.as_ref(), &records);
+
+        assert_eq!(
+            Digest::compute(&bytes).to_string(),
+            diff_id,
+            "{kind}: diffId drifted"
+        );
+        assert_eq!(records.len() as u64 + 1, count, "{kind}: record count");
+        assert_eq!(bytes.len() as u64, size, "{kind}: uncompressed size");
+    }
+}
+
+/// The whole stele: written, read back through the streaming reader under the
+/// default limits, and reproduced byte for byte by a second, independent write.
+#[test]
+fn a_complete_stele_reads_back_and_reproduces_its_digest() {
+    let first = tempfile::tempdir().unwrap();
+    let (inscription, digest) = write_stele(first.path());
+
+    assert_eq!(
+        digest.to_string(),
+        GOLDEN_INSCRIPTION,
+        "inscription digest drifted"
+    );
+
+    // The document survives the trip to disk in canonical form, and belongs to
+    // this profile.
+    let stele = SteleDir::open(first.path()).unwrap();
+    let read = stele.read_inscription().unwrap();
+
+    assert_eq!(read, inscription);
+    assert_eq!(read.digest().unwrap(), digest);
+    read.check_profile(&DolosProfile).unwrap();
+
+    // Every layer streams back under the *default* record ceiling — the
+    // confirmation `crates/stelae`'s streaming reader was left waiting for from
+    // its first real profile.
+    let index = stele.blob_index().unwrap();
+    assert_eq!(index.len(), GOLDEN_LAYERS.len());
+
+    for descriptor in &read.layers {
+        let mut reader = stele
+            .stream_layer(&index, &DolosProfile, descriptor, Limits::default())
+            .unwrap();
+
+        assert_eq!(reader.header().profile, dolos_snapshot::PROFILE_NAME);
+        assert_eq!(reader.header().kind, descriptor.kind);
+
+        let mut records = 1u64;
+        while let Some(record) = reader.next_record() {
+            let record = record.unwrap();
+
+            // Decoded, not merely counted: a record that frames cleanly and
+            // does not decode is a layer this profile cannot restore.
+            decode_one(&descriptor.kind, record);
+            records += 1;
+        }
+
+        // Only now is the layer proven; everything above was read on the
+        // strength of the descriptor.
+        let digests = reader.finish().unwrap();
+
+        assert_eq!(digests.diff_id, descriptor.diff_id, "{}", descriptor.kind);
+        assert_eq!(records, descriptor.records, "{}", descriptor.kind);
+    }
+
+    // Written twice, independently: same document, same bytes, same blobs. This
+    // is the property the whole protocol rests on, now under a real profile.
+    let second = tempfile::tempdir().unwrap();
+    let (again, again_digest) = write_stele(second.path());
+
+    assert_eq!(again, inscription);
+    assert_eq!(again_digest, digest);
+    assert_eq!(
+        std::fs::read(first.path().join("inscription.json")).unwrap(),
+        std::fs::read(second.path().join("inscription.json")).unwrap(),
+    );
+
+    let second_index = SteleDir::open(second.path()).unwrap().blob_index().unwrap();
+    for descriptor in &inscription.layers {
+        assert_eq!(
+            index.blob_for(&descriptor.diff_id),
+            second_index.blob_for(&descriptor.diff_id),
+            "layer {:?}",
+            descriptor.kind,
+        );
+    }
+}
+
+/// The descriptors a `SteleDir` writes are the numbers the per-kind goldens
+/// pin — so the two tests cannot drift apart and quietly agree with themselves.
+#[test]
+fn descriptors_match_the_per_kind_goldens() {
+    let temp = tempfile::tempdir().unwrap();
+    let (inscription, _) = write_stele(temp.path());
+
+    for (descriptor, (kind, diff_id, records, size)) in inscription.layers.iter().zip(GOLDEN_LAYERS)
+    {
+        assert_eq!(descriptor.kind, kind);
+        assert_eq!(descriptor.diff_id.to_string(), diff_id);
+        assert_eq!(descriptor.records, records);
+        assert_eq!(descriptor.uncompressed_size, size);
+    }
+}
+
+/// The canonical document itself, so a change to a key spelling, a media type
+/// or an ordering shows up in the diff as text rather than only as a moved
+/// hash.
+#[test]
+fn the_canonical_inscription_is_pinned() {
+    let temp = tempfile::tempdir().unwrap();
+    let (inscription, _) = write_stele(temp.path());
+
+    let canonical = String::from_utf8(inscription.canonicalize().unwrap()).unwrap();
+
+    assert_eq!(canonical, CANONICAL_INSCRIPTION);
+
+    // The vendor slot is ours and the protocol's reserved one is nowhere near a
+    // payload type.
+    assert!(canonical.contains("application/vnd.dolos.stele.blocks.v1+zstd"));
+    assert!(!canonical.contains("vnd.stelae.stele"));
+}
+
+/// The whole document, so the diff of a format change is readable.
+///
+/// JCS sorts object keys, so the layout below is the protocol's, not this
+/// crate's — but every *string* in it is this profile's, and that is what the
+/// literal is for.
+const CANONICAL_INSCRIPTION: &str = concat!(
+    r#"{"compression":{"algo":"zstd","level":9},"#,
+    r#""history":[{"inscriptionDigest":"sha256:5555555555555555555555555555555555555555555555555555555555555555","sequence":5},"#,
+    r#"{"inscriptionDigest":"sha256:6666666666666666666666666666666666666666666666666666666666666666","sequence":6}],"#,
+    r#""layers":[{"diffId":"sha256:14a05418723da3c0b4117b5f30ef07d96887b3e12eae114988ff299a654ff106","kind":"blocks","#,
+    r#""mediaType":"application/vnd.dolos.stele.blocks.v1+zstd","records":4,"#,
+    r#""scope":{"endSlot":101,"epoch":7,"startSlot":100},"uncompressedSize":167},"#,
+    r#"{"diffId":"sha256:557948cad9dec8605fbde96912db9b6421b47f2ded4c00886ed59f1638b4678c","kind":"indexes","#,
+    r#""mediaType":"application/vnd.dolos.stele.indexes.v1+zstd","records":16,"#,
+    r#""scope":{"endSlot":101,"epoch":7,"startSlot":100},"uncompressedSize":431},"#,
+    r#"{"diffId":"sha256:bbe98e028f2842eafdf570035ec3b27b9f6c8f465e827da31339217ed184d042","kind":"logs","#,
+    r#""mediaType":"application/vnd.dolos.stele.logs.v1+zstd","records":6,"#,
+    r#""scope":{"endSlot":101,"epoch":7,"startSlot":100},"uncompressedSize":337},"#,
+    r#"{"diffId":"sha256:24782c03c7d1e11045425cedad200a2759991f767869f409e05cefaf6743d816","kind":"state","#,
+    r#""mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":16,"#,
+    r#""scope":{"shard":0},"uncompressedSize":767},"#,
+    r#"{"diffId":"sha256:f9e9f22a50f267cda7a0c31d879a8bae9e77fddc335dbb4ae8ca4d24be7c52ea","kind":"state","#,
+    r#""mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":16,"#,
+    r#""scope":{"shard":1},"uncompressedSize":767},"#,
+    r#"{"diffId":"sha256:13f9bbdf676ac47ad7238a52fa525f4413a88335c23d2d567c888abd8dedec80","kind":"digests","#,
+    r#""mediaType":"application/vnd.dolos.stele.digests.v1+zstd","records":3,"#,
+    r#""scope":{"lastImmutable":3},"uncompressedSize":250}],"#,
+    r#""parameters":{"indexKeyHash":"xxh3-64","stateShards":16},"#,
+    r#""position":{"epoch":7,"network":{"magic":764824073,"name":"mainnet"},"#,
+    r#""point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":101}},"#,
+    r#""profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":7}"#,
+);
+
+/// Decode one record with the codec its layer kind names, so the streaming pass
+/// exercises every codec rather than only the framing underneath them.
+fn decode_one(kind: &str, record: &[u8]) {
+    match kind {
+        BLOCKS => {
+            blocks::decode(record).unwrap();
+        }
+        INDEXES => {
+            indexes::decode(record).unwrap();
+        }
+        LOGS => {
+            logs::decode(record).unwrap();
+        }
+        STATE => {
+            state::decode(record).unwrap();
+        }
+        DIGESTS => {
+            digests::decode(record).unwrap();
+        }
+        other => panic!("no codec for layer kind {other:?}"),
+    }
+}

--- a/crates/snapshot/tests/roundtrip.rs
+++ b/crates/snapshot/tests/roundtrip.rs
@@ -1,0 +1,268 @@
+//! Done criterion 2: every layer kind survives a real write and read.
+//!
+//! Not `encode` against `decode` — that pair can agree with each other and with
+//! nothing else. Each kind goes typed record → encode → **layer written to a
+//! `SteleDir`** → layer read back → decode → compared, through both of the
+//! protocol's read paths. A record only counts as round-tripped once it has
+//! been framed, compressed, digested, decompressed and re-framed.
+
+mod common;
+
+use common::*;
+use dolos_core::{
+    key_hash, ExactKind, ExactRecord, IndexRecord, MAX_EXACT_KEY_LEN, VERBATIM_KEY_DIMENSION,
+};
+use dolos_snapshot::{
+    layers::{blocks, digests, indexes, logs, state},
+    DolosProfile, Error, Scope, BLOCKS, DIGESTS, INDEXES, LOGS, STATE,
+};
+use stelae::{
+    dir::SteleDir,
+    frame::{self, CanonicalCbor},
+    Profile,
+};
+
+/// Write one layer, read it back both ways, and decode what comes out.
+fn roundtrip<T>(
+    kind: &'static str,
+    scope: &dyn Scope,
+    records: &[T],
+    encode: impl Fn(&T) -> Result<CanonicalCbor, Error>,
+    decode: impl Fn(&[u8]) -> Result<T, Error>,
+) -> Vec<T>
+where
+    T: std::fmt::Debug + PartialEq,
+{
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let encoded = encode_all(records, encode);
+    let written = write_layer(&stele, kind, scope, &encoded);
+
+    assert_eq!(written.descriptor.kind, kind);
+    assert_eq!(
+        written.descriptor.records,
+        records.len() as u64 + 1,
+        "{kind}: the header record counts too"
+    );
+
+    let index = stele.blob_index().unwrap();
+    let raw = read_both_ways(&stele, &index, &written.descriptor);
+
+    // The bytes that came back are the bytes that went in, before anything is
+    // decoded — so a decode bug cannot hide a framing bug.
+    let expected: Vec<Vec<u8>> = encoded.iter().map(|r| r.as_bytes().to_vec()).collect();
+    assert_eq!(raw, expected, "{kind}: layer content");
+
+    let decoded: Vec<T> = raw.iter().map(|r| decode(r).unwrap()).collect();
+    assert_eq!(&decoded, records, "{kind}: decoded records");
+
+    decoded
+}
+
+#[test]
+fn blocks_round_trip_through_a_layer() {
+    let records = common::blocks();
+    let decoded = roundtrip(
+        BLOCKS,
+        &epoch_scope(),
+        &records,
+        blocks::encode,
+        blocks::decode,
+    );
+
+    // The Byron case: two blocks at one slot, distinguishable only by the order
+    // they arrived in. A layer that sorted its records would swap or drop one.
+    assert_eq!(decoded[0].slot, decoded[1].slot);
+    assert_ne!(decoded[0].hash, decoded[1].hash);
+    assert_eq!(decoded[0].hash, records[0].hash, "stream order survived");
+    assert_eq!(decoded[1].hash, records[1].hash, "stream order survived");
+
+    let mut order = blocks::OrderCheck::default();
+    for record in &decoded {
+        order.check(record).unwrap();
+    }
+}
+
+#[test]
+fn indexes_round_trip_through_a_layer() {
+    let records = common::indexes();
+    let decoded = roundtrip(
+        INDEXES,
+        &epoch_scope(),
+        &records,
+        indexes::encode,
+        indexes::decode,
+    );
+
+    let mut order = indexes::OrderCheck::default();
+    for record in &decoded {
+        order.check(record).unwrap();
+    }
+
+    // The `metadata` dimension carries its logical u64 label verbatim, never
+    // hashed — the one exception to the pre-hashed rule, and the one a
+    // conformance check has to look at specifically, because a hashed label is
+    // structurally valid and permanently unqueryable.
+    let metadata = decoded
+        .iter()
+        .find_map(|record| match record {
+            IndexRecord::Tag(tag) if tag.dimension() == VERBATIM_KEY_DIMENSION => Some(tag),
+            _ => None,
+        })
+        .expect("the fixture carries a metadata tag");
+
+    assert_eq!(metadata.key_hash.len(), 8);
+    assert_eq!(u64::from_be_bytes(metadata.key_hash), METADATA_LABEL);
+    assert_eq!(
+        metadata.key_hash,
+        key_hash(VERBATIM_KEY_DIMENSION, &METADATA_LABEL.to_be_bytes()).unwrap(),
+        "the stored form is the one dolos-core defines",
+    );
+
+    // A block number is an 8-byte big-endian key, unlike the 32-byte hashes
+    // either side of it — the width the exact-record type validates against.
+    let block_num = decoded
+        .iter()
+        .find_map(|record| match record {
+            IndexRecord::Exact(exact) if exact.kind == ExactKind::BlockNumber => Some(exact),
+            _ => None,
+        })
+        .expect("the fixture carries a block_num record");
+
+    assert_eq!(block_num.key().len(), 8);
+    assert_eq!(
+        u64::from_be_bytes(block_num.key().try_into().unwrap()),
+        4242
+    );
+}
+
+#[test]
+fn logs_round_trip_through_a_layer() {
+    let records = common::logs();
+    let decoded = roundtrip(LOGS, &epoch_scope(), &records, logs::encode, logs::decode);
+
+    let mut order = logs::OrderCheck::default();
+    for record in &decoded {
+        order.check(record).unwrap();
+    }
+}
+
+#[test]
+fn state_round_trips_through_a_layer_per_shard() {
+    for shard in SHARDS {
+        let records = common::state(shard);
+        let decoded = roundtrip(
+            STATE,
+            &state_scope(shard),
+            &records,
+            state::encode,
+            state::decode,
+        );
+
+        let mut order = state::OrderCheck::for_shard(shard);
+        for record in &decoded {
+            order.check(record).unwrap();
+        }
+
+        // The utxo value is the one field this profile composes rather than
+        // carries, so it is the one that has to survive the trip as a value and
+        // not merely as bytes.
+        let utxo = decoded
+            .iter()
+            .find(|record| record.ns == dolos_snapshot::UTXOS)
+            .expect("the fixture carries a utxo record");
+
+        let (txo, value) = state::as_utxo(utxo).unwrap();
+        assert_eq!(txo.1, 3);
+        assert_eq!(value.0, 6);
+    }
+}
+
+#[test]
+fn digests_round_trip_through_a_layer() {
+    let records = common::digests();
+    let decoded = roundtrip(
+        DIGESTS,
+        &digests_scope(),
+        &records,
+        digests::encode,
+        digests::decode,
+    );
+
+    let mut order = digests::OrderCheck::default();
+    for record in &decoded {
+        order.check(record).unwrap();
+    }
+}
+
+/// A key wider than any exact kind's is refused *after* a clean layer read.
+///
+/// The framing layer has no opinion about it — the bytes are canonical CBOR and
+/// the layer's digest is whatever it is — so the refusal has to come from the
+/// codec, and it comes from `ExactRecord::new`, which is where the width rule
+/// already lives. Anything else would be a second validation site free to
+/// disagree with the first.
+#[test]
+fn an_over_wide_exact_key_survives_the_layer_and_is_refused_by_the_codec() {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let forged = frame::encode(|e| {
+        e.array(4)?
+            .u64(indexes::EXACT_DISCRIMINANT)?
+            .str(ExactKind::TxHash.as_str())?
+            .bytes(&[0xcc; MAX_EXACT_KEY_LEN + 1])?
+            .u64(END_SLOT)?;
+        Ok(())
+    })
+    .unwrap();
+
+    let written = write_layer(
+        &stele,
+        INDEXES,
+        &epoch_scope(),
+        std::slice::from_ref(&forged),
+    );
+    let index = stele.blob_index().unwrap();
+    let raw = read_both_ways(&stele, &index, &written.descriptor);
+
+    assert_eq!(raw, vec![forged.as_bytes().to_vec()]);
+
+    let err = indexes::decode(&raw[0]).unwrap_err();
+    assert!(matches!(err, Error::Index(_)), "{err:?}");
+
+    // And the width the type does accept is refused when it is the wrong kind's.
+    assert!(ExactRecord::new(ExactKind::TxHash, &4242u64.to_be_bytes(), 1).is_err());
+}
+
+/// A layer whose header names another profile is refused before a record is
+/// handed out — the fail-closed rule, exercised from this profile's side.
+#[test]
+fn a_layer_of_another_profile_is_refused() {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let written = write_layer(
+        &stele,
+        BLOCKS,
+        &epoch_scope(),
+        &encode_all(&common::blocks(), blocks::encode),
+    );
+
+    let index = stele.blob_index().unwrap();
+
+    let mut foreign = written.descriptor.clone();
+    foreign.kind = DIGESTS.to_owned();
+    foreign.media_type = DolosProfile
+        .layer_media_type(DIGESTS)
+        .expect("a kind this profile defines");
+
+    let err = stele
+        .read_layer(&index, &DolosProfile, &foreign)
+        .unwrap_err();
+    assert!(
+        matches!(err, stelae::Error::LayerMismatch { .. }),
+        "{err:?}"
+    );
+}

--- a/crates/snapshot/tests/roundtrip.rs
+++ b/crates/snapshot/tests/roundtrip.rs
@@ -236,10 +236,14 @@ fn an_over_wide_exact_key_survives_the_layer_and_is_refused_by_the_codec() {
     assert!(ExactRecord::new(ExactKind::TxHash, &4242u64.to_be_bytes(), 1).is_err());
 }
 
-/// A layer whose header names another profile is refused before a record is
-/// handed out — the fail-closed rule, exercised from this profile's side.
+/// A layer read under the wrong kind is refused before a record is handed out.
+///
+/// The blob's header names `blocks`; the descriptor claims `digests`. Both
+/// kinds are this profile's, so what refuses it is the kind check and not the
+/// profile check — `a_layer_of_another_profile_is_refused` covers the other
+/// half.
 #[test]
-fn a_layer_of_another_profile_is_refused() {
+fn a_layer_read_under_the_wrong_kind_is_refused() {
     let temp = tempfile::tempdir().unwrap();
     let stele = SteleDir::create(temp.path()).unwrap();
 
@@ -252,17 +256,89 @@ fn a_layer_of_another_profile_is_refused() {
 
     let index = stele.blob_index().unwrap();
 
-    let mut foreign = written.descriptor.clone();
-    foreign.kind = DIGESTS.to_owned();
-    foreign.media_type = DolosProfile
+    let mut mislabelled = written.descriptor.clone();
+    mislabelled.kind = DIGESTS.to_owned();
+    mislabelled.media_type = DolosProfile
         .layer_media_type(DIGESTS)
         .expect("a kind this profile defines");
 
     let err = stele
-        .read_layer(&index, &DolosProfile, &foreign)
+        .read_layer(&index, &DolosProfile, &mislabelled)
         .unwrap_err();
     assert!(
         matches!(err, stelae::Error::LayerMismatch { .. }),
         "{err:?}"
+    );
+}
+
+/// A layer whose header names another profile is refused before a record is
+/// handed out — the fail-closed rule, exercised from this profile's side.
+///
+/// The awkward case on purpose: a vendor whose records frame identically to
+/// ours, under a kind name we also use. Nothing about the bytes distinguishes
+/// the two layers. Only the profile name in the header record does, which is
+/// why the protocol puts it there.
+#[test]
+fn a_layer_of_another_profile_is_refused() {
+    struct Other;
+
+    impl Profile for Other {
+        fn name(&self) -> &str {
+            "com.acme.receipts"
+        }
+
+        fn version(&self) -> u64 {
+            1
+        }
+
+        fn kinds(&self) -> &[&str] {
+            &[BLOCKS]
+        }
+
+        fn layer_media_type(&self, kind: &str) -> Result<String, stelae::Error> {
+            Ok(format!("application/vnd.acme.stele.{kind}.v1+zstd"))
+        }
+
+        fn tag_for_sequence(&self, sequence: u64) -> Result<String, stelae::Error> {
+            Ok(format!("r-{sequence}"))
+        }
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let scope = epoch_scope();
+    let written = stele
+        .write_layer(
+            &Other,
+            &stelae::dir::LayerSpec::new(BLOCKS, scope.header().unwrap(), scope.descriptor()),
+            dolos_snapshot::COMPRESSION_LEVEL,
+            &encode_all(&common::blocks(), blocks::encode),
+        )
+        .unwrap();
+
+    let index = stele.blob_index().unwrap();
+
+    let buffered = stele
+        .read_layer(&index, &DolosProfile, &written.descriptor)
+        .unwrap_err();
+    assert!(
+        matches!(buffered, stelae::Error::UnknownProfile { .. }),
+        "{buffered:?}"
+    );
+
+    // And on the streaming path, which is the one a restore uses.
+    let streamed = stele
+        .stream_layer(
+            &index,
+            &DolosProfile,
+            &written.descriptor,
+            frame::Limits::default(),
+        )
+        .map(|_| ())
+        .unwrap_err();
+    assert!(
+        matches!(streamed, stelae::Error::UnknownProfile { .. }),
+        "{streamed:?}"
     );
 }


### PR DESCRIPTION
Plan: `plans/dolos-stelae-profile-crate.md` (Trellis domain root, `org/coder`) — the second and last half of Phase 1b of ADR-004. The store seam it reads from is delivered and retired (#1150, #1155–#1165); the protocol crate is complete for this slice (#1147, #1148). This is the crate that says what a Dolos stele *is*.

## What this adds

`crates/snapshot` (package `dolos-snapshot`), a new workspace member. It depends on `stelae`, `dolos-core` and `dolos-cardano`; nothing depends on it yet.

- **`DolosProfile`** — `io.txpipe.dolos.cardano` v1, the five kinds, `application/vnd.dolos.stele.{kind}.v1+zstd`, `tag_for_sequence(E) = epoch-E`, `latest`. Plus the builders the `Profile` trait deliberately has no hook for: `position`, `parameters`, and a scope type per shape (`EpochScope`, `StateScope`, `DigestsScope`) carrying both the CBOR header form and the JSON descriptor form, and refusing a kind it does not describe.
- **Five codecs** in `layers/{blocks,indexes,logs,state,digests}.rs`, implementing ADR-004's record table byte for byte. Each exposes `encode`, `decode` and an `OrderCheck`.
- **The profile semantics that would otherwise be homeless**, so Phase 2's driver does not invent them: shard assignment, the per-kind order validators, the `utxos` namespace literal, and the `[era, body]` utxo value.

## Decisions worth a reviewer's eye

**Ordering is content, so it is validated.** A restore ingests these records append-only into sorted stores. Records arriving out of order do not fail loudly — they land in a store whose own queries then miss them. Every kind therefore ships a streaming `OrderCheck`, and `blocks`'s is deliberately weaker than a sort: Byron end-of-epoch boundary blocks share a slot with the block after them and are distinguishable only by arrival order, so the rule is a property of a sequence and no comparator expresses it.

**`indexes` carries tags then exact records.** ADR-004 gives the layer two record shapes with a leading discriminant (`0` tags, `1` exact) and two separate orders. Tags first, then exact, is the only reading consistent with both the discriminant and the two source iterators (`iter_archive_tags`, then `iter_exact_records`), and `OrderCheck` enforces it. Exact records dedupe on `(kind, key)` and not on the slot behind it — a block hash names one slot, so two records sharing a key are a contradiction, not a pair.

**Vocabulary has exactly one definition.** Dimension names come from `dolos_cardano`'s archive registry, exact-kind names from `ExactKind::as_str`/`FromStr`, state namespaces from the entity types' own `FixedNamespace::NS`. Nothing in this crate hashes a key, so the `metadata` verbatim-label exception needs no special case at all — `grep '"metadata"' crates/snapshot` finds nothing, and `dolos_core::key_hash` stays the only place in the tree that decides it. Exact-key widths are validated by `ExactRecord::new` and its refusal surfaced, rather than re-checked here where a second site could disagree.

**One field is built rather than carried.** Entity and log values are the stored minicbor, verbatim. The `utxos` value is not — the state store holds an `EraCbor`, a Rust value — so the codec composes `[era, body]` through `frame::encode`, the same validator every record goes through, making the profile's one transformed field canonical by construction.

## Done criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Workspace member; `DolosProfile` passes `checked_layer_media_type` and `checked_tag_for_sequence` for all five kinds | met — `every_kind_passes_the_protocols_naming_rules` |
| 2 | Per-layer roundtrips through a real layer write/read, incl. `metadata`, an 8-byte `block_num` key, a `MAX_EXACT_KEY_LEN` refusal, and a same-slot blocks pair | met — `tests/roundtrip.rs` (7 tests) |
| 3 | Golden diffIds per kind; one complete stele read back through `stream_layer` under default `Limits` with `finish()` per layer; inscription digest golden, reproduced by a second write | met — `tests/goldens.rs` (4 tests) |
| 4 | Dimension coverage against `archive::ALL`, namespace coverage against `build_schema()` | met — `tests/coverage.rs` (7 tests) |
| 5 | Full gate green | met — see below |
| 6 | This PR body | met |

## Verification

```
cargo test -p dolos-snapshot                            59 passed, 0 failed
cargo test --workspace --all-targets                    all green
cargo test --workspace --all-features \
  --exclude dolos-minibf --exclude dolos-minikupo \
  --exclude dolos-trp                                   all green
cargo clippy --all-targets --all-features -- -D warnings clean
cargo +nightly fmt --all -- --check                     clean
cargo deny check advisories                             advisories ok
cargo tree -p stelae -e normal                          no package matching ^dolos(-|$)
```

The boundary check is manual here by design; the `stelae-boundary` CI job belongs to the crate-hardening plan, not to this PR.

## Fitness answer: did the `Profile` trait suffice unchanged?

**Yes.** Not one line of `crates/stelae` changed, and none wanted to. Specifically:

- The trait's five methods covered every vendor-owned string this profile needs, and `checked_layer_media_type`/`checked_tag_for_sequence` accepted all of them.
- `position`, `parameters` and both scope encodings passed through as opaque values exactly as documented — including a `u8` shard and a hex block hash, neither of which the protocol has an opinion about.
- `LayerSpec`'s split into `header_scope` (CBOR) and `scope` (JSON) is what let one profile-side scope type own both encodings of one idea. That split earns its keep.
- `check_safe_numbers`' ±2^53 rule is comfortable: the largest number this profile puts in an inscription is a mainnet epoch's `uncompressedSize`, around 4×10^10.

Two observations that are *not* gaps, recorded for the export slice rather than acted on here:

1. `SteleDir::write_layer` takes `IntoIterator<Item = &CanonicalCbor>`, so a writer must hold each record while it is written. That is fine for a streaming driver that yields borrowed records, and this PR does not need more, but it is worth checking against the real export loop before assuming it.
2. `SteleDir::blob_index` rebuilds the diffId→blob map by decompressing every blob. That is the documented price of having no manifest and is correct for a fixture; OCI transport supplies the map for free.

## Record sizes against the 16 MiB default `frame::Limits` ceiling

#1148 left this confirmation to the first real profile. Every kind sits at least two orders of magnitude below `DEFAULT_MAX_RECORD`, and **no limit change is warranted**.

| kind | largest plausible record | why |
|---|---|---|
| `blocks` | **~90 KB** | one block body plus a 32-byte hash and a slot. The in-tree mainnet Shelley genesis pins `maxBlockBodySize` at 65 536; the current on-chain value is 90 112. It is a governance-settable protocol parameter, so this is the one number that moves without a code change — but it would have to rise ~180× to reach the ceiling. |
| `indexes` | **~50 bytes** | fixed-width: an 8-byte key hash or a ≤32-byte exact key, plus a dimension name and a slot. |
| `logs` | **~100 KB** | a 40-byte key plus a stored entity value. The reward/stake logs are small fixed-shape structs (tens of bytes); the largest is `epochs`, whose `EpochState` carries `registered_pools` (~3,200 × 29 bytes on mainnet) plus a `PParamsSet` with Plutus cost models. |
| `state` | **~100 KB**, one structurally unbounded case | entity values as above. `PoolState` is bounded by the transaction that registered it (`maxTxSize`, 16 KB); `utxos` values by the same. The exception is `proposals`: `ProposalState` holds `cc_votes`/`drep_votes`/`spo_votes` as maps from credential to vote history, so it grows with the DRep set — ~75 KB at today's ~1,500 mainnet DReps, and it would take roughly 300,000 DReps voting on one proposal to reach 16 MiB. |
| `digests` | **104 bytes** | a number and three sha256 values. |

**Finding, not a request:** `proposals` is the only record kind with no structural bound. It is nowhere near the ceiling and raising the limit now would be premature, but the export slice should measure a real preprod/mainnet `proposals` namespace rather than inherit this estimate. If it ever does approach the ceiling, the answer is a profile-side decision (shard the vote history) rather than a silent limit raise on either side of the boundary.

## Out of scope

No `export.rs`, no `restore.rs`, no store iteration, no CLI, no OCI, no signatures — the parent plan's Phases 2–5. No store trait or backend change. No `stelae-boundary` CI job and no `deny.toml` growth; those belong to `dolos-stelae-crate-hardening`.

## Escalations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Dolos Cardano snapshot profile with metadata, network positioning, scopes, compression, and hashing configuration.
  * Added support for encoding and decoding blocks, indexes, logs, state shards, and immutable-file digests.
  * Added validation for record structure, ordering, namespaces, key sizes, shard assignment, and canonical data formats.
  * Added defined namespace resolution and snapshot layer specifications.

* **Tests**
  * Added comprehensive round-trip, golden, coverage, validation, and streaming-read tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->