### PR TITLE
refactor(minibf): share input resolution for the block addresses endpoint

### DIFF
--- a/crates/minibf/src/inputs.rs
+++ b/crates/minibf/src/inputs.rs
@@ -326,6 +326,65 @@ mod tests {
         );
     }
 
+    /// Exercises the `produces_at` edge. Invalid script txs don't produce
+    /// their regular outputs, but they can produce a collateral return at the
+    /// next output index. Resolution must reach it — `output_at` would not.
+    #[test]
+    fn resolves_spent_collateral_return_output() {
+        use dolos_core::TxoRef;
+        use dolos_testing::{synthetic::build_phase2_invalid_tx_cbor, TestAddress};
+
+        let (blocks, _, _) = build_synthetic_blocks(synthetic_cfg());
+        let raw = blocks.first().expect("missing synthetic block");
+
+        let block = MultiEraBlock::decode(raw).expect("failed to decode block");
+        let txs = block.txs();
+        let spender = txs.get(1).expect("fixture needs a second tx");
+        let inputs = spender.consumes();
+        let input = inputs.first().expect("spender must consume");
+
+        // Phase-2-invalid dep tx with no regular outputs. A collateral return
+        // is indexed after the regular outputs, so with none it sits at
+        // index 0.
+        let collateral_return_address = TestAddress::Alice;
+        let dep_tx_cbor = build_phase2_invalid_tx_cbor(
+            // arbitrary, never resolved in this test
+            TxoRef([1u8; 32].into(), 0),
+            // arbitrary, never resolved in this test
+            TxoRef([2u8; 32].into(), 16),
+            collateral_return_address.clone(), // what the input must resolve to
+            1_500_000,
+        );
+
+        // check test wiring
+        assert_eq!(
+            input.index(),
+            0,
+            "the spender's input index must match the index of the dep's collateral return (0)"
+        );
+
+        // pretend the input's source is the phase-2-invalid tx
+        let mut store = TxMap::new();
+        store.insert(
+            *input.hash(),
+            Some(EraCbor(Era::Conway.into(), dep_tx_cbor)),
+        );
+
+        let mut resolver = InputResolver::new(&store);
+
+        let output = resolver
+            .resolve(input)
+            .expect("resolve failed")
+            .expect("spent collateral return must resolve");
+
+        let address = output
+            .address()
+            .expect("collateral return must have an address")
+            .to_string();
+
+        assert_eq!(address, collateral_return_address.as_str());
+    }
+
     #[test]
     fn records_misses() {
         let vectors = vectors();

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2041,7 +2041,7 @@ pub struct BlockModelBuilder<'a> {
     previous: Option<MultiEraBlock<'a>>,
     next: Option<MultiEraBlock<'a>>,
     tip: Option<MultiEraBlock<'a>>,
-    deps: HashMap<TxHash, MultiEraTx<'a>>,
+    touched_addresses: Vec<BTreeSet<String>>,
 }
 
 impl<'a> BlockModelBuilder<'a> {
@@ -2054,31 +2054,21 @@ impl<'a> BlockModelBuilder<'a> {
             next: None,
             tip: None,
             chain: None,
-            deps: HashMap::new(),
+            touched_addresses: Vec::new(),
         })
     }
 
-    pub fn required_input_deps(&self) -> Vec<TxHash> {
-        let mut seen_tx_hashes = HashSet::new();
-
-        self.block
-            .txs()
-            .iter()
-            .flat_map(|tx| tx.consumes())
-            .map(|input| *input.hash())
-            .filter(|hash| seen_tx_hashes.insert(*hash))
-            .collect()
+    pub fn txs(&self) -> Vec<MultiEraTx<'_>> {
+        self.block.txs()
     }
 
