### PR TITLE
feat(snapshot): publish a stele into a registry, and only what is new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,14 @@ path = "tests/bootstrap.rs"
 [features]
 strict = ["dolos-cardano/strict"]
 mithril = ["mithril-client"]
+
+# `dolos snapshot publish --repo oci://...`. Deliberately NOT in `default`:
+# `stelae`'s registry client keeps a TLS backend, and the only one `oci-client`
+# offers pins `aws-lc-sys`, which needs `cmake` to build — the same C dependency
+# the `mithril-client` entry below goes out of its way to avoid. Until that is
+# resolved, turning this on is a choice a builder makes rather than one every
+# `cargo build` inherits.
+registry = ["dolos-snapshot/oci"]
 utils = ["comfy-table", "inquire", "toml"]
 debug = ["console-subscriber", "tokio/tracing"]
 

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -4,6 +4,14 @@ description = "The io.txpipe.dolos.cardano Stelae profile"
 version.workspace = true
 edition.workspace = true
 
+[features]
+# Publishing into an OCI registry (`src/registry.rs`). Default-off, and it
+# forwards to `stelae/oci` rather than adding anything of its own: a build that
+# only writes steles to a directory keeps the dependency tree it had, which is
+# the whole reason the protocol's transport is behind a feature in the first
+# place. `dolos`'s own `registry` feature is what turns this on.
+oci = ["stelae/oci"]
+
 # This crate is the *profile* half of the Stelae boundary: it may depend on
 # `stelae` and on `dolos-*`, never the other way around. See
 # adrs/004_stelae_snapshots.md, "Code layout".

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -35,13 +35,21 @@
 //! this inscription", and both are the same code whether the bytes land in
 //! `blobs/sha256/` or in a repository.
 //!
+//! ## What a publish inherits from the one before it
+//!
+//! [`export`] takes a [`Predecessor`]: the stele this one follows, wherever it
+//! was published. It answers two questions, and they are one concept rather
+//! than two because both are things only the previous publish can say — what
+//! `history` this inscription attests, and which of its layers this publish may
+//! carry forward instead of rebuilding. A publish with no predecessor passes
+//! [`First`], which answers "no history" and "nothing to inherit", and that is
+//! every directory publish and the first stele of any repository.
+//!
 //! ## What is deliberately not here
 //!
 //! No `digests` layer is *sourced* — [`export`] writes one when handed the
 //! records, but obtaining them means a Mithril aggregator and a certificate
-//! check, which is publisher plumbing. No history: an inscription is permitted
-//! an empty one at any sequence, and filling it belongs to the slice that has a
-//! registry to read. No restore, no signatures.
+//! check, which is publisher plumbing. No restore, no signatures.
 
 use std::ops::Range;
 
@@ -52,7 +60,7 @@ use dolos_core::{
     ArchiveStore, BlockSlot, ChainPoint, EntityKey, IndexStore, LogKey, StateStore, TemporalKey,
 };
 use stelae::{
-    inscription::{Inscription, LayerDescriptor},
+    inscription::{HistoryEntry, Inscription, LayerDescriptor},
     transport::{LayerSpec, RecordSink, SteleWriter},
 };
 
@@ -200,6 +208,61 @@ pub fn plan<S: StateStore>(state: &S, network_magic: u64) -> Result<Plan, Error>
     Plan::new(&summary, Network::for_magic(network_magic), cursor)
 }
 
