### PR TITLE
feat(minibf): add `/accounts/{stake_address}/addresses/total`

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -400,6 +400,10 @@ where
             get(routes::accounts::by_stake_addresses_assets::<D>),
         )
         .route(
+            "/accounts/{stake_address}/addresses/total",
+            get(routes::accounts::by_stake_addresses_total::<D>),
+        )
+        .route(
             "/accounts/{stake_address}/utxos",
             get(routes::accounts::by_stake_utxos::<D>),
         )

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -8,6 +8,8 @@ use axum::{
 use blockfrost_openapi::models::{
     account_addresses_assets_inner::AccountAddressesAssetsInner,
     account_addresses_content_inner::AccountAddressesContentInner,
+    account_addresses_total::AccountAddressesTotal,
+    account_addresses_total_received_sum_inner::AccountAddressesTotalReceivedSumInner,
     account_content::AccountContent,
     account_delegation_content_inner::AccountDelegationContentInner,
     account_history_content_inner::AccountHistoryContentInner,
@@ -42,7 +44,7 @@ use pallas::ledger::primitives::conway::Certificate as ConwayCert;
 use crate::{
     error::Error,
     inputs::{for_each_touched_output, InputDeps, InputResolver},
-    mapping::{self, bech32_drep, bech32_pool, IntoModel},
+    mapping::{self, bech32_drep, bech32_pool, AssetTotals, IntoModel},
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
 };
@@ -297,6 +299,150 @@ where
     }
 
     Ok(Json(items))
+}
+
+/// Fold one block's txs into an account's lifetime totals.
+///
+/// Produced outputs are received and resolved inputs are sent, the same split
+/// `/addresses/{address}/total` makes for a single address; a tx counts once
+/// however many of the account's addresses it touches.
+async fn sum_account_block_txs<D>(
+    domain: &Facade<D>,
+    deps: &mut InputDeps,
+    account: &[u8],
+    block: &[u8],
+    received: &mut AssetTotals,
+    sent: &mut AssetTotals,
+    tx_count: &mut usize,
+) -> Result<(), StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let block = MultiEraBlock::decode(block).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let txs = block.txs();
+
+    let mut resolver = deps.prepare(domain, txs.iter()).await?;
+
+    for tx in txs.iter() {
+        let mut matched = false;
+
+        for (_, output) in tx.produces() {
+            let address = output
+                .address()
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            if address_belongs_to_account(&address, account) {
+                received.add_output(&output);
+                matched = true;
+            }
+        }
+
+        for input in tx.consumes() {
+            if let Some(output) = resolver.resolve(&input)? {
+                let address = output
+                    .address()
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+                if address_belongs_to_account(&address, account) {
+                    sent.add_output(&output);
+                    matched = true;
+                }
+            }
+        }
+
+        if matched {
+            *tx_count += 1;
+        }
+    }
+
+    Ok(())
+}
+
+fn account_amounts(totals: AssetTotals) -> Vec<AccountAddressesTotalReceivedSumInner> {
+    totals
+        .into_amounts()
+        .into_iter()
+        .map(|amount| AccountAddressesTotalReceivedSumInner {
+            unit: amount.unit,
+            quantity: amount.quantity,
+        })
+        .collect()
+}
+
+/// `GET /accounts/{stake_address}/addresses/total`: lifetime sums and tx count
+/// across every address of an account.
+///
+/// The totals are folded from the archive on each request rather than kept as
+/// state: a per-account asset breakdown is unbounded — one row grows with every
+/// distinct asset the account ever touched — and it would ride along in every
+/// stele and every state rebuild. The account therefore pays the same full
+/// scan `/addresses/{address}/total` already pays for a single address, which
+/// also means the answer only covers the history the archive still holds.
+pub async fn by_stake_addresses_total<D>(
+    Path(stake_address): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<AccountAddressesTotal>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
+
+    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let account = account_key.address.to_vec();
+    let end_slot = domain.get_tip_slot()?;
+
+    let stream = domain
+        .query()
+        .blocks_by_stake_stream(&account, 0, end_slot, SlotOrder::Asc);
+
+    let mut received = AssetTotals::default();
+    let mut sent = AssetTotals::default();
+    let mut tx_count: usize = 0;
+    let mut deps = InputDeps::default();
+
+    let mut stream = Box::pin(stream);
+
+    while let Some(res) = stream.next().await {
+        let (_slot, block) = res.map_err(|err| {
+            tracing::error!(?err);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        let Some(block) = block else {
+            continue;
+        };
+
+        sum_account_block_txs(
+            &domain,
+            &mut deps,
+            &account,
+            &block,
+            &mut received,
+            &mut sent,
+            &mut tx_count,
+        )
+        .await?;
+    }
+
+    let stake_address = account_key
+        .address
+        .to_bech32()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let model = AccountAddressesTotal {
+        stake_address,
+        received_sum: account_amounts(received),
+        sent_sum: account_amounts(sent),
+        tx_count: tx_count as i32,
+    };
+
+    Ok(Json(model))
 }
 
 pub async fn by_stake_utxos<D>(

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -379,6 +379,13 @@ fn account_amounts(totals: AssetTotals) -> Vec<AccountAddressesTotalReceivedSumI
 /// stele and every state rebuild. The account therefore pays the same full
 /// scan `/addresses/{address}/total` already pays for a single address, which
 /// also means the answer only covers the history the archive still holds.
+///
+/// Pointer-delegated addresses are out of scope. The archive's stake tag and
+/// this fold both resolve an output's account through
+/// `pallas_extras::shelley_address_to_stake_address`, which has no answer for
+/// a pointer, so those blocks are never tagged and so never scanned. Every
+/// other account endpoint reads that same tag, so the blind spot is the
+/// family's, not this endpoint's.
 pub async fn by_stake_addresses_total<D>(
     Path(stake_address): Path<String>,
     State(domain): State<Facade<D>>,

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -1340,7 +1340,7 @@ mod tests {
     use blockfrost_openapi::models::{
         account_addresses_assets_inner::AccountAddressesAssetsInner,
         account_addresses_content_inner::AccountAddressesContentInner,
-        account_content::AccountContent,
+        account_addresses_total::AccountAddressesTotal, account_content::AccountContent,
         account_delegation_content_inner::AccountDelegationContentInner,
         account_history_content_inner::AccountHistoryContentInner,
         account_registration_content_inner::AccountRegistrationContentInner,
@@ -1794,6 +1794,126 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/addresses");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_total_happy_path() {
+        let app = TestApp::new();
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/addresses/total");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AccountAddressesTotal =
+            serde_json::from_slice(&bytes).expect("failed to parse account addresses total");
+
+        assert_eq!(item.stake_address, stake_address);
+
+        // every synthetic tx produces a single output to one of the account
+        // addresses, so the account totals cover all txs in all blocks
+        let tx_count: usize = app.vectors().blocks.iter().map(|x| x.tx_hashes.len()).sum();
+        assert_eq!(item.tx_count, tx_count as i32);
+
+        assert_eq!(item.received_sum[0].unit, "lovelace");
+        assert_eq!(
+            item.received_sum[0].quantity,
+            (tx_count as u64 * dolos_testing::MIN_UTXO_AMOUNT).to_string()
+        );
+
+        let asset = item
+            .received_sum
+            .iter()
+            .find(|x| x.unit == app.vectors().asset_unit)
+            .expect("expected synthetic asset in received_sum");
+        assert_eq!(asset.quantity, tx_count.to_string());
+
+        // the synthetic account addresses never spend, but lovelace must
+        // still be present (and first) with a zero quantity
+        assert_eq!(item.sent_sum.len(), 1);
+        assert_eq!(item.sent_sum[0].unit, "lovelace");
+        assert_eq!(item.sent_sum[0].quantity, "0");
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_total_counts_spends() {
+        // the default seed address is payment-only and its UTxOs have no
+        // producing tx in the archive, so the account never spends. Funding
+        // each tx from the previous block's output instead gives every tx
+        // after the first block a resolvable input the account owns.
+        let app = TestApp::new_with_cfg(SyntheticBlockConfig {
+            block_count: 3,
+            txs_per_block: 2,
+            spend_previous_outputs: true,
+            ..Default::default()
+        });
+
+        let stake_address = app.vectors().stake_address.as_str();
+        let asset_unit = app.vectors().asset_unit.clone();
+        let path = format!("/accounts/{stake_address}/addresses/total");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AccountAddressesTotal =
+            serde_json::from_slice(&bytes).expect("failed to parse account addresses total");
+
+        let quantity = |sums: &[AccountAddressesTotalReceivedSumInner], unit: &str| {
+            sums.iter()
+                .find(|x| x.unit == unit)
+                .unwrap_or_else(|| panic!("missing {unit} in sums"))
+                .quantity
+                .clone()
+        };
+
+        // a tx that both pays and spends an account address is still one tx
+        assert_eq!(item.tx_count, 6);
+
+        // every tx pays one account address
+        assert_eq!(
+            quantity(&item.received_sum, "lovelace"),
+            (6 * MIN_UTXO_AMOUNT).to_string()
+        );
+        assert_eq!(quantity(&item.received_sum, &asset_unit), "6");
+
+        // the two blocks that follow one spend it, two txs each
+        assert_eq!(
+            quantity(&item.sent_sum, "lovelace"),
+            (4 * MIN_UTXO_AMOUNT).to_string()
+        );
+        assert_eq!(quantity(&item.sent_sum, &asset_unit), "4");
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_total_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/total", invalid_stake_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_total_not_found() {
+        let app = TestApp::new();
+        let path = format!("/accounts/{}/addresses/total", missing_stake_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn accounts_by_stake_addresses_total_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/addresses/total");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -58,6 +58,15 @@ pub struct SyntheticBlockConfig {
     pub drep_deposit: u64,
     pub gov_actions_by_block: Vec<BlockGovActions>,
     pub proposal_deposit: u64,
+    /// Fund each tx from the previous block's tx at the same index instead of
+    /// from a fresh `seed_address` UTxO.
+    ///
+    /// Seed UTxOs are injected as custom UTxOs, so the tx that produced them
+    /// is not in the archive and an endpoint scanning the chain cannot resolve
+    /// them. Spending an earlier synthetic output instead gives the account a
+    /// resolvable input, which is what the endpoints reading the spent side of
+    /// a tx need.
+    pub spend_previous_outputs: bool,
 }
 
 /// Build a testnet Shelley address with both payment and stake key parts.
@@ -116,6 +125,7 @@ impl Default for SyntheticBlockConfig {
             drep_deposit: 1000,
             gov_actions_by_block: vec![],
             proposal_deposit: 100_000_000,
+            spend_previous_outputs: false,
         }
     }
 }
@@ -294,6 +304,7 @@ pub fn build_synthetic_blocks(
         cbor: submit_cbor,
     });
     let mut prev_block_hash: Option<Hash<32>> = None;
+    let mut prev_block_tx_hashes: Vec<Hash<32>> = Vec::new();
 
     for (offset, asset_name) in asset_names.iter().enumerate() {
         let slot = cfg.slot + offset as u64;
@@ -312,16 +323,32 @@ pub fn build_synthetic_blocks(
         let aux_hash = aux_data.compute_hash();
 
         for tx_offset in 0..txs_per_block {
-            let seed_tx_hash = tx_sequence_to_hash(1 + (offset * txs_per_block + tx_offset) as u64);
-            let seed_ref = TxoRef(seed_tx_hash, 0);
-            let seed_utxo = utxo_with_value(cfg.seed_address.clone(), Value::Coin(cfg.seed_amount));
-            let crate::EraCbor(_, seed_cbor) = seed_utxo;
+            // the previous block's tx at this index paid an account address,
+            // and unlike a seed UTxO it was produced by a tx the archive holds
+            let funded_by_account = cfg
+                .spend_previous_outputs
+                .then(|| prev_block_tx_hashes.get(tx_offset).copied())
+                .flatten();
 
-            chain_config.custom_utxos.push(CustomUtxo {
-                ref_: seed_ref,
-                era: Some(pallas::ledger::traverse::Era::Conway.into()),
-                cbor: seed_cbor,
-            });
+            let seed_tx_hash = match funded_by_account {
+                Some(hash) => hash,
+                None => {
+                    let seed_tx_hash =
+                        tx_sequence_to_hash(1 + (offset * txs_per_block + tx_offset) as u64);
+                    let seed_ref = TxoRef(seed_tx_hash, 0);
+                    let seed_utxo =
+                        utxo_with_value(cfg.seed_address.clone(), Value::Coin(cfg.seed_amount));
+                    let crate::EraCbor(_, seed_cbor) = seed_utxo;
+
+                    chain_config.custom_utxos.push(CustomUtxo {
+                        ref_: seed_ref,
+                        era: Some(pallas::ledger::traverse::Era::Conway.into()),
+                        cbor: seed_cbor,
+                    });
+
+                    seed_tx_hash
+                }
+            };
 
             let output_address = if tx_offset == 0 {
                 address_bytes.clone()
@@ -402,6 +429,7 @@ pub fn build_synthetic_blocks(
 
         let block_hash = block.header.compute_hash();
         prev_block_hash = Some(block_hash);
+        prev_block_tx_hashes = hashes.clone();
         let wrapper = (7, block);
         let raw_block = Arc::new(minicbor::to_vec(wrapper).unwrap());
 

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -97,6 +97,8 @@ Check the [Configuration Schema](../configuration/schema) for detailed info on h
 
 Dolos provides many, but not all of the Blockfrost endpoints. The following list represent the endpoints currently supported by Dolos:
 
+Two of them report lifetime totals — `/addresses/{address}/total` and `/accounts/{stake_address}/addresses/total` — by folding every transaction the address or account ever took part in, read from the archive on each request. They are only as complete as the history the node keeps: with `sync.max_history` set, the sums and `tx_count` cover the retained window instead of the whole chain, so a node serving them should run with full history.
+
 | Endpoint                                                   | Description                                              |
 | ---------------------------------------------------------- | -------------------------------------------------------- |
 | `/`                                                        | Service info (version, revision)                         |
@@ -106,6 +108,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}`                                | Get account information for a stake address              |
 | `/accounts/{stake_address}/addresses`                      | Get addresses for a stake address                        |
 | `/accounts/{stake_address}/addresses/assets`               | Get assets held across a stake address's addresses       |
+| `/accounts/{stake_address}/addresses/total`                | Get lifetime received/sent totals for a stake address    |
 | `/accounts/{stake_address}/delegations`                    | Get delegations for a stake address                      |
 | `/accounts/{stake_address}/history`                        | Get the per-epoch stake history for a stake address      |
 | `/accounts/{stake_address}/registrations`                  | Get registrations for a stake address                    |

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -97,8 +97,6 @@ Check the [Configuration Schema](../configuration/schema) for detailed info on h
 
 Dolos provides many, but not all of the Blockfrost endpoints. The following list represent the endpoints currently supported by Dolos:
 
-Two of them report lifetime totals — `/addresses/{address}/total` and `/accounts/{stake_address}/addresses/total` — by folding every transaction the address or account ever took part in, read from the archive on each request. They are only as complete as the history the node keeps: with `sync.max_history` set, the sums and `tx_count` cover the retained window instead of the whole chain, so a node serving them should run with full history.
-
 | Endpoint                                                   | Description                                              |
 | ---------------------------------------------------------- | -------------------------------------------------------- |
 | `/`                                                        | Service info (version, revision)                         |
@@ -189,3 +187,7 @@ Two of them report lifetime totals — `/addresses/{address}/total` and `/accoun
 | `/txs/{tx_hash}/stakes`                                    | Get stakes for a specific transaction                    |
 | `/txs/{tx_hash}/utxos`                                     | Get UTXOs for a specific transaction                     |
 | `/txs/{tx_hash}/withdrawals`                               | Get withdrawals for a specific transaction               |
+
+## Lifetime totals and `sync.max_history`
+
+`/addresses/{address}/total` and `/accounts/{stake_address}/addresses/total` fold every transaction kept in the archive. When `sync.max_history` is set, blocks pruned by housekeeping are not counted, so the sums and `tx_count` only cover the retained window. Run with full history if you need true lifetime totals.

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -267,7 +267,7 @@ The `sync` section controls how Dolos synchronizes the chain from upstream peers
 | sync_limit      | string  | "NoLimit" (default) |
 
 - `pull_batch_size`: the number of blocks that are fetched per batch (defaults to `100`).
-- `max_history`: maximum number of slots to keep in archive history before housekeeping prunes old data. Pruned blocks are also out of reach for the MiniBF endpoints that fold lifetime totals (`/addresses/{address}/total`, `/accounts/{stake_address}/addresses/total`), whose sums then only cover the retained window.
+- `max_history`: maximum number of slots to keep in archive history before housekeeping prunes old data.
 - `max_rollback`: maximum number of slots to keep in WAL history before housekeeping prunes old entries.
 - `sync_limit`: one of `"NoLimit"`, `"UntilTip"`, or `{ MaxBlocks = <number> }` (defaults to `"NoLimit"`).
 

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -267,7 +267,7 @@ The `sync` section controls how Dolos synchronizes the chain from upstream peers
 | sync_limit      | string  | "NoLimit" (default) |
 
 - `pull_batch_size`: the number of blocks that are fetched per batch (defaults to `100`).
-- `max_history`: maximum number of slots to keep in archive history before housekeeping prunes old data.
+- `max_history`: maximum number of slots to keep in archive history before housekeeping prunes old data. Pruned blocks are also out of reach for the MiniBF endpoints that fold lifetime totals (`/addresses/{address}/total`, `/accounts/{stake_address}/addresses/total`), whose sums then only cover the retained window.
 - `max_rollback`: maximum number of slots to keep in WAL history before housekeeping prunes old entries.
 - `sync_limit`: one of `"NoLimit"`, `"UntilTip"`, or `{ MaxBlocks = <number> }` (defaults to `"NoLimit"`).
 


### PR DESCRIPTION
resolves: https://github.com/txpipe/dolos/issues/1066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/accounts/{stake_address}/addresses/total` endpoint.
  * Returns lifetime received and sent asset totals, along with the transaction count, for a stake address.

* **Documentation**
  * Documented the new endpoint and clarified that totals reflect retained archive history when `sync.max_history` is configured.
  * Updated Mini Blockfrost endpoint coverage information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->