### PR TITLE
docs(tx3): fix the Rust SDK signer import path

### DIFF
--- a/docs/content/integrations/tx3.mdx
+++ b/docs/content/integrations/tx3.mdx
@@ -62,8 +62,7 @@ trix invoke --profile local
 ### Using the Rust SDK
 
 ```rust
-use tx3_sdk::{tii::Protocol, trp::Client, trp::ClientOptions, Tx3Client, Party};
-use tx3_sdk::signer::CardanoSigner;
+use tx3_sdk::{tii::Protocol, trp::Client, trp::ClientOptions, CardanoSigner, Tx3Client, Party};
 use serde_json::json;
 
 let protocol = Protocol::from_file("./my-protocol.tii")?;


### PR DESCRIPTION
The Rust SDK snippet in `docs/content/integrations/tx3.mdx` imports
`tx3_sdk::signer::CardanoSigner`, which does not compile: the `signer`
module lives at `facade::signer` and is not public at the crate root. The
crate re-exports the type directly —
`pub use facade::signer::{CardanoSigner, Ed25519Signer};`
(`rust-sdk/sdk/src/lib.rs:51`) — so the correct form is the root import,
which this PR folds it into.

Same form the Tx3 docs already use (`consuming/quick-start.mdx`).
Documentation only; no code or behavior change.

**Cross-root note:** raised from the Tx3 Trellis domain, where this snippet
surfaced as the last unfixed instance of a stale-signer-path audit
(plan `feedback-cba-04`). `txpipe/dolos` belongs to the TxPipe root — this
touches only its Tx3 integration surface, not the Dolos model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Rust SDK integration example to use the current top-level `CardanoSigner` import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->