### PR TITLE
fix(stelae): hold a publisher to the record ceiling its reader enforces

### DIFF
--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -101,6 +101,23 @@ pub const MEDIA_TYPE_VERSION: u64 = 1;
 /// part of a stele's identity — see [`stelae::inscription`].
 pub const MEDIA_TYPE_CODEC: &str = "zstd";
 
+/// Largest single record this profile writes or reads: 64 MiB.
+///
+/// Four times the protocol's 16 MiB default, and raised for one record shape
+/// that genuinely exceeds it. A Cardano block is order 100 KB and every
+/// `blocks`, `indexes` and `logs` record stays far under the default; what does
+/// not is a Conway **governance proposal**, whose action embeds an unbounded
+/// list. A `UpdateCommittee` naming hundreds of members is a single entity of
+/// tens of megabytes, and preprod carries five of them at ~24.7 MiB each.
+///
+/// The ledger is what bounds this, and it bounds it loosely: the ceiling is a
+/// refusal to allocate for a hostile length prefix, not a statement about what
+/// Cardano permits. So it is set with headroom over the largest record the
+/// chain has actually produced, and a proposal that one day exceeds *this* is a
+/// publish-time refusal naming the record — which is the outcome worth having,
+/// because the alternative is a stele that publishes and never restores.
+pub const MAX_RECORD: usize = 64 * 1024 * 1024;
+
 /// The key-hashing scheme index layers ship under, as reported in
 /// `parameters.indexKeyHash`.
 ///
