### PR TITLE
feat(cardano,core,minibf): implement `/assets/policy/{policy_id}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http-body-util",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ reqwest = { version = "0.12.7", default-features = false, features = [
     "rustls-tls",
 ] }
 rayon = "1.11.0"
+indexmap = "2.9.0"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
 num-rational = "0.4.2"
 num-bigint = "0.4.6"

--- a/crates/cardano/src/indexes/ext.rs
+++ b/crates/cardano/src/indexes/ext.rs
@@ -95,6 +95,17 @@ pub trait CardanoIndexExt: IndexStore {
         self.slots_by_tag(archive::ASSET, asset, start, end)
     }
 
+    /// Iterate over slots of blocks that contain transactions for assets of a
+    /// policy.
+    fn slots_by_policy(
+        &self,
+        policy: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, IndexError> {
+        self.slots_by_tag(archive::POLICY, policy, start, end)
+    }
+
     /// Iterate over slots of blocks containing a datum hash.
     fn slots_by_datum(
         &self,

--- a/crates/cardano/src/indexes/query.rs
+++ b/crates/cardano/src/indexes/query.rs
@@ -76,6 +76,14 @@ pub trait AsyncCardanoQueryExt<D: Domain> {
         order: SlotOrder,
     ) -> impl Stream<Item = Result<(BlockSlot, Option<BlockBody>), DomainError>> + Send + 'static;
 
+    fn blocks_by_policy_stream(
+        &self,
+        policy: &[u8],
+        start_slot: BlockSlot,
+        end_slot: BlockSlot,
+        order: SlotOrder,
+    ) -> impl Stream<Item = Result<(BlockSlot, Option<BlockBody>), DomainError>> + Send + 'static;
+
     fn blocks_by_account_certs_stream(
         &self,
         account: &[u8],
@@ -247,6 +255,24 @@ where
             (*self).clone(),
             archive::ASSET,
             asset.to_vec(),
+            start_slot,
+            end_slot,
+            order,
+        )
+    }
+
+    fn blocks_by_policy_stream(
+        &self,
+        policy: &[u8],
+        start_slot: BlockSlot,
+        end_slot: BlockSlot,
+        order: SlotOrder,
+    ) -> impl Stream<Item = Result<(BlockSlot, Option<BlockBody>), DomainError>> + Send + 'static
+    {
+        blocks_by_tag_stream(
+            (*self).clone(),
+            archive::POLICY,
+            policy.to_vec(),
             start_slot,
             end_slot,
             order,

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -477,9 +477,10 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
 
     /// Query slots by tag dimension and key within a slot range.
     ///
-    /// Returns an iterator over slots that contain data tagged with the given
-    /// dimension and key. The iterator is lazy and supports bidirectional
-    /// iteration for efficient pagination.
+    /// This method returns a lazy iterator over the slots that contain data
+    /// with the given dimension and key. Forward iteration gives the slots
+    /// in ascending order. Reverse iteration gives the slots in descending
+    /// order.
     ///
     /// Both `start` and `end` are **inclusive** — unlike the record traversal
     /// methods below, which take a half-open [`Range`]. Reusing one `(start,

--- a/crates/minibf/Cargo.toml
+++ b/crates/minibf/Cargo.toml
@@ -17,6 +17,7 @@ reqwest.workspace = true
 num-rational.workspace = true
 num-bigint.workspace = true
 rayon.workspace = true
+indexmap.workspace = true
 
 dolos-core = { path = "../core" }
 dolos-cardano = { path = "../cardano" }

--- a/crates/minibf/src/error.rs
+++ b/crates/minibf/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     InvalidAddress,
     InvalidStakeAddress,
     InvalidAsset,
+    InvalidPolicy,
     InvalidPoolId,
     InvalidBlockNumber,
     InvalidBlockHash,
@@ -79,6 +80,15 @@ impl IntoResponse for Error {
                     400,
                     "Bad Request",
                     "Invalid or malformed asset format.",
+                )),
+            )
+                .into_response(),
+            Error::InvalidPolicy => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody::new(
+                    400,
+                    "Bad Request",
+                    "Invalid or malformed policy format.",
                 )),
             )
                 .into_response(),

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -476,6 +476,10 @@ where
             "/txs/{tx_hash}/stakes",
             get(routes::txs::by_hash_stakes::<D>),
         )
