### PR TITLE
fix(stelae): a registry client should not need a C toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,30 +201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,15 +771,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -1767,12 +1734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,12 +1974,6 @@ dependencies = [
  "rustix 1.0.5",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -3012,7 +2967,6 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "aws-lc-rs",
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
@@ -4468,7 +4422,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
@@ -4805,7 +4758,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4836,7 +4788,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4909,7 +4861,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4983,10 +4934,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -5574,6 +5524,8 @@ dependencies = [
  "http 1.3.1",
  "minicbor 0.26.4",
  "oci-client",
+ "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -6576,12 +6528,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/crates/stelae/Cargo.toml
+++ b/crates/stelae/Cargo.toml
@@ -17,6 +17,7 @@ oci = [
     "dep:futures-util",
     "dep:http",
     "dep:oci-client",
+    "dep:reqwest",
     "dep:tempfile",
     "dep:tokio",
 ]
@@ -37,16 +38,56 @@ zstd.workspace = true
 
 # --- feature `oci` ---------------------------------------------------------
 #
-# `oci-client` is the oras-project registry client. Its default TLS feature
-# (`rustls-tls`) is kept: without a TLS backend the client can only reach a
-# plaintext registry, which is a test fixture and not a distribution channel.
-# The cost is that it pins `reqwest/rustls` and `jsonwebtoken/aws_lc_rs`, so
-# `aws-lc-sys` enters the tree under `--all-features` and wants `cmake` to
-# build it — the very dependency the root package's `mithril-client` entry
-# goes out of its way to avoid. `test-registry` is dropped: it exists for the
-# crate's own test suite.
-oci-client = { version = "0.17", optional = true, default-features = false, features = [
-    "rustls-tls",
+# `oci-client` is the oras-project registry client, taken with none of its own
+# TLS features. Both of them are pure feature-forwarding — `rustls-tls =
+# ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]`, `native-tls =
+# ["reqwest/native-tls", "jsonwebtoken/rust_crypto"]` — and no line of the
+# crate is `#[cfg]`-gated on `rustls-tls` at all. So the feature does not
+# decide whether the client speaks TLS; it decides which crypto backend two of
+# its dependencies are built with, and that choice is made below instead.
+#
+# It has to be made somewhere, because `rustls-tls` reaches `aws-lc-sys`
+# twice over — through `jsonwebtoken/aws_lc_rs` for registry auth tokens and
+# through `reqwest 0.13`'s `rustls`, which fans out to `rustls/aws-lc-rs` —
+# and `aws-lc-sys` requires `cmake` to build, the very dependency the root
+# package's `mithril-client` entry goes out of its way to avoid. Defeating one
+# path leaves the other, so both are answered here — the `reqwest` one by
+# naming a different feature, the `jsonwebtoken` one by needing nothing.
+#
+# The `jsonwebtoken` half needs nothing to replace it. `oci-client` reaches
+# for that crate in exactly one place outside its own tests —
+# `dangerous::insecure_decode`, reading a bearer token's `exp` claim to decide
+# when the token cache should refetch — and that call is base64 and serde. It
+# never signs and never verifies, so it never asks for a crypto provider, and
+# the backend `rustls-tls` was selecting was paying for capability the client
+# does not use. Leaving `jsonwebtoken` with no backend is a configuration
+# `oci-client` supports rather than a hole punched in it: nothing in the crate
+# is `#[cfg]`-gated on having one.
+#
+# The alternative the mithril precedent suggests, `jsonwebtoken/rust_crypto`,
+# was tried first and rejected on evidence: it pulls `rsa 0.9`, which carries
+# RUSTSEC-2023-0071 with no fixed version, so `cargo deny check advisories`
+# fails from that commit onward — a standing tax on every later PR, bought for
+# an RSA implementation that no reachable line calls.
+#
+# `test-registry` is dropped for its own reason: it exists for the crate's own
+# test suite.
+oci-client = { version = "0.17", optional = true, default-features = false }
+# Named for `oci-client`, not for this crate: nothing here calls it. Cargo
+# unifies features across the graph, so declaring it chooses the TLS `reqwest`
+# that `oci-client` is built against without this crate ever naming the
+# aws-lc-rs one. `default-features = false`, matching what `oci-client` itself
+# asks for, so this adds one capability and no surface.
+#
+# `rustls-no-provider` is rustls with no crypto provider wired in — the same
+# trade the root package already makes for `mithril-client`. It buys a smaller
+# tree by moving a compile-time guarantee to a runtime one: a process that
+# opens a `Registry` must have installed a process-default provider first.
+# That precondition is stated in `oci.rs`'s module documentation, beside the
+# async-context rule, and the tests here install `ring` rather than inheriting
+# one.
+reqwest = { version = "0.13", optional = true, default-features = false, features = [
+    "rustls-no-provider",
 ] }
 # One current-thread runtime, owned by the transport and entered with
 # `block_on` at each call, so the protocol stays synchronous. See `oci.rs`.
@@ -72,3 +113,13 @@ tempfile = { version = "3.20.0", optional = true }
 # above is unaffected.
 stats_alloc = "0.1"
 tempfile = "3.20.0"
+# The registry tests install `ring` as the process-default crypto provider,
+# which is the precondition `oci.rs` puts on a caller and the reason `ring` is
+# named here and nowhere else in this manifest: choosing a provider is the
+# program's job, and under `cargo test` this crate's test binary is the
+# program. A dev-dependency, so `cargo tree -p stelae -e normal
+# --all-features` still matches no provider at all.
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+] }

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -66,6 +66,34 @@
 //! caller that is not is a design question, and the answer is not a second
 //! runtime.
 //!
+//! ## TLS, and the second rule it comes with
+//!
+//! The client speaks TLS through rustls, built with **no crypto provider wired
+//! in** (`reqwest/rustls-no-provider`). The alternative is the backend
+//! `oci-client`'s own `rustls-tls` feature selects, `aws-lc-rs`, whose
+//! `aws-lc-sys` needs `cmake` on the build machine — a build tool this
+//! protocol will not make a contributor install to compile a snapshot format.
+//! `crates/stelae/Cargo.toml` records which dependency each half of that
+//! choice lands on.
+//!
+//! The trade is the same one the async boundary makes: a guarantee moves from
+//! build time to run time.
+//!
+//! **A process that opens a [`Registry`] must have installed a process-default
+//! [`rustls`] `CryptoProvider` before the first connection.** Nothing here can
+//! do it — the choice of provider belongs to the program, not to one of its
+//! transports, and a library that installed one would silently win a race
+//! against whatever its host had chosen. Omitting it fails at the first
+//! request rather than at the build, which is the worse failure mode being
+//! bought: an operator sees a connection error, not a link error.
+//!
+//! In Dolos this is `main()`, which installs `ring` for `mithril-client`'s
+//! sake and covers this transport by the same line. In this crate's own tests
+//! it is an explicit install in the fixture, so the suite proves the
+//! precondition rather than inheriting a provider by luck.
+//!
+//! [`rustls`]: https://docs.rs/rustls
+//!
 //! ## Authentication
 //!
 //! Anonymous, or a bearer token read from [`TOKEN_ENV`]. Nothing else: registry

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -80,12 +80,15 @@
 //! build time to run time.
 //!
 //! **A process that opens a [`Registry`] must have installed a process-default
-//! [`rustls`] `CryptoProvider` before the first connection.** Nothing here can
-//! do it — the choice of provider belongs to the program, not to one of its
+//! [`rustls`] `CryptoProvider` before it does so.** Nothing here can do it —
+//! the choice of provider belongs to the program, not to one of its
 //! transports, and a library that installed one would silently win a race
-//! against whatever its host had chosen. Omitting it fails at the first
-//! request rather than at the build, which is the worse failure mode being
-//! bought: an operator sees a connection error, not a link error.
+//! against whatever its host had chosen. Omitting it panics inside
+//! [`Registry::open`], where `oci-client` builds its HTTP client: `reqwest`
+//! resolves its TLS backend there, before any request and before any URL
+//! scheme, so [`Options::insecure`] does not spare a plaintext registry.
+//! That is the worse failure mode being bought — a runtime abort rather than a
+//! link error — though the panic does name the missing feature.
 //!
 //! In Dolos this is `main()`, which installs `ring` for `mithril-client`'s
 //! sake and covers this transport by the same line. In this crate's own tests
@@ -376,6 +379,15 @@ impl Registry {
     /// Builds the current-thread runtime the whole transport runs on. Reads
     /// [`TOKEN_ENV`] once, here, so a token never has to be threaded through a
     /// profile's call stack.
+    ///
+    /// # Panics
+    ///
+    /// If no process-default [`rustls`] `CryptoProvider` has been installed —
+    /// see the module documentation. The panic comes from `reqwest`, which
+    /// resolves its TLS backend when `oci-client` builds the HTTP client here,
+    /// so [`Options::insecure`] does not avoid it.
+    ///
+    /// [`rustls`]: https://docs.rs/rustls
     pub fn open(repository: &Repository, options: Options) -> Result<Self, Error> {
         let protocol = if options.insecure {
             ClientProtocol::Http

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -23,12 +23,32 @@
 //! `STELAE_TEST_REGISTRY_IMAGE` chooses the server (default `registry:2`), so
 //! the same suite can be pointed at another implementation — which is the only
 //! way to find out whether a given registry accepts an OCI 1.1 `artifactType`.
+//!
+//! ## Running them over TLS
+//!
+//! The fixture speaks plaintext by default, which is enough for everything
+//! about the *protocol* and evidence for nothing about the transport's crypto.
+//! Set both of
+//!
+//! ```text
+//! STELAE_TEST_REGISTRY_TLS_CERT=/abs/path/server.pem
+//! STELAE_TEST_REGISTRY_TLS_KEY=/abs/path/server.key
+//! ```
+//!
+//! and the same suite runs against the same server terminating TLS, with the
+//! client verifying the certificate for real. The certificate has to cover
+//! `127.0.0.1` — that is where the fixture publishes — and its issuer has to be
+//! trusted by the process, which on Linux means `SSL_CERT_FILE` pointing at the
+//! CA. Nothing here weakens verification to make a self-signed certificate
+//! work: a suite that accepted any certificate would pass just as happily with
+//! the handshake broken, which is the one thing this mode exists to detect.
 
 #![cfg(feature = "oci")]
 
 use std::{
     alloc::System,
     collections::BTreeMap,
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Mutex, MutexGuard,
@@ -474,6 +494,70 @@ fn a_manifest_past_the_size_ceiling_is_refused() {
 // A registry the test spawns
 // ---------------------------------------------------------------------------
 
+/// The certificate the fixture hands the server, when the environment supplies
+/// one.
+///
+/// Read from the environment rather than generated here, because the half that
+/// matters is the one this process cannot do to itself: the issuer has to be
+/// trusted *before* the first client is built, and on Linux that is
+/// `SSL_CERT_FILE`, which is read once. A test that minted a certificate would
+/// have nowhere to put its CA.
+struct Tls {
+    certificate: String,
+    key: String,
+}
+
+impl Tls {
+    fn from_env() -> Option<Self> {
+        match (
+            std::env::var("STELAE_TEST_REGISTRY_TLS_CERT"),
+            std::env::var("STELAE_TEST_REGISTRY_TLS_KEY"),
+        ) {
+            (Ok(certificate), Ok(key)) if !certificate.is_empty() && !key.is_empty() => {
+                Some(Self { certificate, key })
+            }
+            (Ok(_), _) | (_, Ok(_)) => {
+                panic!("STELAE_TEST_REGISTRY_TLS_CERT and _KEY are set together or not at all")
+            }
+            _ => None,
+        }
+    }
+
+    /// The `docker run` arguments that make the server terminate TLS.
+    ///
+    /// Single-file bind mounts, so the two may live in different directories
+    /// and neither directory is exposed whole.
+    fn docker_args(&self) -> Vec<String> {
+        vec![
+            "--volume".to_owned(),
+            format!("{}:/tls/certificate.pem:ro", self.certificate),
+            "--volume".to_owned(),
+            format!("{}:/tls/key.pem:ro", self.key),
+            "--env".to_owned(),
+            "REGISTRY_HTTP_TLS_CERTIFICATE=/tls/certificate.pem".to_owned(),
+            "--env".to_owned(),
+            "REGISTRY_HTTP_TLS_KEY=/tls/key.pem".to_owned(),
+        ]
+    }
+}
+
+/// Install `ring` as the process-default crypto provider.
+///
+/// `oci.rs` documents this as the caller's job — the transport is built on
+/// rustls with no provider wired in — so the suite does it explicitly. Doing
+/// it here rather than relying on whatever a dependency might have installed
+/// is the point: if the precondition were ever dropped from the transport's
+/// documentation, this line is what would still be true.
+fn install_crypto_provider() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+
+    ONCE.call_once(|| {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("nothing else installed a provider first");
+    });
+}
+
 /// A container running an OCI Distribution server, removed when this is
 /// dropped.
 ///
@@ -483,22 +567,31 @@ fn a_manifest_past_the_size_ceiling_is_refused() {
 struct Fixture {
     container: String,
     port: u16,
+    tls: bool,
 }
 
 impl Fixture {
     fn spawn() -> Self {
+        install_crypto_provider();
+
         let image =
             std::env::var("STELAE_TEST_REGISTRY_IMAGE").unwrap_or_else(|_| "registry:2".to_owned());
 
+        let tls = Tls::from_env();
+
+        let mut args: Vec<String> = ["run", "--detach", "--rm", "--publish", "127.0.0.1::5000"]
+            .iter()
+            .map(|arg| (*arg).to_owned())
+            .collect();
+
+        if let Some(tls) = &tls {
+            args.extend(tls.docker_args());
+        }
+
+        args.push(image.clone());
+
         let run = std::process::Command::new("docker")
-            .args([
-                "run",
-                "--detach",
-                "--rm",
-                "--publish",
-                "127.0.0.1::5000",
-                &image,
-            ])
+            .args(&args)
             .output()
             .expect("docker is required to run the registry tests");
 
@@ -522,15 +615,28 @@ impl Fixture {
             .and_then(|port| port.trim().parse::<u16>().ok())
             .unwrap_or_else(|| panic!("no published port in {mapped:?}"));
 
-        let fixture = Self { container, port };
+        let fixture = Self {
+            container,
+            port,
+            tls: tls.is_some(),
+        };
+
         fixture.wait_until_ready();
 
-        eprintln!("registry: {image} on 127.0.0.1:{port}");
+        eprintln!(
+            "registry: {image} on {}, {}",
+            fixture.address(),
+            if fixture.tls { "TLS" } else { "plaintext" }
+        );
 
         fixture
     }
 
-    /// Wait until the server answers `GET /v2/`.
+    fn address(&self) -> String {
+        format!("127.0.0.1:{}", self.port)
+    }
+
+    /// Wait until the server answers a real request.
     ///
     /// A connect is *not* the readiness signal, however much it looks like one:
     /// Docker's port forwarder accepts on the published port from the moment
@@ -539,47 +645,53 @@ impl Fixture {
     /// message. That failure looks exactly like a registry rejecting the
     /// request, which is the wrong thing to conclude about a registry.
     ///
-    /// So the probe is a real request, spoken by hand over the socket rather
-    /// than with an HTTP client this crate does not otherwise need.
+    /// So the probe is the client under test asking a repository nothing has
+    /// ever been written to for its latest stele. `Ok(None)` is the answer only
+    /// a registry that read the request can give — and under TLS it is
+    /// reachable only through a handshake that verified, which makes the same
+    /// call the readiness probe and the first assertion.
     fn wait_until_ready(&self) {
-        use std::io::{Read, Write};
-
-        let address = format!("127.0.0.1:{}", self.port);
-
         for _ in 0..300 {
-            let answered = std::net::TcpStream::connect(&address)
-                .ok()
-                .and_then(|mut socket| {
-                    socket
-                        .write_all(
-                            format!("GET /v2/ HTTP/1.0\r\nHost: {address}\r\n\r\n").as_bytes(),
-                        )
-                        .ok()?;
-
-                    let mut answer = [0u8; 16];
-                    let read = socket.read(&mut answer).ok()?;
-
-                    answer[..read].starts_with(b"HTTP/1.").then_some(())
-                });
-
-            if answered.is_some() {
+            if self
+                .registry("stelae/readiness")
+                .latest(&ToyProfile)
+                .is_ok()
+            {
                 return;
             }
 
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
 
-        panic!("the registry never answered GET /v2/ on {address}");
+        let refusal = self
+            .registry("stelae/readiness")
+            .latest(&ToyProfile)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+
+        panic!(
+            "the registry never answered on {}: {refusal}",
+            self.address()
+        );
     }
 
     fn registry(&self, repository: &str) -> Registry {
+        self.registry_staging_in(repository, None)
+    }
+
+    /// Every transport in this file is built here, so that whether the fixture
+    /// is speaking TLS is decided in exactly one place. A test that assembled
+    /// its own [`Options`] to set a scratch directory would keep working
+    /// against a plaintext fixture and quietly send `http://` at a TLS one.
+    fn registry_staging_in(&self, repository: &str, scratch_dir: Option<PathBuf>) -> Registry {
         Registry::open(
-            &format!("oci://127.0.0.1:{}/{repository}", self.port)
+            &format!("oci://{}/{repository}", self.address())
                 .parse()
                 .expect("the fixture named a usable repository"),
             Options {
-                insecure: true,
-                scratch_dir: None,
+                insecure: !self.tls,
+                scratch_dir,
             },
         )
         .unwrap()
@@ -1221,16 +1333,7 @@ fn staging_stays_in_the_scratch_directory_and_leaves_nothing() {
     let fixture = Fixture::spawn();
 
     let scratch = tempfile::tempdir().unwrap();
-    let registry = Registry::open(
-        &format!("oci://127.0.0.1:{}/stelae/scratch", fixture.port)
-            .parse()
-            .expect("the fixture named a usable repository"),
-        Options {
-            insecure: true,
-            scratch_dir: Some(scratch.path().to_owned()),
-        },
-    )
-    .unwrap();
+    let registry = fixture.registry_staging_in("stelae/scratch", Some(scratch.path().to_owned()));
 
     let inscription = write_stele(&registry, 3);
     let stele = registry.pull_latest(&ToyProfile).unwrap();


### PR DESCRIPTION
## Plan

[`plans/dolos-stelae-tls-without-cmake.md`](https://github.com/txpipe/dolos) — *Stelae: a registry client should not need a C toolchain* (Trellis domain root, `owner: org/coder`).

**Objective:** `dolos` builds with every feature on, on a machine that has no `cmake`, and still speaks TLS to a real registry.

## Why now — the plan's premise had already gone from hypothetical to real

The plan was written expecting the blast radius to be zero (`aws-lc-sys` only under `--all-features`). It was not, at pickup. `Cargo.toml:47` makes `dolos-snapshot` a non-optional dependency with `oci` on unconditionally, landed by #1173, so on `main` today:

```
$ cargo tree -e normal -i aws-lc-sys          # default features
aws-lc-sys v0.43.0
└── aws-lc-rs v1.17.3
    ├── jsonwebtoken v10.4.0
    │   └── oci-client v0.17.0 → stelae → dolos-snapshot → dolos
    ├── rustls v0.23.42
    │   ├── dolos v1.6.0
    │   ├── hyper-rustls v0.27.5 → reqwest 0.12.28 / 0.13.4
    │   └── rustls-platform-verifier v0.7.0
    …
```

Two things follow. `cmake` is required to build Dolos **by default**, not hypothetically. And the `ring` precedent the root `Cargo.toml` documents at lines 90–98 had already regressed through feature unification — `aws-lc-rs` was unified into the same `rustls 0.23` the workspace pins to `ring`.

## What changed

One line put it there: `oci-client`'s default TLS feature.

```toml
rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]
```

Both halves reach `aws-lc-sys`, so defeating one leaves the other. Neither half turned out to be needed.

**`reqwest` — name a different feature.** `reqwest 0.13`'s `rustls` is `["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]`; `rustls-no-provider` is the same minus the hard-wired provider, and it is exactly what the root package already takes `mithril-client` with. `crates/stelae` names `reqwest` directly so Cargo's feature unification hands `oci-client` the client it asked for, built against a provider it did not pick.

**`jsonwebtoken` — need nothing.** Outside its own tests, `oci-client` calls that crate in exactly one place:

```rust
// oci-client-0.17.0/src/token_cache.rs:162
match jsonwebtoken::dangerous::insecure_decode::<BearerTokenClaims>(token_str) {
```

Reading a bearer token's `exp` claim to decide when the cache should refetch. Base64 and serde — it never signs and never verifies, so it never requests a `CryptoProvider`. Nothing in `oci-client` is `#[cfg]`-gated on `rustls-tls` at all (only `native-tls` is), so taking it with neither TLS feature is a configuration the crate supports, not a hole punched in it.

**`stelae` is a library, so the provider is the caller's.** `rustls-no-provider` moves a compile-time guarantee to a runtime one. `oci.rs`'s module documentation now states the precondition beside the async-context rule, and the registry tests install `ring` themselves rather than inheriting one — `rustls` is a **dev**-dependency, so `cargo tree -p stelae -e normal --all-features` still matches no provider at all.

**The registry suite can now run over TLS.** `STELAE_TEST_REGISTRY_TLS_CERT` / `_KEY` make the fixture serve HTTPS and the client verify for real. Nothing is relaxed to accommodate a self-signed certificate — the trust anchor is the process's (`SSL_CERT_FILE` on Linux), because a suite that accepted any certificate would pass just as happily with the handshake broken.

Nothing about the wire format, the manifest, or the transport's behaviour changes. `oci` stays default-off.

| file | change |
|---|---|
| `crates/stelae/Cargo.toml` | drop `oci-client/rustls-tls`; add `reqwest` with `rustls-no-provider`; add dev-dep `rustls` with `ring` |
| `crates/stelae/src/oci.rs` | module doc: the crypto-provider precondition |
| `crates/stelae/tests/oci.rs` | optional TLS fixture; provider install; readiness probe via the client under test; one test moved off a hand-built `Options` |
| `Cargo.lock` | 8 crates out (`aws-lc-sys`, `aws-lc-rs`, `jsonwebtoken`'s backend set), 0 in |

## Done criteria

**1. `cargo tree -p stelae -e normal --all-features` matches no `aws-lc-sys` and nothing `^dolos(-|$)` — MET**

```
$ cargo tree -p stelae -e normal --all-features -i aws-lc-sys
error: package ID specification `aws-lc-sys` did not match any packages

$ cargo tree -p stelae -e normal --all-features | grep -E "aws-lc|dolos"
stelae v1.6.0 (…/crates/stelae)          # the root of the tree itself; no dolos-* edge

$ cargo tree -e normal -i aws-lc-sys      # and the default dolos tree, which had matched
error: package ID specification `aws-lc-sys` did not match any packages
```

**2. `--all-features` build in a container with no `cmake` — MET**

`docker run rust:1.93-bookworm` (linux/arm64), source staged without `target/`:

```
=== proof there is no cmake in this image ===
command -v cmake -> (not found)
dpkg -l | grep -c cmake -> 0
ls /usr/bin/cmake /usr/local/bin/cmake -> ls: cannot access '/usr/bin/cmake': No such file or directory
ls: cannot access '/usr/local/bin/cmake': No such file or directory

=== cargo tree -e normal -i aws-lc-sys (default features) ===
error: package ID specification `aws-lc-sys` did not match any packages

=== cargo build --workspace --all-features --locked ===
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 29s

=== BUILD OK, and cmake is still not installed ===
command -v cmake -> (not found)
```

**3. The `#[ignore]`d registry suite against a TLS-terminating registry — MET**

Run on Linux (docker-in-docker, so the fixture's published port and the test process share a namespace), against `registry:2` configured with `REGISTRY_HTTP_TLS_CERTIFICATE`/`_KEY` and a CA minted for the run:

```
=== the registry suite, over TLS, verifying for real ===
running 8 tests
registry: registry:2 on 127.0.0.1:32768, TLS
test a_same_kind_blob_is_refused_when_the_layer_ends ... ok
…
identity: sha256:39d2455e5ffb131021ef4e09872271278b2e3af1b62eb2f36d9262e274420119 (2 layers)
pulled 2 layers, 136 compressed bytes
test a_stele_survives_the_round_trip ... ok
first push:  Transfer { layers_uploaded: 2, layers_skipped: 0, layers_reused: 0, bytes_uploaded: 136, … }
second push: Transfer { layers_uploaded: 1, layers_skipped: 1, layers_reused: 0, bytes_uploaded: 65, bytes_skipped: 68, … }
test a_second_push_uploads_only_what_is_missing ... ok
push: 49495816 uncompressed / 49496956 compressed bytes, peak 1175113 bytes held
pull: 49153 records, peak 227686 bytes held
test neither_direction_holds_a_layer ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 21.93s
```

With a **negative control**, because a green TLS suite proves nothing unless the same suite goes red when verification should fail. Same run, CA removed from the trust bundle:

```
=== negative control: the same suite with the CA removed from the bundle ===
thread 'latest_is_absent_until_something_is_published' panicked at crates/stelae/tests/oci.rs:673:9:
the registry never answered on 127.0.0.1:32777: registry error: error sending request for url
  (https://127.0.0.1:32777/v2/stelae/readiness/manifests/latest)
test result: FAILED. 0 passed; 1 failed; …
negative control exit=101 (non-zero is the expected result)
```

The plaintext suite also still passes unchanged on macOS/arm64 (8 passed).

**4. The precondition is stated where a caller reads it, and the tests install a provider — MET**

`crates/stelae/src/oci.rs` gains a *"TLS, and the second rule it comes with"* section beside the async-context rule; `crates/stelae/tests/oci.rs` installs `ring` in `Fixture::spawn` via a `Once`, with `.expect(…)` rather than a discarded `Result`, so inheriting one by luck would fail the suite.

**5. Full gate — MET**

| command | result |
|---|---|
| `cargo test --workspace --all-targets` | 33 suites, 0 failed |
| `cargo test --workspace --all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` | 33 suites, 0 failed |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo +nightly fmt --all -- --check` | clean |
| `cargo deny check advisories` | `advisories ok` (3 pre-existing `yanked` warnings: `fjall`, `lsm-tree`, `spin`) |

**6. Fallback not needed — approach 1 landed.** No `[patch]`, no fork, no vendor, no TLS-less client. Approach 3 (upstreaming a provider-agnostic feature to `oras-project/rust-oci-client`) was not attempted: it is outside `org/coder`'s boundary and remains `org/founder`'s to initiate — still worth doing, now merely to save the next consumer the same afternoon rather than to unblock us.

## Escalations

Both are recorded in the plan's `## Escalations` section and are open for `org/founder`.

```yaml
raised: 2026-08-07
by: org/coder
to: org/founder
status: open
asks: ratify shipping `jsonwebtoken` with no crypto backend instead of the `rust_crypto` this plan named — or accept RUSTSEC-2023-0071 in deny.toml and take `rust_crypto` back
attempted: approach 1 exactly as written — `reqwest/rustls-no-provider` plus `jsonwebtoken/rust_crypto`; every criterion passed except 5
blocked: `rust_crypto` pulls `rsa 0.9`, which carries RUSTSEC-2023-0071 with no fixed version, so `cargo deny check advisories` fails from that commit onward and criterion 5 cannot be met without a risk acceptance `org/coder` has no authority to make
```

This is the one judgement call in the PR and it is worth a reviewer's attention. `jsonwebtoken/rust_crypto` was implemented first, exactly as the plan specified, and `cargo deny check advisories` went red on `rsa 0.9.10` / RUSTSEC-2023-0071 (Marvin attack, *"No safe upgrade is available"*) — a permanent CI failure for every subsequent PR, bought for an RSA implementation no reachable line calls. Shipping no backend keeps criterion 5 green with no `ignore` entry and six fewer crates. **The residual risk:** a future `oci-client` that does verify a token would panic at the first call rather than fail to compile. The panic names the missing feature, but it would be a runtime failure in a publish path.

```yaml
raised: 2026-08-07
by: org/coder
to: org/founder
status: open
asks: correct this plan's Context — "the blast radius today is zero" was false at pickup, and note that the mithril `ring` precedent had already regressed through feature unification
attempted: re-derived the tree before starting, per the plan's own Verification section
blocked: nothing — the work was unaffected and is complete; the record is wrong and only its owner should rewrite the body
```

## Follow-up

Filed as `plans/dolos-stelae-cmake-tree-guard.md` (`status: draft`, awaiting this plan): **make the C-toolchain refusal a check, not a habit.** The prior plan's own risk bullet asks for it — *"The tree check in done criterion 1 belongs in CI, or this plan buys a state that lasts until the next dependency bump."* Deliberately not in this PR: a workflow change is a different argument from a dependency change, and this repository has now demonstrated once that a refusal written only in prose regresses without anyone noticing.

Recorded there, out of scope for both: `oci-client` brings `reqwest 0.13.4` while the workspace pins `0.12.7`, so two major versions of the HTTP client are compiled into every Dolos binary. Named and left alone, per the plan.

## For a human to sample

- **The `jsonwebtoken` decision above** — the only place this PR departs from what the plan wrote down.
- **`Fixture::wait_until_ready` now probes with the client under test** (`Registry::latest` on an empty repository) instead of a hand-written `GET /v2/` over a raw socket. That was forced — the hand-written probe cannot speak TLS — and it changes the plaintext path too. The original comment's reasoning still holds and is preserved; only the mechanism moved.
- **`staging_stays_in_the_scratch_directory_and_leaves_nothing`** built its own `Options` with `insecure: true` and so silently sent `http://` at the TLS fixture (caught by a 400 during this work). It now goes through `Fixture::registry_staging_in`, so whether the fixture speaks TLS is decided in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved OCI registry connectivity with more predictable TLS configuration.
  - Added secure registry connections with certificate verification.
  - Plaintext and TLS connections are now handled consistently across OCI workflows.
  - Improved registry readiness checks for more reliable connection behavior.
  - Added clearer guidance for configuring TLS security providers and avoiding connection failures.
  - Improved support for testing registries over both secure and plaintext connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->