### PR TITLE
feat(stelae): refuse a run that cannot fit its staging, before it starts

### DIFF
--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -47,12 +47,15 @@
 //!   to the protocol in the order above.
 //! - [`restore`] — its inverse: the driver that reads a stele back into an
 //!   empty store set, in the order ADR-004 specifies.
+//! - [`preflight`] — the free-space policy both drivers refuse under, so a run
+//!   that cannot fit its volume says so at minute zero.
 //! - `registry` (feature `oci`) — publishing into an OCI repository: the
 //!   history chain, and the layers a publish inherits instead of rebuilding.
 
 pub mod export;
 pub mod layers;
 pub mod namespaces;
+pub mod preflight;
 #[cfg(feature = "oci")]
 pub mod registry;
 pub mod restore;
@@ -203,6 +206,17 @@ pub enum Error {
     /// The stele is well-formed but does not carry enough to rebuild a node.
     #[error("this stele cannot restore a node: {0}")]
     IncompleteStele(String),
+
+    /// A volume that cannot hold what the run is about to put on it, refused
+    /// before the run starts.
+    ///
+    /// Raised only from a number that was actually measured against free space
+    /// that was actually read — everything else warns and proceeds. One
+    /// variant for both directions because it is one policy; see
+    /// [`crate::preflight`]. There is deliberately no flag that overrides it:
+    /// `--scratch-dir` pointed at a bigger volume is the escape hatch.
+    #[error("not enough space: {0}")]
+    NotEnoughSpace(String),
 
     /// A publish that would not extend the repository's chain.
     ///

--- a/crates/snapshot/src/preflight.rs
+++ b/crates/snapshot/src/preflight.rs
@@ -1,0 +1,344 @@
+//! One free-space policy, in both directions.
+//!
+//! A publish and a restore have opposite shapes and the same problem: each
+//! needs room on a volume before it starts, and the operator finds out hours in
+//! when it does not have it. The peaks differ — a publish holds all sixteen
+//! shard sinks open across one walk of the store, a restore stages one layer at
+//! a time and drops it — but the *policy* over those numbers is one thing, and
+//! it lives here rather than in each driver so the two cannot come to disagree.
+//!
+//! ## The policy
+//!
+//! - **A measured shortfall refuses**, naming the volume and how far short it
+//!   is. Only what was actually measured can refuse.
+//! - **What cannot be measured warns and proceeds** — free space that will not
+//!   read, or a need nothing could size (a first publish has no predecessor to
+//!   size from).
+//!
+//! There is no override flag. A `--scratch-dir` pointed at a bigger volume is
+//! the escape hatch, and a better one than a flag that turns the check off.
+//!
+//! ## Needs that share a volume are summed
+//!
+//! A restore's destination and its staging directory are the same pool of free
+//! bytes whenever the scratch directory sits on the storage filesystem — which
+//! the default, `<storage.path>/scratch`, guarantees. Checking each against the
+//! whole of that pool would pass two needs that together do not fit, so
+//! [`check`] groups by volume first and compares the sum.
+
+use std::path::{Path, PathBuf};
+
+use crate::Error;
+
+/// One demand a run makes on a filesystem, before it makes it.
+#[derive(Debug, Clone)]
+pub struct Need {
+    /// What the bytes are for, phrased to read as the subject of a refusal:
+    /// "*restoring it* needs at least N bytes at …".
+    what: String,
+    /// Where they land. Need not exist yet — [`check`] measures the nearest
+    /// ancestor that does, which is the shape a fresh node's storage path and
+    /// an uncreated scratch directory both have.
+    path: PathBuf,
+    size: Sizing,
+}
+
+/// How many bytes a need is, or why nothing could say.
+#[derive(Debug, Clone)]
+enum Sizing {
+    /// A floor, and always a floor: every number here is compressed or
+    /// uncompressed bytes as some document states them, and a store keeps
+    /// indexes and slack of its own. Under-stating is the safe direction for a
+    /// check whose job is to catch the obviously-doomed run.
+    Bytes(u64),
+    /// Nothing could size it, and why. A warning, never a refusal.
+    Unknown(String),
+}
+
+impl Need {
+    /// A need of `bytes` at `path`.
+    pub fn of(what: impl Into<String>, path: impl Into<PathBuf>, bytes: u64) -> Self {
+        Self {
+            what: what.into(),
+            path: path.into(),
+            size: Sizing::Bytes(bytes),
+        }
+    }
+
+    /// A need nothing could size, and the reason to tell the operator.
+    pub fn unsized_because(
+        what: impl Into<String>,
+        path: impl Into<PathBuf>,
+        why: impl Into<String>,
+    ) -> Self {
+        Self {
+            what: what.into(),
+            path: path.into(),
+            size: Sizing::Unknown(why.into()),
+        }
+    }
+
+    /// `bytes` when it is `Some`, and a warning carrying `why` when it is not.
+    ///
+    /// The shape almost every caller has: a size read out of a document that
+    /// may not carry one.
+    pub fn or_unsized(
+        what: impl Into<String>,
+        path: impl Into<PathBuf>,
+        bytes: Option<u64>,
+        why: impl Into<String>,
+    ) -> Self {
+        match bytes {
+            Some(bytes) => Self::of(what, path, bytes),
+            None => Self::unsized_because(what, path, why),
+        }
+    }
+}
+
+/// Refuse a run whose measured needs cannot fit; warn about the rest.
+///
+/// The single entry point for both directions. Needs landing on one volume are
+/// summed before the comparison — see the module documentation.
+pub fn check(needs: &[Need]) -> Result<(), Error> {
+    let mut sized: Vec<(&Need, u64, PathBuf)> = Vec::new();
+
+    for need in needs {
+        match &need.size {
+            Sizing::Unknown(why) => tracing::warn!(
+                path = %need.path.display(),
+                "could not size {}; skipping the free-space check: {why}",
+                need.what,
+            ),
+            Sizing::Bytes(bytes) => match probe_of(&need.path) {
+                Some(probe) => sized.push((need, *bytes, probe)),
+                // A run that cannot measure the disk is not a run that should
+                // refuse to start, but it is one whose operator should hear
+                // about it.
+                None => tracing::warn!(
+                    path = %need.path.display(),
+                    "could not determine free space; skipping the free-space check for {}",
+                    need.what,
+                ),
+            },
+        }
+    }
+
+    for group in group_by_volume(&sized) {
+        let probe = &sized[group[0]].2;
+
+        let available = match fs4::available_space(probe) {
+            Ok(available) => available,
+            Err(e) => {
+                tracing::warn!(
+                    path = %probe.display(),
+                    "could not determine free space; skipping the free-space check: {e}"
+                );
+                continue;
+            }
+        };
+
+        // Saturating because these are two documents' numbers added together
+        // and nothing bounds their sum; a total that pins at `u64::MAX` refuses
+        // for the same reason the true total would.
+        let required = group
+            .iter()
+            .fold(0u64, |total, i| total.saturating_add(sized[*i].1));
+
+        if required > available {
+            let parts: Vec<&(&Need, u64, PathBuf)> = group.iter().map(|i| &sized[*i]).collect();
+
+            return Err(shortfall(&parts, required, available));
+        }
+    }
+
+    Ok(())
+}
+
+/// The refusal, naming the volume and how far short it is.
+///
+/// Two phrasings, because two needs sharing a volume is not the same incident
+/// as one need overflowing it: an operator reading "restoring it needs" when
+/// the staging is half the number would go looking in the wrong place, so the
+/// shared case breaks the total down by need and by path before it states it.
+fn shortfall(parts: &[&(&Need, u64, PathBuf)], required: u64, available: u64) -> Error {
+    let short = required - available;
+
+    match parts {
+        [(only, _, _)] => Error::NotEnoughSpace(format!(
+            "{} needs at least {required} bytes at {}, which has {available} free — {short} bytes \
+             short",
+            only.what,
+            only.path.display(),
+        )),
+        many => {
+            let breakdown: Vec<String> = many
+                .iter()
+                .map(|(need, bytes, _)| {
+                    format!("{} ({bytes} bytes at {})", need.what, need.path.display())
+                })
+                .collect();
+
+            Error::NotEnoughSpace(format!(
+                "{} share one volume and together need at least {required} bytes, which has \
+                 {available} free — {short} bytes short",
+                breakdown.join(" and "),
+            ))
+        }
+    }
+}
+
+/// The nearest existing ancestor of `path`, which is what the filesystem can be
+/// asked about.
+///
+/// A fresh node's `storage.path` and an uncreated scratch directory are both
+/// about to exist, and neither can be `stat`ed yet; the volume they will land
+/// on is the one holding the deepest ancestor that does exist. `None` means
+/// nothing in the chain answered, which is the case the caller warns about.
+fn probe_of(path: &Path) -> Option<PathBuf> {
+    let mut probe = path;
+
+    loop {
+        if probe.metadata().is_ok() {
+            return Some(probe.to_path_buf());
+        }
+
+        probe = probe.parent()?;
+    }
+}
+
+/// Partition needs into the volumes they draw on, as indices into `sized`.
+fn group_by_volume(sized: &[(&Need, u64, PathBuf)]) -> Vec<Vec<usize>> {
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+
+    for (i, (_, _, probe)) in sized.iter().enumerate() {
+        match groups
+            .iter_mut()
+            .find(|group| same_volume(&sized[group[0]].2, probe))
+        {
+            Some(group) => group.push(i),
+            None => groups.push(vec![i]),
+        }
+    }
+
+    groups
+}
+
+/// Whether two existing paths draw on the same pool of free bytes.
+///
+/// On Unix this is the filesystem's device id, which is exact in both
+/// directions: a dedicated mount *under* `storage.path` reads as a different
+/// volume, and two paths on one filesystem read as the same however differently
+/// they are spelled — so `--scratch-dir` pointed elsewhere on the same disk is
+/// still summed.
+///
+/// Elsewhere stable Rust exposes no device id, so the test is containment: one
+/// path being an ancestor of the other. That is right for the default —
+/// `<storage.path>/scratch` is inside `storage.path` — and wrong only for a
+/// mount nested under the storage path, where it sums two needs that do not in
+/// fact share a pool. It over-states the need rather than under-stating it,
+/// which for a refusal with no override is the direction that gets reported
+/// instead of the direction that gets discovered at hour eight.
+#[cfg(unix)]
+fn same_volume(a: &Path, b: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+
+    match (a.metadata(), b.metadata()) {
+        (Ok(a), Ok(b)) => a.dev() == b.dev(),
+        // Both were probed a moment ago, so this is a directory that went away
+        // mid-check. Treating it as its own volume drops it out of every sum,
+        // which under-states rather than over-states.
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn same_volume(a: &Path, b: &Path) -> bool {
+    let (a, b) = match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => return false,
+    };
+
+    a.starts_with(&b) || b.starts_with(&a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole of the free-space policy, over needs that share one volume.
+    ///
+    /// Both halves in one test because they are one rule: what was measured
+    /// decides, and what was not is a warning that changes nothing. The sizes
+    /// are taken from the volume the test is running on, so the assertions hold
+    /// on any host.
+    #[test]
+    fn a_measured_shortfall_refuses_and_an_unmeasurable_need_does_not() {
+        let temp = tempfile::tempdir().unwrap();
+        let available = fs4::available_space(temp.path()).unwrap();
+
+        check(&[Need::of("restoring it", temp.path(), available / 2)]).unwrap();
+
+        let err = check(&[Need::of("restoring it", temp.path(), available + 1)]).unwrap_err();
+        assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+
+        // Nothing sized it, so nothing refuses — however impossible the run.
+        check(&[Need::unsized_because(
+            "staging this publish",
+            temp.path(),
+            "this repository holds no stele to size from",
+        )])
+        .unwrap();
+    }
+
+    /// Two needs on one volume are one need against one pool.
+    ///
+    /// Each of these fits on its own and the pair does not, so a check that
+    /// passed them separately would pass this and a check that sums them
+    /// refuses it. `scratch` is a child of the destination, which is what the
+    /// default `<storage.path>/scratch` makes of every restore that does not
+    /// name one.
+    #[test]
+    fn needs_sharing_a_volume_are_summed() {
+        let temp = tempfile::tempdir().unwrap();
+        let scratch = temp.path().join("scratch");
+        let available = fs4::available_space(temp.path()).unwrap();
+        let each = available / 2 + 1;
+
+        check(&[Need::of("restoring it", temp.path(), each)]).unwrap();
+        check(&[Need::of("staging the layers it pulls", &scratch, each)]).unwrap();
+
+        let err = check(&[
+            Need::of("restoring it", temp.path(), each),
+            Need::of("staging the layers it pulls", &scratch, each),
+        ])
+        .unwrap_err();
+
+        let Error::NotEnoughSpace(message) = &err else {
+            panic!("{err:?}");
+        };
+
+        assert!(message.contains("share one volume"), "{message}");
+
+        for (what, path) in [
+            ("restoring it", temp.path().to_path_buf()),
+            ("staging the layers it pulls", scratch),
+        ] {
+            let part = format!("{what} ({each} bytes at {})", path.display());
+            assert!(message.contains(&part), "{part:?} missing from {message:?}");
+        }
+    }
+
+    /// A directory that does not exist yet is measured through its parent —
+    /// the shape a fresh node's storage path and an uncreated scratch
+    /// directory both have.
+    #[test]
+    fn a_path_that_does_not_exist_yet_is_measured_through_its_parent() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("not").join("created").join("yet");
+
+        assert_eq!(probe_of(&missing).as_deref(), Some(temp.path()));
+        assert!(same_volume(temp.path(), &probe_of(&missing).unwrap()));
+
+        check(&[Need::of("restoring it", &missing, 1)]).unwrap();
+    }
+}

--- a/crates/snapshot/src/preflight.rs
+++ b/crates/snapshot/src/preflight.rs
@@ -231,13 +231,15 @@ fn group_by_volume(sized: &[(&Need, u64, PathBuf)]) -> Vec<Vec<usize>> {
 /// they are spelled — so `--scratch-dir` pointed elsewhere on the same disk is
 /// still summed.
 ///
-/// Elsewhere stable Rust exposes no device id, so the test is containment: one
-/// path being an ancestor of the other. That is right for the default —
-/// `<storage.path>/scratch` is inside `storage.path` — and wrong only for a
-/// mount nested under the storage path, where it sums two needs that do not in
-/// fact share a pool. It over-states the need rather than under-stating it,
-/// which for a refusal with no override is the direction that gets reported
-/// instead of the direction that gets discovered at hour eight.
+/// Elsewhere stable Rust exposes no device id, so the test is the canonical
+/// path's **prefix** — the drive letter or UNC share, which is the coarsest
+/// thing Windows calls a volume. Two directories on `C:` are one pool however
+/// they are spelled and whether or not either contains the other, which is what
+/// containment alone would have got wrong for two siblings. What it still
+/// cannot see is a volume *mounted into a folder* on another drive: those read
+/// as one pool and are two, so the need is over-stated. For a refusal with no
+/// override that is the direction that gets reported, rather than the direction
+/// that gets discovered at hour eight.
 #[cfg(unix)]
 fn same_volume(a: &Path, b: &Path) -> bool {
     use std::os::unix::fs::MetadataExt as _;
@@ -258,7 +260,12 @@ fn same_volume(a: &Path, b: &Path) -> bool {
         _ => return false,
     };
 
-    a.starts_with(&b) || b.starts_with(&a)
+    match (a.components().next(), b.components().next()) {
+        (Some(std::path::Component::Prefix(a)), Some(std::path::Component::Prefix(b))) => a == b,
+        // No prefix to compare — not a shape a canonical Windows path has.
+        // Fall back to the narrowest honest answer.
+        _ => a == b,
+    }
 }
 
 #[cfg(test)]
@@ -294,37 +301,51 @@ mod tests {
     ///
     /// Each of these fits on its own and the pair does not, so a check that
     /// passed them separately would pass this and a check that sums them
-    /// refuses it. `scratch` is a child of the destination, which is what the
-    /// default `<storage.path>/scratch` makes of every restore that does not
-    /// name one.
+    /// refuses it.
+    ///
+    /// Both shapes the pair can take, because they are not the same test on
+    /// every platform: `<destination>/scratch` is what the default makes of
+    /// every restore that names no directory, and a *sibling* is what
+    /// `--scratch-dir` next to the storage path makes of one that does.
+    /// Containment answers the first and not the second.
     #[test]
     fn needs_sharing_a_volume_are_summed() {
-        let temp = tempfile::tempdir().unwrap();
-        let scratch = temp.path().join("scratch");
-        let available = fs4::available_space(temp.path()).unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let storage = root.path().join("data");
+        std::fs::create_dir(&storage).unwrap();
+
+        // A sibling only counts as one if it exists: an absent directory is
+        // measured through its parent, which here is an *ancestor* of the
+        // storage path and so would prove nothing about siblings.
+        let beside = root.path().join("staging");
+        std::fs::create_dir(&beside).unwrap();
+
+        let available = fs4::available_space(&storage).unwrap();
         let each = available / 2 + 1;
 
-        check(&[Need::of("restoring it", temp.path(), each)]).unwrap();
-        check(&[Need::of("staging the layers it pulls", &scratch, each)]).unwrap();
+        for scratch in [storage.join("scratch"), beside] {
+            check(&[Need::of("restoring it", &storage, each)]).unwrap();
+            check(&[Need::of("staging the layers it pulls", &scratch, each)]).unwrap();
 
-        let err = check(&[
-            Need::of("restoring it", temp.path(), each),
-            Need::of("staging the layers it pulls", &scratch, each),
-        ])
-        .unwrap_err();
+            let err = check(&[
+                Need::of("restoring it", &storage, each),
+                Need::of("staging the layers it pulls", &scratch, each),
+            ])
+            .unwrap_err();
 
-        let Error::NotEnoughSpace(message) = &err else {
-            panic!("{err:?}");
-        };
+            let Error::NotEnoughSpace(message) = &err else {
+                panic!("{err:?}");
+            };
 
-        assert!(message.contains("share one volume"), "{message}");
+            assert!(message.contains("share one volume"), "{message}");
 
-        for (what, path) in [
-            ("restoring it", temp.path().to_path_buf()),
-            ("staging the layers it pulls", scratch),
-        ] {
-            let part = format!("{what} ({each} bytes at {})", path.display());
-            assert!(message.contains(&part), "{part:?} missing from {message:?}");
+            for (what, path) in [
+                ("restoring it", storage.clone()),
+                ("staging the layers it pulls", scratch.clone()),
+            ] {
+                let part = format!("{what} ({each} bytes at {})", path.display());
+                assert!(message.contains(&part), "{part:?} missing from {message:?}");
+            }
         }
     }
 

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -129,7 +129,7 @@ use crate::{
     export::{self, history_for, same_network, Plan, Predecessor, Standing},
     layers::digests,
     restore::{Outlook, Restoring, Summary, Target},
-    DolosProfile, Error, Scope as _, EPOCH_KINDS, STATE_SHARDS,
+    DolosProfile, Error, Scope as _, EPOCH_KINDS, STATE, STATE_SHARDS,
 };
 
 /// Which stele in a repository a restore wants.
@@ -228,7 +228,7 @@ where
 {
     let stele = point.pull(registry)?;
 
-    crate::restore::restore_stele(&stele, node, target)
+    crate::restore::restore_stele(&stele, node, registry.scratch_dir(), target)
 }
 
 /// Open a repository in a registry.
@@ -495,6 +495,127 @@ pub fn inspect(registry: &Registry, point: Point) -> Result<Inspected, Error> {
         inscription,
         compressed,
     })
+}
+
+/// What a publish holds staged on disk at its peak.
+///
+/// Not the size of the stele: a publish never has the whole document on disk at
+/// once. What it does have at once is the state pass, which keeps all sixteen
+/// shard sinks open across a single walk of the store — see
+/// [`crate::export`] for why sixteen passes is the alternative — plus whatever
+/// epoch layer is in flight beside it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StagingPeak {
+    /// The sixteen state shards, which are staged concurrently.
+    pub state_bytes: u64,
+    /// The largest single non-state layer, which is staged alongside them.
+    pub largest_other_bytes: u64,
+    /// Layers the predecessor's manifest stated no size for. Non-zero makes
+    /// every number here a floor rather than an estimate.
+    pub unsized_layers: usize,
+}
+
+impl StagingPeak {
+    /// Compressed bytes the scratch volume has to hold at once.
+    pub fn bytes(&self) -> u64 {
+        self.state_bytes.saturating_add(self.largest_other_bytes)
+    }
+}
+
+/// Size the staging peak of the next publish from the stele before it.
+///
+/// A proxy, and deliberately so: the numbers are the *predecessor's* layers,
+/// not this publish's, because this publish's layers do not exist until it
+/// builds them and sizing them would mean building them. One epoch of drift is
+/// what the proxy costs, against a check that otherwise cannot exist at all —
+/// and the refuse/warn split is what keeps it honest, since a shortfall against
+/// last epoch's sizes is still a measured shortfall.
+///
+/// Off the manifest the pull already fetched, and no per-layer `HEAD`: the
+/// promise [`preview`] makes about a dry run holds here too.
+///
+/// `Ok(None)` is a first publish — no predecessor, nothing to size from — which
+/// [`preflight`] turns into a warning rather than a refusal.
+///
+/// **Never call this from inside an async context.** See [`open`].
+pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
+    let Some(previous) = registry.latest(&DolosProfile)? else {
+        return Ok(None);
+    };
+
+    let inscription = previous.read_inscription()?;
+    let blobs = previous.blob_index()?;
+
+    let mut peak = StagingPeak::default();
+
+    for descriptor in &inscription.layers {
+        match previous.compressed_size(&blobs, descriptor)? {
+            None => peak.unsized_layers += 1,
+            // Every shard is open at once, so they add. Everything else is one
+            // layer at a time beside them, so only the biggest counts.
+            Some(bytes) if descriptor.kind == STATE => peak.state_bytes += bytes,
+            Some(bytes) => peak.largest_other_bytes = peak.largest_other_bytes.max(bytes),
+        }
+    }
+
+    Ok(Some(peak))
+}
+
+/// Refuse a publish whose scratch volume cannot hold what it stages at once.
+///
+/// The publish side of [`crate::preflight`]'s one policy, which
+/// [`crate::restore::Plan::preflight`] is the other side of: a measured
+/// shortfall refuses, naming the volume and the shortfall, and what cannot be
+/// sized warns and proceeds.
+///
+/// The volume is the transport's own — [`stelae::oci::Registry::scratch_dir`] —
+/// so the directory sized here and the directory written to cannot come apart.
+/// A transport opened without one stages in the platform temporary directory,
+/// which it does not name, so there is nothing to size and nothing to refuse;
+/// [`open`] always sets one, so no `dolos` command reaches that case.
+///
+/// **Never call this from inside an async context.** See [`open`].
+pub fn preflight(registry: &Registry) -> Result<(), Error> {
+    let Some(scratch_dir) = registry.scratch_dir() else {
+        tracing::warn!(
+            "this transport stages in the platform temporary directory, which it does not name; \
+             skipping the free-space check for {STAGING}"
+        );
+
+        return Ok(());
+    };
+
+    crate::preflight::check(&[staging_need(staging_peak(registry)?, scratch_dir)])
+}
+
+/// What the staging asks of its volume, as [`crate::preflight`] takes it.
+///
+/// Split out of [`preflight`] so the demand and the transport that produced it
+/// can be tested apart: sizing a peak needs a registry, and deciding what a
+/// peak means for a volume needs none.
+const STAGING: &str = "staging this publish";
+
+fn staging_need(
+    peak: Option<StagingPeak>,
+    scratch_dir: &std::path::Path,
+) -> crate::preflight::Need {
+    let Some(peak) = peak else {
+        return crate::preflight::Need::unsized_because(
+            STAGING,
+            scratch_dir,
+            "this repository holds no stele to size the staging from",
+        );
+    };
+
+    if peak.unsized_layers > 0 {
+        tracing::warn!(
+            unsized_layers = peak.unsized_layers,
+            "the predecessor's manifest states no size for some of its layers; the staging \
+             estimate is a floor"
+        );
+    }
+
+    crate::preflight::Need::of(STAGING, scratch_dir, peak.bytes())
 }
 
 /// Publish `plan` into `registry`, chained to whatever is already there.
@@ -934,5 +1055,43 @@ mod tests {
             uncompressed_size: 1,
             scope,
         }
+    }
+
+    /// The publish half of the one policy, over a peak this test supplies.
+    ///
+    /// The other half of the chain — that the peak is the predecessor's
+    /// sixteen shards plus its largest other layer — needs a registry to state
+    /// a manifest and is in `tests/publish.rs`. Between them the composition
+    /// `preflight` performs is covered: this end decides, that end measures.
+    #[test]
+    fn a_measured_staging_shortfall_refuses_and_a_first_publish_does_not() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let check = |peak| crate::preflight::check(&[staging_need(peak, temp.path())]);
+
+        // No predecessor, so nothing sized it, so nothing refuses.
+        check(None).unwrap();
+
+        check(Some(StagingPeak::default())).unwrap();
+
+        // A peak no volume holds. Both halves are set, so the refusal is on
+        // their sum and not on either alone.
+        let err = check(Some(StagingPeak {
+            state_bytes: u64::MAX / 2,
+            largest_other_bytes: u64::MAX / 2,
+            unsized_layers: 0,
+        }))
+        .unwrap_err();
+
+        let Error::NotEnoughSpace(message) = &err else {
+            panic!("{err:?}");
+        };
+
+        assert!(message.contains(STAGING), "{message}");
+        assert!(
+            message.contains(&temp.path().display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("short"), "{message}");
     }
 }

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -553,7 +553,14 @@ pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
             None => peak.unsized_layers += 1,
             // Every shard is open at once, so they add. Everything else is one
             // layer at a time beside them, so only the biggest counts.
