### PR TITLE
fix(stelae): a blob that already exists is a dedup, not a rename

### DIFF
--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -155,6 +155,37 @@ impl RecordSink for LayerSink {
     /// happens. A failure anywhere in here leaves the stele exactly as it was:
     /// the staging file is removed on the way out, the same as for a sink that
     /// was simply dropped.
+    ///
+    /// ## A blob that is already there is a success, not a rename
+    ///
+    /// The destination is named by the digest of the very bytes about to be
+    /// moved onto it, so a destination that already exists already holds those
+    /// bytes — that is what content addressing means. Renaming anyway rewrites
+    /// a file with its own contents: hundreds of megabytes of I/O for a mainnet
+    /// state shard, and on Windows a failure. Every reader here opens a blob
+    /// with a plain [`fs::File::open`], without `FILE_SHARE_DELETE`, so
+    /// replacing a blob that a concurrent [`SteleReader::stream_layer`] holds
+    /// open is a sharing violation there and silently fine on Unix. So the blob
+    /// on disk is kept, the staging file goes the way an abandoned one does,
+    /// and the caller gets exactly the [`WrittenLayer`] it would have got had
+    /// it been first: `descriptor` and `digests` are computed from the record
+    /// stream, never from the rename.
+    ///
+    /// The existing blob is **trusted on its name, not re-read**. This writer
+    /// computed that digest itself, out of the bytes it had just written, a
+    /// microsecond earlier, and re-reading a file that may be gigabytes to
+    /// confirm what content addressing already asserts would put a second full
+    /// pass on the write path. That is a deliberate divergence from the
+    /// neighbour: [`SteleDir::blob_index`] re-digests every blob it finds, at a
+    /// cost its own documentation calls out. It is a fixture scanner rebuilding
+    /// a map with no manifest to lean on and no knowledge of who wrote what,
+    /// which is not the position of a writer holding its own digest.
+    ///
+    /// The window between the test and the rename is a TOCTOU, and an unguarded
+    /// one on purpose: the path *is* the digest, so the only racer that can
+    /// create it is another writer of byte-identical content, and both orders
+    /// leave the same blob. A lock here would serialize every layer write to
+    /// arbitrate between two callers who agree.
     fn finish(self) -> Result<WrittenLayer, Error> {
         let Self {
             sequence,
@@ -171,8 +202,14 @@ impl RecordSink for LayerSink {
         drop(file);
 
         // Named by the digest of the bytes stored, per the OCI image layout.
-        fs::rename(&staging.path, blob_path(&root, &digests.blob_digest))?;
-        staging.published();
+        let blob = blob_path(&root, &digests.blob_digest);
+
+        // Already published, by this run or an earlier one: leave it alone and
+        // let `staging` take the duplicate with it on the way out.
+        if !blob.exists() {
+            fs::rename(&staging.path, &blob)?;
+            staging.published();
+        }
 
         Ok(WrittenLayer {
             descriptor: LayerDescriptor {

--- a/crates/stelae/tests/toy_profile.rs
+++ b/crates/stelae/tests/toy_profile.rs
@@ -552,6 +552,94 @@ fn both_write_paths_produce_the_same_layer() {
     }
 }
 
+/// A layer whose blob is already on disk is deduplicated, not rewritten.
+///
+/// The same records under the same header scope hash to the same blob digest,
+/// which is the same file name — so the second write finds its destination
+/// occupied by the bytes it was about to write. Publishing it anyway would
+/// rewrite hundreds of megabytes with their own contents, and on Windows would
+/// collide with any reader holding the blob open. The second write is therefore
+/// expected to keep the file that is there and drop its own staging copy, while
+/// handing back the very same [`WrittenLayer`] the first write produced.
+///
+/// The proof that no bytes moved is a doctored modification time. A rename
+/// replaces the file behind the name, and the timestamp belongs to the file, so
+/// a mark set on the first write's blob survives only if the second write left
+/// it alone — evidence that neither an equality assertion on the descriptor nor
+/// a count of the directory could give on its own.
+#[test]
+fn a_blob_that_already_exists_is_deduplicated() {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+    let blobs = temp.path().join("blobs");
+
+    let (header_scope, scope) = notes_scopes();
+    let spec = LayerSpec::new("notes", header_scope, scope);
+    let records: Vec<CanonicalCbor> = NOTES.iter().map(note_record).collect();
+
+    // Byte-identical writes: same records, same header scope, same stele. The
+    // header scope matters — it is inside the layer, so two shards of one kind
+    // that differ only there are different blobs and never meet here.
+    let write = || {
+        let mut sink = stele
+            .layer_sink(&ToyProfile, &spec, COMPRESSION_LEVEL)
+            .unwrap();
+
+        for record in &records {
+            sink.write_record(record).unwrap();
+        }
+
+        sink.finish().unwrap()
+    };
+
+    let first = write();
+    let blob = stele.blob_path(&first.digests.blob_digest);
+    assert!(blob.is_file());
+
+    let mark = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+    std::fs::File::options()
+        .write(true)
+        .open(&blob)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(mark))
+        .unwrap();
+
+    let second = write();
+
+    // Whatever the writer observes is what it would have observed first: the
+    // descriptor and the digests come from the record stream, not from the
+    // rename that did not happen.
+    assert_eq!(first.descriptor, second.descriptor);
+    assert_eq!(first.digests, second.digests);
+
+    // One blob, and it is the first write's file: the mark is still on it, so
+    // nothing was written over it.
+    assert_eq!(std::fs::read_dir(blobs.join("sha256")).unwrap().count(), 1);
+    assert_eq!(
+        std::fs::metadata(&blob).unwrap().modified().unwrap(),
+        mark,
+        "the blob was rewritten"
+    );
+
+    // And the duplicate staging file went with the sink that made it.
+    assert_eq!(
+        std::fs::read_dir(&blobs).unwrap().count(),
+        1,
+        "only sha256/"
+    );
+
+    // The layer the second writer describes reads back, through both readers,
+    // out of the blob the first writer published.
+    let index = stele.blob_index().unwrap();
+    assert_eq!(index.len(), 1);
+
+    let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_bytes().to_vec()).collect();
+    assert_eq!(
+        read_both_ways(&stele, &index, &second.descriptor).unwrap(),
+        expected
+    );
+}
+
 /// Sixteen sinks open at once, which is the case the sink exists for.
 ///
 /// The Dolos profile shards its state into sixteen layers and cannot walk the


### PR DESCRIPTION
## What and why

`LayerSink::finish` publishes a layer by renaming its staging file onto
`blobs/sha256/<digest>` — where the digest is that of the very bytes being moved. If
that path already exists it already holds those bytes; content addressing says so. The
rename is a no-op in content terms and never the operation the situation calls for.

Doing it anyway costs two things:

- **I/O.** A blob that is already correct is rewritten. For a mainnet state shard that
  is hundreds of megabytes for no change.
- **A platform-divergent failure.** Narrower than #1167's body claimed, and the
  correction matters: `fs::rename` *does* replace an existing **file** on Windows (via
  `MoveFileExW` / `SetFileInformationByHandle`); the divergence std documents is about
  *directories*, which this code never renames. The real Windows divergence here is a
  sharing violation — every reader opens a blob with a plain `fs::File::open`, without
  `FILE_SHARE_DELETE`, so renaming over a blob that a concurrent `read_layer` or
  `stream_layer` holds open fails on Windows and succeeds on Unix.

Dedup removes the rename and both costs with it, without anyone having to reason about
share modes.

Nothing reaches this today, which is why it did not ride #1167: the sixteen state shards
each carry a distinct per-shard scope in their header record, so their blobs cannot
collide, and #1167's tests use separate steles or distinct scopes.

## What changed

**`crates/stelae/src/dir.rs`** — `LayerSink::finish` tests the destination before it
renames. If the blob is there, it stays; `Staging`'s `Drop` takes the duplicate staging
file, and the caller gets the same `WrittenLayer` it would have got had it been first
(`descriptor` and `digests` are computed from the record stream, never from the rename).
Otherwise the rename happens as before. Six lines of behaviour, and a doc-comment
section carrying the three things a reader needs:

- why an existing blob is a success rather than a rename (the Windows sharing violation
  included);
- why the existing blob is **trusted on its name and not re-read** — this writer computed
  that digest itself a microsecond earlier, and verifying would put a second full pass
  over a possibly multi-gigabyte file on the write path. That diverges from the
  neighbour, `blob_index`, which re-digests every blob it scans; the comment says why a
  fixture scanner with no manifest is not in the same position as a writer holding its
  own digest;
- why the check-then-rename window is an unguarded TOCTOU on purpose: the path *is* the
  digest, so the only racer that can create it is another writer of byte-identical
  content, and a lock would serialize every layer write to arbitrate between two callers
  who agree.

**`crates/stelae/tests/toy_profile.rs`** — one new test,
`a_blob_that_already_exists_is_deduplicated`. Same records, same header scope, same
stele, written twice. It asserts the second `WrittenLayer` equals the first's, that one
blob remains, that nothing is left staged beside `sha256/`, and that the layer still
reads back through both readers.

The evidence that **no bytes moved** is a doctored modification time: the first write's
blob is marked with a distinctive mtime, and since a rename replaces the file behind the
name — and the timestamp belongs to the file, not to the name — the mark surviving is
proof the second write left the blob alone. `File::set_times` is stable and
cross-platform, so this needs no `#[cfg]` seam. Reverting `dir.rs` alone makes the test
fail on exactly that assertion (`the blob was rewritten`).

## Out of scope, deliberately

- **No change to how readers open blobs.** Passing `FILE_SHARE_DELETE` is a different fix
  for a problem dedup dissolves, and would put a `#[cfg(windows)]` seam into a crate that
  has none.
- **No `crates/snapshot` change, no new public surface.** This is an internal branch in
  `finish`, not a new method.
- **No dedup across steles.** Blobs are addressed within one `SteleDir`; a registry-wide
  store is the OCI slice's problem.

## Verification

Run on `macos-14` (local, Rust 1.93):

| check | result |
| --- | --- |
| `cargo test --workspace --all-targets` | pass — every suite green, 0 failures |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo +nightly fmt --all -- --check` | pass |
| `cargo deny check advisories` | `advisories ok` |

`cargo deny` also emits three pre-existing `warning[yanked]` notices (`fjall`, `lsm-tree`,
`spin`) that are unrelated to this change and do not fail the check.

The goldens in `crates/stelae/tests/toy_profile.rs` are untouched and
`golden_digests_pin_the_encoding` still passes: this changes *when* bytes are written,
never what they are.

Done criterion 3 — the new test passing on all three CI platforms, which is where the
divergence this change exists for would show — is met by this PR's CI run: `Test
(ubuntu-latest)`, `Test (macos-14)` and `Test (windows-latest)` are all green, as are
`cargo clippy`, `cargo deny (advisories)`, `cargo fmt` and the three registry
round-trips.

## Note for the reviewer

`crates/stelae/tests/toy_profile.rs` is also being edited on `feat/stelae-publisher-commands`.
The new test here is appended between `both_write_paths_produce_the_same_layer` and
`sixteen_sinks_are_written_in_one_pass` and touches nothing else in the file, so whichever
lands second should be a trivial rebase.

## Trellis trail

- Plan: `plans/dolos-stelae-blob-dedup.md` (Brain/txpipe), `owner: org/coder`, now
  `status: active`.
- Done criterion: all five points met — 1, 2, 4 and 5 locally, 3 by this PR's CI.
- Escalations raised: none.
- Follow-up plan filed: none — no residue beyond what the plan covered.