+        .route(
+            "/assets/policy/{policy_id}",
+            get(routes::assets::by_policy::<D>),
+        )
         .route("/assets/{subject}", get(routes::assets::by_subject::<D>))
         .route(
             "/assets/{subject}/addresses",

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, ops::Deref, time::Duration};
 
+use indexmap::IndexSet;
+
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -730,11 +732,12 @@ where
 fn collect_minted_subjects(
     block: &[u8],
     policy: &[u8],
-    seen: &mut Vec<Vec<u8>>,
+    seen: &mut IndexSet<Vec<u8>>,
 ) -> Result<(), StatusCode> {
     // Blockfrost groups the `ma_tx_mint` rows by policy and name. Then it sorts
     // the rows by the first mint event. The caller supplies blocks in ascending
-    // slot order. `seen` keeps the first subject for each name.
+    // slot order. `seen` keeps the first subject for each name. The set skips a
+    // repeated name in O(1) and keeps the first-mint order.
     let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     for tx in block.txs() {
@@ -746,10 +749,7 @@ fn collect_minted_subjects(
             for asset in policy_assets.assets() {
                 let mut subject = policy.to_vec();
                 subject.extend_from_slice(asset.name());
-
-                if !seen.contains(&subject) {
-                    seen.push(subject);
-                }
+                seen.insert(subject);
             }
         }
     }
@@ -784,7 +784,7 @@ where
 
     let needed_unique =
         matches!(pagination.order, Order::Asc).then(|| pagination.from() + pagination.count);
-    let mut subjects: Vec<Vec<u8>> = Vec::new();
+    let mut subjects: IndexSet<Vec<u8>> = IndexSet::new();
     while let Some(res) = stream.next().await {
         let (_slot, block) = res.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         let Some(block) = block else {
@@ -801,16 +801,16 @@ where
         return Err(StatusCode::NOT_FOUND.into());
     }
 
-    if matches!(pagination.order, Order::Desc) {
-        subjects.reverse();
-    }
+    // The scan collects the subjects in ascending first-mint order. For `desc`,
+    // reverse this order.
+    let ordered: Box<dyn Iterator<Item = Vec<u8>>> = if matches!(pagination.order, Order::Desc) {
+        Box::new(subjects.into_iter().rev())
+    } else {
+        Box::new(subjects.into_iter())
+    };
 
     let mut items = Vec::new();
-    for subject in subjects
-        .into_iter()
-        .skip(pagination.skip())
-        .take(pagination.count)
-    {
+    for subject in ordered.skip(pagination.skip()).take(pagination.count) {
         let entity_key = pallas::crypto::hash::Hasher::<256>::hash(subject.as_slice());
         let asset_state = domain
             .read_cardano_entity::<AssetState>(entity_key.as_slice())?

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -727,13 +727,15 @@ where
     Ok(Json(transactions))
 }
 
-fn collect_minted_subjects(block: &[u8], policy: &[u8], seen: &mut Vec<Vec<u8>>) {
+fn collect_minted_subjects(
+    block: &[u8],
+    policy: &[u8],
+    seen: &mut Vec<Vec<u8>>,
+) -> Result<(), StatusCode> {
     // Blockfrost groups the `ma_tx_mint` rows by policy and name. Then it sorts
     // the rows by the first mint event. The caller supplies blocks in ascending
     // slot order. `seen` keeps the first subject for each name.
-    let Ok(block) = MultiEraBlock::decode(block) else {
-        return;
-    };
+    let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     for tx in block.txs() {
         for policy_assets in tx.mints() {
@@ -751,6 +753,8 @@ fn collect_minted_subjects(block: &[u8], policy: &[u8], seen: &mut Vec<Vec<u8>>)
             }
         }
     }
+
+    Ok(())
 }
 
 pub async fn by_policy<D>(
@@ -786,7 +790,7 @@ where
         let Some(block) = block else {
             continue;
         };
-        collect_minted_subjects(&block, &policy, &mut subjects);
+        collect_minted_subjects(&block, &policy, &mut subjects)?;
         if needed_unique.is_some_and(|needed| subjects.len() >= needed) {
             break;
         }

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -9,6 +9,7 @@ use blockfrost_openapi::models::{
     asset::{Asset, OnchainMetadataStandard},
     asset_addresses_inner::AssetAddressesInner,
     asset_metadata::AssetMetadata as OffchainMetadata,
+    asset_policy_inner::AssetPolicyInner,
     asset_transactions_inner::AssetTransactionsInner,
 };
 use dolos_cardano::{
@@ -726,6 +727,96 @@ where
     Ok(Json(transactions))
 }
 
+fn collect_minted_subjects(block: &[u8], policy: &[u8], seen: &mut Vec<Vec<u8>>) {
+    // Blockfrost groups the `ma_tx_mint` rows by policy and name. Then it sorts
+    // the rows by the first mint event. The caller supplies blocks in ascending
+    // slot order. `seen` keeps the first subject for each name.
+    let Ok(block) = MultiEraBlock::decode(block) else {
+        return;
+    };
+
+    for tx in block.txs() {
+        for policy_assets in tx.mints() {
+            if policy_assets.policy().as_slice() != policy {
+                continue;
+            }
+
+            for asset in policy_assets.assets() {
+                let mut subject = policy.to_vec();
+                subject.extend_from_slice(asset.name());
+
+                if !seen.contains(&subject) {
+                    seen.push(subject);
+                }
+            }
+        }
+    }
+}
+
+pub async fn by_policy<D>(
+    Path(policy_hex): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<AssetPolicyInner>>, Error>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+    Option<AssetState>: From<D::Entity>,
+{
+    let pagination = Pagination::try_from(params)?;
+
+    let policy = hex::decode(&policy_hex).map_err(|_| Error::InvalidPolicy)?;
+    if policy.len() != 28 {
+        return Err(Error::InvalidPolicy);
+    }
+
+    // Pagination depends on first-mint order. The scan collects all asset names
+    // before it selects a page because one name can occur in many blocks. It
+    // scans the blocks in ascending slot order and reverses the result for
+    // `desc`.
+    let end_slot = domain.get_tip_slot()?;
+    let stream = domain
+        .query()
+        .blocks_by_policy_stream(&policy, 0, end_slot, SlotOrder::Asc);
+    let mut stream = Box::pin(stream);
+
+    let mut subjects: Vec<Vec<u8>> = Vec::new();
+    while let Some(res) = stream.next().await {
+        let (_slot, block) = res.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let Some(block) = block else {
+            continue;
+        };
+        collect_minted_subjects(&block, &policy, &mut subjects);
+    }
+
+    // Blockfrost returns 404 when the policy has no mint operations.
+    if subjects.is_empty() {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    if matches!(pagination.order, Order::Desc) {
+        subjects.reverse();
+    }
+
+    let mut items = Vec::new();
+    for subject in subjects
+        .into_iter()
+        .skip(pagination.skip())
+        .take(pagination.count)
+    {
+        let entity_key = pallas::crypto::hash::Hasher::<256>::hash(subject.as_slice());
+        let asset_state = domain
+            .read_cardano_entity::<AssetState>(entity_key.as_slice())?
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        items.push(AssetPolicyInner {
+            asset: hex::encode(&subject),
+            quantity: asset_state.quantity().to_string(),
+        });
+    }
+
+    Ok(Json(items))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -825,6 +916,53 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
         let asset = app.vectors().asset_unit.as_str();
         let path = format!("/assets/{asset}/addresses");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    fn unminted_policy() -> &'static str {
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+
+    #[tokio::test]
+    async fn assets_by_policy_happy_path() {
+        let app = TestApp::new();
+        let policy = app.vectors().policy_id.clone();
+        let unit = app.vectors().asset_unit.clone();
+        let path = format!("/assets/policy/{policy}");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let assets: Vec<AssetPolicyInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse policy assets");
+        assert!(assets.iter().any(|a| a.asset == unit));
+    }
+
+    #[tokio::test]
+    async fn assets_by_policy_bad_request() {
+        let app = TestApp::new();
+        // This policy contains non-hexadecimal characters.
+        assert_status(&app, "/assets/policy/not-hex", StatusCode::BAD_REQUEST).await;
+        // This policy contains fewer than 28 bytes.
+        assert_status(&app, "/assets/policy/abcd", StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn assets_by_policy_not_found() {
+        let app = TestApp::new();
+        let path = format!("/assets/policy/{}", unminted_policy());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn assets_by_policy_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let policy = app.vectors().policy_id.clone();
+        let path = format!("/assets/policy/{policy}");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 }

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -769,16 +769,17 @@ where
         return Err(Error::InvalidPolicy);
     }
 
-    // Pagination depends on first-mint order. The scan collects all asset names
-    // before it selects a page because one name can occur in many blocks. It
-    // scans the blocks in ascending slot order and reverses the result for
-    // `desc`.
+    // Pagination depends on first-mint order. An ascending scan stops after it
+    // collects the requested prefix. A descending scan reads all asset names and
+    // then reverses them, because one name can occur in many blocks.
     let end_slot = domain.get_tip_slot()?;
     let stream = domain
         .query()
         .blocks_by_policy_stream(&policy, 0, end_slot, SlotOrder::Asc);
     let mut stream = Box::pin(stream);
 
+    let needed_unique =
+        matches!(pagination.order, Order::Asc).then(|| pagination.from() + pagination.count);
     let mut subjects: Vec<Vec<u8>> = Vec::new();
     while let Some(res) = stream.next().await {
         let (_slot, block) = res.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -786,6 +787,9 @@ where
             continue;
         };
         collect_minted_subjects(&block, &policy, &mut subjects);
+        if needed_unique.is_some_and(|needed| subjects.len() >= needed) {
+            break;
+        }
     }
 
     // Blockfrost returns 404 when the policy has no mint operations.

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -826,6 +826,7 @@ mod tests {
     use super::*;
     use crate::test_support::{TestApp, TestFault};
     use blockfrost_openapi::models::asset::Asset;
+    use dolos_testing::synthetic::SyntheticBlockConfig;
 
     fn invalid_asset() -> &'static str {
         "not-hex-asset"
@@ -944,6 +945,37 @@ mod tests {
         let assets: Vec<AssetPolicyInner> =
             serde_json::from_slice(&bytes).expect("failed to parse policy assets");
         assert!(assets.iter().any(|a| a.asset == unit));
+    }
+
+    #[tokio::test]
+    async fn assets_by_policy_ascending_pagination_preserves_first_mint_order() {
+        let asset_names = ["FIRST", "SECOND", "THIRD"];
+        let app = TestApp::new_with_cfg(SyntheticBlockConfig {
+            block_count: asset_names.len(),
+            txs_per_block: 1,
+            asset_names_by_block: asset_names.iter().map(|x| (*x).to_string()).collect(),
+            ..Default::default()
+        });
+        let policy = app.vectors().policy_id.as_str();
+
+        for (index, asset_name) in asset_names.into_iter().enumerate() {
+            let page = index + 1;
+            let path = format!("/assets/policy/{policy}?order=asc&page={page}&count=1");
+            let (status, bytes) = app.get_bytes(&path).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "unexpected status {status} with body: {}",
+                String::from_utf8_lossy(&bytes)
+            );
+
+            let assets: Vec<AssetPolicyInner> =
+                serde_json::from_slice(&bytes).expect("failed to parse policy assets");
+            let expected = format!("{policy}{}", hex::encode(asset_name));
+            assert_eq!(assets.len(), 1);
+            assert_eq!(assets[0].asset, expected);
+            assert_eq!(assets[0].quantity, "1");
+        }
     }
 
     #[tokio::test]

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -46,6 +46,7 @@ pub struct SyntheticBlockConfig {
     pub metadata_entries: Vec<(u64, alonzo::Metadatum)>,
     pub policy_id: [u8; 28],
     pub asset_name: String,
+    pub asset_names_by_block: Vec<String>,
     pub lovelace: u64,
     pub asset_amount: u64,
     pub mint_amount: i64,
@@ -100,6 +101,7 @@ impl Default for SyntheticBlockConfig {
             metadata_entries: vec![],
             policy_id: [1u8; 28],
             asset_name: "SYNTH".to_string(),
+            asset_names_by_block: vec![],
             lovelace: crate::MIN_UTXO_AMOUNT,
             asset_amount: 1,
             mint_amount: 1,
@@ -223,9 +225,19 @@ pub fn build_synthetic_blocks(
         .unwrap_or(cfg.metadata_label);
 
     let policy_id = Hash::from(cfg.policy_id);
-    let asset_name = Bytes::from(cfg.asset_name.as_bytes().to_vec());
+    let block_count = cfg.block_count.max(1);
+    let asset_names = if cfg.asset_names_by_block.is_empty() {
+        vec![cfg.asset_name.clone(); block_count]
+    } else {
+        assert_eq!(
+            cfg.asset_names_by_block.len(),
+            block_count,
+            "asset_names_by_block must contain one name per block"
+        );
+        cfg.asset_names_by_block.clone()
+    };
     let policy_id_hex = hex::encode(cfg.policy_id);
-    let asset_name_hex = hex::encode(cfg.asset_name.as_bytes());
+    let asset_name_hex = hex::encode(asset_names[0].as_bytes());
     let fixture_extras = Some(build_datum_and_script_fixture());
 
     let stake_cred = Address::from_bech32(&cfg.address)
@@ -253,7 +265,6 @@ pub fn build_synthetic_blocks(
         std::collections::HashMap::new();
     let mut account_withdrawals = Vec::new();
 
-    let block_count = cfg.block_count.max(1);
     let txs_per_block = cfg.txs_per_block.max(1);
     let submit_tx_hash = tx_sequence_to_hash(block_count as u64 * txs_per_block as u64 + 1);
     let submit_ref = TxoRef(submit_tx_hash, 0);
@@ -266,9 +277,10 @@ pub fn build_synthetic_blocks(
     });
     let mut prev_block_hash: Option<Hash<32>> = None;
 
-    for offset in 0..block_count {
+    for (offset, asset_name) in asset_names.iter().enumerate() {
         let slot = cfg.slot + offset as u64;
         let block_number = cfg.start_block + offset as u64;
+        let asset_name = Bytes::from(asset_name.as_bytes().to_vec());
         let mut tx_specs = Vec::with_capacity(txs_per_block);
         let mut tx_hashes = Vec::with_capacity(txs_per_block);
         let mut withdrawal_amounts = Vec::with_capacity(txs_per_block);
@@ -386,7 +398,7 @@ pub fn build_synthetic_blocks(
     let asset_unit = format!(
         "{}{}",
         hex::encode(cfg.policy_id),
-        hex::encode(cfg.asset_name.as_bytes())
+        hex::encode(asset_names[0].as_bytes())
     );
 
     let stake_address = match Address::from_bech32(&cfg.address).expect("invalid synthetic address")

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -294,6 +294,20 @@ impl Backend for Memory {
     }
 }
 
+struct Redb;
+
+impl Backend for Redb {
+    type Store = dolos_redb3::indexes::IndexStore;
+    type Guard = ();
+
+    fn open() -> (Self::Store, Self::Guard) {
+        (
+            dolos_redb3::indexes::IndexStore::in_memory().expect("failed to open redb index store"),
+            (),
+        )
+    }
+}
+
 /// Declare the whole suite for one backend. Adding a backend is one line.
 macro_rules! conformance_suite {
     ($module:ident, $backend:ty) => {
@@ -334,12 +348,22 @@ macro_rules! conformance_suite {
             fn malformed_exact_queries_miss() {
                 super::malformed_exact_queries_miss::<$backend>();
             }
+
+            #[test]
+            fn slots_by_tag_are_ordered_in_both_directions() {
+                super::slots_by_tag_are_ordered_in_both_directions::<$backend>();
+            }
         }
     };
 }
 
 conformance_suite!(fjall, Fjall);
 conformance_suite!(memory, Memory);
+
+#[test]
+fn redb_slots_by_tag_are_ordered_in_both_directions() {
+    slots_by_tag_are_ordered_in_both_directions::<Redb>();
+}
 
 fn epoch_slots(epoch: u64) -> Range<BlockSlot> {
     (epoch * EPOCH_LEN)..((epoch + 1) * EPOCH_LEN)
@@ -416,6 +440,46 @@ fn apply<S: CoreIndexStore>(store: &S, delta: &IndexDelta) {
     let writer = store.start_writer().expect("start_writer failed");
     writer.apply(delta).expect("apply failed");
     writer.commit().expect("commit failed");
+}
+
+fn slots_by_tag_are_ordered_in_both_directions<B: Backend>() {
+    let (store, _guard) = B::open();
+    let policy = vec![0xAA; 28];
+    let slots = [30, 10, 20];
+    let archive = slots
+        .into_iter()
+        .map(|slot| ArchiveIndexDelta {
+            slot,
+            block_hash: hash32(0x0A, slot, 0),
+            block_number: Some(slot),
+            tx_hashes: Vec::new(),
+            tags: vec![Tag::new(archive_dimensions::POLICY, policy.clone())],
+        })
+        .collect();
+
+    apply(
+        &store,
+        &IndexDelta {
+            cursor: ChainPoint::Slot(30),
+            utxo: Default::default(),
+            archive,
+        },
+    );
+
+    let forward = store
+        .slots_by_tag(archive_dimensions::POLICY, &policy, 0, 40)
+        .expect("slots_by_tag failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("forward slot iteration failed");
+    assert_eq!(forward, vec![10, 20, 30]);
+
+    let reverse = store
+        .slots_by_tag(archive_dimensions::POLICY, &policy, 0, 40)
+        .expect("slots_by_tag failed")
+        .rev()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("reverse slot iteration failed");
+    assert_eq!(reverse, vec![30, 20, 10]);
 }
 
 /// Populate a store through the regular delta path, the same one the sync


### PR DESCRIPTION
Resolves #1072.

## Implementation

The implementation reads existing archive and state data. It does not change storage schemas or index data.

- dea4d317522c1a298430ffd6d842f8e580747b76 implements `/assets/policy/{policy_id}`.
  - Add archive slot and block queries for `POLICY` tags.
  - Scan mint and burn operations in first-mint order.
  - Remove duplicate asset names and read current quantities from `AssetState`.
  - Support ascending and descending order, page, and count parameters.
  - Return Blockfrost-compatible validation and not-found responses.
  - Add unit tests for valid, malformed, absent, and storage-error cases.

- 6655bd2904af7fed172d19e25601194df8483dcc stops the policy scan after the ascending page. The `by_policy` route scanned from genesis to tip. It now stops after it collects the requested ascending page. The change also documents the slot order of `IndexStore::slots_by_tag` in `crates/core`: forward iteration gives ascending slots, and reverse iteration gives descending slots.

- 8af0136b8afdbcc4e96da1bc33119d24f6cb6380 adds tests for the policy scan early-exit. The early-exit is correct only if the stream keeps the first mint for each name in slot order, and the index returns the slots in ascending order. New tests make sure that both facts hold. The synthetic fixture in `crates/testing` now sets one asset name per block, because the same name can hide an order fault.

## Testing

Tested on Preview with:

- <https://github.com/blockfrost/blockfrost-tests/blob/38af1d3ee6ecbb17f67b2c3aee9738cf7cb287f1/src/fixtures/preview/assets/asset-policy-policy-id.ts>

We also compared 20 random requests with the original Blockfrost Preview API. We found no discrepancies.