### PR TITLE
feat(stelae): write layers as a stream, bounded by one record

### DIFF
--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -154,6 +154,151 @@ impl Layer {
     }
 }
 
+/// A layer being written, one record at a time.
+///
+/// The mirror of [`LayerReader`] on the write side, and push-style for the same
+/// reason a reader is pull-style: the party that owns the records owns the
+/// errors of producing them. A profile streaming out of a fallible store
+/// iterator keeps its own error type on its own side of the boundary, and the
+/// protocol only ever sees a [`CanonicalCbor`] it was handed.
+///
+/// Nothing is buffered. Records are framed, hashed and compressed on the way
+/// past — [`LayerWriter`] was always a one-pass writer — so a layer of any size
+/// costs the compressor's window and one record, whatever the profile is
+/// publishing.
+///
+/// A sink owns its staging file rather than borrowing the directory, so several
+/// can be open at once; the counter in [`SteleDir::layer_sink`] keeps their
+/// staging names apart.
+///
+/// ## Nothing exists until `finish`
+///
+/// A layer's name is the digest of its own compressed bytes, so it cannot be
+/// known before the last record is written. Until then the layer is a staging
+/// file, invisible to [`SteleDir::blob_index`], and a sink dropped without
+/// [`LayerSink::finish`] takes it with it — an export that fails halfway leaves
+/// no partial layer behind. Only `finish` puts a blob in the stele.
+pub struct LayerSink {
+    /// Declared before `staging` on purpose: fields drop in declaration order,
+    /// so the file handle is closed before the file it names is unlinked. On
+    /// Windows that is the difference between removing an abandoned staging
+    /// file and failing to.
+    sequence: SeqWriter<LayerWriter<fs::File>>,
+    staging: Staging,
+    root: PathBuf,
+    kind: String,
+    media_type: String,
+    scope: serde_json::Value,
+}
+
+impl LayerSink {
+    /// Append one of the profile's records.
+    ///
+    /// The header record is already written; everything a caller adds is
+    /// content. [`CanonicalCbor`] is the proof that the record is in
+    /// deterministic form, so nothing is re-checked here.
+    pub fn write_record(&mut self, record: &CanonicalCbor) -> Result<(), Error> {
+        self.sequence.write_record(record)
+    }
+
+    /// Records written so far, header record included — the number that ends up
+    /// in the descriptor.
+    pub fn records(&self) -> u64 {
+        self.sequence.count()
+    }
+
+    /// Close the layer: finish the compressed frame, name the blob by its own
+    /// digest and hand back the descriptor to put in the inscription.
+    ///
+    /// The rename is what publishes the layer, and it is the last thing that
+    /// happens. A failure anywhere in here leaves the stele exactly as it was:
+    /// the staging file is removed on the way out, the same as for a sink that
+    /// was simply dropped.
+    pub fn finish(self) -> Result<WrittenLayer, Error> {
+        let Self {
+            sequence,
+            mut staging,
+            root,
+            kind,
+            media_type,
+            scope,
+        } = self;
+
+        let count = sequence.count();
+        let (file, digests) = sequence.into_inner().finish()?;
+        file.sync_all()?;
+        drop(file);
+
+        // Named by the digest of the bytes stored, per the OCI image layout.
+        fs::rename(&staging.path, blob_path(&root, &digests.blob_digest))?;
+        staging.published();
+
+        Ok(WrittenLayer {
+            descriptor: LayerDescriptor {
+                kind,
+                media_type,
+                diff_id: digests.diff_id,
+                records: count,
+                uncompressed_size: digests.uncompressed_size,
+                scope,
+            },
+            digests,
+        })
+    }
+}
+
+/// The staging file a layer is written into before it has a name.
+///
+/// Removing it is a `Drop` rather than a step in [`LayerSink::finish`] because
+/// the case that matters is the one nobody writes code for: a producer that
+/// hits an error mid-layer and returns. Nothing *reads* an abandoned staging
+/// file — it sits beside `sha256/` and [`SteleDir::blob_index`] only considers
+/// digest-named entries inside it — but a mainnet state shard is hundreds of
+/// megabytes, and a failed export leaving sixteen of them on the disk is its
+/// own incident.
+struct Staging {
+    path: PathBuf,
+    published: bool,
+}
+
+impl Staging {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            published: false,
+        }
+    }
+
+    /// The file has been renamed to its content-addressed name: nothing is left
+    /// at the staging path, and an unlink of it later could only ever hit
+    /// somebody else's.
+    fn published(&mut self) {
+        self.published = true;
+    }
+}
+
+impl Drop for Staging {
+    fn drop(&mut self) {
+        if !self.published {
+            // The sink has already failed or been abandoned; a failure to
+            // remove the file has nobody left to report it to, and the file is
+            // inert either way.
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// Where a blob of `digest` lives under `root`, per the OCI image layout.
+///
+/// One definition, used both to write a layer and to find it again — a stele
+/// whose writer and reader disagreed about the path would be unreadable by
+/// itself and perfectly readable by nobody.
+fn blob_path(root: &Path, digest: &Digest) -> PathBuf {
+    root.join(BLOBS_DIR)
+        .join(Digest::ALGORITHM)
+        .join(digest.to_hex())
+}
+
 /// A stele directory.
 pub struct SteleDir {
     root: PathBuf,
@@ -195,28 +340,32 @@ impl SteleDir {
     }
 
     pub fn blob_path(&self, digest: &Digest) -> PathBuf {
-        self.root
-            .join(BLOBS_DIR)
-            .join(Digest::ALGORITHM)
-            .join(digest.to_hex())
+        blob_path(&self.root, digest)
     }
 
-    /// Frame, compress and store one layer.
+    /// Open a layer and stream records into it.
     ///
-    /// The records are the profile's; the header record is the protocol's and
-    /// is written first. The media type comes from the profile and is
-    /// validated against the naming rules on the way through — the protocol
-    /// does not build it.
-    pub fn write_layer<'a, I>(
+    /// This is the write side's mirror of [`SteleDir::stream_layer`]: the
+    /// producer holds one record at a time and the layer never exists in
+    /// memory. The header record is written here, before the handle is
+    /// returned, so a sink is always a well-formed layer in progress; the media
+    /// type comes from the profile and is validated against the naming rules
+    /// first, so a profile that claims a name it does not own is refused before
+    /// anything is created on disk.
+    ///
+    /// The handle owns everything it needs — its staging path and the root it
+    /// will land in, not a borrow of this `SteleDir` — so a producer can hold
+    /// many open at once and route each record to one of them. That is the
+    /// shape the Dolos profile's sixteen state shards need: one pass over the
+    /// store, sixteen layers being written.
+    ///
+    /// See [`LayerSink`] for what a sink that is never finished leaves behind.
+    pub fn layer_sink(
         &self,
         profile: &dyn Profile,
         spec: &LayerSpec,
         level: i32,
-        records: I,
-    ) -> Result<WrittenLayer, Error>
-    where
-        I: IntoIterator<Item = &'a CanonicalCbor>,
-    {
+    ) -> Result<LayerSink, Error> {
         let media_type = checked_layer_media_type(profile, &spec.kind)?;
         let header = LayerHeader::new(profile.name(), &spec.kind, spec.header_scope.clone());
 
@@ -228,40 +377,61 @@ impl SteleDir {
         // for a blob.
         static STAGING: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-        let staging = self.root.join(BLOBS_DIR).join(format!(
+        let staging = Staging::new(self.root.join(BLOBS_DIR).join(format!(
             ".staging-{}-{}",
             std::process::id(),
             STAGING.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
+        )));
 
-        let file = fs::File::create(&staging)?;
-        let mut sequence = SeqWriter::new(LayerWriter::new(file, level)?);
+        // From here on every `?` unwinds through `staging`, which removes the
+        // file it named.
+        let file = fs::File::create(&staging.path)?;
 
-        sequence.write_record(&header.encode()?)?;
+        let mut sink = LayerSink {
+            sequence: SeqWriter::new(LayerWriter::new(file, level)?),
+            staging,
+            root: self.root.clone(),
+            kind: spec.kind.clone(),
+            media_type,
+            scope: spec.scope.clone(),
+        };
+
+        sink.write_record(&header.encode()?)?;
+
+        Ok(sink)
+    }
+
+    /// Frame, compress and store one layer.
+    ///
+    /// The records are the profile's; the header record is the protocol's and
+    /// is written first. The media type comes from the profile and is
+    /// validated against the naming rules on the way through — the protocol
+    /// does not build it.
+    ///
+    /// A convenience over [`SteleDir::layer_sink`] and nothing more: staging,
+    /// digest-naming, the rename and the descriptor are that one
+    /// implementation, so the buffered and streaming write paths cannot drift
+    /// apart the way two of them would. It is the right call for a layer a
+    /// caller already holds — every record has to be materialized somewhere
+    /// that outlives the call, which is exactly what the sink exists to avoid
+    /// at profile sizes.
+    pub fn write_layer<'a, I>(
+        &self,
+        profile: &dyn Profile,
+        spec: &LayerSpec,
+        level: i32,
+        records: I,
+    ) -> Result<WrittenLayer, Error>
+    where
+        I: IntoIterator<Item = &'a CanonicalCbor>,
+    {
+        let mut sink = self.layer_sink(profile, spec, level)?;
+
         for record in records {
-            sequence.write_record(record)?;
+            sink.write_record(record)?;
         }
 
-        let count = sequence.count();
-        let (file, digests) = sequence.into_inner().finish()?;
-        file.sync_all()?;
-        drop(file);
-
-        // Named by the digest of the bytes stored, per the OCI image layout.
-        let path = self.blob_path(&digests.blob_digest);
-        fs::rename(&staging, &path)?;
-
-        Ok(WrittenLayer {
-            descriptor: LayerDescriptor {
-                kind: spec.kind.clone(),
-                media_type,
-                diff_id: digests.diff_id,
-                records: count,
-                uncompressed_size: digests.uncompressed_size,
-                scope: spec.scope.clone(),
-            },
-            digests,
-        })
+        sink.finish()
     }
 
     /// Write the inscription in canonical form and return its digest — the

--- a/crates/stelae/tests/memory.rs
+++ b/crates/stelae/tests/memory.rs
@@ -14,6 +14,17 @@
 //! allocated and freed one record per iteration would be caught here, not
 //! excused by its tidiness.
 //!
+//! ## The write path is measured differently, and has to be
+//!
+//! Cumulative is unavailable on the write side. A producer handing 32,768
+//! records to a layer has to *encode* 32,768 records, and those allocations are
+//! its own — incurred identically whether it buffers them or streams them, so a
+//! cumulative figure reports the same ~33 MB for both paths and distinguishes
+//! nothing. What separates them is what is *held*: bytes allocated inside the
+//! region and not yet given back, sampled at every record and maximized. That
+//! is peak rather than a bound on peak, which is the weaker of the two claims —
+//! stated here rather than quietly substituted.
+//!
 //! ## Why these tests take a lock
 //!
 //! A `Region` reads a *process-wide* counter, and the test harness runs tests
@@ -80,6 +91,28 @@ const MINIMUM_WINDOWS: usize = 400;
 /// weaken the claim, but the number below is the Rust side only and saying so
 /// is cheaper than someone rediscovering it.
 const STREAMING_BUDGET: usize = 1024 * 1024;
+
+/// What the streaming *write* path is allowed to hold at any one moment: one
+/// record, the compressor's buffers, and the sink's own handful of fields.
+///
+/// The same figure as the read budget, for the same reasons — the zstd bindings
+/// buffer on either side of the encoder, and libzstd's own context is
+/// `malloc`ed inside the C library where `stats_alloc` cannot see it. The
+/// observed peak is around 34 KB against a 33 MB layer, so this is a ceiling
+/// with room under it rather than a number tuned until the test passed; what
+/// matters is that it does not move when the layer does.
+const SINK_BUDGET: usize = 1024 * 1024;
+
+/// Bytes allocated inside `region` and not yet returned.
+///
+/// Saturating because a region can also *free* memory that was allocated before
+/// it began, which is a negative change and not a measurement of anything.
+fn in_flight(region: &Region<'_, System>) -> usize {
+    let change = region.change();
+    change
+        .bytes_allocated
+        .saturating_sub(change.bytes_deallocated)
+}
 
 struct BulkProfile;
 
@@ -266,5 +299,88 @@ fn streaming_a_layer_does_not_scale_with_its_size() {
         "the buffered path allocated {buffered} bytes for a {}-byte layer; \
          it is supposed to hold the whole thing",
         descriptor.uncompressed_size,
+    );
+}
+
+/// The same property on the way in: a producer streams a layer it could not
+/// hold.
+///
+/// This is the bound the Dolos export needs. `write_layer` takes an iterator of
+/// *references*, so every record has to be materialized somewhere that outlives
+/// the call — fine for a chapter of notes, impossible for a mainnet epoch of
+/// blocks at 0.5–1.5 GB. A sink takes each record by reference for the length
+/// of one call and keeps nothing.
+///
+/// Both paths write the same layer here, so the comparison is between two ways
+/// of producing one artifact and not between two artifacts. They go into
+/// separate steles: the blob is named by its own digest, so writing it twice
+/// into one directory would be a rename onto a file that is already there.
+#[test]
+fn writing_a_layer_through_a_sink_does_not_scale_with_its_size() {
+    let _serial = exclusive();
+
+    let streamed_dir = tempfile::tempdir().unwrap();
+    let buffered_dir = tempfile::tempdir().unwrap();
+
+    let streamed_stele = SteleDir::create(streamed_dir.path()).unwrap();
+    let buffered_stele = SteleDir::create(buffered_dir.path()).unwrap();
+
+    let spec = LayerSpec::new("bulk", scope(), json!({}));
+
+    // The sink. Each record is encoded, written and dropped; the peak is
+    // sampled with the record still in hand, so what it reports is one record
+    // plus whatever the protocol is holding on its behalf.
+    let region = Region::new(GLOBAL);
+
+    let mut sink = streamed_stele
+        .layer_sink(&BulkProfile, &spec, COMPRESSION_LEVEL)
+        .unwrap();
+
+    let mut held = 0usize;
+
+    for i in 0..RECORDS {
+        let record = bulk_record(i);
+        sink.write_record(&record).unwrap();
+        held = held.max(in_flight(&region));
+    }
+
+    let streamed = sink.finish().unwrap();
+    let streamed_held = held.max(in_flight(&region));
+
+    // The control. Without it this test proves only that some number is small:
+    // the buffered path writes the same records and, by construction, has to
+    // hold every one of them until the call returns.
+    let region = Region::new(GLOBAL);
+
+    let records: Vec<CanonicalCbor> = (0..RECORDS).map(bulk_record).collect();
+    let buffered = buffered_stele
+        .write_layer(&BulkProfile, &spec, COMPRESSION_LEVEL, &records)
+        .unwrap();
+
+    let buffered_held = in_flight(&region);
+    drop(records);
+
+    let size = streamed.descriptor.uncompressed_size;
+
+    assert!(
+        size > (16 * SINK_BUDGET) as u64,
+        "the layer has to dwarf the budget for this to prove anything: \
+         {size} bytes against {SINK_BUDGET}"
+    );
+
+    // One artifact, two ways of writing it.
+    assert_eq!(streamed.descriptor, buffered.descriptor);
+    assert_eq!(streamed.digests, buffered.digests);
+
+    assert!(
+        streamed_held < SINK_BUDGET,
+        "streaming a {size}-byte layer held {streamed_held} bytes at peak; \
+         the budget is {SINK_BUDGET}",
+    );
+
+    assert!(
+        buffered_held as u64 > size,
+        "the buffered path held {buffered_held} bytes for a {size}-byte layer; \
+         it is supposed to hold the whole thing",
     );
 }

--- a/crates/stelae/tests/toy_profile.rs
+++ b/crates/stelae/tests/toy_profile.rs
@@ -16,14 +16,16 @@
 //!    core canonicalizes and hashes them without ever typing them.
 //! 5. A stele of a *different* profile, or a profile major version above the
 //!    one implemented, is refused cleanly.
+//! 6. Both write paths — a layer handed over whole, and a layer streamed into a
+//!    sink — produce the same artifact, and this profile publishes one of each.
 
-use std::io::Write as _;
+use std::{collections::BTreeSet, io::Write as _};
 
 use serde_json::json;
 
 use stelae::{
     digest::read_blob,
-    dir::{BlobIndex, LayerSpec, SteleDir},
+    dir::{BlobIndex, LayerSpec, SteleDir, WrittenLayer},
     frame::{encode, CanonicalCbor, Limits},
     Compression, Error, Inscription, LayerDescriptor, LayerWriter, Profile,
 };
@@ -207,9 +209,6 @@ fn write_stele(root: &std::path::Path) -> (Inscription, stelae::Digest) {
     let (index_header_scope, index_scope) = index_scopes();
 
     let notes: Vec<CanonicalCbor> = NOTES.iter().map(note_record).collect();
-    let mut sorted: Vec<&Note> = NOTES.iter().collect();
-    sorted.sort_by_key(|n| n.title);
-    let index: Vec<CanonicalCbor> = sorted.into_iter().map(index_record).collect();
 
     let written_notes = stele
         .write_layer(
@@ -220,14 +219,28 @@ fn write_stele(root: &std::path::Path) -> (Inscription, stelae::Digest) {
         )
         .unwrap();
 
-    let written_index = stele
-        .write_layer(
+    // The index layer is streamed into a sink instead, so this profile — which
+    // the protocol knows nothing about — exercises both write paths in the same
+    // stele. The records are never collected: a profile publishing at Dolos
+    // sizes cannot hold a layer, and the shape it needs has to work for a
+    // three-note chapter too. That the goldens below do not move is the proof
+    // that the two paths produce one artifact.
+    let mut sorted: Vec<&Note> = NOTES.iter().collect();
+    sorted.sort_by_key(|n| n.title);
+
+    let mut index_sink = stele
+        .layer_sink(
             &ToyProfile,
             &LayerSpec::new("index", index_header_scope, index_scope),
             COMPRESSION_LEVEL,
-            &index,
         )
         .unwrap();
+
+    for note in sorted {
+        index_sink.write_record(&index_record(note)).unwrap();
+    }
+
+    let written_index = index_sink.finish().unwrap();
 
     let mut inscription = Inscription::new(
         &ToyProfile,
@@ -469,6 +482,210 @@ fn layers_round_trip_byte_identically() {
             descriptor.kind
         );
     }
+}
+
+/// The two write paths are one write path.
+///
+/// The same records, handed over whole and streamed a record at a time, yield
+/// the same identity digest, the same blob digest, the same descriptor and the
+/// same bytes on disk. `write_layer` is a wrapper over `layer_sink`, so what
+/// this pins is that the wrapper stayed thin: staging, digest-naming, the
+/// rename and the descriptor have one implementation, and a change that made
+/// the buffered path special would have to move a digest here to land.
+#[test]
+fn both_write_paths_produce_the_same_layer() {
+    let buffered_dir = tempfile::tempdir().unwrap();
+    let streamed_dir = tempfile::tempdir().unwrap();
+
+    let buffered_stele = SteleDir::create(buffered_dir.path()).unwrap();
+    let streamed_stele = SteleDir::create(streamed_dir.path()).unwrap();
+
+    let (header_scope, scope) = notes_scopes();
+    let spec = LayerSpec::new("notes", header_scope, scope);
+    let records: Vec<CanonicalCbor> = NOTES.iter().map(note_record).collect();
+
+    let buffered = buffered_stele
+        .write_layer(&ToyProfile, &spec, COMPRESSION_LEVEL, &records)
+        .unwrap();
+
+    let mut sink = streamed_stele
+        .layer_sink(&ToyProfile, &spec, COMPRESSION_LEVEL)
+        .unwrap();
+
+    // A sink is a layer already in progress: the protocol's header record is
+    // written before the handle is returned, so a producer only ever adds its
+    // own records and the count is never off by one.
+    assert_eq!(sink.records(), 1);
+
+    for record in &records {
+        sink.write_record(record).unwrap();
+    }
+
+    assert_eq!(sink.records(), 1 + NOTES.len() as u64);
+
+    let streamed = sink.finish().unwrap();
+
+    assert_eq!(buffered.descriptor, streamed.descriptor);
+    assert_eq!(buffered.digests, streamed.digests);
+
+    // Same blob digest means the same file name; the bytes under it are the
+    // same too, which is what an OCI registry would be asked to deduplicate.
+    let blob = |stele: &SteleDir, written: &WrittenLayer| {
+        std::fs::read(stele.blob_path(&written.digests.blob_digest)).unwrap()
+    };
+
+    assert_eq!(
+        blob(&buffered_stele, &buffered),
+        blob(&streamed_stele, &streamed)
+    );
+
+    // And one layer in each stele, with no staging file beside it.
+    for root in [buffered_dir.path(), streamed_dir.path()] {
+        let blobs = root.join("blobs");
+        assert_eq!(
+            std::fs::read_dir(&blobs).unwrap().count(),
+            1,
+            "only sha256/"
+        );
+        assert_eq!(std::fs::read_dir(blobs.join("sha256")).unwrap().count(), 1);
+    }
+}
+
+/// Sixteen sinks open at once, which is the case the sink exists for.
+///
+/// The Dolos profile shards its state into sixteen layers and cannot walk the
+/// store sixteen times, so it walks once and routes each record to the shard it
+/// belongs in. That works only if a sink is an ordinary independent value: no
+/// borrow of the stele it will land in, no shared staging name, no ordering
+/// between them. Here the records interleave across all sixteen and every layer
+/// still reads back — through both readers — exactly what was routed to it.
+#[test]
+fn sixteen_sinks_are_written_in_one_pass() {
+    const SHARDS: u64 = 16;
+    const RECORDS: u64 = 8 * SHARDS;
+
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+    let blobs = temp.path().join("blobs");
+
+    let mut sinks: Vec<_> = (0..SHARDS)
+        .map(|shard| {
+            let header_scope = encode(|e| {
+                e.array(1)?.u64(shard)?;
+                Ok(())
+            })
+            .unwrap();
+
+            stele
+                .layer_sink(
+                    &ToyProfile,
+                    &LayerSpec::new("notes", header_scope, json!({"shard": shard})),
+                    COMPRESSION_LEVEL,
+                )
+                .unwrap()
+        })
+        .collect();
+
+    let mut routed: Vec<Vec<Vec<u8>>> = vec![Vec::new(); SHARDS as usize];
+
+    for id in 0..RECORDS {
+        let shard = (id % SHARDS) as usize;
+        let record = encode(|e| {
+            e.array(2)?.u64(id)?.str("routed")?;
+            Ok(())
+        })
+        .unwrap();
+
+        sinks[shard].write_record(&record).unwrap();
+        routed[shard].push(record.as_bytes().to_vec());
+    }
+
+    // Sixteen staging files beside `sha256/`, and not one layer yet: nothing is
+    // published until its digest is known, which is not until `finish`.
+    assert_eq!(
+        std::fs::read_dir(&blobs).unwrap().count() as u64,
+        SHARDS + 1
+    );
+    assert!(stele.blob_index().unwrap().is_empty());
+
+    let written: Vec<WrittenLayer> = sinks
+        .into_iter()
+        .map(|sink| sink.finish().unwrap())
+        .collect();
+
+    // Sixteen distinct layers, sixteen distinct blobs, nothing staged left.
+    let diff_ids: BTreeSet<_> = written.iter().map(|w| w.descriptor.diff_id).collect();
+    let blob_digests: BTreeSet<_> = written.iter().map(|w| w.digests.blob_digest).collect();
+    assert_eq!(diff_ids.len() as u64, SHARDS);
+    assert_eq!(blob_digests.len() as u64, SHARDS);
+    assert_eq!(
+        std::fs::read_dir(&blobs).unwrap().count(),
+        1,
+        "only sha256/"
+    );
+
+    let index = stele.blob_index().unwrap();
+    assert_eq!(index.len() as u64, SHARDS);
+
+    for (shard, written) in written.iter().enumerate() {
+        let records = read_both_ways(&stele, &index, &written.descriptor).unwrap();
+        assert_eq!(records, routed[shard], "shard {shard}");
+        assert_eq!(
+            written.descriptor.records,
+            routed[shard].len() as u64 + 1,
+            "shard {shard} record count, header included"
+        );
+    }
+}
+
+/// A sink that is never finished leaves nothing behind.
+///
+/// The case is a mainnet export that fails partway: sixteen state shards open,
+/// hundreds of megabytes written, and then a store iterator returns an error.
+/// Nothing would ever *read* what is left — staging files sit beside `sha256/`
+/// and `blob_index` only considers digest-named entries inside it — but leaving
+/// them on the disk is its own incident, so the sink removes its file on the
+/// way out.
+#[test]
+fn a_sink_dropped_without_finishing_leaves_nothing() {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+    let blobs = temp.path().join("blobs");
+
+    let (header_scope, scope) = notes_scopes();
+
+    {
+        let mut sink = stele
+            .layer_sink(
+                &ToyProfile,
+                &LayerSpec::new("notes", header_scope, scope),
+                COMPRESSION_LEVEL,
+            )
+            .unwrap();
+
+        for note in NOTES {
+            sink.write_record(&note_record(note)).unwrap();
+        }
+
+        // Open: one staging file, which is not a blob and never was.
+        let staged: Vec<_> = std::fs::read_dir(&blobs)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.is_file())
+            .collect();
+
+        assert_eq!(staged.len(), 1, "{staged:?}");
+        assert!(stele.blob_index().unwrap().is_empty());
+    }
+
+    // Dropped: nothing staged, nothing published.
+    assert_eq!(
+        std::fs::read_dir(&blobs).unwrap().count(),
+        1,
+        "only sha256/"
+    );
+    assert_eq!(std::fs::read_dir(blobs.join("sha256")).unwrap().count(), 0);
+    assert!(stele.blob_index().unwrap().is_empty());
 }
 
 /// Unknown #4: nothing vendor-owned in the artifact was composed by the core.


### PR DESCRIPTION
Plan: `plans/dolos-stelae-streaming-writes.md` (Trellis domain `txpipe`) — *Stelae: streaming layer writes*. Base: `main` at `54bfc576`.

## Why

`SteleDir::write_layer` takes `I: IntoIterator<Item = &'a CanonicalCbor>`. The iterator yields *references*, so every record of a layer has to be materialized somewhere that outlives the call. #1148 built the streaming *read* path for exactly this reason — `dir.rs` says it outright, "on a Dolos state shard that is 402 MB" — and the write side never got its mirror. A mainnet epoch's `blocks` layer is 0.5–1.5 GB by ADR-004's own sizing.

The pieces underneath were already incremental and already public: `SeqWriter` and `LayerWriter` stream, hash and compress a record at a time. What was not reachable is everything around them — the staging file, the digest-named rename, the descriptor assembly — which lived only inside `write_layer`. An exporter that wanted to stream would have had to reimplement the protocol's own file-layout rules on the profile's side of the boundary, which is the duplication the two-crate split exists to prevent.

## What changed

Only `crates/stelae`. Nothing in `crates/snapshot`, no store trait, no new protocol surface beyond the sink.

**`crates/stelae/src/dir.rs`**

- `SteleDir::layer_sink(profile, spec, level) -> Result<LayerSink, Error>` — a push-style handle mirroring `LayerReader` on the read side. `write_record(&CanonicalCbor)`, `records()`, `finish() -> Result<WrittenLayer, Error>`. The media type is validated and the protocol's header record is written before the handle is returned, so a sink is always a well-formed layer in progress and a profile that claims a name it does not own is still refused before anything lands on disk.
- `LayerSink` owns its staging path and the root it will land in rather than borrowing the `SteleDir`, so a producer can hold many open at once — the sixteen-shard state pass the export slice needs.
- A `Staging` drop guard removes the staging file unless `finish` renamed it away. That covers both the abandoned sink and a failure *inside* `finish`, with one implementation. The `sequence` field is declared before `staging` so the file handle is closed before the unlink, which is what makes the removal work on Windows.
- `write_layer` is now a thin wrapper: open a sink, write the records, finish. Staging, digest-naming, the rename and descriptor assembly are one implementation rather than two that can drift. It stays in the public API — it is the right call for a small layer and it is what every existing test and `crates/snapshot` use.
- `blob_path` is now one free function, called by both `SteleDir::blob_path` and `LayerSink::finish`, so the writer and the reader cannot disagree about where a blob lives.

**`crates/stelae/tests/toy_profile.rs`** — `write_stele` now streams the `index` layer into a sink while `notes` still goes through `write_layer`, so the non-Dolos profile exercises both write paths in one stele. **The golden digests are untouched and still pass**, which is the proof that the wrapper is faithful. Three new tests: both write paths produce the same layer, sixteen sinks written in one pass, a sink dropped without finishing leaves nothing.

**`crates/stelae/tests/memory.rs`** — the existing harness extended (not a sibling variant) with the write-side bound.

## Done criterion

| # | Criterion | Met | Evidence |
|---|---|---|---|
| 1 | Byte-identity: `layer_sink` and `write_layer` produce the same `diffId`, the same blob digest and an equal `LayerDescriptor` | yes | `toy_profile::both_write_paths_produce_the_same_layer` compares `descriptor`, `digests` and the blob bytes on disk; `memory::writing_a_layer_through_a_sink_does_not_scale_with_its_size` repeats it at 33 MB. The unchanged `golden_digests_pin_the_encoding` is the absolute statement of the same claim: the `index` layer is now written through the sink and its `diffId` `sha256:c00d73e0…` and the inscription digest `sha256:127aa748…` did not move. |
| 2 | A memory test in `tests/memory.rs` writes a ~33 MB layer through the sink and asserts peak allocation stays bounded against the buffered control | yes | `writing_a_layer_through_a_sink_does_not_scale_with_its_size`. Layer 32,997,121 bytes. Sink peak held **34,044 bytes**; buffered control (`write_layer` over a materialized `Vec`) peak held **33,783,608 bytes**. Budget 1 MiB. Identical to the byte across three runs. |
| 3 | Sixteen sinks open concurrently produce sixteen distinct blobs, each verifying under both `read_layer` and `stream_layer` | yes | `toy_profile::sixteen_sinks_are_written_in_one_pass`: sixteen sinks held in a `Vec`, records interleaved across them in one pass, sixteen distinct `diffId`s and sixteen distinct blob digests, each read back through the existing `read_both_ways` helper (which runs `read_layer` and `stream_layer` and insists they agree). |
| 4 | A sink dropped without `finish` leaves no staging file and no blob | yes | `toy_profile::a_sink_dropped_without_finishing_leaves_nothing`: one staging file while open (and `blob_index` empty), nothing but `sha256/` after the drop. |
| 5 | `tests/toy_profile.rs` writes at least one of its layers through the sink | yes | `write_stele` streams the `index` layer; every test in the file, goldens included, goes through it. |
| 6 | Full gate | yes | below |

### Measurement note on criterion 2

`bytes_allocated` is cumulative, which on the read side is a *stronger* claim than peak. It is unavailable on the write side: a producer handing 32,768 records to a layer has to encode 32,768 records, and those allocations are its own — incurred identically whether it buffers them or streams them, so a cumulative figure reports the same ~33 MB for both paths and distinguishes nothing. The new test therefore measures what is *held* — bytes allocated inside the region and not yet given back, sampled at every record and maximized. That is peak rather than a bound on peak, which is the weaker of the two claims; it is stated in the module docs rather than quietly substituted. The bound was not weakened to pass: observed peak is 34 KB against a 1 MiB ceiling.

## Verification

```
$ cargo test --workspace --all-targets
29 suites, all `test result: ok`; 0 failed

$ cargo test --workspace --all-features \
    --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp
34 suites, all `test result: ok`; 0 failed

$ cargo test -p stelae
   src (unit)      62 passed; 0 failed
   tests/memory     3 passed; 0 failed
   tests/rfc8785    5 passed; 0 failed
   tests/toy_profile 17 passed; 0 failed
   doc-tests        3 passed; 0 failed

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.48s

$ cargo +nightly fmt --all -- --check
(clean)

$ cargo deny check advisories
advisories ok
warning[yanked]: detected yanked crate (try `cargo update -p fjall`)
warning[yanked]: detected yanked crate (try `cargo update -p lsm-tree`)
warning[yanked]: detected yanked crate (try `cargo update -p spin`)
```

The three yanked-crate warnings are pre-existing: `Cargo.lock` is untouched by this PR.

```
$ cargo tree -p stelae -e normal | <package names> | grep -E '^dolos(-|$)'
(no matches)

packages: block-buffer cfg-if cpufeatures crypto-common digest generic-array hex
itoa libc memchr minicbor proc-macro2 quote ryu-js serde serde_core serde_derive
serde_jcs serde_json sha2 stelae syn thiserror thiserror-impl typenum
unicode-ident zmij zstd zstd-safe zstd-sys
```

## Escalations

None. Nothing in this slice needed a `crates/snapshot` change, the sink expresses everything `write_layer` did (it *is* `write_layer` now), and the allocation assertion is stable to the byte.

## Finding, not fixed here

`fs::rename` onto a blob path that already exists succeeds on Unix and fails on Windows. Writing the same layer twice into one stele — identical records *and* identical header scope — would therefore behave differently by platform. It is pre-existing behaviour of `write_layer`, unchanged by this PR (the rename moved verbatim into `LayerSink::finish`), and no test or caller hits it: the new tests use separate steles or distinct per-shard scopes for exactly this reason. Flagging it rather than widening this PR; content-addressed writes deduplicating rather than colliding is its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming layer writing, allowing records to be written incrementally instead of buffering an entire layer.
  * Added record counting and finalization support for streamed layers.
  * Added safe staging and cleanup for incomplete or failed writes.

* **Bug Fixes**
  * Ensured layers are published only after compression, syncing, and verification complete.

* **Tests**
  * Added coverage for streaming memory usage, equivalent output, concurrent writes, and staging-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->