### PR TITLE
chore: let dolos-devs own crates/minibf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 *       @scarmuega
+
+# minibf is owned by the dolos-devs team: PRs touching only this path can be
+# approved and merged without a review from @scarmuega.
+/crates/minibf/ @scarmuega @txpipe/dolos-devs


### PR DESCRIPTION
## What

Adds a path rule to `.github/CODEOWNERS` so that `crates/minibf/` is owned by `@scarmuega` **and** `@txpipe/dolos-devs`, rather than by the catch-all `* @scarmuega` rule.

```
*       @scarmuega

# minibf is owned by the dolos-devs team: PRs touching only this path can be
# approved and merged without a review from @scarmuega.
/crates/minibf/ @scarmuega @txpipe/dolos-devs
```

## Why

`main` is protected with `require_code_owner_reviews: true` and one required approval, so today every PR — including minibf-only ones — waits on @scarmuega. This lets the minibf work move on its own.

## Effect

- A PR touching **only** `crates/minibf/**` matches the last rule and can be approved by any `@txpipe/dolos-devs` member (the team holds `maintain` on this repo, so it has the write access a code owner needs).
- A PR touching anything else still matches `*` and needs @scarmuega. Last matching rule wins, so a mixed PR is gated by both rules and still requires @scarmuega for the non-minibf paths.
- Nothing else about branch protection changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code ownership and review policy documentation for the MiniBF component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->