### PR TITLE
fix(minibf): return a JSON error body for a malformed stake address

### DIFF
--- a/crates/minibf/src/error.rs
+++ b/crates/minibf/src/error.rs
@@ -12,6 +12,7 @@ pub enum Error {
     Pagination(PaginationError),
     Code(StatusCode),
     InvalidAddress,
+    InvalidStakeAddress,
     InvalidAsset,
     InvalidPoolId,
     InvalidBlockNumber,
@@ -60,6 +61,15 @@ impl IntoResponse for Error {
                     400,
                     "Bad Request",
                     "Invalid address for this network or malformed address format.",
+                )),
+            )
+                .into_response(),
+            Error::InvalidStakeAddress => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody::new(
+                    400,
+                    "Bad Request",
+                    "Invalid or malformed stake address format.",
                 )),
             )
                 .into_response(),

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -83,13 +83,13 @@ fn stake_address_from_cip_19_credential(address: &str, network: Network) -> Opti
     Some(StakeAddress::new(network, payload))
 }
 
-fn parse_account_key_param(address: &str, network: Network) -> Result<AccountKeyParam, StatusCode> {
+fn parse_account_key_param(address: &str, network: Network) -> Result<AccountKeyParam, Error> {
     let address =
         if let Some(stake_address) = stake_address_from_cip_19_credential(address, network) {
             stake_address
         } else {
             let parsed = pallas::ledger::addresses::Address::from_bech32(address)
-                .map_err(|_| StatusCode::BAD_REQUEST)?;
+                .map_err(|_| Error::InvalidStakeAddress)?;
 
             let stake_address = match parsed {
                 Address::Shelley(x) => pallas_extras::shelley_address_to_stake_address(&x),
@@ -97,7 +97,7 @@ fn parse_account_key_param(address: &str, network: Network) -> Result<AccountKey
                 _ => None,
             };
 
-            stake_address.ok_or(StatusCode::BAD_REQUEST)?
+            stake_address.ok_or(Error::InvalidStakeAddress)?
         };
 
     let stake_cred = dolos_cardano::pallas_extras::stake_address_to_cred(&address);
@@ -193,7 +193,7 @@ impl<'a> IntoModel<Vec<AccountAddressesContentInner>> for AccountModelBuilder<'a
 pub async fn by_stake<D>(
     Path(stake_address): Path<String>,
     State(domain): State<Facade<D>>,
-) -> Result<Json<AccountContent>, StatusCode>
+) -> Result<Json<AccountContent>, Error>
 where
     Option<AccountState>: From<D::Entity>,
     Option<DRepState>: From<D::Entity>,
@@ -1223,7 +1223,7 @@ mod tests {
 
         let assert_bad_request = |address: String| {
             let result = parse_account_key_param(&address, network).err();
-            assert_eq!(result, Some(StatusCode::BAD_REQUEST));
+            assert!(matches!(result, Some(Error::InvalidStakeAddress)));
         };
 
         // `stake_vk` requires a 32-byte key.


### PR DESCRIPTION
Resolves #1178.

Follow-up to:
- #1067
- #1126

## Problem

The account endpoints resolved the stake address with `parse_account_key_param`.

For a malformed address, the helper returned a bare `http/400` with an **empty body**.

The real Blockfrost API returns a JSON body with the message "**Invalid or malformed stake address format.**" on every account endpoint.

A `blockfrost-tests` run found this mismatch on `/accounts/{stake_address}/addresses/assets`.

## Solution

The helper now returns `Error::InvalidStakeAddress`, so all account endpoints send the correct 400 body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid stake addresses in account lookups.
  * Requests with malformed stake addresses now return a clear `400 Bad Request` response with a specific error message.
  * Standardized error reporting for invalid account credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->