-    pub fn load_dep(&mut self, key: TxHash, cbor: &'a EraCbor) -> Result<(), StatusCode> {
-        let era = try_into_or_500!(cbor.era());
-
-        let tx = MultiEraTx::decode_for_era(era, cbor.cbor())
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-        self.deps.insert(key, tx);
-
-        Ok(())
+    /// The addresses touched by each tx, in block order, collected by the
+    /// caller (see `inputs::for_each_touched_output`).
+    pub fn with_touched_addresses(self, touched_addresses: Vec<BTreeSet<String>>) -> Self {
+        Self {
+            touched_addresses,
+            ..self
+        }
     }
 
     pub fn with_chain(self, chain: &'a ChainSummary) -> Self {
@@ -2390,46 +2380,24 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
     type SortKey = ();
 
     fn into_model(self) -> Result<Vec<BlockContentAddressesInner>, StatusCode> {
-        let block = &self.block;
+        let Self {
+            block,
+            touched_addresses,
+            ..
+        } = self;
 
         // BTreeMap keeps entries sorted alphabetically by address, matching
         // Blockfrost. Tx hashes are appended in block order and deduped per
-        // address by collecting each tx's touched addresses into a set first.
+        // address because each tx's touched addresses arrive as a set.
         let mut by_address: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
-        // Phase-2-failed txs are deliberately NOT skipped here, diverging
-        // from Blockfrost: their collateral inputs and collateral-return
-        // outputs move funds, so those addresses are affected in ledger
-        // terms - considered a bug in BF, not behavior worth reproducing
+        let mut touched = touched_addresses.into_iter();
+
         for tx in block.txs() {
-            let mut touched = BTreeSet::new();
-
-            for (_, output) in tx.produces() {
-                let address = output
-                    .address()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-                touched.insert(address.to_string());
-            }
-
-            for input in tx.consumes() {
-                let as_output = self
-                    .deps
-                    .get(input.hash())
-                    .and_then(|dep| dep.produces_at(input.index() as usize));
-
-                if let Some(output) = as_output {
-                    let address = output
-                        .address()
-                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-                    touched.insert(address.to_string());
-                }
-            }
-
+            let touched_by_tx = touched.next().unwrap_or_default();
             let tx_hash = tx.hash().to_string();
 
-            for address in touched {
+            for address in touched_by_tx {
                 by_address.entry(address).or_default().push(tx_hash.clone());
             }
         }

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2041,7 +2041,7 @@ pub struct BlockModelBuilder<'a> {
     previous: Option<MultiEraBlock<'a>>,
     next: Option<MultiEraBlock<'a>>,
     tip: Option<MultiEraBlock<'a>>,
-    touched_addresses: Option<Vec<BTreeSet<String>>>,
+    touched_addresses: Option<Vec<(String, BTreeSet<String>)>>,
 }
 
 impl<'a> BlockModelBuilder<'a> {
@@ -2065,7 +2065,7 @@ impl<'a> BlockModelBuilder<'a> {
     /// Collect the addresses each tx touches by asking `collect` for every tx
     /// of the block, in block order. The builder drives the walk itself, so
     /// the sets cannot fall out of sync with the txs they describe.
-    pub fn with_touched_addresses<F>(mut self, collect: F) -> Result<Self, StatusCode>
+    pub fn collect_touched_addresses_with<F>(mut self, mut collect: F) -> Result<Self, StatusCode>
     where
         F: FnMut(&MultiEraTx<'_>) -> Result<BTreeSet<String>, StatusCode>,
     {
@@ -2073,8 +2073,8 @@ impl<'a> BlockModelBuilder<'a> {
             self.block
                 .txs()
                 .iter()
-                .map(collect)
-                .collect::<Result<_, _>>()?,
+                .map(|tx| collect(tx).map(|addresses| (tx.hash().to_string(), addresses)))
+                .try_collect()?,
         );
 
         Ok(self)
@@ -2389,40 +2389,17 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
     type SortKey = ();
 
     fn into_model(self) -> Result<Vec<BlockContentAddressesInner>, StatusCode> {
-        let Self {
-            block,
-            touched_addresses,
-            ..
-        } = self;
-
-        let txs = block.txs();
-
-        let touched_addresses = touched_addresses.ok_or_else(|| {
+        let touched_addresses = self.touched_addresses.ok_or_else(|| {
             tracing::error!("touched addresses not collected for block");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-
-        // `with_touched_addresses` walks the block itself, so one set per tx
-        // is guaranteed. Refuse any mismatch rather than silently returning a
-        // partial response.
-        if touched_addresses.len() != txs.len() {
-            tracing::error!(
-                txs = txs.len(),
-                touched = touched_addresses.len(),
-                "touched addresses out of sync with block txs"
-            );
-
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
 
         // BTreeMap keeps entries sorted alphabetically by address, matching
         // Blockfrost. Tx hashes are appended in block order and deduped per
         // address because each tx's touched addresses arrive as a set.
         let mut by_address: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
-        for (tx, touched_by_tx) in txs.iter().zip(touched_addresses) {
-            let tx_hash = tx.hash().to_string();
-
+        for (tx_hash, touched_by_tx) in touched_addresses {
             for address in touched_by_tx {
                 by_address.entry(address).or_default().push(tx_hash.clone());
             }

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2041,7 +2041,7 @@ pub struct BlockModelBuilder<'a> {
     previous: Option<MultiEraBlock<'a>>,
     next: Option<MultiEraBlock<'a>>,
     tip: Option<MultiEraBlock<'a>>,
-    touched_addresses: Vec<BTreeSet<String>>,
+    touched_addresses: Option<Vec<BTreeSet<String>>>,
 }
 
 impl<'a> BlockModelBuilder<'a> {
@@ -2054,7 +2054,7 @@ impl<'a> BlockModelBuilder<'a> {
             next: None,
             tip: None,
             chain: None,
-            touched_addresses: Vec::new(),
+            touched_addresses: None,
         })
     }
 
@@ -2069,12 +2069,13 @@ impl<'a> BlockModelBuilder<'a> {
     where
         F: FnMut(&MultiEraTx<'_>) -> Result<BTreeSet<String>, StatusCode>,
     {
-        self.touched_addresses = self
-            .block
-            .txs()
-            .iter()
-            .map(collect)
-            .collect::<Result<_, _>>()?;
+        self.touched_addresses = Some(
+            self.block
+                .txs()
+                .iter()
+                .map(collect)
+                .collect::<Result<_, _>>()?,
+        );
 
         Ok(self)
     }
@@ -2396,11 +2397,14 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
 
         let txs = block.txs();
 
+        let touched_addresses = touched_addresses.ok_or_else(|| {
+            tracing::error!("touched addresses not collected for block");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
         // `with_touched_addresses` walks the block itself, so one set per tx
-        // is guaranteed; a mismatch here means it was never called. Zipping
-        // anyway would silently return an empty or partial response - refuse
-        // instead, the same way InputResolver::resolve refuses an input it
-        // was never prepared for.
+        // is guaranteed. Refuse any mismatch rather than silently returning a
+        // partial response.
         if touched_addresses.len() != txs.len() {
             tracing::error!(
                 txs = txs.len(),

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -2062,13 +2062,21 @@ impl<'a> BlockModelBuilder<'a> {
         self.block.txs()
     }
 
-    /// The addresses touched by each tx, in block order, collected by the
-    /// caller (see `inputs::for_each_touched_output`).
-    pub fn with_touched_addresses(self, touched_addresses: Vec<BTreeSet<String>>) -> Self {
-        Self {
-            touched_addresses,
-            ..self
-        }
+    /// Collect the addresses each tx touches by asking `collect` for every tx
+    /// of the block, in block order. The builder drives the walk itself, so
+    /// the sets cannot fall out of sync with the txs they describe.
+    pub fn with_touched_addresses<F>(mut self, collect: F) -> Result<Self, StatusCode>
+    where
+        F: FnMut(&MultiEraTx<'_>) -> Result<BTreeSet<String>, StatusCode>,
+    {
+        self.touched_addresses = self
+            .block
+            .txs()
+            .iter()
+            .map(collect)
+            .collect::<Result<_, _>>()?;
+
+        Ok(self)
     }
 
     pub fn with_chain(self, chain: &'a ChainSummary) -> Self {
@@ -2386,15 +2394,29 @@ impl<'a> IntoModel<Vec<BlockContentAddressesInner>> for BlockModelBuilder<'a> {
             ..
         } = self;
 
+        let txs = block.txs();
+
+        // `with_touched_addresses` walks the block itself, so one set per tx
+        // is guaranteed; a mismatch here means it was never called. Zipping
+        // anyway would silently return an empty or partial response - refuse
+        // instead, the same way InputResolver::resolve refuses an input it
+        // was never prepared for.
+        if touched_addresses.len() != txs.len() {
+            tracing::error!(
+                txs = txs.len(),
+                touched = touched_addresses.len(),
+                "touched addresses out of sync with block txs"
+            );
+
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+
         // BTreeMap keeps entries sorted alphabetically by address, matching
         // Blockfrost. Tx hashes are appended in block order and deduped per
         // address because each tx's touched addresses arrive as a set.
         let mut by_address: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
-        let mut touched = touched_addresses.into_iter();
-
-        for tx in block.txs() {
-            let touched_by_tx = touched.next().unwrap_or_default();
+        for (tx, touched_by_tx) in txs.iter().zip(touched_addresses) {
             let tx_hash = tx.hash().to_string();
 
             for address in touched_by_tx {

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -13,9 +13,12 @@ use futures::future::try_join_all;
 use itertools::Either;
 use pallas::ledger::traverse::MultiEraBlock;
 
+use std::collections::BTreeSet;
+
 use crate::{
     error::Error,
     hacks,
+    inputs::{for_each_touched_output, InputDeps},
     mapping::{BlockModelBuilder, IntoModel as _},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
@@ -444,21 +447,48 @@ where
     let hash_or_number = parse_hash_or_number(&hash_or_number)?;
     let block = load_block_by_hash_or_number(&domain, &hash_or_number).await?;
 
-    let mut builder = BlockModelBuilder::new(&block)?;
+    let builder = BlockModelBuilder::new(&block)?;
 
-    let deps = builder.required_input_deps();
-    let deps = domain.get_tx_batch(deps).await?;
+    let mut deps = InputDeps::default();
 
-    // deps missing from the archive (possible on nodes without full history)
-    // are skipped, omitting their addresses from the response — the same
-    // graceful degradation as /txs/{hash}/utxos
-    for (key, cbor) in deps.iter() {
-        if let Some(cbor) = cbor {
-            builder.load_dep(*key, cbor)?;
+    // Collect the addresses each tx touches: its produced outputs plus the
+    // source outputs of its inputs. Inputs whose source tx is missing from
+    // the archive (possible on nodes without full history) are skipped,
+    // omitting their addresses from the response — the same graceful
+    // degradation as /txs/{hash}/utxos.
+    //
+    // Phase-2-failed txs are deliberately NOT skipped, diverging from
+    // Blockfrost: their collateral inputs and collateral-return outputs move
+    // funds, so those addresses are affected in ledger terms - considered a
+    // bug in BF, not behavior worth reproducing
+    let touched_addresses = {
+        let txs = builder.txs();
+        let mut resolver = deps.prepare(&domain, txs.iter()).await?;
+
+        let mut touched = Vec::with_capacity(txs.len());
+
+        for tx in &txs {
+            let mut addresses = BTreeSet::new();
+
+            for_each_touched_output(&mut resolver, tx, |output| {
+                let address = output
+                    .address()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                addresses.insert(address.to_string());
+
+                Ok(false)
+            })?;
+
+            touched.push(addresses);
         }
-    }
 
-    let addresses: Vec<BlockContentAddressesInner> = builder.into_model()?;
+        touched
+    };
+
+    let addresses: Vec<BlockContentAddressesInner> = builder
+        .with_touched_addresses(touched_addresses)
+        .into_model()?;
 
     // Blockfrost sorts this endpoint alphabetically by address and ignores
     // the `order` param; only count/page apply.
@@ -922,69 +952,47 @@ mod tests {
         );
     }
 
-    /// Exercises the `produces_at` edge for input-side address resolution.
-    /// Invalid script txs don't produce their regular outputs, but they can
-    /// produce a collateral return at the next output index. When a later tx
-    /// spends that collateral return, block-address mapping must resolve the
-    /// collateral-return address from the dependency tx CBOR.
+    /// Feeds the builder one set of touched addresses per tx and checks the
+    /// grouping: a fake address touched only by the second tx must come back
+    /// listed under exactly that tx.
     #[test]
-    fn block_addresses_resolves_spent_collateral_return_address() {
-        use dolos_core::{EraCbor, TxoRef};
-        use dolos_testing::{
-            synthetic::{
-                build_phase2_invalid_tx_cbor, build_synthetic_blocks, SyntheticBlockConfig,
-            },
-            TestAddress,
-        };
-        use pallas::ledger::traverse::{Era, MultiEraBlock};
-
-        // Phase-2-invalid dep tx with no regular outputs. A collateral return
-        // is indexed after the regular outputs, so with none it sits at
-        // index 0.
-        let collateral_return_address = TestAddress::Alice;
-        let dep_tx_cbor = build_phase2_invalid_tx_cbor(
-            // arbitrary, never resolved in this test
-            TxoRef([1u8; 32].into(), 0),
-            // arbitrary, never resolved in this test
-            TxoRef([2u8; 32].into(), 16),
-            collateral_return_address.clone(), // what the spender's input must resolve to
-            1_500_000,
-        );
+    fn block_addresses_attribute_touched_addresses() {
+        use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
+        use pallas::ledger::traverse::MultiEraBlock;
 
         let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig::default());
         let raw = blocks.first().expect("missing synthetic block");
 
         let block = MultiEraBlock::decode(raw).expect("failed to decode block");
         let txs = block.txs();
+        // the second tx, so attribution can't pass by "always the first tx"
         let spender = txs.get(1).expect("fixture needs a second tx");
-        let consumed = spender.consumes();
-        let input = consumed.first().expect("spender must consume");
-        // check test wiring
-        assert_eq!(
-            input.index(),
-            0,
-            "the spender's input index must match the index of the dep's collateral return (0)"
-        );
+        let spender_hash = spender.hash().to_string();
 
-        let mut builder = BlockModelBuilder::new(raw).expect("failed to build block model");
-        let dep_cbor = EraCbor(Era::Conway.into(), dep_tx_cbor);
-        builder
-            .load_dep(*input.hash(), &dep_cbor)
-            .expect("failed to load dep");
-        let addresses: Vec<BlockContentAddressesInner> =
-            builder.into_model().expect("failed to map block addresses");
+        // an address only reachable through input resolution, never produced
+        // by any tx of the block
+        let input_side_address = "addr_input_side_only";
+
+        let mut touched = vec![BTreeSet::new(); txs.len()];
+        touched[1].insert(input_side_address.to_string());
+
+        let builder = BlockModelBuilder::new(raw).expect("failed to build block model");
+        let addresses: Vec<BlockContentAddressesInner> = builder
+            .with_touched_addresses(touched)
+            .into_model()
+            .expect("failed to map block addresses");
 
         let entry = addresses
             .iter()
-            .find(|entry| entry.address == collateral_return_address.as_str())
-            .expect("collateral-return address missing from response");
+            .find(|entry| entry.address == input_side_address)
+            .expect("touched address missing from response");
 
         assert!(
             entry
                 .transactions
                 .iter()
-                .any(|tx| tx.tx_hash == spender.hash().to_string()),
-            "spender tx must be attributed to the consumed collateral-return address"
+                .any(|tx| tx.tx_hash == spender_hash),
+            "spender tx must be attributed to the touched address"
         );
     }
 

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -466,7 +466,7 @@ where
     // Blockfrost: their collateral inputs and collateral-return outputs move
     // funds, so those addresses are affected in ledger terms - considered a
     // bug in BF, not behavior worth reproducing
-    let builder = builder.with_touched_addresses(|tx| {
+    let builder = builder.collect_touched_addresses_with(|tx| {
         let mut addresses = BTreeSet::new();
 
         for_each_touched_output(&mut resolver, tx, |output| {
@@ -969,7 +969,7 @@ mod tests {
 
         let builder = BlockModelBuilder::new(raw).expect("failed to build block model");
         let addresses: Vec<BlockContentAddressesInner> = builder
-            .with_touched_addresses(|tx| {
+            .collect_touched_addresses_with(|tx| {
                 let mut touched = BTreeSet::new();
 
                 if tx.hash().to_string() == spender_hash {
@@ -987,13 +987,13 @@ mod tests {
             .find(|entry| entry.address == input_side_address)
             .expect("touched address missing from response");
 
-        assert!(
-            entry
-                .transactions
-                .iter()
-                .any(|tx| tx.tx_hash == spender_hash),
-            "spender tx must be attributed to the touched address"
-        );
+        let tx_hashes: Vec<_> = entry
+            .transactions
+            .iter()
+            .map(|tx| tx.tx_hash.as_str())
+            .collect();
+
+        assert_eq!(tx_hashes, vec![spender_hash]);
     }
 
     /// Mapping to the addresses model without collecting touched addresses

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -451,6 +451,11 @@ where
 
     let mut deps = InputDeps::default();
 
+    let mut resolver = {
+        let txs = builder.txs();
+        deps.prepare(&domain, txs.iter()).await?
+    };
+
     // Collect the addresses each tx touches: its produced outputs plus the
     // source outputs of its inputs. Inputs whose source tx is missing from
     // the archive (possible on nodes without full history) are skipped,
@@ -461,34 +466,23 @@ where
     // Blockfrost: their collateral inputs and collateral-return outputs move
     // funds, so those addresses are affected in ledger terms - considered a
     // bug in BF, not behavior worth reproducing
-    let touched_addresses = {
-        let txs = builder.txs();
-        let mut resolver = deps.prepare(&domain, txs.iter()).await?;
+    let builder = builder.with_touched_addresses(|tx| {
+        let mut addresses = BTreeSet::new();
 
-        let mut touched = Vec::with_capacity(txs.len());
+        for_each_touched_output(&mut resolver, tx, |output| {
+            let address = output
+                .address()
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-        for tx in &txs {
-            let mut addresses = BTreeSet::new();
+            addresses.insert(address.to_string());
 
-            for_each_touched_output(&mut resolver, tx, |output| {
-                let address = output
-                    .address()
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            Ok(false)
+        })?;
 
-                addresses.insert(address.to_string());
+        Ok(addresses)
+    })?;
 
-                Ok(false)
-            })?;
-
-            touched.push(addresses);
-        }
-
-        touched
-    };
-
-    let addresses: Vec<BlockContentAddressesInner> = builder
-        .with_touched_addresses(touched_addresses)
-        .into_model()?;
+    let addresses: Vec<BlockContentAddressesInner> = builder.into_model()?;
 
     // Blockfrost sorts this endpoint alphabetically by address and ignores
     // the `order` param; only count/page apply.
@@ -973,12 +967,18 @@ mod tests {
         // by any tx of the block
         let input_side_address = "addr_input_side_only";
 
-        let mut touched = vec![BTreeSet::new(); txs.len()];
-        touched[1].insert(input_side_address.to_string());
-
         let builder = BlockModelBuilder::new(raw).expect("failed to build block model");
         let addresses: Vec<BlockContentAddressesInner> = builder
-            .with_touched_addresses(touched)
+            .with_touched_addresses(|tx| {
+                let mut touched = BTreeSet::new();
+
+                if tx.hash().to_string() == spender_hash {
+                    touched.insert(input_side_address.to_string());
+                }
+
+                Ok(touched)
+            })
+            .expect("failed to collect touched addresses")
             .into_model()
             .expect("failed to map block addresses");
 
@@ -994,6 +994,22 @@ mod tests {
                 .any(|tx| tx.tx_hash == spender_hash),
             "spender tx must be attributed to the touched address"
         );
+    }
+
+    /// Mapping to the addresses model without collecting touched addresses
+    /// first must be a 500, not a silently empty response.
+    #[test]
+    fn block_addresses_require_touched_addresses() {
+        use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
+
+        let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig::default());
+        let raw = blocks.first().expect("missing synthetic block");
+
+        let builder = BlockModelBuilder::new(raw).expect("failed to build block model");
+
+        let result: Result<Vec<BlockContentAddressesInner>, StatusCode> = builder.into_model();
+
+        assert_eq!(result, Err(StatusCode::INTERNAL_SERVER_ERROR));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Resolves #1197.

## Problem

`/blocks/{hash_or_number}/addresses` (#1124) predates the shared input resolver (#1134): `BlockModelBuilder` hand-rolls the same dependency handling the resolver was built to unify — `required_input_deps` to collect hashes, `get_tx_batch` in the route, `load_dep` to decode into a builder-owned `HashMap<TxHash, MultiEraTx>`, and a manual `produces_at` walk inside `into_model`.

## What changed

- The route now prepares one `InputDeps`/`InputResolver` for the block and supplies a per-tx collector built on `inputs::for_each_touched_output` (#1174's primitive).
- `BlockModelBuilder` loses `deps`/`required_input_deps`/`load_dep` (and the lifetime-carrying decoded-tx map) and gains `txs()` plus `collect_touched_addresses_with`. The builder drives its own tx walk, invokes the collector exactly once per tx, and stores each collected set alongside that tx's hash, while `mapping.rs` remains independent of input resolution; `into_model` only groups those stored pairs into the Blockfrost response shape.
- Collected addresses are represented as `Option<Vec<(String, BTreeSet<String>)>>`, distinguishing "not collected" from a valid empty block. Mapping without collecting first returns 500; transaction identity is captured by the same builder-owned walk, so mapping needs neither a positional zip nor a second tx walk.
- The spent-collateral-return regression test moves to `inputs.rs`, where the `produces_at` edge now lives (`resolves_spent_collateral_return_output`, built on `build_phase2_invalid_tx_cbor`). The blocks test targets the second tx specifically so an "attribute everything to the first tx" bug cannot pass, and mapping without collecting first is covered as a 500.

Behavior is preserved exactly: miss → address omitted (same graceful degradation as `/txs/{hash}/utxos`), decode/era failure → 500, phase-2-failed txs still contribute collateral addresses.

## Verification

- `cargo test -p dolos-minibf`: 279 passed, 0 failed (1 pre-existing ignore); endpoint suite unchanged as the behavior lock.
- `cargo +nightly fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean.
- Official blockfrost-tests (preview, synced local node): all 4 `blocks/:hash_or_number/addresses` fixture tests pass.
- Differential against an unmodified main binary on the same data: responses for both fixture blocks plus a paginated page are **byte-identical**; the wider `blocks` family shows identical results on both binaries (95 passed and the same 28 pre-existing failures — unimplemented `/epochs/{n}/blocks/{pool}` and `/blocks/epoch/{e}/slot/{s}` routes, plus tip-drift tests on a catching-up node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block address mapping to include addresses from transaction inputs, outputs, and collateral returns.
  * Corrected address attribution for transactions that fail phase-two validation.
  * Preserved available address data when historical transaction dependencies are missing.
  * Address extraction failures now return a clear server error instead of incomplete results.

* **Tests**
  * Added regression coverage for collateral return address resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->