+/// The publish this one follows.
+///
+/// Two questions, one concept: what a new inscription attests about the steles
+/// before it, and which of their layers it may carry forward rather than build
+/// again. Both are answers only the previous publish has, and holding them
+/// together is what lets a publisher rebuild everything while still chaining —
+/// the `--rebuild` case, which suppresses [`Predecessor::adopt`] and leaves
+/// [`Predecessor::history`] exactly as it was.
+pub trait Predecessor {
+    /// The history the new inscription carries: every prior publication,
+    /// contiguous and ascending, ending at `sequence - 1`.
+    ///
+    /// Assembling it is the implementor's business, and the protocol holds it
+    /// to the invariant when the document is validated
+    /// (`stelae::inscription`).
+    fn history(&self) -> &[HistoryEntry];
+
+    /// The descriptor to adopt for a layer of `kind` at `scope`, or `None` to
+    /// build it from the stores.
+    ///
+    /// An implementation that answers `Some` **has already arranged for the
+    /// transport to carry the layer's blob**; all that is left for [`export`]
+    /// is to not walk the store. That ordering is why this returns a descriptor
+    /// rather than a boolean: the answer and the arrangement are one act, and
+    /// an export that reused a descriptor whose blob nothing carried would
+    /// publish a manifest with a hole in it.
+    ///
+    /// The default reuses nothing, which is what makes [`First`] one line and
+    /// what a transport with no notion of "already there" — a directory —
+    /// wants.
+    fn adopt(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<Option<LayerDescriptor>, Error> {
+        let _ = (kind, scope);
+
+        Ok(None)
+    }
+}
+
+/// The first stele of a repository: no history, nothing to inherit.
+///
+/// The protocol permits an empty history at any sequence, so this is not only
+/// the very first publish — it is every publish into a directory, which has no
+/// way to be asked what it already holds.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct First;
+
+impl Predecessor for First {
+    fn history(&self) -> &[HistoryEntry] {
+        &[]
+    }
+}
+
 /// Export a complete stele into `stele`: every layer, then the inscription.
 ///
 /// Layers are listed in [`crate::KINDS`] order, and within a kind in ascending
@@ -209,6 +272,11 @@ pub fn plan<S: StateStore>(state: &S, network_magic: u64) -> Result<Plan, Error>
 /// `digest_records` is optional and has no source in this slice — a stele
 /// without a `digests` layer is valid, since ADR-004 makes every layer
 /// individually non-mandatory.
+///
+/// `previous` is the stele this one follows; pass [`First`] when there is none.
+/// A layer it adopts is *attested without being reproduced*: this function
+/// never opens a sink for it and never touches a store on its behalf, which is
+/// the whole saving and the whole risk. See [`Predecessor::adopt`].
 pub fn export<W, A, S, I>(
     stele: &W,
     plan: &Plan,
@@ -216,6 +284,7 @@ pub fn export<W, A, S, I>(
     state: &S,
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
+    previous: &dyn Predecessor,
 ) -> Result<Inscription, Error>
 where
     W: SteleWriter,
@@ -226,15 +295,15 @@ where
     let mut layers = Vec::new();
 
     for window in &plan.epochs {
-        layers.push(write_blocks(stele, plan, archive, window)?);
+        layers.push(write_blocks(stele, plan, archive, window, previous)?);
     }
 
     for window in &plan.epochs {
-        layers.push(write_indexes(stele, plan, indexes, window)?);
+        layers.push(write_indexes(stele, plan, indexes, window, previous)?);
     }
 
     for window in &plan.epochs {
-        layers.push(write_logs(stele, plan, archive, window)?);
+        layers.push(write_logs(stele, plan, archive, window, previous)?);
     }
 
     layers.extend(write_state(stele, plan, state)?);
@@ -251,6 +320,7 @@ where
         crate::compression(),
     );
 
+    inscription.history = previous.history().to_vec();
     inscription.layers = layers;
 
     // Validated before it is written, so a stele is never sealed over a
@@ -282,11 +352,35 @@ where
 {
     let stele = stelae::dir::SteleDir::create(root)?;
 
-    export(&stele, plan, archive, state, indexes, digest_records)
+    export(
+        &stele,
+        plan,
+        archive,
+        state,
+        indexes,
+        digest_records,
+        &First,
+    )
 }
 
 fn sink<W: SteleWriter>(stele: &W, spec: &LayerSpec) -> Result<W::Sink, Error> {
     Ok(stele.layer_sink(&DolosProfile, spec, COMPRESSION_LEVEL)?)
+}
+
+/// The layer spec for one epoch window, and what the predecessor says about it.
+///
+/// The lookup happens **before the store is touched**, which is the entire
+/// point: the cost this saves is the traversal, not the compression. A hit
+/// short-circuits the caller's whole function.
+fn inherit(
+    scope: &EpochScope,
+    kind: &'static str,
+    previous: &dyn Predecessor,
+) -> Result<(LayerSpec, Option<LayerDescriptor>), Error> {
+    let spec = scope.layer_spec(kind)?;
+    let adopted = previous.adopt(kind, &spec.scope)?;
+
+    Ok((spec, adopted))
 }
 
 /// One epoch's blocks, ascending slot.
@@ -299,9 +393,17 @@ fn write_blocks<W: SteleWriter, A: ArchiveStore>(
     plan: &Plan,
     archive: &A,
     window: &EpochWindow,
+    previous: &dyn Predecessor,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
-    let mut sink = sink(stele, &scope.layer_spec(BLOCKS)?)?;
+
+    let (spec, adopted) = inherit(&scope, BLOCKS, previous)?;
+
+    if let Some(descriptor) = adopted {
+        return Ok(descriptor);
+    }
+
+    let mut sink = sink(stele, &spec)?;
     let mut order = blocks::OrderCheck::default();
 
     let slots = window.slots();
@@ -331,9 +433,17 @@ fn write_logs<W: SteleWriter, A: ArchiveStore>(
     plan: &Plan,
     archive: &A,
     window: &EpochWindow,
+    previous: &dyn Predecessor,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
-    let mut sink = sink(stele, &scope.layer_spec(LOGS)?)?;
+
+    let (spec, adopted) = inherit(&scope, LOGS, previous)?;
+
+    if let Some(descriptor) = adopted {
+        return Ok(descriptor);
+    }
+
+    let mut sink = sink(stele, &spec)?;
     let mut order = logs::OrderCheck::default();
 
     let slots = window.slots();
@@ -384,9 +494,20 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
     plan: &Plan,
     store: &I,
     window: &EpochWindow,
+    previous: &dyn Predecessor,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
-    let mut sink = sink(stele, &scope.layer_spec(INDEXES)?)?;
+
+    // The layer this saves the most: a publish that inherits a closed epoch's
+    // index layer skips a whole pass over the index store, which is the cost
+    // the doc comment above measures.
+    let (spec, adopted) = inherit(&scope, INDEXES, previous)?;
+
+    if let Some(descriptor) = adopted {
+        return Ok(descriptor);
+    }
+
+    let mut sink = sink(stele, &spec)?;
     let mut order = indexes::OrderCheck::default();
 
     let slots = window.slots();
@@ -418,6 +539,18 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
 /// Every shard is written, including an empty one, so the shard count a reader
 /// sees is [`STATE_SHARDS`] and never a function of what the data happened to
 /// contain.
+///
+/// ## No shard is ever inherited from a predecessor
+///
+/// Two reasons, and the second is the one that matters. The first is what a
+/// reader expects: the state is the *tip*, so it changes every publish and
+/// there would be nothing to inherit. The second is that scope equality — the
+/// rule a [`Predecessor`] decides by — could not detect it if there were:
+/// [`StateScope::descriptor`](crate::StateScope) is `{"shard": n}` and carries
+/// no epoch, so every previous publish's shard `n` compares equal to this
+/// one's. The rule here is therefore not a policy that could be relaxed; it is
+/// the only safe reading of a descriptor scope that does not identify the
+/// stele it came from.
 fn write_state<W: SteleWriter, S: StateStore>(
     stele: &W,
     plan: &Plan,

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -47,10 +47,14 @@
 //!   to the protocol in the order above.
 //! - [`restore`] — its inverse: the driver that reads a stele back into an
 //!   empty store set, in the order ADR-004 specifies.
+//! - `registry` (feature `oci`) — publishing into an OCI repository: the
+//!   history chain, and the layers a publish inherits instead of rebuilding.
 
 pub mod export;
 pub mod layers;
 pub mod namespaces;
+#[cfg(feature = "oci")]
+pub mod registry;
 pub mod restore;
 
 use dolos_core::ChainPoint;
@@ -182,6 +186,22 @@ pub enum Error {
     /// The stele is well-formed but does not carry enough to rebuild a node.
     #[error("this stele cannot restore a node: {0}")]
     IncompleteStele(String),
+
+    /// A publish that would not extend the repository's chain.
+    ///
+    /// Both sequences are in the message because the fix depends on which of
+    /// them is wrong: a gap means a publisher skipped epochs, an equal or lower
+    /// sequence means it is republishing one. There is deliberately no flag
+    /// that overrides this — see [`crate::registry`].
+    #[error(
+        "this repository's latest stele is sequence {latest} and this publish is sequence \
+         {publishing}: {reason}"
+    )]
+    HistoryBreak {
+        latest: u64,
+        publishing: u64,
+        reason: &'static str,
+    },
 }
 
 impl Error {

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -199,21 +199,25 @@ pub fn preview(registry: &Registry, plan: &Plan, rebuild: bool) -> Result<Previe
     // tip contributes its sixteen shards however the epochs were restricted.
     let total = plan.epochs.len() * EPOCH_KINDS.len() + STATE_SHARDS as usize;
 
-    let layers_reused = plan
-        .epochs
-        .iter()
-        .flat_map(|window| {
-            let scope = window.scope(plan.network.magic());
+    // The same lookup `export` will make, through the same `layer_spec`, so a
+    // preview and the publish that follows it cannot disagree about which
+    // layers are inherited. A failure here is the scope refusing a kind it does
+    // not describe, and it propagates rather than counting as a miss: a dry run
+    // that quietly reported "build it" for a layer nobody could build would be
+    // the one number a publisher trusts, wrong.
+    let mut layers_reused = 0;
 
-            EPOCH_KINDS.map(move |kind| (kind, scope))
-        })
-        .filter(|(kind, scope)| {
-            scope
-                .layer_spec(kind)
-                .map(|spec| previous.inheritable(kind, &spec.scope).is_some())
-                .unwrap_or(false)
-        })
-        .count();
+    for window in &plan.epochs {
+        let scope = window.scope(plan.network.magic());
+
+        for kind in EPOCH_KINDS {
+            let spec = scope.layer_spec(kind)?;
+
+            if previous.inheritable(kind, &spec.scope)?.is_some() {
+                layers_reused += 1;
+            }
+        }
+    }
 
     Ok(Preview {
         sequence: plan.sequence,
@@ -276,8 +280,12 @@ impl<'a> Chained<'a> {
         })
     }
 
-    fn inheritable(&self, kind: &str, scope: &serde_json::Value) -> Option<&LayerDescriptor> {
-        self.inheritable.get(&key(kind, scope).ok()?)
+    fn inheritable(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<Option<&LayerDescriptor>, Error> {
+        Ok(self.inheritable.get(&key(kind, scope)?))
     }
 }
 
@@ -291,7 +299,7 @@ impl Predecessor for Chained<'_> {
         kind: &str,
         scope: &serde_json::Value,
     ) -> Result<Option<LayerDescriptor>, Error> {
-        let (Some(source), Some(descriptor)) = (self.source, self.inheritable(kind, scope)) else {
+        let (Some(source), Some(descriptor)) = (self.source, self.inheritable(kind, scope)?) else {
             return Ok(None);
         };
 

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -73,6 +73,13 @@ use stelae::{
     Digest, SteleReader as _,
 };
 
+/// How a repository is named, re-exported so the binary need not name the
+/// protocol crate to hold an operator's `--repo` to the distribution grammar.
+///
+/// The profile is the only thing in `dolos` that reaches into `stelae`, here as
+/// everywhere else.
+pub use stelae::oci::Reference;
+
 use crate::{
     export::{self, Plan, Predecessor},
     layers::digests,
@@ -191,13 +198,28 @@ where
 }
 
 /// What [`publish`] would do, without writing anything.
-pub fn preview(registry: &Registry, plan: &Plan, rebuild: bool) -> Result<Preview, Error> {
+///
+/// Takes `digest_records` for the same reason [`publish`] does, and not because
+/// anything supplies them yet: a `digests` layer is one more layer, and a dry
+/// run that counted the layers of a *different* publish than the one that
+/// follows it is the one number a publisher trusts, wrong. The two entry points
+/// read the same input so they cannot drift when Phase 4 gives the records a
+/// source.
+pub fn preview(
+    registry: &Registry,
+    plan: &Plan,
+    digest_records: Option<&[digests::ImmutableDigests]>,
+    rebuild: bool,
+) -> Result<Preview, Error> {
     let latest = registry.latest(&DolosProfile)?;
     let previous = Chained::new(latest.as_ref(), registry, plan, rebuild)?;
 
-    // Every epoch selected contributes one layer per epoch kind, and the state
-    // tip contributes its sixteen shards however the epochs were restricted.
-    let total = plan.epochs.len() * EPOCH_KINDS.len() + STATE_SHARDS as usize;
+    // Every epoch selected contributes one layer per epoch kind, the state tip
+    // contributes its sixteen shards however the epochs were restricted, and
+    // the digests layer is there exactly when its records are.
+    let total = plan.epochs.len() * EPOCH_KINDS.len()
+        + STATE_SHARDS as usize
+        + usize::from(digest_records.is_some());
 
     // The same lookup `export` will make, through the same `layer_spec`, so a
     // preview and the publish that follows it cannot disagree about which
@@ -320,10 +342,14 @@ impl Predecessor for Chained<'_> {
 /// equality could not tell one publish's shard from another's. `digests` has no
 /// source in this slice.
 ///
-/// Two layers of one kind claiming one scope with different identities is a
-/// refusal rather than a first-wins: it means the stele being chained to
-/// describes the same window twice and disagrees with itself about what is in
-/// it, and inheriting either answer would publish that disagreement forward.
+/// Two layers of one kind claiming one scope, described differently in any
+/// respect, is a refusal rather than a first-wins: it means the stele being
+/// chained to describes the same window twice and disagrees with itself about
+/// what is in it, and inheriting either answer would publish that disagreement
+/// forward. "In any respect" and not "with different identities", because
+/// `records` and `uncompressed_size` are determined by the bytes a `diff_id`
+/// names — so a disagreement about them under one identity is the same
+/// contradiction wearing a quieter shape.
 fn inheritable_layers(
     previous: &Inscription,
 ) -> Result<BTreeMap<(String, String), LayerDescriptor>, Error> {
@@ -339,12 +365,32 @@ fn inheritable_layers(
         if let Some(existing) = inheritable.get(&key) {
             let existing: &LayerDescriptor = existing;
 
-            if existing.diff_id != layer.diff_id {
+            // The whole descriptor, not the identity alone. `records` and
+            // `uncompressed_size` are functions of the bytes `diff_id` names,
+            // so two descriptors sharing an identity and disagreeing about
+            // either are a stele contradicting itself just as surely as two
+            // identities would be — and `adopt_layer` carries
+            // `uncompressed_size` forward into a stele that never reads the
+            // bytes that would settle it.
+            if existing != layer {
+                // Spelled out rather than named by identity alone: the two can
+                // now differ while sharing a `diff_id`, and a message printing
+                // one digest twice would describe nothing.
+                let describe = |layer: &LayerDescriptor| {
+                    format!(
+                        "{} ({} records, {} bytes)",
+                        layer.diff_id, layer.records, layer.uncompressed_size,
+                    )
+                };
+
                 return Err(Error::malformed_inscription(
                     format!("layers[{}]", layer.kind),
                     format!(
                         "sequence {} describes {} twice at one scope, as {} and as {}",
-                        previous.sequence, layer.kind, existing.diff_id, layer.diff_id,
+                        previous.sequence,
+                        layer.kind,
+                        describe(existing),
+                        describe(layer),
                     ),
                 ));
             }
@@ -444,10 +490,12 @@ fn same_network(previous: &Inscription, plan: &Plan) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
+    use dolos_core::{BlockHash, ChainPoint};
     use serde_json::json;
     use stelae::Profile as _;
 
     use super::*;
+    use crate::Network;
 
     fn inscription(sequence: u64, history: Vec<HistoryEntry>) -> Inscription {
         let mut inscription = Inscription::new(
@@ -603,6 +651,90 @@ mod tests {
         let err = inheritable_layers(&previous).unwrap_err();
 
         assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
+    }
+
+    /// The quieter half of the same contradiction: one identity, two
+    /// descriptions of what it contains.
+    ///
+    /// `records` and `uncompressed_size` are determined by the bytes a
+    /// `diff_id` names, so a stele describing them two ways is describing
+    /// bytes that cannot exist. It matters because `adopt_layer` carries
+    /// `uncompressed_size` into the new stele without reading the blob, so
+    /// whichever of the two came first would be published forward as fact.
+    #[test]
+    fn one_identity_described_two_ways_is_refused() {
+        let mut previous = inscription(3, vec![]);
+        let scope = json!({"epoch": 2, "startSlot": 200, "endSlot": 299});
+
+        let mut second = layer(crate::BLOCKS, scope.clone(), 1);
+        second.records = 2;
+        second.uncompressed_size = 4096;
+
+        previous.layers = vec![layer(crate::BLOCKS, scope, 1), second];
+
+        let err = inheritable_layers(&previous).unwrap_err();
+
+        assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
+
+        // Both descriptions are in the message: naming the shared identity
+        // twice would describe nothing.
+        let message = err.to_string();
+        assert!(message.contains("1 records"), "{message}");
+        assert!(message.contains("2 records"), "{message}");
+    }
+
+    /// The only thing standing between a publisher and a history chained onto
+    /// another chain's stele.
+    ///
+    /// A publish reads its own magic from genesis and the predecessor's from
+    /// the predecessor. If they were allowed to differ, the new inscription
+    /// would attest a chain of steles from a network it has never seen — and
+    /// nothing downstream re-checks it, because `history` entries carry a
+    /// sequence and a digest and no position at all.
+    #[test]
+    fn a_predecessor_from_another_network_is_refused() {
+        let preview = Network::for_magic(crate::PREVIEW_MAGIC);
+        let preprod = Network::for_magic(crate::PREPROD_MAGIC);
+
+        let plan = plan_at(preview.clone());
+
+        // Built by `crate::position`, not by the `inscription` helper's shape:
+        // `same_network` reads it back through `crate::read_position`, which
+        // the helper's bare `{"epoch": n}` would not survive.
+        let stele = |network: &Network| {
+            let mut previous = inscription(3, vec![]);
+
+            previous.position = crate::position(
+                network,
+                &ChainPoint::Specific(250, BlockHash::from([0xab; 32])),
+                2,
+            )
+            .unwrap();
+
+            previous
+        };
+
+        same_network(&stele(&preview), &plan).unwrap();
+
+        let err = same_network(&stele(&preprod), &plan).unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                Error::NetworkMismatch { expected, found }
+                    if expected == preview.magic() && found == preprod.magic()
+            ),
+            "{err:?}"
+        );
+    }
+
+    fn plan_at(network: Network) -> Plan {
+        Plan {
+            network,
+            cursor: ChainPoint::Specific(250, BlockHash::from([0xab; 32])),
+            sequence: 3,
+            epochs: vec![],
+        }
     }
 
     fn layer(kind: &str, scope: serde_json::Value, identity: u8) -> LayerDescriptor {

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -1,0 +1,610 @@
+//! Publishing a Dolos stele into an OCI repository.
+//!
+//! [`crate::export`] knows how to walk a store set into any transport, and
+//! `stelae::oci` knows how to move bytes into a registry. This module is the
+//! part that only exists once a publisher is standing in front of a
+//! *repository*: what the new stele says about the ones already in it, and what
+//! it may take from them.
+//!
+//! ## A publish is chained, or it is refused
+//!
+//! Every stele carries a `history`: one entry per prior publication,
+//! contiguous, ending at `sequence - 1`. A publish therefore reads the
+//! repository's moving tag before it writes anything, and there are exactly
+//! three outcomes — the repository is empty and this stele starts a chain, the
+//! latest stele is this one's predecessor and the chain extends, or **the
+//! publish is refused**. A publisher that skipped an epoch has an operational
+//! fault, and silently starting a second chain in one repository is precisely
+//! what the field exists to prevent. There is no flag here that overrides that.
+//!
+//! ## A reused layer is attested without being reproduced
+//!
+//! The layers of an epoch that has closed cannot change, so a publish that
+//! already published them has no reason to build them again: it points its
+//! manifest at the blobs the previous manifest pointed at and never opens the
+//! store. That is worth a plain sentence, because it changes what a publish
+//! asserts. The new inscription describes those layers, and this node did not
+//! read a single byte of them out of its own stores to check. Three things make
+//! the trade defensible and all three are load-bearing:
+//!
+//! - **Scope equality is the entire test** — for an epoch layer that is
+//!   `epoch`, `startSlot` and `endSlot`, all three. It is what makes a
+//!   previously *clamped* final epoch — one whose window stopped at the cursor
+//!   rather than at the epoch boundary — correctly fail to match the same epoch
+//!   published later in full, and be rebuilt.
+//! - **The blob is checked to still exist**, one `HEAD` per layer, inside
+//!   `Registry::adopt_layer`. ADR-004 argues epoch blobs stay referenced by
+//!   later manifests and so survive garbage collection; a descriptor pointing
+//!   at a blob that is gone is a stele nobody can restore, and the argument is
+//!   not a substitute for the check.
+//! - **A publisher can always choose to reproduce**, with `rebuild`. It
+//!   suppresses inheritance and nothing else — the history still chains,
+//!   because rebuilding what you published is not the same act as forgetting
+//!   that you published it.
+//!
+//! State shards are never inherited; [`crate::export`] says why, and the second
+//! of its two reasons is the one that matters.
+//!
+//! ## Two consequences a publisher should hear from the documentation
+//!
+//! **A repository's identity is path-dependent.** `history` is inside the
+//! canonical document, so a stele's digest depends on the chain it extends.
+//! Two repositories that were published into differently — even once, even by
+//! the same node from the same stores — never agree on a digest again at any
+//! later sequence. That is deliberate: it is what makes the newest inscription
+//! an attestation of every earlier one rather than a snapshot of a moment.
+//! Reproducibility lives one level down, in the layers: same stores and same
+//! predecessor gives the same digest, which is what the `rebuild` comparison
+//! checks.
+//!
+//! **A publish that dies half way leaves blobs behind.** Layers upload one at a
+//! time and the manifest is written last, so an interrupted publish leaves
+//! uploaded blobs that no manifest references. They are harmless — a registry's
+//! garbage collection reclaims exactly that — and the moving tag still resolves
+//! to the previous stele, which is a stele, and restores. Publishing again
+//! re-uploads nothing it already sent, because the blob check finds them.
+
+use std::{cell::Cell, collections::BTreeMap};
+
+use dolos_core::{ArchiveStore, IndexStore, StateStore};
+use stelae::{
+    inscription::{HistoryEntry, Inscription, LayerDescriptor},
+    oci::{Options, Registry, Stele, Transfer},
+    Digest, SteleReader as _,
+};
+
+use crate::{
+    export::{self, Plan, Predecessor},
+    layers::digests,
+    DolosProfile, Error, Scope as _, EPOCH_KINDS, STATE_SHARDS,
+};
+
+/// Open a repository in a registry.
+///
+/// Here rather than at the call site so the `dolos` binary keeps never naming
+/// the protocol crate — the same property [`crate::export::publish`] and
+/// [`crate::restore::restore_dir`] hold for a directory.
+///
+/// `insecure` speaks plaintext HTTP. It is for a registry on a loopback address
+/// or a mirror inside a cluster, and for nothing that is reachable from outside
+/// one.
+///
+/// **Never call any of this from inside an async context.** The transport owns
+/// a current-thread runtime and enters it with `block_on`; `stelae::oci`'s
+/// module documentation states the rule and the reason.
+pub fn open(
+    host: impl Into<String>,
+    repository: impl Into<String>,
+    insecure: bool,
+) -> Result<Registry, Error> {
+    Ok(Registry::open(
+        host,
+        repository,
+        Options {
+            insecure,
+            scratch_dir: None,
+        },
+    )?)
+}
+
+/// What a publish into a repository did.
+#[derive(Debug, Clone)]
+pub struct Published {
+    pub inscription: Inscription,
+    /// The stele's identity: sha256 of the canonical inscription.
+    pub identity: Digest,
+    /// Layers this publish read out of the stores and compressed.
+    pub layers_built: usize,
+    /// Layers it inherited from the stele before it, and never built.
+    pub layers_reused: usize,
+    /// What the transport moved, as it counted it.
+    pub transfer: Transfer,
+}
+
+/// What a publish into a repository *would* do.
+///
+/// The `--dry-run` half, and it answers the question a publisher wants before
+/// committing hours: how much of this is new. It reports what the scopes
+/// permit and deliberately spends no `HEAD` per layer — the publish itself
+/// verifies every blob it inherits, and a dry run that promised a reuse the
+/// publish then refused would be worse than one that does not promise.
+#[derive(Debug, Clone)]
+pub struct Preview {
+    /// The sequence this publish would write.
+    pub sequence: u64,
+    /// The stele it would chain to, if the repository holds one.
+    pub predecessor: Option<(u64, Digest)>,
+    /// How many entries the new `history` would carry.
+    pub history: usize,
+    pub layers_reused: usize,
+    pub layers_built: usize,
+}
+
+/// Publish `plan` into `registry`, chained to whatever is already there.
+///
+/// Reads the repository's moving tag first: an absent one starts a history, a
+/// predecessor at `sequence - 1` extends it, and anything else is refused
+/// before a single layer is built. `rebuild` reproduces every layer instead of
+/// inheriting the ones whose scope is unchanged — see the module
+/// documentation.
+pub fn publish<A, S, I>(
+    registry: &Registry,
+    plan: &Plan,
+    archive: &A,
+    state: &S,
+    indexes: &I,
+    digest_records: Option<&[digests::ImmutableDigests]>,
+    rebuild: bool,
+) -> Result<Published, Error>
+where
+    A: ArchiveStore,
+    S: StateStore,
+    I: IndexStore,
+{
+    let latest = registry.latest(&DolosProfile)?;
+    let previous = Chained::new(latest.as_ref(), registry, plan, rebuild)?;
+
+    // Reset before the export, so what comes back is this publish's cost and
+    // not a total carried over from an earlier one through the same transport.
+    registry.take_transfer();
+
+    let inscription = export::export(
+        registry,
+        plan,
+        archive,
+        state,
+        indexes,
+        digest_records,
+        &previous,
+    )?;
+
+    let identity = inscription.digest()?;
+    let layers_reused = previous.adopted.get();
+
+    Ok(Published {
+        layers_built: inscription.layers.len() - layers_reused,
+        layers_reused,
+        transfer: registry.transfer(),
+        identity,
+        inscription,
+    })
+}
+
+/// What [`publish`] would do, without writing anything.
+pub fn preview(registry: &Registry, plan: &Plan, rebuild: bool) -> Result<Preview, Error> {
+    let latest = registry.latest(&DolosProfile)?;
+    let previous = Chained::new(latest.as_ref(), registry, plan, rebuild)?;
+
+    // Every epoch selected contributes one layer per epoch kind, and the state
+    // tip contributes its sixteen shards however the epochs were restricted.
+    let total = plan.epochs.len() * EPOCH_KINDS.len() + STATE_SHARDS as usize;
+
+    let layers_reused = plan
+        .epochs
+        .iter()
+        .flat_map(|window| {
+            let scope = window.scope(plan.network.magic());
+
+            EPOCH_KINDS.map(move |kind| (kind, scope))
+        })
+        .filter(|(kind, scope)| {
+            scope
+                .layer_spec(kind)
+                .map(|spec| previous.inheritable(kind, &spec.scope).is_some())
+                .unwrap_or(false)
+        })
+        .count();
+
+    Ok(Preview {
+        sequence: plan.sequence,
+        predecessor: previous.predecessor,
+        history: previous.history.len(),
+        layers_built: total - layers_reused,
+        layers_reused,
+    })
+}
+
+/// The stele this publish follows, in a repository.
+///
+/// Holds the history it hands to the new inscription and the table of layers it
+/// is willing to let the new stele inherit, keyed by the pair that decides it:
+/// the layer's kind and the canonical encoding of its profile-owned scope.
+struct Chained<'a> {
+    registry: &'a Registry,
+    source: Option<&'a Stele>,
+    predecessor: Option<(u64, Digest)>,
+    history: Vec<HistoryEntry>,
+    inheritable: BTreeMap<(String, String), LayerDescriptor>,
+    adopted: Cell<usize>,
+}
+
+impl<'a> Chained<'a> {
+    fn new(
+        latest: Option<&'a Stele>,
+        registry: &'a Registry,
+        plan: &Plan,
+        rebuild: bool,
+    ) -> Result<Self, Error> {
+        let inscription = latest.map(|stele| stele.read_inscription()).transpose()?;
+
+        if let Some(previous) = &inscription {
+            same_network(previous, plan)?;
+        }
+
+        let history = history_for(inscription.as_ref(), plan.sequence)?;
+
+        let predecessor = inscription
+            .as_ref()
+            .map(|previous| Ok::<_, Error>((previous.sequence, previous.digest()?)))
+            .transpose()?;
+
+        // Built only when it can be used. `rebuild` is the publisher choosing
+        // to reproduce rather than inherit, and it stops here rather than at
+        // `adopt` so that nothing downstream has to remember it was set.
+        let inheritable = match (rebuild, &inscription) {
+            (false, Some(previous)) => inheritable_layers(previous)?,
+            _ => BTreeMap::new(),
+        };
+
+        Ok(Self {
+            registry,
+            source: latest.filter(|_| !rebuild),
+            predecessor,
+            history,
+            inheritable,
+            adopted: Cell::new(0),
+        })
+    }
+
+    fn inheritable(&self, kind: &str, scope: &serde_json::Value) -> Option<&LayerDescriptor> {
+        self.inheritable.get(&key(kind, scope).ok()?)
+    }
+}
+
+impl Predecessor for Chained<'_> {
+    fn history(&self) -> &[HistoryEntry] {
+        &self.history
+    }
+
+    fn adopt(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<Option<LayerDescriptor>, Error> {
+        let (Some(source), Some(descriptor)) = (self.source, self.inheritable(kind, scope)) else {
+            return Ok(None);
+        };
+
+        // The arrangement and the answer are one act: by the time this returns
+        // a descriptor, the transport is already carrying the blob, and the
+        // `HEAD` that proves the registry still has it has already happened.
+        self.registry.adopt_layer(source, descriptor.clone())?;
+        self.adopted.set(self.adopted.get() + 1);
+
+        Ok(Some(descriptor.clone()))
+    }
+}
+
+/// The layers a new stele may inherit from `previous`, keyed by kind and scope.
+///
+/// Only the epoch kinds are in it. A state shard is the tip and changes every
+/// publish, and — independently — its descriptor scope names no epoch, so scope
+/// equality could not tell one publish's shard from another's. `digests` has no
+/// source in this slice.
+///
+/// Two layers of one kind claiming one scope with different identities is a
+/// refusal rather than a first-wins: it means the stele being chained to
+/// describes the same window twice and disagrees with itself about what is in
+/// it, and inheriting either answer would publish that disagreement forward.
+fn inheritable_layers(
+    previous: &Inscription,
+) -> Result<BTreeMap<(String, String), LayerDescriptor>, Error> {
+    let mut inheritable = BTreeMap::new();
+
+    for layer in &previous.layers {
+        if !EPOCH_KINDS.contains(&layer.kind.as_str()) {
+            continue;
+        }
+
+        let key = key(&layer.kind, &layer.scope)?;
+
+        if let Some(existing) = inheritable.get(&key) {
+            let existing: &LayerDescriptor = existing;
+
+            if existing.diff_id != layer.diff_id {
+                return Err(Error::malformed_inscription(
+                    format!("layers[{}]", layer.kind),
+                    format!(
+                        "sequence {} describes {} twice at one scope, as {} and as {}",
+                        previous.sequence, layer.kind, existing.diff_id, layer.diff_id,
+                    ),
+                ));
+            }
+
+            continue;
+        }
+
+        inheritable.insert(key, layer.clone());
+    }
+
+    Ok(inheritable)
+}
+
+/// The table key: a layer's kind and the canonical encoding of its scope.
+///
+/// Canonical rather than `serde_json::Value` equality, so that two scopes are
+/// the same key exactly when they are the same bytes inside the canonical
+/// document — which is the only sense of "the same scope" the protocol has.
+fn key(kind: &str, scope: &serde_json::Value) -> Result<(String, String), Error> {
+    let canonical = stelae::inscription::canonical_json(scope)?;
+
+    let canonical = String::from_utf8(canonical)
+        .map_err(|e| Error::malformed_inscription("layer scope", e.to_string()))?;
+
+    Ok((kind.to_owned(), canonical))
+}
+
+/// The history a stele at `sequence` carries when it follows `previous`.
+///
+/// The three legal readings of a repository, and the one refusal:
+///
+/// - **nothing there** — an empty history, which the protocol permits at any
+///   sequence. The first stele of a repository carries no history, and so does
+///   a publisher deliberately starting a new one at epoch 500;
+/// - **the stele before this one** — the old history plus an entry naming it.
+///   Contiguous by construction, so the protocol's invariant passes rather than
+///   being relied upon;
+/// - **anything else** — refused, naming both sequences. A gap means a
+///   publisher skipped epochs, an equal sequence means it is republishing one,
+///   and a higher one means the repository is ahead of this node. All three are
+///   operational faults with different fixes, so the message says which.
+///
+/// Whether a deliberate gap ever gets a policy is not this function's to
+/// invent; there is no flag here that overrides the refusal.
+fn history_for(previous: Option<&Inscription>, sequence: u64) -> Result<Vec<HistoryEntry>, Error> {
+    let Some(previous) = previous else {
+        return Ok(Vec::new());
+    };
+
+    let latest = previous.sequence;
+
+    let reason = match latest.checked_add(1) {
+        Some(next) if next == sequence => {
+            let mut history = previous.history.clone();
+
+            history.push(HistoryEntry {
+                sequence: latest,
+                inscription_digest: previous.digest()?,
+            });
+
+            return Ok(history);
+        }
+        _ if latest >= sequence => {
+            "this stele is at or behind the repository's latest; a republish would restart the \
+             chain rather than extend it"
+        }
+        _ => {
+            "a publish must follow the repository's latest stele, and this one would leave a gap \
+             no later stele could close"
+        }
+    };
+
+    Err(Error::HistoryBreak {
+        latest,
+        publishing: sequence,
+        reason,
+    })
+}
+
+/// Refuse a predecessor from another chain.
+///
+/// A repository holding two networks' steles is an operator fault, and the
+/// check costs nothing: the previous stele's `position` already names its
+/// network, and reading it is the same function a restore uses.
+fn same_network(previous: &Inscription, plan: &Plan) -> Result<(), Error> {
+    let found = crate::read_position(&previous.position)?.network;
+
+    if found.magic() != plan.network.magic() {
+        return Err(Error::NetworkMismatch {
+            expected: plan.network.magic(),
+            found: found.magic(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use stelae::Profile as _;
+
+    use super::*;
+
+    fn inscription(sequence: u64, history: Vec<HistoryEntry>) -> Inscription {
+        let mut inscription = Inscription::new(
+            &DolosProfile,
+            sequence,
+            json!({"epoch": sequence.saturating_sub(1)}),
+            crate::parameters(),
+            crate::compression(),
+        );
+
+        inscription.history = history;
+        inscription
+    }
+
+    fn entry(sequence: u64) -> HistoryEntry {
+        HistoryEntry {
+            sequence,
+            inscription_digest: Digest::compute(sequence.to_be_bytes()),
+        }
+    }
+
+    /// The first stele of a repository carries no history, at any sequence.
+    #[test]
+    fn an_empty_repository_starts_a_history() {
+        assert!(history_for(None, 0).unwrap().is_empty());
+        assert!(history_for(None, 500).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_publish_that_follows_latest_extends_the_chain() {
+        let previous = inscription(3, vec![entry(1), entry(2)]);
+
+        let history = history_for(Some(&previous), 4).unwrap();
+
+        assert_eq!(
+            history.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            vec![1, 2, 3],
+            "the old history plus an entry naming the stele it came from"
+        );
+
+        assert_eq!(history[2].inscription_digest, previous.digest().unwrap());
+
+        // The invariant holds by construction rather than by inspection: a
+        // document built on this history validates.
+        inscription(4, history).validate().unwrap();
+    }
+
+    /// All three refusals name both sequences, because which of the three it is
+    /// decides what the publisher does about it.
+    #[test]
+    fn a_publish_that_does_not_follow_latest_is_refused() {
+        let previous = inscription(497, vec![]);
+
+        for publishing in [500, 497, 496] {
+            let err = history_for(Some(&previous), publishing).unwrap_err();
+            let message = err.to_string();
+
+            assert!(
+                matches!(err, Error::HistoryBreak { .. }),
+                "{publishing}: {err:?}"
+            );
+
+            assert!(message.contains("497"), "{publishing}: {message}");
+            assert!(
+                message.contains(&publishing.to_string()),
+                "{publishing}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_gap_and_a_republish_are_told_apart() {
+        let previous = inscription(497, vec![]);
+
+        assert!(history_for(Some(&previous), 500)
+            .unwrap_err()
+            .to_string()
+            .contains("gap"));
+
+        assert!(history_for(Some(&previous), 497)
+            .unwrap_err()
+            .to_string()
+            .contains("republish"));
+
+        assert!(history_for(Some(&previous), 496)
+            .unwrap_err()
+            .to_string()
+            .contains("republish"));
+    }
+
+    /// Only the epoch kinds are inheritable, and a state shard is excluded by
+    /// this table rather than by the caller remembering to.
+    #[test]
+    fn only_epoch_layers_are_inheritable() {
+        let mut previous = inscription(3, vec![]);
+
+        previous.layers = vec![
+            layer(
+                crate::BLOCKS,
+                json!({"epoch": 2, "startSlot": 200, "endSlot": 299}),
+                1,
+            ),
+            layer(crate::STATE, json!({"shard": 0}), 2),
+            layer(crate::DIGESTS, json!({"lastImmutable": 7}), 3),
+        ];
+
+        let table = inheritable_layers(&previous).unwrap();
+
+        assert_eq!(table.len(), 1);
+        assert!(table.contains_key(
+            &key(
+                crate::BLOCKS,
+                &json!({"epoch": 2, "startSlot": 200, "endSlot": 299})
+            )
+            .unwrap()
+        ));
+    }
+
+    /// The clamp rule, as a table lookup: a window that stopped at the cursor
+    /// is a different scope from the same epoch published in full, so it is a
+    /// miss and the layer is rebuilt.
+    #[test]
+    fn a_clamped_window_does_not_match_the_full_epoch() {
+        let mut previous = inscription(3, vec![]);
+
+        previous.layers = vec![layer(
+            crate::BLOCKS,
+            json!({"epoch": 2, "startSlot": 200, "endSlot": 250}),
+            1,
+        )];
+
+        let table = inheritable_layers(&previous).unwrap();
+
+        let full = key(
+            crate::BLOCKS,
+            &json!({"epoch": 2, "startSlot": 200, "endSlot": 299}),
+        )
+        .unwrap();
+
+        assert!(!table.contains_key(&full));
+    }
+
+    #[test]
+    fn one_scope_described_twice_two_ways_is_refused() {
+        let mut previous = inscription(3, vec![]);
+        let scope = json!({"epoch": 2, "startSlot": 200, "endSlot": 299});
+
+        previous.layers = vec![
+            layer(crate::BLOCKS, scope.clone(), 1),
+            layer(crate::BLOCKS, scope, 2),
+        ];
+
+        let err = inheritable_layers(&previous).unwrap_err();
+
+        assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
+    }
+
+    fn layer(kind: &str, scope: serde_json::Value, identity: u8) -> LayerDescriptor {
+        LayerDescriptor {
+            kind: kind.to_owned(),
+            media_type: DolosProfile.layer_media_type(kind).unwrap(),
+            diff_id: Digest::compute([identity]),
+            records: 1,
+            uncompressed_size: 1,
+            scope,
+        }
+    }
+}

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -121,7 +121,16 @@ fn an_empty_store_set_exports_the_pinned_skeleton() {
     )
     .unwrap();
 
-    let inscription = export::export(&stele, &plan, &archive, &state, &index, None).unwrap();
+    let inscription = export::export(
+        &stele,
+        &plan,
+        &archive,
+        &state,
+        &index,
+        None,
+        &export::First,
+    )
+    .unwrap();
 
     // Three epochs of blocks, indexes and logs, then sixteen state shards. No
     // `digests` layer: nothing supplies one.

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use dolos_core::{import::ImportExt as _, Domain as _, StateStore as _};
-use dolos_snapshot::export::{self, Plan};
+use dolos_snapshot::export::{self, First, Plan};
 use dolos_testing::{
     synthetic::{build_synthetic_blocks, seed_epoch_logs, seed_reward_logs, SyntheticBlockConfig},
     toy_domain::{ToyDomain, ToyStores},
@@ -116,6 +116,7 @@ pub fn export_to<B: ToyStores>(root: &std::path::Path, domain: &ToyDomain<B>) ->
         domain.state(),
         domain.indexes(),
         None,
+        &First,
     )
     .unwrap()
 }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -328,6 +328,68 @@ fn a_second_publish_builds_and_uploads_only_what_is_new() {
     );
 }
 
+/// A dry run says what the publish then does.
+///
+/// The number a publisher checks before committing hours is worth nothing if it
+/// is computed by a second reading of the same rules, so this holds the two
+/// against each other rather than against a literal.
+#[test]
+#[ignore]
+fn a_dry_run_agrees_with_the_publish_that_follows_it() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/dry-run");
+
+    // Against an empty repository: nothing to follow, nothing to inherit.
+    let empty = registry::preview(&repository, &node.first, false).unwrap();
+
+    assert_eq!(empty.predecessor, None);
+    assert_eq!(empty.history, 0);
+    assert_eq!(empty.layers_reused, 0);
+    assert_eq!(empty.layers_built, PER_PUBLISH);
+
+    let first = node.publish(&repository, &node.first, false);
+
+    assert_eq!(first.layers_built, empty.layers_built);
+    assert_eq!(first.layers_reused, empty.layers_reused);
+
+    // And against the stele that is now there.
+    let next = registry::preview(&repository, &node.second, false).unwrap();
+
+    assert_eq!(next.predecessor, Some((1, first.identity)));
+    assert_eq!(next.history, 1);
+
+    // `--rebuild` is visible in the preview, not only in the publish. Asked
+    // here, while sequence 2 is still unpublished: a preview reads the chain
+    // through the same rule a publish does, so asking after the fact would be
+    // refused as a republish.
+    let rebuilding = registry::preview(&repository, &node.second, true).unwrap();
+
+    assert_eq!(rebuilding.layers_reused, 0);
+    assert_eq!(rebuilding.layers_built, PER_PUBLISH + 3);
+    assert_eq!(rebuilding.history, 1, "a rebuild still chains");
+
+    let second = node.publish(&repository, &node.second, false);
+
+    assert_eq!(
+        (next.layers_built, next.layers_reused),
+        (second.layers_built, second.layers_reused),
+        "the dry run and the publish read the same rules once, not twice"
+    );
+
+    assert_eq!(
+        next.history,
+        second.inscription.history.len(),
+        "and agree about the chain they extend"
+    );
+
+    // A preview reaches the chain refusal too, which is what makes `--dry-run`
+    // the cheap way to find out that a publisher has skipped an epoch.
+    let refused = registry::preview(&repository, &node.second, false).unwrap_err();
+
+    assert!(matches!(refused, Error::HistoryBreak { .. }), "{refused:?}");
+}
+
 /// Done criterion 3. The check that inheritance is *faithful* rather than fast.
 #[test]
 #[ignore]

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -1,0 +1,459 @@
+//! Publishing a Dolos stele into a repository, twice.
+//!
+//! Everything here needs a **registry**, and spawns one: `docker run` of an OCI
+//! Distribution server, torn down on the way out. So everything here is
+//! `#[ignore]`d, and an `#[ignore]`d test that was never executed proves
+//! nothing — run it with:
+//!
+//! ```text
+//! cargo test -p dolos-snapshot --features oci --test publish -- --ignored --nocapture
+//! ```
+//!
+//! `STELAE_TEST_REGISTRY_IMAGE` chooses the server (default `registry:2`), the
+//! same knob `crates/stelae/tests/oci.rs` uses, so this suite can be pointed at
+//! another implementation.
+//!
+//! ## The four properties
+//!
+//! 1. **A second publish builds and uploads only what is new.** Both numbers
+//!    come from counters the code keeps, not from a duration and not from
+//!    asking the registry afterwards — a publish that was merely *fast* would
+//!    satisfy neither.
+//! 2. **The history chains, and a publish that would break it is refused**
+//!    before a single layer is built.
+//! 3. **Reuse is faithful.** The same pair of publishes, one inheriting and one
+//!    rebuilding from the stores, produce the same inscription digest. This is
+//!    the check that inheritance is correct rather than merely cheap, and no
+//!    other check here can stand in for it.
+//! 4. **A different predecessor is a different digest**, deliberately —
+//!    `history` is inside the canonical document, so a repository's identity is
+//!    path-dependent.
+//!
+//! ## Why the two cursors sit where they do
+//!
+//! The harness ledger lives inside epoch zero, so the two publishes are made by
+//! standing at two synthetic chain points and letting `Plan::new` derive
+//! everything: one at the last slot of epoch 0, which publishes sequence 1 with
+//! epoch 0's window **unclamped**, and one at the first slot of epoch 1, which
+//! publishes sequence 2 with an identical epoch-0 window plus an empty epoch 1.
+//!
+//! That the first cursor has to sit on the boundary is not a convenience. A
+//! stele cut mid-epoch clamps its last window to the cursor, so the same epoch
+//! published later in full has a *different scope* and is correctly rebuilt
+//! rather than inherited. Reuse across a sequence is a property of a publisher
+//! that stops on epoch boundaries, which is what ADR-004's pipeline does.
+
+#![cfg(feature = "oci")]
+
+mod node;
+
+use dolos_core::{BlockHash, ChainPoint, Domain as _};
+use dolos_snapshot::{
+    export::Plan,
+    registry::{self, Published},
+    DolosProfile, Error, Network, BLOCKS, INDEXES, LOGS, STATE_SHARDS,
+};
+use dolos_testing::toy_domain::{MemoryStores, ToyDomain};
+use stelae::{oci::Registry, SteleReader as _};
+
+use node::harness;
+
+/// Layers a publish of one epoch writes: three epoch kinds plus the state tip.
+const PER_PUBLISH: usize = 3 + STATE_SHARDS as usize;
+
+// ---------------------------------------------------------------------------
+// A registry the test spawns
+// ---------------------------------------------------------------------------
+
+/// A container running an OCI Distribution server, removed when this is
+/// dropped.
+///
+/// Deliberately a second copy of `Fixture` in `crates/stelae/tests/oci.rs`
+/// rather than a shared one. `stelae` must never depend on a `dolos-*` package
+/// — that is the boundary ADR-004 sets and `cargo tree` checks — so a fixture
+/// both suites could import would have to live somewhere neither of them owns.
+/// Two copies of sixty lines is the cheaper of the two prices. Keep them in
+/// step; the readiness probe below in particular was arrived at the hard way.
+struct Fixture {
+    container: String,
+    port: u16,
+}
+
+impl Fixture {
+    fn spawn() -> Self {
+        let image =
+            std::env::var("STELAE_TEST_REGISTRY_IMAGE").unwrap_or_else(|_| "registry:2".to_owned());
+
+        let run = std::process::Command::new("docker")
+            .args([
+                "run",
+                "--detach",
+                "--rm",
+                "--publish",
+                "127.0.0.1::5000",
+                &image,
+            ])
+            .output()
+            .expect("docker is required to run the registry tests");
+
+        assert!(
+            run.status.success(),
+            "docker run {image}: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+
+        let container = String::from_utf8(run.stdout).unwrap().trim().to_owned();
+
+        let ports = std::process::Command::new("docker")
+            .args(["port", &container, "5000/tcp"])
+            .output()
+            .expect("docker port");
+
+        let mapped = String::from_utf8(ports.stdout).unwrap();
+        let port = mapped
+            .lines()
+            .find_map(|line| line.rsplit(':').next())
+            .and_then(|port| port.trim().parse::<u16>().ok())
+            .unwrap_or_else(|| panic!("no published port in {mapped:?}"));
+
+        let fixture = Self { container, port };
+        fixture.wait_until_ready();
+
+        eprintln!("registry: {image} on 127.0.0.1:{port}");
+
+        fixture
+    }
+
+    /// Wait until the server answers `GET /v2/`.
+    ///
+    /// A connect is *not* the readiness signal, however much it looks like one:
+    /// Docker's port forwarder accepts on the published port from the moment
+    /// the container exists and only then tries to reach the process inside.
+    fn wait_until_ready(&self) {
+        use std::io::{Read, Write};
+
+        let address = format!("127.0.0.1:{}", self.port);
+
+        for _ in 0..300 {
+            let answered = std::net::TcpStream::connect(&address)
+                .ok()
+                .and_then(|mut socket| {
+                    socket
+                        .write_all(
+                            format!("GET /v2/ HTTP/1.0\r\nHost: {address}\r\n\r\n").as_bytes(),
+                        )
+                        .ok()?;
+
+                    let mut answer = [0u8; 16];
+                    let read = socket.read(&mut answer).ok()?;
+
+                    answer[..read].starts_with(b"HTTP/1.").then_some(())
+                });
+
+            if answered.is_some() {
+                return;
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        panic!("the registry never answered GET /v2/ on {address}");
+    }
+
+    fn repository(&self, name: &str) -> Registry {
+        registry::open(format!("127.0.0.1:{}", self.port), name.to_owned(), true).unwrap()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "--force", &self.container])
+            .output();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The node, and the two chain points it publishes from
+// ---------------------------------------------------------------------------
+
+/// The harness ledger and the two plans it publishes: sequence 1 standing on
+/// the epoch-0 boundary, and sequence 2 one slot past it.
+struct Node {
+    domain: ToyDomain<MemoryStores>,
+    first: Plan,
+    second: Plan,
+}
+
+impl Node {
+    fn build() -> Self {
+        let domain = harness::<MemoryStores>();
+
+        let summary = dolos_cardano::eras::load_chain_summary_from_state(domain.state()).unwrap();
+
+        let magic = u64::from(domain.genesis().network_magic());
+        let network = Network::for_magic(magic);
+        let boundary = summary.epoch_start(1);
+
+        // Any hash will do: `position` needs one to exist, and nothing in an
+        // export reads it back out of the store.
+        let point = |slot| ChainPoint::Specific(slot, BlockHash::new([0xab; 32]));
+
+        let first = Plan::new(&summary, network.clone(), point(boundary - 1)).unwrap();
+        let second = Plan::new(&summary, network, point(boundary)).unwrap();
+
+        assert_eq!(first.sequence, 1);
+        assert_eq!(second.sequence, 2);
+        assert_eq!(
+            first.epochs,
+            second.epochs[..1],
+            "epoch 0's window has to be the same in both, or there is nothing to inherit"
+        );
+
+        Self {
+            domain,
+            first,
+            second,
+        }
+    }
+
+    fn publish(&self, repository: &Registry, plan: &Plan, rebuild: bool) -> Published {
+        registry::publish(
+            repository,
+            plan,
+            self.domain.archive(),
+            self.domain.state(),
+            self.domain.indexes(),
+            None,
+            rebuild,
+        )
+        .unwrap()
+    }
+
+    fn refuse(&self, repository: &Registry, plan: &Plan) -> Error {
+        registry::publish(
+            repository,
+            plan,
+            self.domain.archive(),
+            self.domain.state(),
+            self.domain.indexes(),
+            None,
+            false,
+        )
+        .unwrap_err()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Done criteria 1 and 2
+// ---------------------------------------------------------------------------
+
+/// The whole point of the slice: the second publish pays for one epoch.
+#[test]
+#[ignore]
+fn a_second_publish_builds_and_uploads_only_what_is_new() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/incremental");
+
+    let first = node.publish(&repository, &node.first, false);
+
+    assert!(
+        first.inscription.history.is_empty(),
+        "the first stele of a repository carries no history"
+    );
+    assert_eq!(first.layers_built, PER_PUBLISH);
+    assert_eq!(first.layers_reused, 0);
+    assert_eq!(first.transfer.layers_uploaded, PER_PUBLISH as u64);
+
+    let second = node.publish(&repository, &node.second, false);
+
+    // Epoch 0's three layers are inherited; epoch 1's three and the sixteen
+    // state shards are built. The state tip is never inherited — it is the tip,
+    // and its scope names no epoch that could distinguish two publishes.
+    assert_eq!(
+        second.layers_reused, 3,
+        "epoch 0's blocks, indexes and logs"
+    );
+    assert_eq!(
+        second.layers_built, PER_PUBLISH,
+        "epoch 1's three layers and the sixteen state shards"
+    );
+    assert_eq!(second.inscription.layers.len(), PER_PUBLISH + 3);
+
+    // Uploaded, not merely "not rebuilt": an inherited layer moves no bytes at
+    // all, and every built one here is genuinely new to the registry because a
+    // state shard's header record names its epoch.
+    assert_eq!(second.transfer.layers_uploaded, PER_PUBLISH as u64);
+    assert_eq!(second.transfer.layers_reused, 3);
+    assert_eq!(second.transfer.layers_skipped, 0);
+
+    eprintln!(
+        "publish 1: built {}, reused {}, uploaded {} ({} bytes)\n\
+         publish 2: built {}, reused {} ({} bytes not moved), uploaded {} ({} bytes)",
+        first.layers_built,
+        first.layers_reused,
+        first.transfer.layers_uploaded,
+        first.transfer.bytes_uploaded,
+        second.layers_built,
+        second.layers_reused,
+        second.transfer.bytes_reused,
+        second.transfer.layers_uploaded,
+        second.transfer.bytes_uploaded,
+    );
+
+    // Done criterion 2: the chain, and that it validates.
+    assert_eq!(second.inscription.history.len(), 1);
+    assert_eq!(second.inscription.history[0].sequence, 1);
+    assert_eq!(
+        second.inscription.history[0].inscription_digest,
+        first.identity
+    );
+    second.inscription.validate().unwrap();
+
+    // And the inherited descriptors are the predecessor's, byte for byte.
+    for kind in [BLOCKS, INDEXES, LOGS] {
+        let before = layer(&first.inscription, kind, 0);
+        let after = layer(&second.inscription, kind, 0);
+
+        assert_eq!(before, after, "{kind}: epoch 0's layer was inherited whole");
+    }
+
+    // The moving tag resolves, and what comes back is what was published.
+    let latest = repository.pull_latest(&DolosProfile).unwrap();
+
+    assert_eq!(
+        latest.read_inscription().unwrap().digest().unwrap(),
+        second.identity
+    );
+}
+
+/// Done criterion 3. The check that inheritance is *faithful* rather than fast.
+#[test]
+#[ignore]
+fn reuse_and_a_forced_rebuild_agree_on_the_digest() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+
+    let inherited = fixture.repository("dolos/inherited");
+    node.publish(&inherited, &node.first, false);
+    let inherited = node.publish(&inherited, &node.second, false);
+
+    let rebuilt = fixture.repository("dolos/rebuilt");
+    node.publish(&rebuilt, &node.first, false);
+    let rebuilt = node.publish(&rebuilt, &node.second, true);
+
+    assert_eq!(inherited.layers_reused, 3);
+    assert_eq!(rebuilt.layers_reused, 0, "--rebuild inherits nothing");
+    assert_eq!(
+        rebuilt.layers_built,
+        PER_PUBLISH + 3,
+        "and builds everything"
+    );
+
+    // A rebuild still chains: reproducing what you published is not the same
+    // act as forgetting that you published it.
+    assert_eq!(rebuilt.inscription.history, inherited.inscription.history);
+
+    assert_eq!(
+        inherited.identity, rebuilt.identity,
+        "a layer carried forward is the layer this node would have built"
+    );
+
+    eprintln!(
+        "inherited {} == rebuilt {}",
+        inherited.identity, rebuilt.identity
+    );
+}
+
+/// Done criterion 3's other half, and the determinism consequence the history
+/// field brings with it: two repositories that diverged once never agree again.
+#[test]
+#[ignore]
+fn a_different_predecessor_is_a_different_digest() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+
+    let chained = fixture.repository("dolos/chained");
+    node.publish(&chained, &node.first, false);
+    let chained = node.publish(&chained, &node.second, false);
+
+    // Sequence 2 into an empty repository is legal — the protocol permits an
+    // empty history at any sequence — and it is the same stores, the same plan
+    // and the same layers.
+    let fresh = fixture.repository("dolos/fresh");
+    let fresh = node.publish(&fresh, &node.second, false);
+
+    assert!(fresh.inscription.history.is_empty());
+    assert_eq!(fresh.layers_reused, 0);
+
+    assert_eq!(
+        fresh.inscription.layers, chained.inscription.layers,
+        "the layers are identical; `history` is the only field that differs"
+    );
+
+    assert_ne!(
+        fresh.identity, chained.identity,
+        "a stele's identity depends on the chain it extends, deliberately"
+    );
+}
+
+/// Done criterion 2's refusal, in all three shapes.
+#[test]
+#[ignore]
+fn a_publish_that_does_not_follow_latest_is_refused() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/broken-chain");
+
+    node.publish(&repository, &node.first, false);
+    let second = node.publish(&repository, &node.second, false);
+
+    // A republish of the sequence already there.
+    expect_break(node.refuse(&repository, &node.second), 2, 2);
+
+    // And one behind it.
+    expect_break(node.refuse(&repository, &node.first), 2, 1);
+
+    // A gap: the repository is at 2 and this stele is sequence 4.
+    let mut skipped = node.second.clone();
+    skipped.sequence = 4;
+    expect_break(node.refuse(&repository, &skipped), 2, 4);
+
+    // Every refusal happened before anything was written, so the repository is
+    // exactly where it was.
+    let latest = repository.pull_latest(&DolosProfile).unwrap();
+
+    assert_eq!(
+        latest.read_inscription().unwrap().digest().unwrap(),
+        second.identity,
+        "a refused publish moved nothing"
+    );
+}
+
+fn expect_break(error: Error, latest: u64, publishing: u64) {
+    let message = error.to_string();
+
+    assert!(
+        matches!(error, Error::HistoryBreak { .. }),
+        "publishing {publishing}: {error:?}"
+    );
+
+    assert!(
+        message.contains(&latest.to_string()) && message.contains(&publishing.to_string()),
+        "both sequences belong in the message: {message}"
+    );
+}
+
+/// One epoch layer of a given kind, by the epoch its scope names.
+fn layer<'a>(
+    inscription: &'a stelae::inscription::Inscription,
+    kind: &str,
+    epoch: u64,
+) -> &'a stelae::inscription::LayerDescriptor {
+    inscription
+        .layers
+        .iter()
+        .find(|layer| layer.kind == kind && layer.scope["epoch"] == epoch)
+        .unwrap_or_else(|| panic!("no {kind} layer for epoch {epoch}"))
+}

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -129,15 +129,27 @@ impl Fixture {
     /// A connect is *not* the readiness signal, however much it looks like one:
     /// Docker's port forwarder accepts on the published port from the moment
     /// the container exists and only then tries to reach the process inside.
+    ///
+    /// Every socket operation is bounded, because that forwarder is exactly the
+    /// thing that accepts and then says nothing. Without the timeouts the three
+    /// hundred attempts below are not the thirty seconds they read as: one
+    /// silent connection blocks the loop indefinitely, and a test meant to fail
+    /// with a message hangs instead.
     fn wait_until_ready(&self) {
         use std::io::{Read, Write};
 
         let address = format!("127.0.0.1:{}", self.port);
+        let socket_address: std::net::SocketAddr =
+            address.parse().expect("a loopback address and a port");
+        let patience = std::time::Duration::from_millis(500);
 
         for _ in 0..300 {
-            let answered = std::net::TcpStream::connect(&address)
+            let answered = std::net::TcpStream::connect_timeout(&socket_address, patience)
                 .ok()
                 .and_then(|mut socket| {
+                    socket.set_write_timeout(Some(patience)).ok()?;
+                    socket.set_read_timeout(Some(patience)).ok()?;
+
                     socket
                         .write_all(
                             format!("GET /v2/ HTTP/1.0\r\nHost: {address}\r\n\r\n").as_bytes(),
@@ -341,7 +353,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     let repository = fixture.repository("dolos/dry-run");
 
     // Against an empty repository: nothing to follow, nothing to inherit.
-    let empty = registry::preview(&repository, &node.first, false).unwrap();
+    let empty = registry::preview(&repository, &node.first, None, false).unwrap();
 
     assert_eq!(empty.predecessor, None);
     assert_eq!(empty.history, 0);
@@ -354,7 +366,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     assert_eq!(first.layers_reused, empty.layers_reused);
 
     // And against the stele that is now there.
-    let next = registry::preview(&repository, &node.second, false).unwrap();
+    let next = registry::preview(&repository, &node.second, None, false).unwrap();
 
     assert_eq!(next.predecessor, Some((1, first.identity)));
     assert_eq!(next.history, 1);
@@ -363,7 +375,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     // here, while sequence 2 is still unpublished: a preview reads the chain
     // through the same rule a publish does, so asking after the fact would be
     // refused as a republish.
-    let rebuilding = registry::preview(&repository, &node.second, true).unwrap();
+    let rebuilding = registry::preview(&repository, &node.second, None, true).unwrap();
 
     assert_eq!(rebuilding.layers_reused, 0);
     assert_eq!(rebuilding.layers_built, PER_PUBLISH + 3);
@@ -385,7 +397,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
 
     // A preview reaches the chain refusal too, which is what makes `--dry-run`
     // the cheap way to find out that a publisher has skipped an epoch.
-    let refused = registry::preview(&repository, &node.second, false).unwrap_err();
+    let refused = registry::preview(&repository, &node.second, None, false).unwrap_err();
 
     assert!(matches!(refused, Error::HistoryBreak { .. }), "{refused:?}");
 }

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -273,6 +273,7 @@ fn roundtrip<B: ToyStores>() {
             blank.state(),
             blank.indexes(),
             None,
+            &dolos_snapshot::export::First,
         )
         .unwrap()
     };

--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -247,6 +247,26 @@ pub enum Error {
     )]
     ManifestTooLarge { size: usize, layers: usize },
 
+    /// A layer a publisher asked to carry forward, whose blob the repository no
+    /// longer holds.
+    ///
+    /// Distinct from [`Error::LayerNotFound`], which is about a stele that does
+    /// not describe a layer. This one is the opposite shape: a stele describes
+    /// it, and the bytes are gone — a descriptor pointing at a blob a registry
+    /// has reclaimed. Publishing it would produce a well-formed stele nobody
+    /// can restore, so it is refused where it is discovered rather than where
+    /// it would eventually be noticed.
+    #[cfg(feature = "oci")]
+    #[error(
+        "layer {kind:?} ({diff_id}) cannot be carried forward: this repository no longer holds \
+         its blob {blob}"
+    )]
+    BlobMissing {
+        kind: String,
+        diff_id: String,
+        blob: String,
+    },
+
     /// Anything the registry client reported.
     #[cfg(feature = "oci")]
     #[error("registry error: {0}")]

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -91,7 +91,7 @@ use oci_client::{
 };
 
 use crate::{
-    digest::LayerWriter,
+    digest::{LayerDigests, LayerWriter},
     frame::{CanonicalCbor, LayerHeader, Limits, SeqWriter},
     inscription::{canonical_json, Inscription, LayerDescriptor},
     layer::LayerReader,
@@ -149,10 +149,22 @@ pub struct Transfer {
     pub layers_uploaded: u64,
     /// Layer blobs the registry already had, and that were not.
     pub layers_skipped: u64,
+    /// Layer blobs that were never built, because [`Registry::adopt_layer`]
+    /// took them from a stele already in this repository.
+    ///
+    /// Deliberately not folded into `layers_skipped`. A skipped layer was
+    /// built, hashed and then found to be present already, so the publisher
+    /// paid for it and saved only the upload; an adopted one was never read out
+    /// of a store at all. They are different costs and a publisher comparing
+    /// two publishes wants to tell them apart.
+    pub layers_reused: u64,
     /// Compressed bytes uploaded.
     pub bytes_uploaded: u64,
     /// Compressed bytes the skip saved.
     pub bytes_skipped: u64,
+    /// Compressed bytes an adopted layer did not move, as the manifest it came
+    /// from reports them.
+    pub bytes_reused: u64,
 }
 
 /// How to reach a registry.
@@ -343,6 +355,126 @@ impl Registry {
     pub fn pull_latest(&self, profile: &dyn Profile) -> Result<Stele, Error> {
         let tag = profile.moving_tag().to_owned();
         self.pull(profile, &tag)
+    }
+
+    /// The most recent stele, or `None` if this repository has never held one.
+    ///
+    /// The whole value of this over [`Registry::pull_latest`] is the
+    /// distinction it draws, and the distinction is load-bearing rather than
+    /// convenient. A publisher chains each stele to the one before it, so
+    /// "there is nothing to chain to" starts a history and *anything else*
+    /// must not: a timeout, a 500 or an expired token read as absence would
+    /// silently restart the chain, which is the exact outcome an inscription's
+    /// `history` exists to prevent. So only the shapes a registry uses to say
+    /// "no such manifest" become `None`, and every other failure propagates.
+    ///
+    /// Those shapes are three, because `oci-client` reports a 404 in three
+    /// ways depending on which layer of the client noticed it. Matching them
+    /// here rather than at a caller is the point: this is the only module in
+    /// the crate that has any business naming an `oci_client` error type.
+    pub fn latest(&self, profile: &dyn Profile) -> Result<Option<Stele>, Error> {
+        match self.pull_latest(profile) {
+            Ok(stele) => Ok(Some(stele)),
+            Err(Error::Registry(e)) if is_absent(&e) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Carry a layer this repository already holds into the stele being
+    /// written, without building it.
+    ///
+    /// This is the operation a content-addressed registry makes possible and a
+    /// directory does not: the caller has established — by whatever rule its
+    /// profile owns — that a layer it *would* write is the layer a previous
+    /// stele already published, so the bytes need neither be produced nor sent,
+    /// and the new manifest simply points at the blob the old one pointed at.
+    ///
+    /// **The new stele attests a layer it did not reproduce.** That is the
+    /// trade, and it is the caller's to make: nothing here can check that the
+    /// descriptor describes those bytes, because checking would mean reading
+    /// them, which is the cost being avoided. What *is* checked is that the
+    /// blob is still there — one `HEAD`, before the manifest is written —
+    /// because a descriptor pointing at a blob the registry has reclaimed is a
+    /// stele nobody can restore, and it would be published looking perfectly
+    /// well-formed.
+    ///
+    /// The caller names the layer by its `descriptor` — identity, out of an
+    /// inscription — and the stele it came from. The blob digest and the
+    /// compressed size are read off *that stele's manifest*, by exactly the
+    /// lookup [`SteleReader::stream_layer`] uses, rather than passed in beside
+    /// the descriptor: they are transport facts, they belong to the manifest,
+    /// and a caller assembling the pair by hand is a caller that can mismatch
+    /// them.
+    pub fn adopt_layer(&self, source: &Stele, descriptor: LayerDescriptor) -> Result<(), Error> {
+        let missing = || Error::LayerNotFound {
+            kind: descriptor.kind.clone(),
+            diff_id: descriptor.diff_id.to_string(),
+        };
+
+        let blob = source
+            .blobs
+            .blob_for(&descriptor.diff_id)
+            .ok_or_else(missing)?;
+        let named = blob.to_string();
+
+        let oci = source
+            .manifest
+            .layers
+            .iter()
+            .find(|layer| layer.digest == named)
+            .ok_or_else(missing)?;
+
+        let compressed_size = oci.size.max(0) as u64;
+
+        if !self.shared.blob_exists(&blob)? {
+            return Err(Error::BlobMissing {
+                kind: descriptor.kind,
+                diff_id: descriptor.diff_id.to_string(),
+                blob: named,
+            });
+        }
+
+        let adopted = WrittenLayer {
+            digests: LayerDigests {
+                diff_id: descriptor.diff_id,
+                blob_digest: blob,
+                uncompressed_size: descriptor.uncompressed_size,
+                compressed_size,
+            },
+            descriptor,
+        };
+
+        let mut state = self.shared.locked();
+        state.transfer.layers_reused += 1;
+        state.transfer.bytes_reused += compressed_size;
+        state.pending.push(adopted);
+
+        Ok(())
+    }
+}
+
+/// Whether a registry error means "no such manifest" rather than "something
+/// went wrong".
+///
+/// `oci-client` does not normalize this, and the three shapes are not
+/// interchangeable in practice: `distribution` answers a missing tag with a
+/// `MANIFEST_UNKNOWN` envelope, a repository that has never existed with
+/// `NAME_UNKNOWN`, and some registries answer with a bare 404 that the client
+/// turns into `ImageManifestNotFoundError` or a `ServerError`. The client's own
+/// referrers fallback matches the same set, for the same reason.
+fn is_absent(error: &oci_client::errors::OciDistributionError) -> bool {
+    use oci_client::errors::{OciDistributionError as E, OciErrorCode};
+
+    match error {
+        E::ImageManifestNotFoundError(_) => true,
+        E::ServerError { code: 404, .. } => true,
+        E::RegistryError { envelope, .. } => envelope.errors.iter().any(|e| {
+            matches!(
+                e.code,
+                OciErrorCode::ManifestUnknown | OciErrorCode::NameUnknown
+            )
+        }),
+        _ => false,
     }
 }
 

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -87,8 +87,17 @@ use oci_client::{
     client::{ClientConfig, ClientProtocol},
     manifest::{OciDescriptor, OciImageManifest, OCI_IMAGE_MEDIA_TYPE},
     secrets::RegistryAuth,
-    Client, Reference,
+    Client,
 };
+
+/// The reference type this transport addresses a repository by.
+///
+/// Re-exported because its `FromStr` is the distribution grammar — lowercase
+/// name components, `.`/`_`/`-` separators, no empty segments — and a caller
+/// taking a repository from an operator wants that verdict rather than a second
+/// copy of the grammar of its own. `dolos snapshot publish --repo` is the
+/// caller that does.
+pub use oci_client::Reference;
 
 use crate::{
     digest::{LayerDigests, LayerWriter},
@@ -424,7 +433,18 @@ impl Registry {
             .find(|layer| layer.digest == named)
             .ok_or_else(missing)?;
 
-        let compressed_size = oci.size.max(0) as u64;
+        // Refused rather than clamped. A descriptor's size is an `i64` and a
+        // negative one is a manifest saying something impossible; clamping it
+        // to zero would carry that zero into the new manifest, where it becomes
+        // the ceiling a later reader holds the download to — so the stele would
+        // publish looking well-formed and refuse to restore. Every other
+        // malformed-manifest shape here is a refusal, and this is one too.
+        let compressed_size = u64::try_from(oci.size).map_err(|_| {
+            Error::ManifestMismatch(format!(
+                "layer {:?} ({}) claims a compressed size of {}",
+                descriptor.kind, descriptor.diff_id, oci.size,
+            ))
+        })?;
 
         if !self.shared.blob_exists(&blob)? {
             return Err(Error::BlobMissing {
@@ -1118,6 +1138,13 @@ fn blob_stream(file: File) -> impl Stream<Item = oci_client::errors::Result<byte
 /// fails at the *end*, after every byte has been written; the ceiling fails as
 /// soon as the stream exceeds what its descriptor claims, so a blob that lies
 /// about its size costs its size and not the disk.
+///
+/// A negative size clamps to a ceiling of zero here, and that is deliberate
+/// rather than an oversight — unlike [`Registry::adopt_layer`], which refuses
+/// one. The directions differ: a zero ceiling refuses every non-empty blob,
+/// which is the safe answer to a manifest claiming something impossible, while
+/// clamping on the way *into* a manifest would publish that impossible claim
+/// forward as a number a later reader trusts.
 struct Blocking<'a, W: Write> {
     inner: &'a mut W,
     written: u64,
@@ -1175,5 +1202,64 @@ impl<W: Write + Unpin> tokio::io::AsyncWrite for Blocking<'_, W> {
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         Poll::Ready(self.get_mut().inner.flush())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oci_client::errors::{OciDistributionError, OciEnvelope, OciError, OciErrorCode};
+
+    use super::*;
+
+    fn envelope(code: OciErrorCode) -> OciDistributionError {
+        OciDistributionError::RegistryError {
+            envelope: OciEnvelope {
+                errors: vec![OciError {
+                    code,
+                    message: String::new(),
+                    detail: serde_json::Value::Null,
+                }],
+            },
+            url: "https://registry.invalid/v2/x/manifests/latest".to_owned(),
+        }
+    }
+
+    fn server_error(code: u16) -> OciDistributionError {
+        OciDistributionError::ServerError {
+            code,
+            url: "https://registry.invalid/v2/x/manifests/latest".to_owned(),
+            message: String::new(),
+        }
+    }
+
+    /// The three shapes a registry uses to say "no such manifest".
+    #[test]
+    fn absence_is_the_three_shapes_of_a_missing_manifest() {
+        assert!(is_absent(
+            &OciDistributionError::ImageManifestNotFoundError("latest".to_owned())
+        ));
+        assert!(is_absent(&server_error(404)));
+        assert!(is_absent(&envelope(OciErrorCode::ManifestUnknown)));
+        assert!(is_absent(&envelope(OciErrorCode::NameUnknown)));
+    }
+
+    /// The half that carries the weight: a registry that failed is not a
+    /// registry that is empty.
+    ///
+    /// [`Registry::latest`] turns absence into `None`, and a publisher reads
+    /// `None` as "nothing to chain to" and starts a fresh history. So a
+    /// timeout, a 500 or an expired token widening into absence would silently
+    /// restart the attestation chain — which is the outcome an inscription's
+    /// `history` exists to prevent, arrived at without anything looking wrong.
+    #[test]
+    fn a_failed_request_is_never_absence() {
+        assert!(!is_absent(&server_error(500)));
+        assert!(!is_absent(&server_error(503)));
+        assert!(!is_absent(&envelope(OciErrorCode::Unauthorized)));
+        assert!(!is_absent(&envelope(OciErrorCode::Denied)));
+        assert!(!is_absent(&OciDistributionError::UnauthorizedError {
+            url: "https://registry.invalid/v2/x/manifests/latest".to_owned(),
+        }));
+        assert!(!is_absent(&OciDistributionError::GenericError(None)));
     }
 }

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -43,8 +43,8 @@ use stelae::{
     frame::{encode, CanonicalCbor, Limits},
     inscription::LayerDescriptor,
     oci::{
-        build_manifest, manifest_bytes, read_manifest, Options, Registry, DIFF_ID_ANNOTATION,
-        KIND_ANNOTATION, SCOPE_ANNOTATION,
+        build_manifest, manifest_bytes, read_manifest, Options, Registry, Transfer,
+        DIFF_ID_ANNOTATION, KIND_ANNOTATION, SCOPE_ANNOTATION,
     },
     Compression, Digest, Error, HistoryEntry, Inscription, LayerDigests, LayerSpec, Profile,
     RecordSink, SteleReader, SteleWriter, WrittenLayer,
@@ -1243,6 +1243,94 @@ fn staging_stays_in_the_scratch_directory_and_leaves_nothing() {
         .collect();
 
     assert!(left.is_empty(), "{left:?}");
+}
+
+/// `latest` tells "this repository holds nothing" apart from "this repository
+/// could not be read", which is the distinction a publisher's history chain
+/// rests on.
+///
+/// Both halves against a real server, because the shape a registry uses to say
+/// "no such manifest" is exactly the thing that cannot be established by
+/// reading a client's source.
+#[test]
+#[ignore = "spawns a registry"]
+fn latest_is_absent_until_something_is_published() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+    let registry = fixture.registry("stelae/eventually");
+
+    assert!(
+        registry.latest(&ToyProfile).unwrap().is_none(),
+        "an empty repository holds no stele, and that is not an error"
+    );
+
+    let published = write_stele(&registry, 3);
+
+    let found = registry
+        .latest(&ToyProfile)
+        .unwrap()
+        .expect("the repository holds a stele now");
+
+    assert_eq!(found.read_inscription().unwrap(), published);
+
+    // A repository that never existed is absent too, and by a different
+    // registry error code than a missing tag in one that does.
+    let empty = fixture.registry("stelae/never-written-to");
+    assert!(empty.latest(&ToyProfile).unwrap().is_none());
+}
+
+/// A layer cannot be carried forward into a repository that does not hold its
+/// blob.
+///
+/// The guard exists because the failure it prevents is invisible: a manifest
+/// pointing at a reclaimed blob is a perfectly well-formed stele that nobody
+/// can restore.
+///
+/// **Provoked with a second registry, not a second repository**, and the
+/// difference is a real one this test found. `zot` answers `HEAD` *and* `GET`
+/// for a blob under a repository it was never pushed to — its storage is
+/// content-addressed across the whole registry — while `distribution` 2.8 and
+/// 3.0 answer 404. So a sibling repository is not reliably a place a blob is
+/// absent from, and on `zot` it would not even be the wrong answer: a registry
+/// that will serve the blob is a registry where the manifest works. Only a
+/// separate server is absent everywhere.
+#[test]
+#[ignore = "spawns a registry"]
+fn a_layer_whose_blob_is_not_there_cannot_be_carried_forward() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    let source = fixture.registry("stelae/source");
+    let published = write_stele(&source, 3);
+    let stele = source.latest(&ToyProfile).unwrap().unwrap();
+
+    let somewhere_else = Fixture::spawn();
+    let elsewhere = somewhere_else.registry("stelae/source");
+
+    let err = elsewhere
+        .adopt_layer(&stele, published.layers[0].clone())
+        .unwrap_err();
+
+    assert!(matches!(err, Error::BlobMissing { .. }), "{err:?}");
+    assert_eq!(elsewhere.transfer(), Transfer::default(), "nothing counted");
+
+    // The same call against the repository that does hold it is the whole
+    // operation: no bytes move, and the layer is counted as carried forward.
+    // Reset first, so what is read back is this call's cost and not the two
+    // layers `write_stele` pushed through the same transport.
+    source.take_transfer();
+
+    source
+        .adopt_layer(&stele, published.layers[0].clone())
+        .unwrap();
+
+    let transfer = source.take_transfer();
+
+    assert_eq!(transfer.layers_reused, 1);
+    assert_eq!(transfer.layers_uploaded, 0);
+    assert!(transfer.bytes_reused > 0);
 }
 
 /// The annotation map is a `BTreeMap`, so the canonical JSON above is not

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -6,6 +6,9 @@
 //!
 //! Only `publish` exists so far. `digest`, `verify`, `inspect` and `sign` are
 //! the publisher-productization slice, and restore is its own.
+//!
+//! Publishing into a registry is behind the `registry` feature, which is
+//! default-off; `--repo` in a build without it is a refusal naming the feature.
 
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
@@ -14,7 +17,7 @@ mod publish;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// writes a stele to a local directory
+    /// writes a stele to a local directory or an OCI repository
     Publish(publish::Args),
 }
 

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -56,6 +56,16 @@ pub struct Args {
 /// particular: the tag a stele publishes under is the profile's — `epoch-{n}`
 /// and `latest` — so a URL naming one is a publisher expecting something this
 /// command will not do.
+///
+/// The repository *name* is held to the distribution grammar — lowercase
+/// components, `.`/`_`/`-` separators, no empty segments — by handing it to the
+/// parser `oci-client` already ships rather than by a second copy of that
+/// grammar living here. It is a validator only: its own splitter applies
+/// registry defaults (a bare name becomes `docker.io/...`) that would quietly
+/// rewrite what the operator typed, so the split above stays ours. Without the
+/// check, `oci://ghcr.io//txpipe/dolos` or an uppercase component is accepted
+/// here and refused by the registry, hours later, in its words rather than
+/// ours.
 #[derive(Debug, Clone)]
 struct RepoRef {
     host: String,
@@ -91,6 +101,16 @@ impl std::str::FromStr for RepoRef {
                  profile's",
             ));
         }
+
+        // Checked here, discarded here: what is wanted is the grammar's verdict
+        // on the name, not the reference it would build out of it.
+        //
+        // Gated because the parser arrives with the registry client. A build
+        // without one refuses `--repo` outright, so the check it cannot make is
+        // one nothing would reach.
+        #[cfg(feature = "registry")]
+        rest.parse::<dolos_snapshot::registry::Reference>()
+            .map_err(|_| bad("its repository path is not a valid OCI name"))?;
 
         Ok(Self {
             host: host.to_owned(),
@@ -210,7 +230,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     match (&args.repo, &args.output_dir) {
         (Some(repo), _) => to_repository(args, repo, &plan, &stores),
         (None, Some(dir)) => to_directory(args, dir, &plan, &stores),
-        // clap's `required_unless_present` already refuses this.
+        // The required `destination` group already refuses this.
         (None, None) => unreachable!("one of --output-dir and --repo is required"),
     }
 }
@@ -269,7 +289,10 @@ fn to_repository(
         .context("opening the repository")?;
 
     if args.dry_run {
-        let preview = registry::preview(&registry, plan, args.rebuild)
+        // `None` here and `None` at the `publish` below are one decision: a dry
+        // run describes the publish that follows it, so the two calls are
+        // handed the same digest records or the number is about something else.
+        let preview = registry::preview(&registry, plan, None, args.rebuild)
             .into_diagnostic()
             .context("planning the publish")?;
 
@@ -406,6 +429,45 @@ mod tests {
             "",
         ] {
             assert!(raw.parse::<RepoRef>().is_err(), "{raw:?}");
+        }
+    }
+
+    /// Names the distribution grammar refuses, which a split on `/` alone
+    /// cannot see.
+    ///
+    /// Each of these reaches the registry as part of the request path, so
+    /// accepting them here buys the operator an opaque error from someone
+    /// else's server at the end of a publish rather than a sentence from this
+    /// command at the start of one.
+    #[cfg(feature = "registry")]
+    #[test]
+    fn a_repository_path_outside_the_grammar_is_refused() {
+        for raw in [
+            "oci://ghcr.io//txpipe/dolos",      // an empty component
+            "oci://ghcr.io/txpipe//dolos",      // an empty component, inside
+            "oci://ghcr.io/TxPipe/dolos",       // uppercase; names are lowercase
+            "oci://ghcr.io/txpipe/dolos?x=1",   // a query
+            "oci://ghcr.io/txpipe/dolos#frag",  // a fragment
+            "oci://ghcr.io/txpipe/dolos snaps", // whitespace
+            "oci://ghcr.io/txpipe/-dolos",      // a component opening on a separator
+        ] {
+            assert!(raw.parse::<RepoRef>().is_err(), "{raw:?}");
+        }
+    }
+
+    /// And the shapes it allows, so the check above is not quietly refusing
+    /// everything.
+    #[cfg(feature = "registry")]
+    #[test]
+    fn ordinary_repository_paths_still_parse() {
+        for raw in [
+            "oci://ghcr.io/txpipe/dolos-snapshots/mainnet",
+            "oci://ghcr.io/txpipe/dolos_snapshots",
+            "oci://ghcr.io/txpipe/dolos.snapshots",
+            "oci://localhost:5000/dolos/mainnet",
+            "oci://127.0.0.1:5000/dolos",
+        ] {
+            assert!(raw.parse::<RepoRef>().is_ok(), "{raw:?}");
         }
     }
 }

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -5,20 +5,98 @@ use dolos_core::config::RootConfig;
 use dolos_snapshot::export;
 use miette::{Context as _, IntoDiagnostic as _};
 
+/// Where a stele goes, and it goes to exactly one place.
+///
+/// An [`ArgGroup`] rather than a pair of `conflicts_with`/`required_unless`
+/// attributes, because it is the only spelling whose *message* names both
+/// options when neither is given. `--rebuild` and `--insecure` then say they
+/// conflict with `--output-dir` rather than that they require `--repo`: a
+/// boolean flag is always "present" to clap's `requires`, so the requirement
+/// would never fire.
 #[derive(Debug, Parser)]
+#[command(group(
+    clap::ArgGroup::new("destination").required(true).args(["output_dir", "repo"])
+))]
 pub struct Args {
     /// directory to write the stele into; must not already hold one
     #[arg(long)]
-    output_dir: PathBuf,
+    output_dir: Option<PathBuf>,
+
+    /// OCI repository to publish into, e.g.
+    /// `oci://ghcr.io/txpipe/dolos-mainnet`
+    #[arg(long, value_name = "OCI_URL")]
+    repo: Option<RepoRef>,
 
     /// epochs to write layers for, e.g. `500..520`, `500..=520`, `500..`,
     /// `..520` or `500`; defaults to every epoch below the cursor
     #[arg(long, value_name = "RANGE")]
     epochs: Option<EpochRange>,
 
+    /// rebuild every layer instead of carrying forward the ones a previous
+    /// publish already put in the repository
+    #[arg(long, action, conflicts_with = "output_dir")]
+    rebuild: bool,
+
+    /// talk to the repository over plaintext HTTP rather than HTTPS; for a
+    /// registry on a loopback address or a mirror inside a cluster, and for
+    /// nothing reachable from outside one
+    #[arg(long, action, conflicts_with = "output_dir")]
+    insecure: bool,
+
     /// report what would be written and exit
     #[arg(long, action)]
     dry_run: bool,
+}
+
+/// An OCI repository, as `oci://HOST/PATH`.
+///
+/// Split into the registry host and the repository path the way a registry
+/// client wants them, and refused rather than guessed at where the URL says
+/// something a publish cannot honour. A `:tag` or `@digest` is refused in
+/// particular: the tag a stele publishes under is the profile's — `epoch-{n}`
+/// and `latest` — so a URL naming one is a publisher expecting something this
+/// command will not do.
+#[derive(Debug, Clone)]
+struct RepoRef {
+    host: String,
+    repository: String,
+}
+
+impl std::str::FromStr for RepoRef {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let bad = |why: &str| format!("{raw:?} is not an OCI repository: {why}");
+
+        let rest = raw
+            .strip_prefix("oci://")
+            .ok_or_else(|| bad("it does not start with `oci://`"))?;
+
+        let (host, repository) = rest
+            .split_once('/')
+            .ok_or_else(|| bad("it names a registry but no repository path"))?;
+
+        if host.is_empty() {
+            return Err(bad("it names no registry host"));
+        }
+
+        if repository.is_empty() || repository.ends_with('/') {
+            return Err(bad("it names no repository path"));
+        }
+
+        // A host may carry a port, so only the path is checked for a reference.
+        if repository.contains(':') || repository.contains('@') {
+            return Err(bad(
+                "it names a tag or a digest, and the tag a stele publishes under is the \
+                 profile's",
+            ));
+        }
+
+        Ok(Self {
+            host: host.to_owned(),
+            repository: repository.to_owned(),
+        })
+    }
 }
 
 /// An epoch selection, in Rust's own range spellings.
@@ -129,14 +207,28 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         _ => println!("epochs:   none selected; the state tip only"),
     }
 
+    match (&args.repo, &args.output_dir) {
+        (Some(repo), _) => to_repository(args, repo, &plan, &stores),
+        (None, Some(dir)) => to_directory(args, dir, &plan, &stores),
+        // clap's `required_unless_present` already refuses this.
+        (None, None) => unreachable!("one of --output-dir and --repo is required"),
+    }
+}
+
+fn to_directory(
+    args: &Args,
+    dir: &std::path::Path,
+    plan: &export::Plan,
+    stores: &crate::common::Stores,
+) -> miette::Result<()> {
     if args.dry_run {
-        println!("dry run: nothing written to {}", args.output_dir.display());
+        println!("dry run: nothing written to {}", dir.display());
         return Ok(());
     }
 
     let inscription = export::publish(
-        &args.output_dir,
-        &plan,
+        dir,
+        plan,
         &stores.archive,
         &stores.state,
         &stores.indexes,
@@ -147,7 +239,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
     let digest = inscription.digest().into_diagnostic()?;
 
-    println!("wrote {}", args.output_dir.display());
+    println!("wrote {}", dir.display());
     println!("layers:   {}", inscription.layers.len());
     println!(
         "size:     {} uncompressed bytes",
@@ -156,6 +248,104 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     println!("identity: {digest}");
 
     Ok(())
+}
+
+/// Publish into an OCI repository, chained to whatever is already in it.
+///
+/// The report is what a publisher wants to check rather than trust: how much of
+/// this stele was inherited rather than built, and how much of it moved. Both
+/// are numbers the code counted, not an inference from a duration.
+#[cfg(feature = "registry")]
+fn to_repository(
+    args: &Args,
+    repo: &RepoRef,
+    plan: &export::Plan,
+    stores: &crate::common::Stores,
+) -> miette::Result<()> {
+    use dolos_snapshot::registry;
+
+    let registry = registry::open(&repo.host, &repo.repository, args.insecure)
+        .into_diagnostic()
+        .context("opening the repository")?;
+
+    if args.dry_run {
+        let preview = registry::preview(&registry, plan, args.rebuild)
+            .into_diagnostic()
+            .context("planning the publish")?;
+
+        match preview.predecessor {
+            Some((sequence, digest)) => println!("follows:  sequence {sequence} ({digest})"),
+            None => println!("follows:  nothing; this repository holds no stele"),
+        }
+
+        println!("history:  {} entries", preview.history);
+        println!("reuse:    {} layers carried forward", preview.layers_reused);
+        println!("build:    {} layers", preview.layers_built);
+        println!(
+            "dry run: nothing written to oci://{}/{}",
+            repo.host, repo.repository
+        );
+
+        return Ok(());
+    }
+
+    let published = registry::publish(
+        &registry,
+        plan,
+        &stores.archive,
+        &stores.state,
+        &stores.indexes,
+        None,
+        args.rebuild,
+    )
+    .into_diagnostic()
+    .context("publishing the stele")?;
+
+    let transfer = published.transfer;
+
+    println!("wrote oci://{}/{}", repo.host, repo.repository);
+    println!("history:  {} entries", published.inscription.history.len());
+    println!(
+        "layers:   {} ({} built, {} carried forward)",
+        published.inscription.layers.len(),
+        published.layers_built,
+        published.layers_reused,
+    );
+    println!(
+        "uploaded: {} layers, {} compressed bytes",
+        transfer.layers_uploaded, transfer.bytes_uploaded,
+    );
+    println!(
+        "skipped:  {} layers already in the registry, {} compressed bytes",
+        transfer.layers_skipped, transfer.bytes_skipped,
+    );
+    println!(
+        "size:     {} uncompressed bytes",
+        published.inscription.uncompressed_size()
+    );
+    println!("identity: {}", published.identity);
+
+    Ok(())
+}
+
+/// The same command in a build that has no registry client.
+///
+/// A clean refusal naming the feature, rather than a flag that parses and then
+/// does nothing. The `registry` feature is default-off because the TLS stack it
+/// brings needs `cmake` to build.
+#[cfg(not(feature = "registry"))]
+fn to_repository(
+    _args: &Args,
+    repo: &RepoRef,
+    _plan: &export::Plan,
+    _stores: &crate::common::Stores,
+) -> miette::Result<()> {
+    miette::bail!(
+        "cannot publish to oci://{}/{}: this build has no registry client; \
+         rebuild dolos with `--features registry`",
+        repo.host,
+        repo.repository,
+    )
 }
 
 #[cfg(test)]
@@ -182,6 +372,40 @@ mod tests {
     fn a_nonsensical_range_is_refused() {
         for raw in ["520..500", "..0", "abc", "", "500..abc", "500..=", "-1"] {
             assert!(raw.parse::<EpochRange>().is_err(), "{raw:?}");
+        }
+    }
+
+    #[test]
+    fn a_repository_splits_into_a_host_and_a_path() {
+        let parsed: RepoRef = "oci://ghcr.io/txpipe/dolos-snapshots/mainnet"
+            .parse()
+            .unwrap();
+
+        assert_eq!(parsed.host, "ghcr.io");
+        assert_eq!(parsed.repository, "txpipe/dolos-snapshots/mainnet");
+
+        // A port belongs to the host, which is what makes the tag check below
+        // safe to run on the path alone.
+        let local: RepoRef = "oci://127.0.0.1:5000/dolos".parse().unwrap();
+
+        assert_eq!(local.host, "127.0.0.1:5000");
+        assert_eq!(local.repository, "dolos");
+    }
+
+    #[test]
+    fn a_nonsensical_repository_is_refused() {
+        for raw in [
+            "ghcr.io/txpipe/dolos",                  // no scheme
+            "https://ghcr.io/txpipe/dolos",          // the wrong scheme
+            "oci://ghcr.io",                         // no repository path
+            "oci://ghcr.io/",                        // still no repository path
+            "oci:///txpipe/dolos",                   // no host
+            "oci://ghcr.io/txpipe/dolos/",           // a trailing slash
+            "oci://ghcr.io/txpipe/dolos:v1",         // a tag is the profile's to render
+            "oci://ghcr.io/txpipe/dolos@sha256:abc", // and so is a digest
+            "",
+        ] {
+            assert!(raw.parse::<RepoRef>().is_err(), "{raw:?}");
         }
     }
 }


### PR DESCRIPTION
Plan: [`plans/dolos-stelae-registry-publish.md`](https://github.com/txpipe/dolos) (Trellis domain, `org/coder`). Base: `main` at `f58e9be3`, the [dolos-stelae-oci-transport](https://github.com/txpipe/dolos/pull/1170) merge.

A Dolos node publishes a stele into an OCI repository, chained to the one before it, and a second publish costs the epoch that closed since the first.

## Done criteria

| # | Criterion | Met |
|---|---|---|
| 1 | Publishing E then E+1 uploads only the new epoch's layers plus the sixteen state shards, and *builds* only the new epoch's layers, both counted by the code | ✅ |
| 2 | The second inscription carries a contiguous `history` ending at E and validates; a publish whose `latest` is not `sequence - 1` is refused, naming both sequences | ✅ |
| 3 | Reuse and `--rebuild` produce identical inscription digests | ✅ |
| 4 | The registry end-to-end test is `#[ignore]`d, **run**, and quoted below | ✅ |
| 5 | `cargo test`, clippy `-D warnings`, nightly fmt, `cargo deny`, and the `stelae` boundary tree check | ✅ |

## What changed

**`crates/stelae/src/oci.rs` — two additive methods.** See "Scope calls" below for why they exist at all.

- `Registry::latest(&dyn Profile) -> Option<Stele>` distinguishes "this repository holds nothing" from "this repository could not be read". The distinction is load-bearing rather than convenient: a timeout or a 500 read as absence would silently restart the history chain, which is the exact outcome the field exists to prevent. `oci-client` reports a 404 in three shapes depending on which layer of the client noticed it; matching them belongs in the only module that has any business naming an `oci_client` error type.
- `Registry::adopt_layer(&Stele, LayerDescriptor)` carries a layer forward without building it. The blob digest and compressed size are read off the source stele's own manifest, by the same lookup `stream_layer` uses, rather than passed in beside the descriptor — they are transport facts and a caller assembling the pair by hand is a caller that can mismatch them. `blob_exists` runs first.
- `Transfer` gains `layers_reused`/`bytes_reused`, deliberately not folded into `layers_skipped`: a skipped layer was built and then found present, an adopted one was never read out of a store at all.

**`crates/snapshot/src/export.rs` — one new parameter, one concept.** `Predecessor` answers what `history` the new inscription carries and which layers it may inherit. One trait rather than two parameters because both are things only the previous publish can say, and because `--rebuild` has to suppress inheritance *without* suppressing chaining. `First` is the no-predecessor case, which is every directory publish. The lookup happens before any store is touched — the cost being saved is the traversal, not the compression.

**`crates/snapshot/src/registry.rs` (new, feature `oci`)** — the publisher: the chain, the refusal, the inheritance table keyed by `(kind, canonical scope)`, and `publish`/`preview`.

**`src/bin/dolos/snapshot/publish.rs`** — `--repo oci://HOST/PATH`, mutually exclusive with `--output-dir` through an `ArgGroup`, plus `--rebuild` and `--insecure`.

### Three rules that are in the code because they are not obvious

- **Scope equality is the entire test** — `epoch`, `startSlot`, `endSlot`. That is what makes a previously *clamped* final epoch correctly fail to match the same epoch published later in full, and be rebuilt. Reuse across a sequence is therefore a property of a publisher that stops on epoch boundaries.
- **State shards are never inherited.** The obvious reason is that they are the tip. The reason that actually matters is that `StateScope::descriptor` is `{"shard": n}` and names no epoch, so scope equality *could not* tell one publish's shard from another's. The rule is not a policy that could be relaxed.
- **A repository's identity is path-dependent.** `history` is inside the canonical document, so two repositories that diverged once never agree on a digest again. Deliberate, and pinned by a test.

## Scope calls

**1 — Two additive methods in `crates/stelae`, which the plan's Approach says not to touch.** Confirmed with `org/founder` before implementation. Reuse cannot be built under that constraint, and this is a fact about the code rather than a preference: `PushState::pending` is private and appended to only by `RegistrySink::finish`, and `seal` builds the manifest from it — so a layer that is not rebuilt has no way into the manifest. Likewise a missing `latest` arrives as an opaque `Error::Registry`, and classifying it outside `oci.rs` means reimplementing the client's own heuristic in the profile crate. Nothing about the wire format, the `SteleWriter`/`SteleReader` seam, the inscription or the manifest shape changes.

**2 — `registry` is a default-off feature of `dolos`.** Turning `stelae/oci` on pulls `aws-lc-sys`, which needs `cmake` — the dependency the root `Cargo.toml` already refuses in writing for `mithril-client`, and the subject of a separate plan. `cargo tree -e normal -i aws-lc-sys` matches nothing under default features and only `oci-client → jsonwebtoken`/`reqwest` under `--features registry`. Adding it to `default` is a one-line follow-up once that is resolved; that is `org/founder`'s call and not this slice's.

## Findings this slice reports rather than absorbs

- **`zot` serves a blob from a repository it was never pushed to.** Found by a test that used a sibling repository as a stand-in for "a repository that does not hold this blob". Probed directly: after a blob is pushed to `/v2/one/`, `zot` answers `HEAD` **and** `GET` 200 on `/v2/two/` for the same digest, while `distribution` 2.8 and 3.0 answer 404. Its storage is content-addressed registry-wide. This is not a defect in the guard — a registry that will serve the blob is a registry where the manifest works — but it means a sibling repository is not a place a blob is reliably absent from. The test now spawns a second registry instead, which is absent everywhere.
- **`--dry-run` reports what the scopes permit and spends no `HEAD` per layer.** The publish verifies every blob it inherits, so a dry run can promise a reuse that the publish then refuses — loudly, naming the blob. Stated in the doc comment; the alternative was N extra round trips for an answer the publish rechecks anyway.
- **`--scratch-dir` is not here.** `Options::scratch_dir` exists and its own documentation asks for it — sixteen mainnet state shards will not fit in `/tmp` on every host — but no done criterion needs it and widening the plan is not this role's call. Filed as residual work.
- **The live-relay e2e failure the transport slice reported did not reproduce here.** `Run e2e tests` ran and passed on both Linux and macOS on this branch (step-level conclusions, not just the job's). That is one green data point, not a fix: the failure was already characterised as a fixture race between two scenarios sharing a data directory, so intermittent is exactly what it should look like. This branch touches none of that path. Recorded so nobody reads a green run as the issue being closed; it is owned by a separate plan.

## Verification

All run on this branch. `docker`, `cmake`, nightly and `cargo-deny` present.

### Done criterion 4 — the `#[ignore]`d registry suite, run

`cargo test -p dolos-snapshot --features oci --test publish -- --ignored --nocapture --test-threads=1`

```
running 5 tests
test a_different_predecessor_is_a_different_digest ... registry: registry:2 on 127.0.0.1:57012
ok
test a_dry_run_agrees_with_the_publish_that_follows_it ... registry: registry:2 on 127.0.0.1:58048
ok
test a_publish_that_does_not_follow_latest_is_refused ... registry: registry:2 on 127.0.0.1:57017
ok
test a_second_publish_builds_and_uploads_only_what_is_new ... registry: registry:2 on 127.0.0.1:57021
publish 1: built 19, reused 0, uploaded 19 (7666 bytes)
publish 2: built 19, reused 3 (3390 bytes not moved), uploaded 19 (4440 bytes)
ok
test reuse_and_a_forced_rebuild_agree_on_the_digest ... registry: registry:2 on 127.0.0.1:57025
inherited sha256:ef955801a19cee27e7a6069f7b653cda2b2402fc167746b2e8059f8a41b1881f == rebuilt sha256:ef955801a19cee27e7a6069f7b653cda2b2402fc167746b2e8059f8a41b1881f
ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.65s
```

**Done criterion 1, as numbers**: the first publish builds 19 layers (3 epoch layers + 16 state shards) and uploads 19. The second builds 19 — epoch 1's three and the sixteen shards — inherits 3, and uploads 19. Zero skipped, because a state shard's header record names its epoch, so every built layer is genuinely new to the registry.

Also run against `registry:3` and `zot`, the standard the transport slice set — 5/5 on both:

```
########## registry:3 ##########
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s
########## ghcr.io/project-zot/zot-linux-amd64:latest ##########
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.32s
```

`cargo test -p stelae --all-features --test oci -- --ignored`, all three registries, including the two new transport cases:

```
running 8 tests
test a_layer_that_is_not_the_one_described_is_refused ... ok
test a_layer_whose_blob_is_not_there_cannot_be_carried_forward ... ok
test a_same_kind_blob_is_refused_when_the_layer_ends ... ok
test a_second_push_uploads_only_what_is_missing ... ok
test a_stele_survives_the_round_trip ... ok
test latest_is_absent_until_something_is_published ... ok
test neither_direction_holds_a_layer ... ok
test staging_stays_in_the_scratch_directory_and_leaves_nothing ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 12.61s   (registry:2)
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 12.20s   (registry:3)
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 16.43s   (zot)
```

### The CLI, against a real node and a real registry

A preview node synced from a live relay, published through the binary rather than the library:

```
$ dolos snapshot publish --repo oci://127.0.0.1:57838/dolos/preview --insecure --dry-run
network:  preview (2)
cursor:   5980(65f174205757d71031f3d75275f42bb1606139cd626b20cd724aeb39c2f28391)
sequence: 1 (tag epoch-1)
epochs:   0..=0 (1 of them, slots 0..=5980)
follows:  nothing; this repository holds no stele
history:  0 entries
reuse:    0 layers carried forward
build:    19 layers
dry run: nothing written to oci://127.0.0.1:57838/dolos/preview

$ dolos snapshot publish --repo oci://127.0.0.1:57838/dolos/preview --insecure
wrote oci://127.0.0.1:57838/dolos/preview
history:  0 entries
layers:   19 (19 built, 0 carried forward)
uploaded: 19 layers, 144120 compressed bytes
skipped:  0 layers already in the registry, 0 compressed bytes
size:     343212 uncompressed bytes
identity: sha256:f1b113c841861599d0531f5c5e9dccee5f78193bf8e93468177a3d1776d24d8a
```

The refusal, and that the dry run reaches it before writing anything:

```
$ dolos snapshot publish --repo oci://127.0.0.1:57838/dolos/preview --insecure
Error:   × publishing the stele
  ╰─▶ this repository's latest stele is sequence 1 and this publish is
      sequence 1: this stele is at or behind the repository's latest; a
      republish would restart the chain rather than extend it
```

And a build without the feature:

```
$ dolos snapshot publish --repo oci://127.0.0.1:57838/dolos/preview --insecure
Error:   × cannot publish to oci://127.0.0.1:57838/dolos/preview: this build has no
  │ registry client; rebuild dolos with `--features registry`
```

### Done criterion 5 — the gate

```
$ cargo +nightly fmt --all -- --check                                       # clean
$ cargo clippy --workspace --all-targets --all-features -- -D warnings      # exit 0
$ cargo test --workspace --all-targets                                      # all green, 0 failed
$ cargo test --workspace --all-targets --all-features \
      --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp   # all green, 0 failed
$ cargo deny check advisories
advisories ok
$ cargo tree -p stelae -e normal --all-features --prefix none | awk '{print $1}' | sort -u | grep -E '^dolos(-|$)'
                                                                            # empty: the boundary holds
$ cargo tree -e normal -i aws-lc-sys
error: package ID specification `aws-lc-sys` did not match any packages      # default build unchanged
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OCI registry publishing for snapshots.
  * Added dry-run previews, layer reuse, transfer reporting, and optional layer rebuilding.
  * Snapshot publishing now requires exactly one destination: a local directory or OCI repository.
  * Added publication history tracking and validation.
* **Bug Fixes**
  * Added clear errors for missing layers and invalid publication sequences.
* **Tests**
  * Added coverage for registry publishing, chaining, reuse, previews, and refusal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->