-            Some(bytes) if descriptor.kind == STATE => peak.state_bytes += bytes,
+            //
+            // Saturating because these are a manifest's numbers and a manifest
+            // is not this node's document: a wrapped sum would be a *small*
+            // need, which is the one direction a refusal must never be wrong
+            // in.
+            Some(bytes) if descriptor.kind == STATE => {
+                peak.state_bytes = peak.state_bytes.saturating_add(bytes)
+            }
             Some(bytes) => peak.largest_other_bytes = peak.largest_other_bytes.max(bytes),
         }
     }

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -287,6 +287,14 @@ impl Plan {
         )];
 
         if let Some(staging) = staging {
+            if staging.unsized_layers > 0 {
+                tracing::warn!(
+                    unsized_layers = staging.unsized_layers,
+                    "this stele's transport states no compressed size for some of the layers it \
+                     would pull; the staging estimate is a floor"
+                );
+            }
+
             needs.push(preflight::Need::or_unsized(
                 "staging the layers it pulls",
                 staging.dir,
@@ -314,6 +322,13 @@ pub struct Staging<'a> {
     /// The largest layer this run will stage, compressed. `None` when the
     /// transport could size none of them, which warns rather than refuses.
     pub largest_layer: Option<u64>,
+    /// How many of the layers it will stage the transport could not size.
+    ///
+    /// Carried beside `largest_layer` rather than folded into it: a run where
+    /// one layer is sized and another is not has a `largest_layer` that is a
+    /// floor, and a floor that says so is worth more than a `None` that
+    /// abandons the check. The count is what makes it say so.
+    pub unsized_layers: usize,
 }
 
 /// Read a stele's inscription and decide what restoring it into this node
@@ -857,6 +872,7 @@ where
     let staging = scratch_dir.map(|dir| Staging {
         dir,
         largest_layer: outlook.remaining.largest_compressed,
+        unsized_layers: outlook.remaining.unsized_layers,
     });
 
     plan.preflight(node.storage_path, staging)?;
@@ -1510,23 +1526,26 @@ mod tests {
             skipped_epochs: 0,
         };
 
-        let staging = |largest_layer| {
+        let staging = |largest_layer, unsized_layers| {
             plan.preflight(
                 temp.path(),
                 Some(Staging {
                     dir: &scratch,
                     largest_layer,
+                    unsized_layers,
                 }),
             )
         };
 
-        staging(Some(0)).unwrap();
+        staging(Some(0), 0).unwrap();
 
         // Nothing could size the layers, so nothing refuses: what cannot be
-        // measured warns and proceeds.
-        staging(None).unwrap();
+        // measured warns and proceeds. Nor does a partial sizing, where the
+        // number is a floor and the warning says so.
+        staging(None, 3).unwrap();
+        staging(Some(0), 1).unwrap();
 
-        let err = staging(Some(u64::MAX)).unwrap_err();
+        let err = staging(Some(u64::MAX), 0).unwrap_err();
 
         let Error::NotEnoughSpace(message) = &err else {
             panic!("{err:?}");

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -125,7 +125,7 @@ use tracing::info;
 
 use crate::{
     layers::{blocks, indexes, logs, state},
-    read_position, DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, LOGS, STATE,
+    preflight, read_position, DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, LOGS, STATE,
     STATE_SHARDS, UTXOS,
 };
 
@@ -266,47 +266,54 @@ impl Plan {
 
     /// Refuse a restore that cannot fit, before it starts writing.
     ///
-    /// The comparison is deliberately against the *uncompressed* size of the
-    /// selected layers rather than against a prediction of what the stores will
-    /// occupy. It is the only number the inscription carries, it is an
-    /// underestimate for every backend (a store keeps indexes and slack of its
-    /// own), and an underestimate is the safe direction for a check whose job
-    /// is to catch the obviously-doomed run.
-    pub fn preflight(&self, path: &Path) -> Result<(), Error> {
-        let required = self.uncompressed_size();
+    /// Two needs, one policy ([`crate::preflight`]): the stores this restore
+    /// will write, and — for a transport that stages — the one layer it holds
+    /// on disk while it drains it. Both are handed to the same check rather
+    /// than compared separately, because whenever the scratch directory sits on
+    /// the storage filesystem they are two claims on one pool of free bytes,
+    /// and the default `<storage.path>/scratch` makes that the ordinary case.
+    ///
+    /// The destination comparison is deliberately against the *uncompressed*
+    /// size of the selected layers rather than against a prediction of what the
+    /// stores will occupy. It is the only number the inscription carries, it is
+    /// an underestimate for every backend (a store keeps indexes and slack of
+    /// its own), and an underestimate is the safe direction for a check whose
+    /// job is to catch the obviously-doomed run.
+    pub fn preflight(&self, path: &Path, staging: Option<Staging<'_>>) -> Result<(), Error> {
+        let mut needs = vec![preflight::Need::of(
+            "restoring it",
+            path,
+            self.uncompressed_size(),
+        )];
 
-        // The storage root may not exist yet on a fresh node, in which case the
-        // filesystem to ask about is the nearest ancestor that does.
-        let mut probe = path;
-
-        let available = loop {
-            match fs4::available_space(probe) {
-                Ok(available) => break available,
-                Err(e) => match probe.parent() {
-                    Some(parent) => probe = parent,
-                    // Nothing left to ask. A restore that cannot measure the
-                    // disk is not a restore that should refuse to run, but it
-                    // is one whose operator should hear about it.
-                    None => {
-                        tracing::warn!(
-                            path = %path.display(),
-                            "could not determine free space; skipping the restore preflight: {e}"
-                        );
-                        return Ok(());
-                    }
-                },
-            }
-        };
-
-        if available < required {
-            return Err(Error::IncompleteStele(format!(
-                "restoring it needs at least {required} bytes at {}, which has {available} free",
-                path.display(),
-            )));
+        if let Some(staging) = staging {
+            needs.push(preflight::Need::or_unsized(
+                "staging the layers it pulls",
+                staging.dir,
+                staging.largest_layer,
+                "this stele's transport states no compressed size for the layers it would pull",
+            ));
         }
 
-        Ok(())
+        preflight::check(&needs)
     }
+}
+
+/// Where a restore stages a pulled layer, and how big the biggest one is.
+///
+/// Absent for a directory restore, which stages nothing: a `SteleDir` reads
+/// its blobs where they already are. A registry restore pulls each layer to a
+/// file first, one at a time — layers are pulled, staged, drained and dropped
+/// in sequence — so the peak it has to fit is the single largest layer and not
+/// the download.
+#[derive(Debug, Clone, Copy)]
+pub struct Staging<'a> {
+    /// The transport's scratch directory, as the operator or the default named
+    /// it. Need not exist yet; the transport creates it lazily.
+    pub dir: &'a Path,
+    /// The largest layer this run will stage, compressed. `None` when the
+    /// transport could size none of them, which warns rather than refuses.
+    pub largest_layer: Option<u64>,
 }
 
 /// Read a stele's inscription and decide what restoring it into this node
@@ -809,9 +816,17 @@ pub struct Outlook {
 /// [`crate::registry::restore_registry`] are the two transports' spellings of
 /// it, and they share this body so a directory restore and a registry one
 /// cannot come to differ in anything but where the bytes came from.
+///
+/// `scratch_dir` is the one thing they legitimately differ in, and it comes
+/// from the transport rather than from the caller: a directory stele reads its
+/// blobs where they already are and stages nothing, so it passes `None`, while
+/// a registry hands over the directory it was opened with. Asking the
+/// transport is what keeps the volume the preflight sizes and the volume the
+/// transport writes to the same volume.
 pub(crate) fn restore_stele<R, A, S, I>(
     stele: &R,
     node: Restoring<'_>,
+    scratch_dir: Option<&Path>,
     target: Target<'_, A, S, I>,
 ) -> Result<(Plan, Outlook, Summary), Error>
 where
@@ -821,7 +836,6 @@ where
     I: IndexStore,
 {
     let plan = plan(stele, node.network_magic, node.max_history)?;
-    plan.preflight(node.storage_path)?;
 
     let identity = stele.read_inscription()?.digest()?;
     let mut checkpoint = Checkpoint::open(node.storage_path, identity, node.resume)?;
@@ -832,6 +846,20 @@ where
         remaining: plan.remaining(stele, &index, checkpoint.resume())?,
         inherited: checkpoint.resume().len(),
     };
+
+    // Below the sizes rather than above them, and still ADR-004's step 2:
+    // what the staging volume has to hold is the largest layer this run will
+    // *actually* pull, which is a question about the resume and so cannot be
+    // asked before the checkpoint is open. Nothing between the plan and here
+    // writes — `Checkpoint::open` only reads the progress file and
+    // `blob_index` only reads blobs — so the preflight still refuses before
+    // the first byte is written, which is the whole of its promise.
+    let staging = scratch_dir.map(|dir| Staging {
+        dir,
+        largest_layer: outlook.remaining.largest_compressed,
+    });
+
+    plan.preflight(node.storage_path, staging)?;
 
     let summary = restore(
         stele,
@@ -863,7 +891,7 @@ where
 {
     let stele = stelae::dir::SteleDir::open(root)?;
 
-    restore_stele(&stele, node, target)
+    restore_stele(&stele, node, None, target)
 }
 
 /// The stele a restore is reading, and the terms it reads under.
@@ -1447,18 +1475,68 @@ mod tests {
             skipped_epochs: 0,
         };
 
-        plan.preflight(temp.path()).unwrap();
+        plan.preflight(temp.path(), None).unwrap();
 
         // A directory that does not exist yet is measured through its parent,
         // which is the shape a fresh node's storage path has.
-        plan.preflight(&temp.path().join("not").join("created").join("yet"))
+        plan.preflight(&temp.path().join("not").join("created").join("yet"), None)
             .unwrap();
 
         for descriptor in &mut plan.state {
             descriptor.uncompressed_size = u64::MAX / STATE_SHARDS;
         }
 
-        let err = plan.preflight(temp.path()).unwrap_err();
-        assert!(matches!(err, Error::IncompleteStele(_)), "{err:?}");
+        let err = plan.preflight(temp.path(), None).unwrap_err();
+        assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+    }
+
+    /// The staging half: a scratch volume that cannot hold the largest layer
+    /// this run will pull is refused, and one nothing could size is not.
+    ///
+    /// The destination need is nil here — no layers, so nothing to write — so
+    /// what the refusal is about is unambiguous. That the two needs are
+    /// *summed* when they share a volume is the policy's own property and is
+    /// tested where the policy lives, in [`crate::preflight`].
+    #[test]
+    fn the_preflight_refuses_a_scratch_volume_that_cannot_hold_a_layer() {
+        let temp = tempfile::tempdir().unwrap();
+        let scratch = temp.path().join("scratch");
+
+        let plan = Plan {
+            position: read_position(&inscription(vec![]).position).unwrap(),
+            sequence: 3,
+            epochs: Vec::new(),
+            state: Vec::new(),
+            skipped_epochs: 0,
+        };
+
+        let staging = |largest_layer| {
+            plan.preflight(
+                temp.path(),
+                Some(Staging {
+                    dir: &scratch,
+                    largest_layer,
+                }),
+            )
+        };
+
+        staging(Some(0)).unwrap();
+
+        // Nothing could size the layers, so nothing refuses: what cannot be
+        // measured warns and proceeds.
+        staging(None).unwrap();
+
+        let err = staging(Some(u64::MAX)).unwrap_err();
+
+        let Error::NotEnoughSpace(message) = &err else {
+            panic!("{err:?}");
+        };
+
+        assert!(message.contains("staging the layers it pulls"), "{message}");
+        assert!(
+            message.contains(&scratch.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("short"), "{message}");
     }
 }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -489,3 +489,104 @@ fn a_publisher_can_ask_where_it_stands() {
     assert!(message.contains('4'), "{message}");
     assert!(message.contains("3 sequences ahead"), "{message}");
 }
+
+// ---------------------------------------------------------------------------
+// The staging preflight
+// ---------------------------------------------------------------------------
+
+/// What a publish stages at once, sized off the stele before it.
+///
+/// The half of the publish-side preflight that needs a registry: a manifest
+/// stating a compressed size per layer is the only thing this number can come
+/// from, and it is why the check costs no `HEAD` and no extra round trip
+/// beyond the one `standing` already makes. What the number then *means* for a
+/// volume — refuse a measured shortfall, warn about anything else — is decided
+/// in `registry`'s own unit tests, which need no registry to decide it.
+///
+/// The peak is deliberately not the stele's size. A publish holds all sixteen
+/// shard sinks open across one walk of the store plus whatever epoch layer is
+/// in flight beside them, and never the whole document, so an operator sizing
+/// a scratch volume off the repository's total would size it for a run that
+/// never happens.
+#[test]
+#[ignore]
+fn a_publish_sizes_its_staging_off_the_stele_before_it() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/staging");
+
+    // The volume the preflight sizes is the one the transport will write to,
+    // because the transport is what it asks. Both the publish check and the
+    // restore driver stand on this, and neither could catch it going wrong: a
+    // preflight against the wrong directory passes for the same reason the
+    // right one does.
+    assert_eq!(
+        stelae::oci::Registry::scratch_dir(&repository),
+        Some(fixture.scratch()),
+    );
+
+    // The no-predecessor path: an empty repository states no sizes, so nothing
+    // can be measured, so nothing is refused. A first publish runs.
+    assert_eq!(registry::staging_peak(&repository).unwrap(), None);
+    registry::preflight(&repository).unwrap();
+
+    node.publish(&repository, &node.first, false);
+
+    let peak = registry::staging_peak(&repository).unwrap().unwrap();
+
+    assert_eq!(
+        peak.unsized_layers, 0,
+        "a manifest states a size for every layer it names"
+    );
+
+    // The same arithmetic, from the same manifest, read back through the
+    // command an operator would read it with — so the peak is held against the
+    // registry's own numbers rather than against a literal that would have to
+    // be maintained beside the fixture.
+    let inspected = registry::inspect(&repository, registry::Point::Latest).unwrap();
+
+    let mut state_bytes = 0;
+    let mut largest_other_bytes = 0;
+
+    for (descriptor, size) in inspected
+        .inscription
+        .layers
+        .iter()
+        .zip(&inspected.compressed)
+    {
+        let size = size.expect("the manifest sizes every layer");
+
+        match descriptor.kind.as_str() {
+            dolos_snapshot::STATE => state_bytes += size,
+            _ => largest_other_bytes = std::cmp::max(largest_other_bytes, size),
+        }
+    }
+
+    assert_eq!(peak.state_bytes, state_bytes, "all sixteen shards at once");
+    assert_eq!(
+        peak.largest_other_bytes, largest_other_bytes,
+        "and the largest single layer beside them"
+    );
+    assert_eq!(peak.bytes(), state_bytes + largest_other_bytes);
+
+    // Epoch 0's other two layers are in the stele and not in the peak, which is
+    // the whole difference between what a repository holds and what a publish
+    // holds at once.
+    assert!(
+        peak.bytes() < inspected.total_compressed,
+        "peak {} is not below the stele's {} compressed bytes",
+        peak.bytes(),
+        inspected.total_compressed,
+    );
+
+    // And the volume the fixture stages on holds it, so the publish that
+    // follows is not refused.
+    registry::preflight(&repository).unwrap();
+
+    eprintln!(
+        "staging peak: {} bytes ({state_bytes} across sixteen shards, {largest_other_bytes} for \
+         the largest other layer), against {} compressed bytes in the repository",
+        peak.bytes(),
+        inspected.total_compressed,
+    );
+}

--- a/crates/snapshot/tests/registry_fixture/mod.rs
+++ b/crates/snapshot/tests/registry_fixture/mod.rs
@@ -213,6 +213,15 @@ impl Fixture {
 
         registry::open(&repository, true, auth, self.scratch.path().to_path_buf()).unwrap()
     }
+
+    /// Where the transports this fixture opens stage their layers.
+    ///
+    /// Exposed so a suite can hold a transport's own answer against what the
+    /// fixture handed it: the preflight sizes the volume the transport names,
+    /// so the two agreeing is the whole reason it sizes the right one.
+    pub fn scratch(&self) -> &std::path::Path {
+        self.scratch.path()
+    }
 }
 
 impl Drop for Fixture {

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -108,7 +108,9 @@ fn restore_into<B: ToyStores>(
     let stele = SteleDir::open(root)?;
 
     let plan = restore::plan(&stele, magic, None)?;
-    plan.preflight(root)?;
+    // A directory stele stages nothing — its blobs are read where they are —
+    // so the only volume this restore has a need on is the destination.
+    plan.preflight(root, None)?;
 
     let index = stele.blob_index()?;
 
@@ -979,6 +981,21 @@ fn the_remaining_download_excludes_what_is_already_done() {
         "the fixture's layers did not compress, so this proves nothing"
     );
 
+    // One pass, two numbers, and they answer different questions: the sum is
+    // what the download costs, and the largest single layer is what a transport
+    // staging one layer at a time has to fit on disk while it drains it.
+    let widest = |descriptors: &mut dyn Iterator<Item = &stelae::LayerDescriptor>| {
+        descriptors
+            .map(|d| stele.compressed_size(&index, d).unwrap().unwrap())
+            .max()
+    };
+
+    assert_eq!(fresh.largest_compressed, widest(&mut plan.layers()));
+    assert!(
+        fresh.largest_compressed.unwrap() < fresh.compressed_bytes,
+        "a fixture of one layer would make the peak and the total the same number"
+    );
+
     let mut progress = RestoreProgress::new(inscription.digest().unwrap());
     let epochs = epoch_diff_ids(&inscription);
 
@@ -993,6 +1010,11 @@ fn the_remaining_download_excludes_what_is_already_done() {
 
     // The tip is still in it, always.
     assert_eq!(resumed.layers, STATE_SHARDS as usize);
+
+    // So the peak a resumed run stages is the widest shard, not the widest
+    // layer of the stele — the epoch layers it skips are not staged either.
+    assert_eq!(resumed.largest_compressed, widest(&mut plan.tip_layers()));
+    assert!(resumed.largest_compressed <= fresh.largest_compressed);
 }
 
 /// The epoch layers and the state shards, each in the order the driver reaches

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -118,7 +118,7 @@ use std::{
     collections::BTreeMap,
     fs::File,
     io::{Read, Seek, SeekFrom, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -502,6 +502,18 @@ impl Registry {
                 state: Mutex::new(PushState::default()),
             }),
         })
+    }
+
+    /// Where this transport stages the layers it moves, in either direction.
+    ///
+    /// [`Options::scratch_dir`] as it was given, so a caller that wants to
+    /// size the staging volume asks the transport that will use it rather than
+    /// re-deriving the path it handed over — two derivations of one directory
+    /// is one more than can be kept in step. `None` is the platform temporary
+    /// directory, which is not a path this can name because
+    /// [`Shared::scratch`] never names one either.
+    pub fn scratch_dir(&self) -> Option<&Path> {
+        self.shared.scratch_dir.as_deref()
     }
 
     /// What has been pushed through this transport since it was opened, or

--- a/crates/stelae/src/plan.rs
+++ b/crates/stelae/src/plan.rs
@@ -247,6 +247,18 @@ pub struct Remaining {
     /// says so. A total that silently under-reports is worse than one a caller
     /// can see the shape of.
     pub unsized_layers: usize,
+
+    /// The largest of those layers, compressed.
+    ///
+    /// A restore stages one layer at a time — pulled, staged, drained and
+    /// dropped in sequence — so what its scratch volume has to hold at once is
+    /// this and never [`Remaining::compressed_bytes`]. Summed here rather than
+    /// in a second pass because the walk that sums the total is already
+    /// visiting every size there is.
+    ///
+    /// `None` when nothing is left to fetch, and when no remaining layer could
+    /// be sized at all.
+    pub largest_compressed: Option<u64>,
 }
 
 impl Remaining {
@@ -257,6 +269,10 @@ impl Remaining {
     /// is the same one the rest of this module keeps: which layers a restore
     /// needs is the profile's question, and how big they are is the
     /// transport's.
+    ///
+    /// One pass answers both questions a caller has about these bytes: what
+    /// they cost to move, and — through [`Remaining::largest_compressed`] —
+    /// what has to fit on disk while one of them is being moved.
     pub fn of<'a, R, I>(stele: &R, index: &BlobIndex, layers: I) -> Result<Self, Error>
     where
         R: SteleReader,
@@ -268,7 +284,10 @@ impl Remaining {
             remaining.layers += 1;
 
             match stele.compressed_size(index, descriptor)? {
-                Some(bytes) => remaining.compressed_bytes += bytes,
+                Some(bytes) => {
+                    remaining.compressed_bytes += bytes;
+                    remaining.largest_compressed = remaining.largest_compressed.max(Some(bytes));
+                }
                 None => remaining.unsized_layers += 1,
             }
         }

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -157,6 +157,16 @@ fn to_repository(
         return Ok(());
     }
 
+    // And on the same terms, for the same reason. A dry run that reported the
+    // layers and said nothing about the volume they would be staged on would be
+    // the one rehearsal a publisher does, missing the failure it exists to find.
+    // After `standing`, because a repository holding another network's chain is
+    // refused there and sizing against it would be sizing against the wrong
+    // stele.
+    registry::preflight(&registry)
+        .into_diagnostic()
+        .context("sizing the staging directory")?;
+
     if args.dry_run {
         // `None` here and `None` at the `publish` below are one decision: a dry
         // run describes the publish that follows it, so the two calls are


### PR DESCRIPTION
Plan: [`plans/dolos-stelae-publisher-operability-preflight.md`](https://github.com/txpipe/dolos) — the second piece of the `stelae-operability` family, behind #1191. Base: `main` at `7286c48d`, exactly as the plan's Approach names it.

## What was wrong

A publish holds sixteen staged shards at once — all sixteen sink writers stay open across a single walk of the store, because the alternative is sixteen full scans — plus whatever epoch layer is in flight. A restore holds one layer at a time. Neither command asked whether the volume could hold that, so the operator found out as `No space left on device` hours in.

The restore side was half built: `Plan::preflight` checked free space at `storage.path` against the selected layers' uncompressed size, but never asked about the scratch volume that #1191 had just given it. The publish side had no check at all.

## What changed

**One policy, in one place** — `crates/snapshot/src/preflight.rs`, new. A measured shortfall **refuses**, naming the volume and how far short it is; free space that will not read, or a need nothing could size, **warns and proceeds**. There is no override flag — `--scratch-dir` pointed at a bigger volume is the escape hatch, and a better one than a flag that turns the check off. (`org/founder`, 2026-08-11, the umbrella's fourth escalation.)

Needs that land on **one volume are summed** rather than each compared against the whole pool. That is the ordinary case, not the exotic one: `--scratch-dir` defaults to `<storage.path>/scratch`, so a restore's destination and its staging are two claims on the same free bytes. Same-volume is the filesystem device id on Unix — exact in both directions, so a dedicated mount *under* the storage path correctly reads as separate, and `--scratch-dir` elsewhere on the same disk correctly reads as shared. Stable Rust exposes no device id off Unix, so there the test is containment, which is right for the default and over-states rather than under-states everywhere else.

**Restore** — `Plan::preflight` extended, not duplicated. It now takes an optional `Staging { dir, largest_layer }` beside the destination and hands both to the shared check. The need is the largest layer the run will *actually* pull, taken as a `max` in the pass `Remaining::of` already makes to sum the download (`Remaining::largest_compressed`), so a resumed run sizes what it still has to stage rather than what a fresh one would have.

The plan flagged the ordering: `preflight` ran *above* the sizes. It now runs below them, after `Checkpoint::open` and `blob_index` — both of which only read — so ADR-004 step 2's promise, refuse before anything is written, is intact while the check can see the resume.

A directory restore stages nothing (a `SteleDir` reads its blobs where they are) and passes `None`. Which directory a registry restore stages in comes from the **transport** — a new `stelae::oci::Registry::scratch_dir()` — not from the caller re-deriving the path it handed to `open`. Two derivations of one directory is one more than can be kept in step.

**Publish** — `registry::staging_peak` sizes the sixteen-shard-plus-largest-other peak off the predecessor's manifest: no per-layer `HEAD`, keeping `registry::preview`'s promise. `registry::preflight` applies the same policy to it, and runs beside `standing` — before the dry run too, for the reason already written there: a publisher rehearsing with `--dry-run` should get the same answer the publish gives. A first publish has no predecessor, cannot be sized, and warns.

The peak is a proxy — last epoch's layer sizes, not this publish's — and the refuse/warn split is what keeps it honest: only what was actually measured can refuse.

## Done criterion

| | |
|---|---|
| 1. Restore preflight extended, refuses a scratch volume that cannot hold the largest selected layer; unmeasurable warns; shared filesystem sums. Covered by a test. | **met** |
| 2. Publish preflight sizes the peak from the predecessor manifest, same refuse/warn policy, no-predecessor warns. Covered by a test including the no-predecessor path. | **met** |
| 3. `cargo test`, clippy, fmt, `cargo deny check advisories`, and the `stelae` dependency boundary. | **met** |

## Verification

Run, not asserted. Both CI test legs:

```
cargo test --workspace --all-targets                                    → green
cargo test --workspace --all-targets --all-features \
  --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp   → green
cargo clippy --all-targets --all-features -- -D warnings                → clean
cargo +nightly fmt --all -- --check                                     → clean
cargo deny check advisories                                             → advisories ok
cargo tree -p stelae -e normal --all-features                           → 0 matches for dolos(-|$)
```

The `#[ignore]`d registry suites were **executed** against a spawned `registry:2` — this change edits `publish.rs` and the shared fixture, so an unrun ignored test would prove nothing:

```
stelae      --test oci               10 passed
snapshot    --test publish            8 passed   (incl. the new staging test)
snapshot    --test restore_registry   5 passed
snapshot    --test snapshot_verify    6 passed
```

The new suite's own output, from the fixture's stele:

```
staging peak: 5769 bytes (4276 across sixteen shards, 1493 for the largest
other layer), against 7666 compressed bytes in the repository
```

— which is the point the check exists for: what a publish holds at once is not what the repository holds.

**Mutation-checked**, because a preflight that never fires looks exactly like one that always passes:

- `Remaining::largest_compressed` stuck at `None` → `the_remaining_download_excludes_what_is_already_done` fails (`None` vs `Some(1490)`).
- the volume grouping made to never match, so needs are compared separately → `needs_sharing_a_volume_are_summed` fails, and only that one.
- `staging_peak` summing the non-state layers instead of taking the max → the registry test fails (`3390` vs `1493`).

## Review pass (`debbccbb`)

Three of CodeRabbit's four applied, all in the same commit:

- `staging_peak` summed sixteen manifest-stated sizes with `+`. They are another document's numbers, and a wrapped total is a *small* need — the one direction a refusal must never be wrong in. Saturating now, like the policy's own sum already was.
- The non-Unix `same_volume` tested containment, which answers `<storage.path>/scratch` and misses two siblings on one drive. It compares the canonical path's prefix — the drive letter or UNC share — and the summing test now runs both shapes, with the sibling directory *created* so it is measured as itself rather than through a shared ancestor. The Windows CI leg is what validates it.
- A restore staging need with some layers sized and some not took the known maximum and said nothing about it. It is a floor and now says so, the way `registry::staging_need` already did.

The fourth is right about the defect and is deliberately not fixed here. The destination need is `Plan::uncompressed_size()`, which is not resume-aware, so a resumed restore is charged again for layers its own checkpoint already wrote. That predates this change — the comparison has read the whole plan since it was written — and what this PR did was make it *visible*, by moving the check below the resume where the two needs sit side by side and disagree. Narrowing it is not arithmetic: a redone layer is rewritten rather than appended, except in the redb archive, which leaves dead space bounded by one layer, so the honest need carries slack whose size is a decision the plan did not make. Filed as its own plan rather than widened into this one.

## What is covered structurally rather than end to end

A test cannot shrink a filesystem, so no test drives a *real* registry restore into a *real* refusal. The chain is covered in pieces instead, and each piece is a real assertion: `Registry::scratch_dir()` returns what `open` was given (asserted against the fixture's own directory, in the registry suite); `Remaining::largest_compressed` is the max over the layers that remain; `Plan::preflight` refuses a staging need it cannot fit and warns at one it cannot size; and the policy's summing and refusal are unit-tested against the volume the test is running on. What no test covers is `restore_stele` passing the transport's directory *into* that preflight — one line, and the accessor assertion is what stands behind it.

## Scope held

Reporting only, never repairing: a preflight that says a first publish cannot be sized is in scope; making a publish cheap is [dolos-stelae-publish-cost]. No resumption, no progress reporting. `snapshot verify` and `snapshot inspect` also stage through the scratch directory and are not preflighted here — neither is a publish or a restore, and widening to them is not this plan's.

## Escalations

None.

## On the test level, given #1191's review

#1191 landed with `69f8007d`, "drop the CLI staging suite" — a container-spawning suite and its CI leg traded away for a unit test on `stele_scratch_dir` plus the transport's own staging test, on the grounds that what it guarded was a `PathBuf` argument on two commands. This change follows that line rather than re-opening it: the new coverage is unit tests on the policy and on each side's need, plus one assertion inside the existing registry suite where a real manifest is the only thing that can state the sizes. No new suite, no new CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
