### PR TITLE
feat(stelae): name the official registry's published read-only pair

### DIFF
--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -196,8 +196,8 @@ impl From<&KnownNetwork> for MithrilConfig {
 /// generated `dolos.toml` gets everything it points at. Written into the file,
 /// so a config says which identity it reads the registry as.
 ///
-/// Empty until the registry that issues it exists.
-const OFFICIAL_REGISTRY_USER: &str = "";
+/// Issued by the official registry at `oci.stelae.store`.
+const OFFICIAL_REGISTRY_USER: &str = "stelae";
 
 /// The password that goes with [`OFFICIAL_REGISTRY_USER`], compiled in rather
 /// than written to `dolos.toml`.
@@ -218,16 +218,18 @@ const OFFICIAL_REGISTRY_USER: &str = "";
 /// `doctor` reaches into it for [`KnownNetwork`] rather than keeping a second
 /// account of what the defaults are.
 ///
-/// Empty until the registry exists. Filling both constants is a two-line change
-/// here and nowhere else.
-pub const OFFICIAL_REGISTRY_PASSWORD: &str = "";
+/// Rotating the pair is a change here and nowhere else — paired with a release
+/// and comms, because generated configs and released binaries carry the old one
+/// until their nodes update.
+pub const OFFICIAL_REGISTRY_PASSWORD: &str = "7214892e36157f4051677b51526382cc96693d45eda4e4cd";
 
 /// `[stelae]` as a generated config carries it: the official registry's user,
 /// and no password.
 ///
-/// Empty while [`OFFICIAL_REGISTRY_USER`] is, which is why it is a function
-/// rather than a `Default` impl on the config type — it asks for the official
-/// registry specifically, and gives the honest answer while there is not one.
+/// Empty only while [`OFFICIAL_REGISTRY_USER`] is, which is why it is a
+/// function rather than a `Default` impl on the config type — it asks for the
+/// official registry specifically, and would give the honest answer if there
+/// were not one.
 fn official_stelae() -> StelaeConfig {
     StelaeConfig {
         registry: (!OFFICIAL_REGISTRY_USER.is_empty()).then(|| StelaeRegistryConfig {


### PR DESCRIPTION
## Plan

`Brain/txpipe` plan: **dolos-stelae-cloudflare-registry** — this is the hand-off that plan owed #1184: the registry now exists (`oci.stelae.store`, stock `cloudflare/serverless-registry` on Workers/R2, all nine validation gates passed), so the constants it issues stop being empty.

## What changed

The two-line change #1184 designed for, plus the doc lines that said "empty until the registry exists":

- `OFFICIAL_REGISTRY_USER = "stelae"`, `OFFICIAL_REGISTRY_PASSWORD = <the published pair>` in `src/bin/dolos/init.rs`. The password is the **published read-only credential** — public by design (it will sit in every consumer's docs), pull-only by the registry's capability enforcement (`capabilities: ["pull"]`; verified as gate 7 of the deployment plan: an upload through it is refused with 401).
- Rotation note replaces the "empty until" note: rotating is a change here and nowhere else, paired with a release and comms.

A fresh `dolos init` now writes:

```toml
[stelae.registry]
user = "stelae"
```

and never a password — the binary supplies it (`stele_registry_auth`), exactly as #1184 pinned.

## Verification

- `init::tests::a_fresh_config_seeds_the_official_registry_and_no_password`, `a_configured_password_survives_the_round_trip`, `common`'s `a_seeded_user_takes_the_compiled_in_password`, `the_section_names_a_user_a_token_or_nobody`, `two_identities_at_once_are_refused` — all green (they were written to hold on the day the constants filled).
- The compiled pair against the live deployment: `curl -u stelae:… https://oci.stelae.store/v2/` → `200`.
- `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New configurations now default to the official registry with the `stelae` username.
  - Registry authentication is automatically configured for supported initialization flows.

- **Documentation**
  - Added guidance for the published registry credential and its rotation process.
  - Generated TOML configuration continues to exclude the registry password for improved safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->