@@ -270,6 +287,10 @@ impl Profile for DolosProfile {
     /// immutable tag names it.
     fn tag_for_sequence(&self, sequence: u64) -> Result<String, stelae::Error> {
         Ok(format!("epoch-{sequence}"))
+    }
+
+    fn max_record(&self) -> usize {
+        MAX_RECORD
     }
 }
 

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -149,7 +149,13 @@ pub struct Budget {
 impl Default for Budget {
     fn default() -> Self {
         Self {
-            limits: Limits::default(),
+            // The profile's ceiling, not the protocol's default: a restore that
+            // read under a tighter limit than the publisher wrote under would
+            // refuse this profile's own steles.
+            limits: Limits {
+                max_record: crate::MAX_RECORD,
+                ..Limits::default()
+            },
             commit_records: 50_000,
             commit_bytes: 64 * 1024 * 1024,
         }

--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -325,7 +325,10 @@ impl SteleWriter for SteleDir {
         let file = fs::File::create(&staging.path)?;
 
         let mut sink = LayerSink {
-            sequence: SeqWriter::new(LayerWriter::new(file, level)?),
+            sequence: SeqWriter::with_max_record(
+                LayerWriter::new(file, level)?,
+                profile.max_record(),
+            ),
             staging,
             root: self.root.clone(),
             kind: spec.kind.clone(),

--- a/crates/stelae/src/frame.rs
+++ b/crates/stelae/src/frame.rs
@@ -493,12 +493,20 @@ impl<W: Write> SeqWriter<W> {
     /// `max_record` must be the ceiling the eventual reader is given, which is
     /// why the profile owns the number rather than each end picking its own —
     /// see [`crate::profile::Profile::max_record`].
+    ///
+    /// Floored at one byte to agree with [`Limits::normalized`], which floors a
+    /// reader's ceiling the same way. Zero is not a meaningful ceiling for
+    /// either end — the smallest CBOR item is one byte — so what matters about
+    /// it is not which behaviour it selects but that both ends select the same
+    /// one. A writer keeping a literal zero would refuse every record a reader
+    /// at that ceiling goes on to accept, which is the disagreement this type
+    /// exists to prevent.
     pub fn with_max_record(inner: W, max_record: usize) -> Self {
         Self {
             inner,
             count: 0,
             written: 0,
-            max_record,
+            max_record: max_record.max(1),
         }
     }
 
@@ -1312,6 +1320,62 @@ mod tests {
         };
 
         assert_eq!(offset, small.as_bytes().len() * 2);
+    }
+
+    /// At any ceiling, the writer accepts exactly what a reader at that same
+    /// ceiling will.
+    ///
+    /// The guarantee the profile's number buys is that one value binds both
+    /// ends; a ceiling where the two disagree is that guarantee with a hole in
+    /// it, and the hole does not have to be a reachable value to be worth
+    /// closing. Zero is the only such value, because [`Limits::normalized`]
+    /// floors a reader at one byte: a writer keeping a literal zero refuses the
+    /// one-byte records that reader accepts.
+    #[test]
+    fn the_writer_accepts_exactly_what_the_reader_will() {
+        let one_byte = encode(|e| {
+            e.u64(0)?;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(one_byte.as_bytes().len(), 1, "smallest possible record");
+
+        let larger = encode(|e| {
+            e.bytes(&[0xab; 1000])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let ceilings = [0, 1, 2, larger.as_bytes().len(), DEFAULT_MAX_RECORD];
+
+        for ceiling in ceilings {
+            for record in [&one_byte, &larger] {
+                let mut writer = SeqWriter::with_max_record(Vec::new(), ceiling);
+                let writer_took = writer.write_record(record).is_ok();
+
+                // The reader needs a sequence to walk, so the record is laid
+                // down by a writer with a ceiling that refuses nothing.
+                let mut permissive = SeqWriter::with_max_record(Vec::new(), usize::MAX);
+                permissive.write_record(record).unwrap();
+                let sequence = permissive.into_inner();
+
+                let mut reader = RecordReader::with_limits(
+                    std::io::Cursor::new(&sequence),
+                    Limits {
+                        max_record: ceiling,
+                        window: 64,
+                    },
+                );
+                let reader_took = matches!(reader.next_record(), Some(Ok(_)));
+
+                assert_eq!(
+                    writer_took,
+                    reader_took,
+                    "ceiling {ceiling} disagrees on a {}-byte record",
+                    record.as_bytes().len()
+                );
+            }
+        }
     }
 
     /// A profile that raises its ceiling can write what the default refuses,

--- a/crates/stelae/src/frame.rs
+++ b/crates/stelae/src/frame.rs
@@ -473,22 +473,60 @@ impl<'a> Scanner<'a> {
     }
 }
 
-/// Writes a CBOR sequence, counting the records it emits.
+/// Writes a CBOR sequence, counting the records it emits and holding each to
+/// the ceiling its reader will apply.
 pub struct SeqWriter<W> {
     inner: W,
     count: u64,
+    written: u64,
+    max_record: usize,
 }
 
 impl<W: Write> SeqWriter<W> {
+    /// A writer holding records to [`DEFAULT_MAX_RECORD`].
     pub fn new(inner: W) -> Self {
-        Self { inner, count: 0 }
+        Self::with_max_record(inner, DEFAULT_MAX_RECORD)
+    }
+
+    /// A writer holding records to `max_record`.
+    ///
+    /// `max_record` must be the ceiling the eventual reader is given, which is
+    /// why the profile owns the number rather than each end picking its own —
+    /// see [`crate::profile::Profile::max_record`].
+    pub fn with_max_record(inner: W, max_record: usize) -> Self {
+        Self {
+            inner,
+            count: 0,
+            written: 0,
+            max_record,
+        }
     }
 
     /// Append one record. The [`CanonicalCbor`] type is the proof that it is in
     /// deterministic form, so nothing is re-checked here.
+    ///
+    /// Its *size* is checked, and that check is the writer's whole reason for
+    /// knowing a ceiling. A record past it is refused here rather than written
+    /// and discovered by whoever tries to read the layer back: a stele whose
+    /// records no reader will accept is not a stele, and the publisher is the
+    /// only party positioned to say so while the fix is still cheap. Reported
+    /// in the record's offset within the layer, the same coordinate
+    /// [`RecordReader`] fails in, so the two ends name the same byte.
     pub fn write_record(&mut self, record: &CanonicalCbor) -> Result<(), Error> {
-        self.inner.write_all(record.as_bytes())?;
+        let bytes = record.as_bytes();
+
+        if bytes.len() > self.max_record {
+            return Err(Error::RecordTooLarge {
+                offset: self.written as usize,
+                required: bytes.len() as u64,
+                limit: self.max_record,
+            });
+        }
+
+        self.inner.write_all(bytes)?;
         self.count += 1;
+        self.written += bytes.len() as u64;
+
         Ok(())
     }
 
@@ -1220,6 +1258,80 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(rewriter.into_inner(), written);
+    }
+
+    /// The writer refuses what the reader would refuse, at the same ceiling.
+    ///
+    /// Regression for a stele that published cleanly and restored nowhere: the
+    /// reader held records to 16 MiB, nothing held the writer to anything, and
+    /// a profile with a 24 MiB record produced 928 layers, a valid manifest and
+    /// an artifact whose first oversized record ended every restore of it.
+    #[test]
+    fn writer_refuses_a_record_past_its_ceiling() {
+        let big = encode(|e| {
+            e.bytes(&[0u8; 4096])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let mut writer = SeqWriter::with_max_record(Vec::new(), 1024);
+        let err = writer.write_record(&big).unwrap_err();
+
+        assert!(
+            matches!(err, Error::RecordTooLarge { limit: 1024, .. }),
+            "{err:?}"
+        );
+
+        // Refused before the write, so nothing partial reached the sink.
+        assert_eq!(writer.count(), 0);
+        assert!(writer.into_inner().is_empty());
+    }
+
+    /// The offset a refusal names is the record's offset in the layer, so a
+    /// publisher and a reader failing on the same record report the same byte.
+    #[test]
+    fn writer_refusal_names_the_offset_the_reader_would() {
+        let small = encode(|e| {
+            e.bytes(&[0u8; 8])?;
+            Ok(())
+        })
+        .unwrap();
+        let big = encode(|e| {
+            e.bytes(&[0u8; 4096])?;
+            Ok(())
+        })
+        .unwrap();
+
+        let mut writer = SeqWriter::with_max_record(Vec::new(), 1024);
+        writer.write_record(&small).unwrap();
+        writer.write_record(&small).unwrap();
+
+        let err = writer.write_record(&big).unwrap_err();
+        let Error::RecordTooLarge { offset, .. } = err else {
+            panic!("{err:?}");
+        };
+
+        assert_eq!(offset, small.as_bytes().len() * 2);
+    }
+
+    /// A profile that raises its ceiling can write what the default refuses,
+    /// which is the whole point of the number being the profile's.
+    #[test]
+    fn a_raised_ceiling_admits_a_record_the_default_would_refuse() {
+        let record = encode(|e| {
+            e.bytes(&[0u8; DEFAULT_MAX_RECORD + 1])?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(SeqWriter::new(Vec::new()).write_record(&record).is_err());
+
+        let mut writer = SeqWriter::with_max_record(Vec::new(), DEFAULT_MAX_RECORD * 4);
+        writer
+            .write_record(&record)
+            .expect("within the raised ceiling");
+
+        assert_eq!(writer.count(), 1);
     }
 
     #[test]

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -795,7 +795,10 @@ impl SteleWriter for Registry {
 
         let mut sink = RegistrySink {
             shared: Arc::clone(&self.shared),
-            sequence: SeqWriter::new(LayerWriter::new(self.shared.scratch()?, level)?),
+            sequence: SeqWriter::with_max_record(
+                LayerWriter::new(self.shared.scratch()?, level)?,
+                profile.max_record(),
+            ),
             kind: spec.kind.clone(),
             media_type,
             scope: spec.scope.clone(),

--- a/crates/stelae/src/profile.rs
+++ b/crates/stelae/src/profile.rs
@@ -26,7 +26,7 @@
 //! 3. The protocol never parses layer bodies or a profile's opaque objects. An
 //!    unknown profile is a clean refusal, never a partial restore.
 
-use crate::{Error, MOVING_TAG, RESERVED_VENDOR};
+use crate::{frame::DEFAULT_MAX_RECORD, Error, MOVING_TAG, RESERVED_VENDOR};
 
 /// A vendor's definition of what its stelae contain.
 ///
@@ -62,6 +62,22 @@ pub trait Profile {
     /// the spelling; the protocol only requires that one exists.
     fn moving_tag(&self) -> &str {
         MOVING_TAG
+    }
+
+    /// Largest single record this profile's layers may contain.
+    ///
+    /// One number, asked of one party, and it bounds **both** ends: what a
+    /// publisher is allowed to write and what a reader will accept. That is the
+    /// point of putting it here rather than letting each end carry a constant.
+    /// A writer with the looser of two ceilings publishes a stele that restores
+    /// nowhere, and it publishes it *successfully* — the failure surfaces on
+    /// whoever tries to read it back, which is the party least able to fix it.
+    ///
+    /// The default is [`DEFAULT_MAX_RECORD`]. A profile whose records genuinely
+    /// exceed it raises this deliberately and says why, which is the
+    /// conversation `DEFAULT_MAX_RECORD`'s own documentation asks for.
+    fn max_record(&self) -> usize {
+        DEFAULT_MAX_RECORD
     }
 }
 


### PR DESCRIPTION
## The bug

`RecordReader` refuses records past `DEFAULT_MAX_RECORD` (16 MiB). `SeqWriter` was held to nothing.

So a profile with a record above that ceiling published **successfully** — full manifest, all blobs uploaded, `identity` printed — and produced a stele that no restore of it could get past. The write side never learned; the failure surfaced on whoever pulled it, which is the party least able to fix it.

`frame.rs` anticipated exactly this case in prose — *"A profile whose records genuinely approach this is telling its publisher something... raise the limit deliberately through `Limits`, with the profile's own reason"* — but since only the reader checked, the publisher was never told.

## How it was found

Publishing a full preprod chain into a local zot registry, then restoring from it:

```
stelae error: record at offset 12694754 needs at least 25950274 bytes,
past the 16777216-byte ceiling set for a single record
```

`state` shard 0 carries **five Conway `proposals` entities of ~24.7 MiB each** — `UpdateCommittee` actions naming hundreds of members. The 928-layer stele published clean and died on the first of them, at a fixed offset, every time.

Two things make this worse than it looks: `--epochs` can't dodge it (the state tip is always published), and `Budget::limits` isn't reachable from the CLI, so there was no operator-side workaround at all.

## The fix

The ceiling becomes the **profile's**, so one number bounds both ends and they cannot drift apart again.

| File | Change |
|---|---|
| `stelae/profile.rs` | `Profile::max_record()`, defaults to `DEFAULT_MAX_RECORD` |
| `stelae/frame.rs` | `SeqWriter::with_max_record` refuses at the write, before the sink, naming the record's offset in the layer — the same coordinate `RecordReader` fails in |
| `stelae/dir.rs`, `stelae/oci.rs` | both layer-sink sites take the ceiling from the profile they already receive |
| `snapshot/lib.rs` | `MAX_RECORD = 64 MiB` for `io.txpipe.dolos.cardano`, documented against the record shape that needs it |
| `snapshot/restore.rs` | `Budget::default()` reads under the profile's ceiling, not the protocol default |

A publish exceeding even the raised ceiling is now a refusal naming the record. That is the outcome worth having — the alternative is an artifact that publishes and never restores.

## Verification

195 tests pass. Three new ones in `frame.rs`, including a regression test that pins the write/read asymmetry itself.

End to end against a local zot registry, full preprod:

- **304 epochs, 928 layers, 5.19 GB compressed / 21.06 GB uncompressed**
- **Restore: 210s**, versus ~33 min for the Mithril bootstrap that built the same node (~9.4x)
- Restored node's `data summary` is **identical** to the Mithril-bootstrapped original — all four stores at slot 129,319,190

## Judgment calls worth a reviewer's attention

**64 MiB is headroom, not a derived bound.** The ledger doesn't meaningfully bound proposal size, so any number here is a guess above what the chain has actually produced (24.7 MiB). The durable half of this PR is the publish-time refusal, which converts "unrestorable artifact" into "publish fails, naming the record" — that part holds regardless of where the number lands.

**Mainnet is worth checking.** If it carries proposals over 16 MiB, every mainnet stele published before this has the same defect.

**Not re-published.** Raising a ceiling doesn't alter layer bytes, so the existing stele is what the fixed publisher would emit, and the 210s restore above ran against it. Confirming that empirically — republish from the restored node, compare identity — would also serve as the determinism check `dolos snapshot digest` is meant to automate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum record sizes, with a default limit of 64 MiB.
  * Profiles can override the default maximum record size.
  * Oversized records are rejected before output is written, with their position reported.

* **Bug Fixes**
  * Enforced consistent record-size limits across streaming, reading, writing, and restoration workflows.
  * Improved handling of configured zero-byte limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->