### PR TITLE
refactor(minibf): share input resolution for the account transactions scan

### DIFF
--- a/crates/minibf/src/inputs.rs
+++ b/crates/minibf/src/inputs.rs
@@ -212,6 +212,51 @@ impl<'a> InputResolver<'a> {
     }
 }
 
+/// Call `visit` on every output that the tx touches. A touched output is one
+/// that the tx produces, or one that the tx consumes. The `resolver` supplies
+/// the consumed outputs.
+///
+/// `visit` returns `true` to stop early. It returns `false` to continue. The
+/// result is `true` when a call to `visit` stopped the scan early.
+pub fn for_each_touched_output<F>(
+    resolver: &mut InputResolver<'_>,
+    tx: &MultiEraTx<'_>,
+    mut visit: F,
+) -> Result<bool, StatusCode>
+where
+    F: FnMut(&MultiEraOutput<'_>) -> Result<bool, StatusCode>,
+{
+    for (_, output) in tx.produces() {
+        if visit(&output)? {
+            return Ok(true);
+        }
+    }
+
+    for input in tx.consumes() {
+        if let Some(output) = resolver.resolve(&input)? {
+            if visit(&output)? {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+/// Return `true` when the tx touches an output that satisfies `matches`.
+///
+/// The scan stops at the first output that satisfies `matches`.
+pub fn tx_touches_output<F>(
+    resolver: &mut InputResolver<'_>,
+    tx: &MultiEraTx<'_>,
+    matches: F,
+) -> Result<bool, StatusCode>
+where
+    F: FnMut(&MultiEraOutput<'_>) -> Result<bool, StatusCode>,
+{
+    for_each_touched_output(resolver, tx, matches)
+}
+
 #[cfg(test)]
 mod tests {
     use dolos_core::config::MinibfConfig;

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -27,8 +27,8 @@ use dolos_cardano::{
     PoolDepositRefundLog,
 };
 use dolos_core::{
-    async_query::BlockRefMeta, ArchiveStore as _, Domain, EntityKey, EraCbor, LogKey,
-    StateStore as _, TemporalKey, TxHash,
+    async_query::BlockRefMeta, ArchiveStore as _, Domain, EntityKey, LogKey, StateStore as _,
+    TemporalKey, TxHash,
 };
 use futures::future::join_all;
 use futures_util::StreamExt;
@@ -48,6 +48,7 @@ use pallas::ledger::primitives::conway::Certificate as ConwayCert;
 
 use crate::{
     error::Error,
+    inputs::{InputDeps, InputResolver},
     mapping::{self, bech32_drep, bech32_pool, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
@@ -993,14 +994,11 @@ fn address_belongs_to_account(address: &Address, account: &[u8]) -> bool {
     }
 }
 
-async fn account_addresses_in_tx<D>(
-    domain: &Facade<D>,
+fn account_addresses_in_tx(
+    resolver: &mut InputResolver<'_>,
     account: &[u8],
     tx: &MultiEraTx<'_>,
-) -> Result<BTreeSet<String>, StatusCode>
-where
-    D: Domain + Clone + Send + Sync + 'static,
-{
+) -> Result<BTreeSet<String>, StatusCode> {
     let mut addresses = BTreeSet::new();
 
     for (_, output) in tx.produces() {
@@ -1014,27 +1012,13 @@ where
     }
 
     for input in tx.consumes() {
-        if let Some(EraCbor(era, cbor)) = domain
-            .query()
-            .tx_cbor(input.hash().as_slice().to_vec())
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        {
-            let parsed = MultiEraTx::decode_for_era(
-                era.try_into()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
-                &cbor,
-            )
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if let Some(output) = resolver.resolve(&input)? {
+            let candidate = output
+                .address()
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-            if let Some(output) = parsed.produces_at(input.index() as usize) {
-                let candidate = output
-                    .address()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-                if address_belongs_to_account(&candidate, account) {
-                    addresses.insert(candidate.to_string());
-                }
+            if address_belongs_to_account(&candidate, account) {
+                addresses.insert(candidate.to_string());
             }
         }
     }
@@ -1044,6 +1028,7 @@ where
 
 async fn find_account_txs_in_block<D>(
     domain: &Facade<D>,
+    deps: &mut InputDeps,
     account: &[u8],
     chain: &ChainSummary,
     pagination: &Pagination,
@@ -1054,14 +1039,25 @@ where
 {
     let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let txs = block.txs();
+
+    // only the txs that will actually be scanned contribute dependencies
+    let scanned = txs
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !pagination.should_skip(block.number(), *idx))
+        .map(|(_, tx)| tx);
+
+    let mut resolver = deps.prepare(domain, scanned).await?;
+
     let mut matches = vec![];
 
-    for (idx, tx) in block.txs().iter().enumerate() {
+    for (idx, tx) in txs.iter().enumerate() {
         if pagination.should_skip(block.number(), idx) {
             continue;
         }
 
-        let addresses = account_addresses_in_tx(domain, account, tx).await?;
+        let addresses = account_addresses_in_tx(&mut resolver, account, tx)?;
 
         let tx_hash = hex::encode(tx.hash().as_slice());
         let block_height = block.number() as i32;
@@ -1117,6 +1113,7 @@ where
     );
 
     let mut matches = Vec::new();
+    let mut deps = InputDeps::default();
     let mut stream = Box::pin(stream);
 
     while let Some(res) = stream.next().await {
@@ -1127,7 +1124,8 @@ where
         };
 
         let mut txs =
-            find_account_txs_in_block(&domain, &account, &chain, &pagination, &block).await?;
+            find_account_txs_in_block(&domain, &mut deps, &account, &chain, &pagination, &block)
+                .await?;
         matches.append(&mut txs);
 
         if matches.len() >= pagination.from() + pagination.count {

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -48,7 +48,7 @@ use pallas::ledger::primitives::conway::Certificate as ConwayCert;
 
 use crate::{
     error::Error,
-    inputs::{InputDeps, InputResolver},
+    inputs::{for_each_touched_output, InputDeps, InputResolver},
     mapping::{self, bech32_drep, bech32_pool, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
@@ -1001,7 +1001,9 @@ fn account_addresses_in_tx(
 ) -> Result<BTreeSet<String>, StatusCode> {
     let mut addresses = BTreeSet::new();
 
-    for (_, output) in tx.produces() {
+    // never stops early: every touched output that belongs to the account
+    // contributes its address to the set.
+    for_each_touched_output(resolver, tx, |output| {
         let candidate = output
             .address()
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -1009,19 +1011,9 @@ fn account_addresses_in_tx(
         if address_belongs_to_account(&candidate, account) {
             addresses.insert(candidate.to_string());
         }
-    }
 
-    for input in tx.consumes() {
-        if let Some(output) = resolver.resolve(&input)? {
-            let candidate = output
-                .address()
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-            if address_belongs_to_account(&candidate, account) {
-                addresses.insert(candidate.to_string());
-            }
-        }
-    }
+        Ok(false)
+    })?;
 
     Ok(addresses)
 }

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -26,7 +26,7 @@ use dolos_core::{BlockBody, BlockSlot, Domain, StateStore as _, TxoRef};
 
 use crate::{
     error::Error,
-    inputs::{InputDeps, InputResolver},
+    inputs::{tx_touches_output, InputDeps, InputResolver},
     mapping::{aggregate_assets, AddressKind, AddressModelBuilder, AssetTotals, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
@@ -384,29 +384,13 @@ fn has_address(
     address: &VKeyOrAddress,
     tx: &MultiEraTx<'_>,
 ) -> Result<bool, StatusCode> {
-    for (_, output) in tx.produces() {
+    tx_touches_output(resolver, tx, |output| {
         let candidate = output
             .address()
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-        if address_matches(address, &candidate) {
-            return Ok(true);
-        }
-    }
-
-    for input in tx.consumes() {
-        if let Some(output) = resolver.resolve(&input)? {
-            let candidate = output
-                .address()
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-            if address_matches(address, &candidate) {
-                return Ok(true);
-            }
-        }
-    }
-
-    Ok(false)
+        Ok(address_matches(address, &candidate))
+    })
 }
 
 async fn sum_block_txs<D>(

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -34,7 +34,7 @@ use serde::Deserialize;
 
 use crate::{
     error::Error,
-    inputs::{InputDeps, InputResolver},
+    inputs::{tx_touches_output, InputDeps, InputResolver},
     mapping::{asset_fingerprint, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
@@ -618,21 +618,9 @@ fn tx_has_subject(
     subject: &[u8],
     tx: &MultiEraTx<'_>,
 ) -> Result<bool, StatusCode> {
-    for (_, output) in tx.produces() {
-        if output_has_subject(subject, &output) {
-            return Ok(true);
-        }
-    }
-
-    for input in tx.consumes() {
-        if let Some(output) = resolver.resolve(&input)? {
-            if output_has_subject(subject, &output) {
-                return Ok(true);
-            }
-        }
-    }
-
-    Ok(false)
+    tx_touches_output(resolver, tx, |output| {
+        Ok(output_has_subject(subject, output))
+    })
 }
 
 async fn find_txs<D>(


### PR DESCRIPTION
Resolves #1175.

Follow-up to:
- #1127,
- #1134.

This change applies the input-resolution work from PR #1134 to the `/accounts/{stake_address}/transactions` endpoint from PR #1127. That endpoint kept the naive per-input scan that #1134 already corrected for the address and asset endpoints.

- cd2ae617b6c380cd49e1c35af966e8a2e515a949 routes the account scan through the shared `InputDeps` and `InputResolver`. Before this, the scan resolved each consumed input on its own and fetched the full source block one time for each input. Now it fetches and decodes each distinct source tx one time per request.

- d9c3d44a0deaca645bf2ab04e87d187f7a71e7f7 extracts the shared scan loop into `for_each_touched_output` and `tx_touches_output`. Four sites held their own copy of the same "read produced outputs, resolve consumed inputs, run a predicate" loop. Each endpoint now gives only its predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved transaction discovery for account, address, and asset queries.
- Searches now consistently include both outputs created by transactions and outputs they consume.
- Address and asset filtering provide more complete and reliable results.
- Transaction pagination and scanning handle output resolution more consistently across blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->