### PR TITLE
feat(stelae): resume an interrupted publish from the layers it uploaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
  "hex",
  "minicbor 0.26.4",
  "rustls",
+ "serde",
  "serde_json",
  "stelae",
  "tempfile",

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -23,6 +23,7 @@ dolos-cardano = { path = "../cardano" }
 fs4.workspace = true
 hex.workspace = true
 minicbor.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -573,8 +573,7 @@ where
         )?;
     }
 
-    // Not offered to the predecessor: a shard is the tip, and a restart rebuilds
-    // it. See [`Predecessor::landed`].
+    // Not offered to the predecessor: see [`Predecessor::landed`].
     layers.extend(write_state(stele, plan, state)?);
 
     if let Some(records) = digest_records {

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -216,6 +216,12 @@ pub fn plan<S: StateStore>(state: &S, network_magic: u64) -> Result<Plan, Error>
 /// together is what lets a publisher rebuild everything while still chaining —
 /// the `--rebuild` case, which suppresses [`Predecessor::adopt`] and leaves
 /// [`Predecessor::history`] exactly as it was.
+///
+/// The publish this one follows can be **this publish, interrupted**, which is
+/// what [`Predecessor::landed`] is for: a stele that never got sealed left
+/// layers behind that a restart may carry forward on exactly the terms a
+/// predecessor's do. Nothing here decides where that is written down — that is
+/// the implementor's, as `adopt` already is.
 pub trait Predecessor {
     /// The history the new inscription carries: every prior publication,
     /// contiguous and ascending, ending at `sequence - 1`.
@@ -246,6 +252,28 @@ pub trait Predecessor {
         let _ = (kind, scope);
 
         Ok(None)
+    }
+
+    /// Note that `descriptor`'s layer is in the transport and will be in the
+    /// manifest, whether it was built here or adopted.
+    ///
+    /// Called once per epoch layer, as it lands and before the next one starts,
+    /// so an implementor writing it down leaves a record that means "this layer
+    /// is up" rather than "this layer was attempted" — the same boundary
+    /// [`crate::restore::Checkpoint`] records on its side. The state shards are
+    /// deliberately never offered: they describe a moving tip, and a restart
+    /// must rebuild them.
+    ///
+    /// A failure here **fails the publish**. Recording is not a courtesy: a
+    /// record that silently stopped being written would cost the hours it
+    /// exists to save, at the moment nobody is watching.
+    ///
+    /// The default does nothing, which is what a publish with no host behind it
+    /// — a directory, a reproduction — wants.
+    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
+        let _ = descriptor;
+
+        Ok(())
     }
 }
 
@@ -522,17 +550,31 @@ where
     let mut layers = Vec::new();
 
     for window in &plan.epochs {
-        layers.push(write_blocks(stele, plan, archive, window, previous)?);
+        landed(
+            write_blocks(stele, plan, archive, window, previous)?,
+            previous,
+            &mut layers,
+        )?;
     }
 
     for window in &plan.epochs {
-        layers.push(write_indexes(stele, plan, indexes, window, previous)?);
+        landed(
+            write_indexes(stele, plan, indexes, window, previous)?,
+            previous,
+            &mut layers,
+        )?;
     }
 
     for window in &plan.epochs {
-        layers.push(write_logs(stele, plan, archive, window, previous)?);
+        landed(
+            write_logs(stele, plan, archive, window, previous)?,
+            previous,
+            &mut layers,
+        )?;
     }
 
+    // Not offered to the predecessor: a shard is the tip, and a restart rebuilds
+    // it. See [`Predecessor::landed`].
     layers.extend(write_state(stele, plan, state)?);
 
     if let Some(records) = digest_records {
@@ -824,6 +866,23 @@ fn layers_by_scope(
 
 fn sink<W: SteleWriter>(stele: &W, spec: &LayerSpec) -> Result<W::Sink, Error> {
     Ok(stele.layer_sink(&DolosProfile, spec, COMPRESSION_LEVEL)?)
+}
+
+/// One epoch layer is in the transport: tell the predecessor before counting
+/// it.
+///
+/// In that order, and one layer at a time, because the two together are what
+/// make the note honest — a record written after the loop would describe a
+/// publish that finished, which is the one case it is no use in.
+fn landed(
+    descriptor: LayerDescriptor,
+    previous: &dyn Predecessor,
+    layers: &mut Vec<LayerDescriptor>,
+) -> Result<(), Error> {
+    previous.landed(&descriptor)?;
+    layers.push(descriptor);
+
+    Ok(())
 }
 
 /// The layer spec for one epoch window, and what the predecessor says about it.

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -1518,10 +1518,6 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
-    // The resumption record
-    // -----------------------------------------------------------------------
-    //
     // What a record decides on its own, which is everything except whether the
     // registry still holds a blob. That last question needs a registry and is
     // in `tests/publish.rs`, with the interruption that raises it.

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -78,6 +78,39 @@
 //! to the previous stele, which is a stele, and restores. Publishing again
 //! re-uploads nothing it already sent, because the blob check finds them.
 //!
+//! ## A restarted publish skips the layers that finished
+//!
+//! The blob check makes that retry cheap in *bytes* and not in *work*: a
+//! `diffId` is the digest of bytes that do not exist until they are built, so
+//! rediscovering that the registry already has a layer costs the whole walk of
+//! the stores that produced it. For an interrupted mainnet publish that is the
+//! same hours again, and nothing in the format asks for it — the manifest is
+//! written last precisely so an interrupted publish is safe to repeat.
+//!
+//! [`PublishRecord`] closes it, and it is the mirror of the restore's progress
+//! file: a host-local note beside the stores, naming each **epoch layer** whose
+//! upload succeeded. A restart reads it and adopts those layers through
+//! [`Registry::adopt_carried`] — the same move an inherited layer makes, one
+//! `HEAD` and no store read. The sixteen state shards are never in it, for the
+//! reason they are never inherited.
+//!
+//! The record is **a stand-in for the predecessor manifest an unfinished
+//! publish never got to write, and nothing more.** Four properties keep it from
+//! becoming a second source of truth:
+//!
+//! - **a skip is gated on the registry's own blob check**, so the record alone
+//!   can never place a digest in a manifest the registry cannot serve. Where a
+//!   manifest naming a reclaimed blob is a refusal, a record naming one is a
+//!   rebuild;
+//! - **a recorded digest equals a rebuilt one**, because an epoch layer is
+//!   deterministic for a closed epoch — the property the export golden and the
+//!   two-backend determinism test already pin — and the record refuses itself
+//!   if anything the bytes depend on has moved ([`Origin`]);
+//! - **`--rebuild` ignores it wholesale**, exactly as it already ignores
+//!   inheritance, and overwrites it rather than reading it;
+//! - **the manifest remains the only statement of what the repository holds.**
+//!   A stale or deleted record costs a rebuild, never a wrong publish.
+//!
 //! ## Reading one back
 //!
 //! [`restore_registry`] is the other half, and almost all of it is
@@ -100,16 +133,22 @@
 //! configuration and its own environment and hands the answer to [`open`]. The
 //! same goes for where the layers are staged on the way through.
 
-use std::{cell::Cell, collections::BTreeMap, path::PathBuf};
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeMap,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
 
 use dolos_core::{ArchiveStore, IndexStore, StateStore};
+use serde::{Deserialize, Serialize};
 use stelae::{
     digest::LayerDigests,
     frame::Limits,
-    inscription::{HistoryEntry, Inscription, LayerDescriptor},
+    inscription::{Compression, HistoryEntry, Inscription, LayerDescriptor},
     oci::{Options, Stele, Transfer},
-    transport::BlobIndex,
-    Digest, SteleReader as _,
+    transport::{BlobIndex, WrittenLayer},
+    Digest, SteleReader as _, SteleWriter,
 };
 
 /// How a repository is named, re-exported so the binary can take one from an
@@ -266,6 +305,252 @@ pub fn open(
             auth,
         },
     )?)
+}
+
+/// Where a publish is going, and what the host running it knows about itself.
+///
+/// The publish-side counterpart of [`crate::restore::Restoring`], and it holds
+/// the transport for the same reason that one holds `storage_path`: these are
+/// the facts a publish is *given*, as against the ones it derives. Threading
+/// them separately is what took [`publish`] to the edge of its signature, and
+/// they have never been supplied from different places.
+#[derive(Clone, Copy)]
+pub struct Publishing<'a> {
+    /// The repository being published into, already opened.
+    pub registry: &'a Registry,
+
+    /// `storage.path` — where the stores live, and with them the resumption
+    /// record. `None` for a caller with no node behind it, which records
+    /// nothing and resumes nothing.
+    pub storage_path: Option<&'a Path>,
+
+    /// The operator's `--rebuild`: build every layer, inherit none, and start
+    /// the record over.
+    pub rebuild: bool,
+}
+
+impl<'a> Publishing<'a> {
+    /// A publish into `registry` that keeps no record and rebuilds nothing.
+    pub fn new(registry: &'a Registry) -> Self {
+        Self {
+            registry,
+            storage_path: None,
+            rebuild: false,
+        }
+    }
+
+    /// The same publish, recording what it finishes beside the stores at
+    /// `storage_path`.
+    pub fn recording_in(self, storage_path: &'a Path) -> Self {
+        Self {
+            storage_path: Some(storage_path),
+            ..self
+        }
+    }
+
+    /// The same publish, with the operator's `--rebuild`.
+    pub fn rebuilding(self, rebuild: bool) -> Self {
+        Self { rebuild, ..self }
+    }
+}
+
+/// Name of the resumption record inside a node's storage directory.
+///
+/// Beside [`crate::restore::PROGRESS_FILE`] and spelled the same way, because
+/// they are the same kind of thing: host-local state about a run in flight,
+/// inside `storage.path` so that anything clearing a node's storage clears it
+/// too. "Snapshot" is this profile's word for a stele.
+pub const PUBLISH_RECORD_FILE: &str = ".snapshot-publish.json";
+
+/// Where a node with storage at `storage_path` keeps its resumption record.
+pub fn record_path_in(storage_path: &Path) -> PathBuf {
+    storage_path.join(PUBLISH_RECORD_FILE)
+}
+
+/// What a record has to agree with before a single layer in it is adopted.
+///
+/// Everything a recorded layer's bytes and address depend on that is *not* in
+/// the layer's own key. The key is the kind plus the descriptor scope, and that
+/// scope names an epoch and a slot window and nothing else — so:
+///
+/// - **the repository**, because a blob digest is an address in one repository
+///   and means nothing in another;
+/// - **the network magic**, because two chains' epoch 500 are different bytes
+///   under one key. The descriptor scope deliberately carries no magic — the
+///   layer's own header record does — so this is the only place the record can
+///   hold it;
+/// - **the parameters and the compression**, which are the inscription's own
+///   statement of how its layers were built. A binary that changed either would
+///   rebuild a recorded layer into different bytes, and the record would be
+///   offering an answer to a question nobody is asking any more.
+///
+/// A mismatch in any of them makes the record a fresh one for the origin at
+/// hand. Nothing is repaired and nothing is merged: the layers it named are
+/// still in the registry, and the publish that wants them will build them
+/// again and find them there.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Origin {
+    /// The repository the layers were uploaded to, as the transport names it.
+    pub repository: String,
+    /// The network the stores stood on.
+    pub network_magic: u64,
+    /// The inscription parameters the layers were built under.
+    pub parameters: serde_json::Value,
+    /// The compression they were built with.
+    pub compression: Compression,
+}
+
+impl Origin {
+    /// What a publish of `plan` into `registry` would record under.
+    fn of(registry: &Registry, plan: &Plan) -> Self {
+        Self {
+            repository: registry.repository().to_string(),
+            network_magic: plan.network.magic(),
+            parameters: crate::parameters(),
+            compression: crate::compression(),
+        }
+    }
+}
+
+/// The epoch layers an interrupted publish got as far as uploading.
+///
+/// Written after each layer's upload succeeds and deleted once the stele is
+/// sealed, so a record that exists describes a publish that did not finish. See
+/// the module documentation for what it is and — more to the point — what it is
+/// not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PublishRecord {
+    pub origin: Origin,
+
+    /// The layers whose blobs are up, each as the transport measured it.
+    ///
+    /// The whole [`WrittenLayer`] rather than the digest pair the adoption
+    /// needs: the descriptor is what the new manifest has to state about the
+    /// layer, and a record that held only its identity would have to invent the
+    /// rest. In the canonical order of their keys, so the same progress is the
+    /// same bytes.
+    pub layers: Vec<WrittenLayer>,
+}
+
+impl PublishRecord {
+    /// Read the record at `path`, or `None` if there is none.
+    ///
+    /// **Only absence is `None`**, on [`crate::restore::PROGRESS_FILE`]'s
+    /// reasoning turned around: a file that exists and does not parse is an
+    /// error rather than an empty resume, because reading it as "nothing has
+    /// been uploaded" silently costs the rebuild this file exists to avoid.
+    /// `--rebuild` is how an operator asks for that outcome on purpose.
+    pub fn load(path: &Path) -> Result<Option<Self>, Error> {
+        let raw = match read_file(path) {
+            Ok(raw) => raw,
+            Err(e) => return Err(Error::Stelae(e)),
+        };
+
+        let Some(raw) = raw else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            serde_json::from_slice(&raw).map_err(|e| Error::Stelae(e.into()))?,
+        ))
+    }
+
+    /// Delete the record at `path`. A file that is not there is not an error.
+    pub fn remove(path: &Path) -> Result<(), Error> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::Stelae(e.into())),
+        }
+    }
+
+    /// Write the record at `path`, atomically.
+    ///
+    /// Through a temporary sibling and a rename, for the reason
+    /// `stelae::plan::RestoreProgress::save` states on its side: the failure
+    /// this file exists to survive is a process that stops mid-write, and a
+    /// half-written record would be refused by [`PublishRecord::load`] —
+    /// correctly, and uselessly, since the publish it described would then have
+    /// to start over.
+    pub fn save(&self, path: &Path) -> Result<(), Error> {
+        save_atomically(
+            path,
+            &serde_json::to_vec(self).map_err(stelae::Error::from)?,
+        )
+        .map_err(Error::Stelae)
+    }
+
+    /// The layers this record offers, keyed the way [`Chained`] looks them up.
+    ///
+    /// An [`Origin`] the caller is not publishing under offers nothing: see
+    /// [`Origin`] for why a mismatch is a fresh start rather than a merge.
+    fn table(&self, origin: &Origin) -> Result<BTreeMap<(String, String), WrittenLayer>, Error> {
+        if &self.origin != origin {
+            tracing::info!(
+                recorded = %self.origin.repository,
+                publishing = %origin.repository,
+                "a resumption record was left by a publish this one does not continue; \
+                 every layer will be rebuilt"
+            );
+
+            return Ok(BTreeMap::new());
+        }
+
+        let mut table = BTreeMap::new();
+
+        for layer in &self.layers {
+            // The same filter `inheritable_layers` applies to a predecessor's
+            // manifest, applied again on the way in: a record naming a state
+            // shard is a record nothing wrote, and honouring one would carry a
+            // stale tip into a manifest.
+            if !EPOCH_KINDS.contains(&layer.descriptor.kind.as_str()) {
+                continue;
+            }
+
+            table.insert(
+                key(&layer.descriptor.kind, &layer.descriptor.scope)?,
+                layer.clone(),
+            );
+        }
+
+        Ok(table)
+    }
+}
+
+fn read_file(path: &Path) -> Result<Option<Vec<u8>>, stelae::Error> {
+    match std::fs::read(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn save_atomically(path: &Path, bytes: &[u8]) -> Result<(), stelae::Error> {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let staging = path.with_file_name(format!(".{name}.{}.tmp", std::process::id()));
+
+    // Scoped so the handle is closed before the rename: Windows refuses to
+    // rename a file that is still open.
+    {
+        let mut file = std::fs::File::create(&staging)?;
+
+        file.write_all(bytes)?;
+
+        // Before the rename, not after: a rename that lands pointing at bytes
+        // the page cache has not written yet is the same truncated file by
+        // another route.
+        file.sync_all()?;
+    }
+
+    std::fs::rename(&staging, path)?;
+
+    Ok(())
 }
 
 /// What a publish into a repository did.
@@ -625,36 +910,76 @@ fn staging_need(
     crate::preflight::Need::of(STAGING, scratch_dir, peak.bytes())
 }
 
-/// Publish `plan` into `registry`, chained to whatever is already there.
+/// Publish `plan` into the repository `publishing` names, chained to whatever
+/// is already there.
 ///
 /// Reads the repository's moving tag first: an absent one starts a history, a
 /// predecessor at `sequence - 1` extends it, and anything else is refused
-/// before a single layer is built. `rebuild` reproduces every layer instead of
-/// inheriting the ones whose scope is unchanged — see the module
-/// documentation.
+/// before a single layer is built. [`Publishing::rebuild`] reproduces every
+/// layer instead of inheriting the ones whose scope is unchanged, and
+/// [`Publishing::storage_path`] is where the resumption record lives — see the
+/// module documentation for both.
 pub fn publish<A, S, I>(
-    registry: &Registry,
+    publishing: Publishing<'_>,
     plan: &Plan,
     archive: &A,
     state: &S,
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
-    rebuild: bool,
 ) -> Result<Published, Error>
 where
     A: ArchiveStore,
     S: StateStore,
     I: IndexStore,
 {
+    publish_into(
+        publishing.registry,
+        publishing,
+        plan,
+        archive,
+        state,
+        indexes,
+        digest_records,
+    )
+}
+
+/// The same publish, through a writer the caller supplies.
+///
+/// The generic half of [`publish`], as [`crate::restore::restore`] is of
+/// [`restore_registry`], and for the same kind of caller: one that has to
+/// observe or interrupt the writes rather than only their result. The resume
+/// suite's transport, which fails at a layer the test chose, is what this
+/// exists for.
+///
+/// **`stele` must write into `publishing.registry`.** The manifest is built
+/// from what that transport is carrying, so a writer that puts the layers
+/// somewhere else would seal a manifest with holes in it. A decorator over the
+/// registry is the shape this takes; anything else is a caller misusing it.
+pub fn publish_into<W, A, S, I>(
+    stele: &W,
+    publishing: Publishing<'_>,
+    plan: &Plan,
+    archive: &A,
+    state: &S,
+    indexes: &I,
+    digest_records: Option<&[digests::ImmutableDigests]>,
+) -> Result<Published, Error>
+where
+    W: SteleWriter,
+    A: ArchiveStore,
+    S: StateStore,
+    I: IndexStore,
+{
+    let registry = publishing.registry;
     let latest = registry.latest(&DolosProfile)?;
-    let previous = Chained::new(latest.as_ref(), registry, plan, rebuild)?;
+    let previous = Chained::new(publishing, latest.as_ref(), plan)?;
 
     // Reset before the export, so what comes back is this publish's cost and
     // not a total carried over from an earlier one through the same transport.
     registry.take_transfer();
 
     let inscription = export::export(
-        registry,
+        stele,
         plan,
         archive,
         state,
@@ -662,6 +987,11 @@ where
         digest_records,
         &previous,
     )?;
+
+    // Only here: the stele is sealed, so the note about what was uploaded on the
+    // way to it has nothing left to say. Before the seal it would be a record
+    // that outlived neither the run nor its usefulness.
+    previous.forget_record()?;
 
     let identity = inscription.digest()?;
     let layers_reused = previous.adopted.get();
@@ -684,13 +1014,13 @@ where
 /// read the same input so they cannot drift when Phase 4 gives the records a
 /// source.
 pub fn preview(
-    registry: &Registry,
+    publishing: Publishing<'_>,
     plan: &Plan,
     digest_records: Option<&[digests::ImmutableDigests]>,
-    rebuild: bool,
 ) -> Result<Preview, Error> {
+    let registry = publishing.registry;
     let latest = registry.latest(&DolosProfile)?;
-    let previous = Chained::new(latest.as_ref(), registry, plan, rebuild)?;
+    let previous = Chained::new(publishing, latest.as_ref(), plan)?;
 
     // Every epoch selected contributes one layer per epoch kind, the state tip
     // contributes its sixteen shards however the epochs were restricted, and
@@ -713,7 +1043,7 @@ pub fn preview(
         for kind in EPOCH_KINDS {
             let spec = scope.layer_spec(kind)?;
 
-            if previous.inheritable(kind, &spec.scope)?.is_some() {
+            if previous.carried_forward(kind, &spec.scope)? {
                 layers_reused += 1;
             }
         }
@@ -728,27 +1058,55 @@ pub fn preview(
     })
 }
 
-/// The stele this publish follows, in a repository.
+/// The publish this one follows, in a repository — which may be itself.
 ///
-/// Holds the history it hands to the new inscription and the table of layers it
-/// is willing to let the new stele inherit, keyed by the pair that decides it:
-/// the layer's kind and the canonical encoding of its profile-owned scope.
+/// Holds the history it hands to the new inscription and the two tables of
+/// layers it is willing to let the new stele carry forward rather than build,
+/// both keyed by the pair that decides it: the layer's kind and the canonical
+/// encoding of its profile-owned scope.
+///
+/// The tables answer the same question from different standing. `inheritable`
+/// is the *predecessor's manifest* — a stele the repository serves, so a layer
+/// missing from it is a fault. `resumable` is *this publish's own record* of an
+/// attempt that died before it could write a manifest — a note, so a layer
+/// missing from the registry is only a rebuild. The manifest is consulted
+/// first, because a repository that states it holds a layer needs no note to
+/// say so.
 struct Chained<'a> {
     registry: &'a Registry,
     source: Option<&'a Stele>,
     predecessor: Option<(u64, Digest)>,
     history: Vec<HistoryEntry>,
     inheritable: BTreeMap<(String, String), LayerDescriptor>,
+    resumable: BTreeMap<(String, String), WrittenLayer>,
+    record: Option<Recording>,
     adopted: Cell<usize>,
+}
+
+/// The resumption record this publish is writing, open.
+///
+/// Seeded with what it inherits, so the file is the whole of what is up rather
+/// than the whole of what *this attempt* put up: an attempt that adopts twenty
+/// layers and adds one, then dies, has to leave twenty-one behind or the third
+/// attempt pays for the difference.
+struct Recording {
+    path: PathBuf,
+    origin: Origin,
+    layers: RefCell<BTreeMap<(String, String), WrittenLayer>>,
 }
 
 impl<'a> Chained<'a> {
     fn new(
+        publishing: Publishing<'a>,
         latest: Option<&'a Stele>,
-        registry: &'a Registry,
         plan: &Plan,
-        rebuild: bool,
     ) -> Result<Self, Error> {
+        let Publishing {
+            registry,
+            storage_path,
+            rebuild,
+        } = publishing;
+
         let inscription = latest.map(|stele| stele.read_inscription()).transpose()?;
 
         if let Some(previous) = &inscription {
@@ -770,22 +1128,73 @@ impl<'a> Chained<'a> {
             _ => BTreeMap::new(),
         };
 
+        let origin = Origin::of(registry, plan);
+
+        // Read on the same terms, and it is the *honouring* that `rebuild`
+        // gates rather than the reading — the asymmetry
+        // `crate::restore::Checkpoint::open` states, for the same reason. A
+        // publisher that asked to rebuild gets a record that starts empty and
+        // overwrites whatever was there, so nothing an earlier attempt believed
+        // can survive the run that was meant to settle it.
+        let resumable = match (rebuild, storage_path) {
+            (false, Some(storage_path)) => {
+                match PublishRecord::load(&record_path_in(storage_path))? {
+                    Some(record) => record.table(&origin)?,
+                    None => BTreeMap::new(),
+                }
+            }
+            _ => BTreeMap::new(),
+        };
+
+        if !resumable.is_empty() {
+            tracing::info!(
+                layers = resumable.len(),
+                "an interrupted publish left epoch layers in this repository; \
+                 they will be carried forward rather than rebuilt"
+            );
+        }
+
+        let record = storage_path.map(|storage_path| Recording {
+            path: record_path_in(storage_path),
+            origin,
+            layers: RefCell::new(resumable.clone()),
+        });
+
         Ok(Self {
             registry,
             source: latest.filter(|_| !rebuild),
             predecessor,
             history,
             inheritable,
+            resumable,
+            record,
             adopted: Cell::new(0),
         })
     }
 
-    fn inheritable(
-        &self,
-        kind: &str,
-        scope: &serde_json::Value,
-    ) -> Result<Option<&LayerDescriptor>, Error> {
-        Ok(self.inheritable.get(&key(kind, scope)?))
+    /// Whether a layer of `kind` at `scope` would be carried forward rather
+    /// than built.
+    ///
+    /// What [`preview`] reports, and it spends no `HEAD`: the promise a dry run
+    /// makes is about what the scopes permit. The record's own gate — that the
+    /// registry still holds the blob — runs in [`Predecessor::adopt`] and can
+    /// turn one of these into a rebuild, which is the direction a dry run is
+    /// allowed to be wrong in.
+    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
+        let key = key(kind, scope)?;
+
+        Ok(self.inheritable.contains_key(&key) || self.resumable.contains_key(&key))
+    }
+
+    /// Delete the resumption record.
+    ///
+    /// Called once the stele is sealed and never before it. See
+    /// [`publish_into`].
+    fn forget_record(&self) -> Result<(), Error> {
+        match &self.record {
+            Some(record) => PublishRecord::remove(&record.path),
+            None => Ok(()),
+        }
     }
 }
 
@@ -799,17 +1208,73 @@ impl Predecessor for Chained<'_> {
         kind: &str,
         scope: &serde_json::Value,
     ) -> Result<Option<LayerDescriptor>, Error> {
-        let (Some(source), Some(descriptor)) = (self.source, self.inheritable(kind, scope)?) else {
+        let key = key(kind, scope)?;
+
+        // The arrangement and the answer are one act, in both branches: by the
+        // time this returns a descriptor, the transport is already carrying the
+        // blob, and the `HEAD` that proves the registry still has it has already
+        // happened.
+        if let (Some(source), Some(descriptor)) = (self.source, self.inheritable.get(&key)) {
+            self.registry.adopt_layer(source, descriptor.clone())?;
+            self.adopted.set(self.adopted.get() + 1);
+
+            return Ok(Some(descriptor.clone()));
+        }
+
+        let Some(recorded) = self.resumable.get(&key) else {
             return Ok(None);
         };
 
-        // The arrangement and the answer are one act: by the time this returns
-        // a descriptor, the transport is already carrying the blob, and the
-        // `HEAD` that proves the registry still has it has already happened.
-        self.registry.adopt_layer(source, descriptor.clone())?;
+        // The one place the record's standing differs from a manifest's: a blob
+        // the registry no longer holds costs this layer its skip and nothing
+        // more. Whatever reclaimed it, the publish is still correct — it builds
+        // the layer and uploads it again.
+        if !self.registry.adopt_carried(recorded.clone())? {
+            tracing::warn!(
+                kind,
+                %scope,
+                "a recorded layer's blob is no longer in the repository; rebuilding it"
+            );
+
+            return Ok(None);
+        }
+
         self.adopted.set(self.adopted.get() + 1);
 
-        Ok(Some(descriptor.clone()))
+        Ok(Some(recorded.descriptor.clone()))
+    }
+
+    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
+        let Some(record) = &self.record else {
+            return Ok(());
+        };
+
+        if !EPOCH_KINDS.contains(&descriptor.kind.as_str()) {
+            return Ok(());
+        }
+
+        // The transport's own measurement, not a reconstruction of it: what
+        // goes in the record is what the manifest is about to say.
+        let Some(written) = self.registry.carried(&descriptor.diff_id) else {
+            tracing::warn!(
+                kind = descriptor.kind,
+                scope = %descriptor.scope,
+                "this layer is not in the transport, so nothing was recorded for it; \
+                 an interrupted publish will rebuild it"
+            );
+
+            return Ok(());
+        };
+
+        let mut layers = record.layers.borrow_mut();
+
+        layers.insert(key(&descriptor.kind, &descriptor.scope)?, written);
+
+        PublishRecord {
+            origin: record.origin.clone(),
+            layers: layers.values().cloned().collect(),
+        }
+        .save(&record.path)
     }
 }
 
@@ -1050,6 +1515,143 @@ mod tests {
             "",
         ] {
             assert!(raw.parse::<Point>().is_err(), "{raw:?}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The resumption record
+    // -----------------------------------------------------------------------
+    //
+    // What a record decides on its own, which is everything except whether the
+    // registry still holds a blob. That last question needs a registry and is
+    // in `tests/publish.rs`, with the interruption that raises it.
+
+    fn origin(repository: &str) -> Origin {
+        Origin {
+            repository: repository.to_owned(),
+            network_magic: 2,
+            parameters: crate::parameters(),
+            compression: crate::compression(),
+        }
+    }
+
+    fn written(kind: &str, scope: serde_json::Value, identity: u8) -> WrittenLayer {
+        WrittenLayer {
+            descriptor: layer(kind, scope, identity),
+            digests: LayerDigests {
+                diff_id: Digest::compute([identity]),
+                blob_digest: Digest::compute([identity, 0xff]),
+                uncompressed_size: 1,
+                compressed_size: 1,
+            },
+        }
+    }
+
+    fn record(origin: Origin) -> PublishRecord {
+        PublishRecord {
+            origin,
+            layers: vec![
+                written(
+                    crate::BLOCKS,
+                    json!({"epoch": 2, "startSlot": 200, "endSlot": 299}),
+                    1,
+                ),
+                written(crate::STATE, json!({"shard": 0}), 2),
+            ],
+        }
+    }
+
+    /// The record round-trips, and only absence reads as a fresh start.
+    ///
+    /// The second half is the one that matters: a record read as "nothing has
+    /// been uploaded" costs the rebuild the file exists to avoid, and does it
+    /// without anything looking wrong.
+    #[test]
+    fn a_record_round_trips_and_a_corrupt_one_is_not_an_absent_one() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = record_path_in(temp.path());
+
+        assert_eq!(path.file_name().unwrap(), PUBLISH_RECORD_FILE);
+        assert_eq!(PublishRecord::load(&path).unwrap(), None);
+
+        let record = record(origin("oci://example.test/dolos"));
+        record.save(&path).unwrap();
+
+        assert_eq!(PublishRecord::load(&path).unwrap(), Some(record));
+
+        // The staging sibling is renamed, not left for the next reader.
+        let found: Vec<String> = std::fs::read_dir(temp.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(found, vec![PUBLISH_RECORD_FILE.to_owned()]);
+
+        std::fs::write(&path, b"{\"origin\": ").unwrap();
+        assert!(PublishRecord::load(&path).is_err());
+
+        PublishRecord::remove(&path).unwrap();
+        assert_eq!(PublishRecord::load(&path).unwrap(), None);
+
+        // Removing what is not there is what the end of every publish does.
+        PublishRecord::remove(&path).unwrap();
+    }
+
+    /// Only the epoch kinds come out of a record, whatever went into one.
+    #[test]
+    fn a_record_offers_epoch_layers_and_nothing_else() {
+        let origin = origin("oci://example.test/dolos");
+        let table = record(origin.clone()).table(&origin).unwrap();
+
+        assert_eq!(table.len(), 1);
+        assert!(table.contains_key(
+            &key(
+                crate::BLOCKS,
+                &json!({"epoch": 2, "startSlot": 200, "endSlot": 299})
+            )
+            .unwrap()
+        ));
+    }
+
+    /// Done criterion 2's second half, decided without a registry: a record
+    /// left by a publish this one does not continue offers nothing.
+    ///
+    /// Four ways to not be that publish, and each one alone is enough. The
+    /// repository is the one an operator will meet; the other three are what
+    /// stops a recorded digest from being adopted into a manifest whose layers
+    /// a rebuild would compute differently.
+    #[test]
+    fn a_record_from_another_publish_offers_nothing() {
+        let mine = origin("oci://example.test/dolos");
+
+        for theirs in [
+            origin("oci://example.test/dolos-preprod"),
+            Origin {
+                network_magic: 1,
+                ..mine.clone()
+            },
+            Origin {
+                parameters: json!({"stateShards": 1}),
+                ..mine.clone()
+            },
+            Origin {
+                compression: Compression {
+                    algo: "zstd".to_owned(),
+                    level: 1,
+                },
+                ..mine.clone()
+            },
+        ] {
+            assert_ne!(theirs, mine);
+
+            let table = record(theirs.clone()).table(&mine).unwrap();
+
+            assert!(table.is_empty(), "{theirs:?}");
+
+            // And the same layers under the origin they were written for are
+            // offered, so what the guard refuses is the mismatch and not the
+            // record.
+            assert_eq!(record(theirs.clone()).table(&theirs).unwrap().len(), 1);
         }
     }
 

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -1225,10 +1225,6 @@ impl Predecessor for Chained<'_> {
             return Ok(None);
         };
 
-        // The one place the record's standing differs from a manifest's: a blob
-        // the registry no longer holds costs this layer its skip and nothing
-        // more. Whatever reclaimed it, the publish is still correct — it builds
-        // the layer and uploads it again.
         if !self.registry.adopt_carried(recorded.clone())? {
             tracing::warn!(
                 kind,
@@ -1253,8 +1249,6 @@ impl Predecessor for Chained<'_> {
             return Ok(());
         }
 
-        // The transport's own measurement, not a reconstruction of it: what
-        // goes in the record is what the manifest is about to say.
         let Some(written) = self.registry.carried(&descriptor.diff_id) else {
             tracing::warn!(
                 kind = descriptor.kind,

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -411,6 +411,26 @@ impl Origin {
             compression: crate::compression(),
         }
     }
+
+    /// The fields `self` and `other` disagree on, in the order [`Origin`]
+    /// states them.
+    ///
+    /// One of the four ways to differ changes the repository, so a refusal
+    /// that reported the two repository names alone would read, in the other
+    /// three, as though the two publishes matched. Names rather than values:
+    /// `parameters` is arbitrary JSON, and what an operator needs from the
+    /// event is which knob moved between the two runs.
+    fn differences_from(&self, other: &Self) -> Vec<&'static str> {
+        [
+            (self.repository != other.repository, "repository"),
+            (self.network_magic != other.network_magic, "network magic"),
+            (self.parameters != other.parameters, "parameters"),
+            (self.compression != other.compression, "compression"),
+        ]
+        .into_iter()
+        .filter_map(|(differs, field)| differs.then_some(field))
+        .collect()
+    }
 }
 
 /// The epoch layers an interrupted publish got as far as uploading.
@@ -489,6 +509,7 @@ impl PublishRecord {
     fn table(&self, origin: &Origin) -> Result<BTreeMap<(String, String), WrittenLayer>, Error> {
         if &self.origin != origin {
             tracing::info!(
+                differs = %self.origin.differences_from(origin).join(", "),
                 recorded = %self.origin.repository,
                 publishing = %origin.repository,
                 "a resumption record was left by a publish this one does not continue; \
@@ -1609,30 +1630,42 @@ mod tests {
     /// Four ways to not be that publish, and each one alone is enough. The
     /// repository is the one an operator will meet; the other three are what
     /// stops a recorded digest from being adopted into a manifest whose layers
-    /// a rebuild would compute differently.
+    /// a rebuild would compute differently. Each case also pins the field the
+    /// refusal names, because in three of the four the two repository names
+    /// the event carries are identical.
     #[test]
     fn a_record_from_another_publish_offers_nothing() {
         let mine = origin("oci://example.test/dolos");
 
-        for theirs in [
-            origin("oci://example.test/dolos-preprod"),
-            Origin {
-                network_magic: 1,
-                ..mine.clone()
-            },
-            Origin {
-                parameters: json!({"stateShards": 1}),
-                ..mine.clone()
-            },
-            Origin {
-                compression: Compression {
-                    algo: "zstd".to_owned(),
-                    level: 1,
+        for (theirs, named) in [
+            (origin("oci://example.test/dolos-preprod"), "repository"),
+            (
+                Origin {
+                    network_magic: 1,
+                    ..mine.clone()
                 },
-                ..mine.clone()
-            },
+                "network magic",
+            ),
+            (
+                Origin {
+                    parameters: json!({"stateShards": 1}),
+                    ..mine.clone()
+                },
+                "parameters",
+            ),
+            (
+                Origin {
+                    compression: Compression {
+                        algo: "zstd".to_owned(),
+                        level: 1,
+                    },
+                    ..mine.clone()
+                },
+                "compression",
+            ),
         ] {
             assert_ne!(theirs, mine);
+            assert_eq!(theirs.differences_from(&mine), vec![named]);
 
             let table = record(theirs.clone()).table(&mine).unwrap();
 
@@ -1643,6 +1676,22 @@ mod tests {
             // record.
             assert_eq!(record(theirs.clone()).table(&theirs).unwrap().len(), 1);
         }
+
+        // An origin that matches names nothing, and one that differs in every
+        // field names them all rather than stopping at the first.
+        assert!(mine.differences_from(&mine).is_empty());
+        assert_eq!(
+            origin("oci://example.test/other").differences_from(&Origin {
+                network_magic: 1,
+                parameters: json!({"stateShards": 1}),
+                compression: Compression {
+                    algo: "zstd".to_owned(),
+                    level: 1,
+                },
+                ..mine.clone()
+            }),
+            vec!["repository", "network magic", "parameters", "compression"]
+        );
     }
 
     fn layer(kind: &str, scope: serde_json::Value, identity: u8) -> LayerDescriptor {

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -121,7 +121,7 @@ mod registry_node {
     use dolos_core::{BlockHash, ChainPoint, Domain as _};
     use dolos_snapshot::{
         export::Plan,
-        registry::{self, Published, Registry},
+        registry::{self, Published, Publishing, Registry},
         Error, Network,
     };
     use dolos_testing::toy_domain::{MemoryStores, ToyDomain};
@@ -176,29 +176,50 @@ mod registry_node {
         }
 
         pub fn publish(&self, repository: &Registry, plan: &Plan, rebuild: bool) -> Published {
+            self.publish_as(Publishing::new(repository).rebuilding(rebuild), plan)
+                .unwrap()
+        }
+
+        /// A publish with the whole of [`Publishing`] chosen by the caller —
+        /// what the resume suite needs, since a resumption record is the one
+        /// input a publish takes from the host rather than from the repository.
+        pub fn publish_as(
+            &self,
+            publishing: Publishing<'_>,
+            plan: &Plan,
+        ) -> Result<Published, Error> {
             registry::publish(
-                repository,
+                publishing,
                 plan,
                 self.domain.archive(),
                 self.domain.state(),
                 self.domain.indexes(),
                 None,
-                rebuild,
             )
-            .unwrap()
+        }
+
+        /// The same publish, through a writer of the caller's — the interrupted
+        /// transport the resume suite kills at a layer it chose.
+        pub fn publish_through<W: stelae::SteleWriter>(
+            &self,
+            stele: &W,
+            publishing: Publishing<'_>,
+            plan: &Plan,
+        ) -> Result<Published, Error> {
+            registry::publish_into(
+                stele,
+                publishing,
+                plan,
+                self.domain.archive(),
+                self.domain.state(),
+                self.domain.indexes(),
+                None,
+            )
         }
 
         pub fn refuse(&self, repository: &Registry, plan: &Plan) -> Error {
-            registry::publish(
-                repository,
-                plan,
-                self.domain.archive(),
-                self.domain.state(),
-                self.domain.indexes(),
-                None,
-                false,
-            )
-            .unwrap_err()
+            self.publish_as(Publishing::new(repository), plan)
+                .unwrap_err()
         }
     }
 }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -768,7 +768,6 @@ fn a_rebuild_and_another_repository_both_ignore_the_record() {
             .len()
     };
 
-    // A record for `ignored-a`, five layers deep.
     let dying = fixture.repository("dolos/ignored-a");
     assert_eq!(interrupt(&dying), 5);
 

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -13,7 +13,7 @@
 //! same knob `crates/stelae/tests/oci.rs` uses, so this suite can be pointed at
 //! another implementation.
 //!
-//! ## The four properties
+//! ## The properties
 //!
 //! 1. **A second publish builds and uploads only what is new.** Both numbers
 //!    come from counters the code keeps, not from a duration and not from
@@ -36,6 +36,10 @@
 //! 6. **A repository already at this node's sequence is not a fault.** The
 //!    detection a publisher on a timer needs, read off the same moving tag a
 //!    publish reads.
+//! 7. **A restarted publish never rebuilds an epoch layer it already uploaded**
+//!    — and produces the manifest an uninterrupted publish would have, byte for
+//!    byte. The interruption is real: a transport that dies at a layer the test
+//!    named, leaving blobs up that no manifest references.
 //!
 //! ## Why the two cursors sit where they do
 //!
@@ -59,7 +63,8 @@ mod registry_fixture;
 use dolos_core::Domain as _;
 use dolos_snapshot::{
     export::{self, Following, Predecessor as _, Standing},
-    registry, DolosProfile, Error, BLOCKS, INDEXES, LOGS, STATE_SHARDS,
+    registry::{self, Publishing},
+    DolosProfile, Error, BLOCKS, INDEXES, LOGS, STATE_SHARDS,
 };
 use stelae::SteleReader as _;
 
@@ -166,7 +171,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     let repository = fixture.repository("dolos/dry-run");
 
     // Against an empty repository: nothing to follow, nothing to inherit.
-    let empty = registry::preview(&repository, &node.first, None, false).unwrap();
+    let empty = registry::preview(Publishing::new(&repository), &node.first, None).unwrap();
 
     assert_eq!(empty.predecessor, None);
     assert_eq!(empty.history, 0);
@@ -179,7 +184,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     assert_eq!(first.layers_reused, empty.layers_reused);
 
     // And against the stele that is now there.
-    let next = registry::preview(&repository, &node.second, None, false).unwrap();
+    let next = registry::preview(Publishing::new(&repository), &node.second, None).unwrap();
 
     assert_eq!(next.predecessor, Some((1, first.identity)));
     assert_eq!(next.history, 1);
@@ -188,7 +193,12 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     // here, while sequence 2 is still unpublished: a preview reads the chain
     // through the same rule a publish does, so asking after the fact would be
     // refused as a republish.
-    let rebuilding = registry::preview(&repository, &node.second, None, true).unwrap();
+    let rebuilding = registry::preview(
+        Publishing::new(&repository).rebuilding(true),
+        &node.second,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(rebuilding.layers_reused, 0);
     assert_eq!(rebuilding.layers_built, PER_PUBLISH + 3);
@@ -210,7 +220,7 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
 
     // A preview reaches the chain refusal too, which is what makes `--dry-run`
     // the cheap way to find out that a publisher has skipped an epoch.
-    let refused = registry::preview(&repository, &node.second, None, false).unwrap_err();
+    let refused = registry::preview(Publishing::new(&repository), &node.second, None).unwrap_err();
 
     assert!(matches!(refused, Error::HistoryBreak { .. }), "{refused:?}");
 }
@@ -589,4 +599,290 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
         peak.bytes(),
         inspected.total_compressed,
     );
+}
+
+// ---------------------------------------------------------------------------
+// Resuming an interrupted publish
+// ---------------------------------------------------------------------------
+
+/// Done criterion 1: a restarted publish never rebuilds an epoch layer it
+/// already uploaded.
+///
+/// The interruption lands at a layer this test names rather than after a
+/// wall-clock delay, for the reason `tests/restore_registry.rs` states about
+/// its own: a kill on a timer over a loopback registry sometimes interrupts
+/// nothing. Here it is `logs` for epoch 1, which is the last of the six epoch
+/// layers sequence 2 writes — so the interrupted run got five of them up, and
+/// two of those five are ones no manifest in the repository mentions.
+///
+/// That last part is what makes the record load-bearing rather than decorative.
+/// Epoch 0's three layers would be inherited from sequence 1's manifest with or
+/// without a record; epoch 1's `blocks` and `indexes` exist only as blobs
+/// nothing references, and only the record knows they are there.
+#[test]
+#[ignore]
+fn a_restarted_publish_carries_forward_the_layers_it_finished() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let storage = tempfile::tempdir().unwrap();
+
+    let first = fixture.repository("dolos/resume");
+
+    node.publish_as(publishing(&first, &storage), &node.first)
+        .unwrap();
+
+    assert_eq!(
+        registry::PublishRecord::load(&record_path(&storage)).unwrap(),
+        None,
+        "a publish that sealed left its record behind",
+    );
+
+    // The interruption. A fresh transport each time, because the process this
+    // stands in for is a fresh process.
+    let dying = fixture.repository("dolos/resume");
+
+    let killed = node
+        .publish_through(
+            &Interrupted {
+                inner: &dying,
+                kind: LOGS,
+                epoch: 1,
+            },
+            publishing(&dying, &storage),
+            &node.second,
+        )
+        .unwrap_err();
+
+    assert!(
+        matches!(killed, Error::Stelae(stelae::Error::Io(_))),
+        "{killed:?}"
+    );
+
+    let record = registry::PublishRecord::load(&record_path(&storage))
+        .unwrap()
+        .expect("an interrupted publish left no record");
+
+    assert_eq!(
+        record.layers.len(),
+        5,
+        "every epoch layer ahead of the one that died, and only those",
+    );
+
+    assert!(
+        record
+            .layers
+            .iter()
+            .all(|layer| layer.descriptor.kind != dolos_snapshot::STATE),
+        "a state shard is the tip, and is never recorded",
+    );
+
+    // The restart, against the same repository and the same storage.
+    let resumed_into = fixture.repository("dolos/resume");
+
+    let resumed = node
+        .publish_as(publishing(&resumed_into, &storage), &node.second)
+        .unwrap();
+
+    assert_eq!(
+        resumed.layers_reused, 5,
+        "epoch 0's three off the manifest, epoch 1's blocks and indexes off the record",
+    );
+
+    assert_eq!(
+        resumed.layers_built,
+        1 + STATE_SHARDS as usize,
+        "epoch 1's logs and the sixteen state shards, and nothing else",
+    );
+
+    // The claim in the counters the transport keeps: the two layers the record
+    // carried moved no bytes at all, and the shards it never carried did.
+    assert_eq!(resumed.transfer.layers_reused, 5);
+    assert_eq!(resumed.transfer.layers_uploaded, 1 + STATE_SHARDS);
+    assert_eq!(
+        resumed.transfer.layers_skipped, 0,
+        "a layer skipped by the blob check is one that was built first, which is \
+         the cost this record exists to remove",
+    );
+
+    assert_eq!(
+        registry::PublishRecord::load(&record_path(&storage)).unwrap(),
+        None,
+        "a resumed publish that sealed left its record behind",
+    );
+
+    // Done criterion 1's other half: the stele is the one an uninterrupted
+    // publish would have produced, down to the manifest bytes. A second
+    // repository published into identically is the only thing that can say so —
+    // a repository's identity is path-dependent, so the comparison has to be
+    // against a chain built the same way rather than against a literal.
+    let clean = fixture.repository("dolos/uninterrupted");
+
+    node.publish(&clean, &node.first, false);
+    let uninterrupted = node.publish(&clean, &node.second, false);
+
+    assert_eq!(resumed.identity, uninterrupted.identity);
+    assert_eq!(resumed.inscription, uninterrupted.inscription);
+    assert_eq!(manifest_of(&resumed_into), manifest_of(&clean));
+
+    eprintln!(
+        "resumed: {} layers carried forward, {} built, {} bytes not moved — and the same manifest",
+        resumed.layers_reused, resumed.layers_built, resumed.transfer.bytes_reused,
+    );
+}
+
+/// Done criterion 2, both halves: the two ways a record is not honoured.
+///
+/// `--rebuild` is the publisher choosing to reproduce, and it ignores the
+/// record exactly as it already ignores inheritance. A record naming another
+/// repository is ignored because a blob digest is an address in one repository
+/// and means nothing in another — and this is the case a record could get
+/// silently wrong, since the layers it names would be adopted into a manifest
+/// the registry cannot serve.
+#[test]
+#[ignore]
+fn a_rebuild_and_another_repository_both_ignore_the_record() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let storage = tempfile::tempdir().unwrap();
+
+    let first = fixture.repository("dolos/ignored-a");
+    node.publish_as(publishing(&first, &storage), &node.first)
+        .unwrap();
+
+    let other = fixture.repository("dolos/ignored-b");
+    node.publish_as(publishing(&other, &storage), &node.first)
+        .unwrap();
+
+    let interrupt = |repository: &registry::Registry| {
+        node.publish_through(
+            &Interrupted {
+                inner: repository,
+                kind: LOGS,
+                epoch: 1,
+            },
+            publishing(repository, &storage),
+            &node.second,
+        )
+        .unwrap_err();
+
+        registry::PublishRecord::load(&record_path(&storage))
+            .unwrap()
+            .expect("an interrupted publish left no record")
+            .layers
+            .len()
+    };
+
+    // A record for `ignored-a`, five layers deep.
+    let dying = fixture.repository("dolos/ignored-a");
+    assert_eq!(interrupt(&dying), 5);
+
+    // The other repository's publish reaches the same record and takes nothing
+    // from it: epoch 0's three layers come off *its own* manifest, and epoch
+    // 1's come out of the stores.
+    let elsewhere = fixture.repository("dolos/ignored-b");
+
+    let published = node
+        .publish_as(publishing(&elsewhere, &storage), &node.second)
+        .unwrap();
+
+    assert_eq!(
+        published.layers_reused, 3,
+        "epoch 0's three, off this repository's own manifest and nothing else",
+    );
+    assert_eq!(
+        published.layers_built, PER_PUBLISH,
+        "epoch 1's three layers and the sixteen state shards, exactly as if no \
+         record existed",
+    );
+
+    // Back to the first repository, now with `--rebuild`. The record is there
+    // and describes layers this publish could carry; it is ignored wholesale,
+    // and overwritten rather than read.
+    let dying = fixture.repository("dolos/ignored-a");
+    assert_eq!(interrupt(&dying), 5);
+
+    let rebuilt_into = fixture.repository("dolos/ignored-a");
+
+    let rebuilt = node
+        .publish_as(
+            publishing(&rebuilt_into, &storage).rebuilding(true),
+            &node.second,
+        )
+        .unwrap();
+
+    assert_eq!(
+        rebuilt.layers_reused, 0,
+        "a rebuild carries nothing forward"
+    );
+    assert_eq!(rebuilt.layers_built, PER_PUBLISH + 3);
+
+    // And it is the same stele either way, which is the point of being allowed
+    // to ignore the record: reproducing what you published is not the same act
+    // as forgetting that you published it.
+    assert_eq!(
+        rebuilt.inscription.history.len(),
+        1,
+        "a rebuild still chains",
+    );
+}
+
+/// A publish into `repository`, recording beside the stores at `storage`.
+fn publishing<'a>(
+    repository: &'a registry::Registry,
+    storage: &'a tempfile::TempDir,
+) -> registry::Publishing<'a> {
+    registry::Publishing::new(repository).recording_in(storage.path())
+}
+
+fn record_path(storage: &tempfile::TempDir) -> std::path::PathBuf {
+    registry::record_path_in(storage.path())
+}
+
+/// The manifest a repository's moving tag resolves to, as bytes.
+fn manifest_of(repository: &registry::Registry) -> Vec<u8> {
+    let stele = repository.pull_latest(&DolosProfile).unwrap();
+
+    stelae::oci::manifest_bytes(stele.manifest()).unwrap()
+}
+
+/// A transport that stops at a layer the test chose.
+///
+/// The publish-side twin of `tests/restore_registry.rs`'s interrupted reader:
+/// it refuses the moment a sink is asked for the named layer, so the
+/// interrupted run uploaded exactly the layers ahead of that one and nothing of
+/// it. Everything else goes straight through to the registry, which is what
+/// `registry::publish_into` requires of a writer it is handed.
+struct Interrupted<'a> {
+    inner: &'a registry::Registry,
+    kind: &'static str,
+    epoch: u64,
+}
+
+impl stelae::SteleWriter for Interrupted<'_> {
+    type Sink = stelae::oci::RegistrySink;
+
+    fn layer_sink(
+        &self,
+        profile: &dyn stelae::Profile,
+        spec: &stelae::transport::LayerSpec,
+        level: i32,
+    ) -> Result<Self::Sink, stelae::Error> {
+        let epoch = spec.scope.get("epoch").and_then(serde_json::Value::as_u64);
+
+        if spec.kind == self.kind && epoch == Some(self.epoch) {
+            return Err(stelae::Error::Io(std::io::Error::other(
+                "the machine went away",
+            )));
+        }
+
+        self.inner.layer_sink(profile, spec, level)
+    }
+
+    fn seal(
+        &self,
+        profile: &dyn stelae::Profile,
+        inscription: &stelae::inscription::Inscription,
+    ) -> Result<stelae::Digest, stelae::Error> {
+        self.inner.seal(profile, inscription)
+    }
 }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -601,10 +601,6 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Resuming an interrupted publish
-// ---------------------------------------------------------------------------
-
 /// Done criterion 1: a restarted publish never rebuilds an epoch layer it
 /// already uploaded.
 ///

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -118,13 +118,12 @@ impl Node {
 
     fn publish(&self, repository: &Registry, plan: &Plan) {
         registry::publish(
-            repository,
+            registry::Publishing::new(repository),
             plan,
             self.domain.archive(),
             self.domain.state(),
             self.domain.indexes(),
             None,
-            false,
         )
         .unwrap();
     }

--- a/crates/stelae/src/digest.rs
+++ b/crates/stelae/src/digest.rs
@@ -107,7 +107,12 @@ impl<'de> serde::Deserialize<'de> for Digest {
 }
 
 /// What one pass over a layer blob establishes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializable for the reason [`crate::transport::WrittenLayer`] is: the two
+/// digests and the two sizes are one measurement, and a host writing part of it
+/// down is a host that can read back a pair that never described one layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LayerDigests {
     /// sha256 over the uncompressed CBOR sequence — the layer's identity.
     pub diff_id: Digest,

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -248,7 +248,9 @@ pub struct Transfer {
     /// Layer blobs the registry already had, and that were not.
     pub layers_skipped: u64,
     /// Layer blobs that were never built, because [`Registry::adopt_layer`]
-    /// took them from a stele already in this repository.
+    /// took them from a stele already in this repository — or because
+    /// [`Registry::adopt_carried`] took them from an earlier attempt of this
+    /// same publish.
     ///
     /// Deliberately not folded into `layers_skipped`. A skipped layer was
     /// built, hashed and then found to be present already, so the publisher
@@ -260,8 +262,8 @@ pub struct Transfer {
     pub bytes_uploaded: u64,
     /// Compressed bytes the skip saved.
     pub bytes_skipped: u64,
-    /// Compressed bytes an adopted layer did not move, as the manifest it came
-    /// from reports them.
+    /// Compressed bytes an adopted layer did not move, as the manifest or the
+    /// record it came from reports them.
     pub bytes_reused: u64,
 }
 
@@ -426,6 +428,9 @@ struct Shared {
     /// Registry and repository. The tag is a placeholder — blob operations do
     /// not use one, and manifest operations build their own.
     repository: Reference,
+    /// The same repository in the spelling it was opened with, for a caller
+    /// that has to write down where this transport publishes.
+    name: Repository,
     auth: RegistryAuth,
     scratch_dir: Option<PathBuf>,
     state: Mutex<PushState>,
@@ -497,6 +502,7 @@ impl Registry {
                 runtime,
                 client,
                 repository: reference,
+                name: repository.clone(),
                 auth,
                 scratch_dir: options.scratch_dir,
                 state: Mutex::new(PushState::default()),
@@ -514,6 +520,17 @@ impl Registry {
     /// [`Shared::scratch`] never names one either.
     pub fn scratch_dir(&self) -> Option<&Path> {
         self.shared.scratch_dir.as_deref()
+    }
+
+    /// The repository this transport was opened on.
+    ///
+    /// Here for the reason [`Registry::scratch_dir`] is: a caller that has to
+    /// write down where its layers went asks the transport that sent them,
+    /// rather than carrying the name alongside the handle. Two spellings of one
+    /// destination is one more than can be kept in step, and the one that
+    /// drifts is the one a later run compares against.
+    pub fn repository(&self) -> &Repository {
+        &self.shared.name
     }
 
     /// What has been pushed through this transport since it was opened, or
@@ -680,14 +697,6 @@ impl Registry {
             ))
         })?;
 
-        if !self.shared.blob_exists(&blob)? {
-            return Err(Error::BlobMissing {
-                kind: descriptor.kind,
-                diff_id: descriptor.diff_id.to_string(),
-                blob: named,
-            });
-        }
-
         let adopted = WrittenLayer {
             digests: LayerDigests {
                 diff_id: descriptor.diff_id,
@@ -698,12 +707,70 @@ impl Registry {
             descriptor,
         };
 
-        let mut state = self.shared.locked();
-        state.transfer.layers_reused += 1;
-        state.transfer.bytes_reused += compressed_size;
-        state.pending.push(adopted);
+        let kind = adopted.descriptor.kind.clone();
+        let diff_id = adopted.descriptor.diff_id;
+
+        // A manifest naming a blob the registry no longer has is a refusal and
+        // not a miss: the stele that named it is published, and something has
+        // reclaimed underneath it. See [`Registry::adopt_carried`] for the case
+        // where the same absence is merely a rebuild.
+        if !self.adopt_carried(adopted)? {
+            return Err(Error::BlobMissing {
+                kind,
+                diff_id: diff_id.to_string(),
+                blob: named,
+            });
+        }
 
         Ok(())
+    }
+
+    /// Carry a layer that is already in this repository, named in full.
+    ///
+    /// [`Registry::adopt_layer`] with the lookup already done — for a caller
+    /// holding a [`WrittenLayer`] this transport produced earlier rather than a
+    /// stele to read one out of. The pair is still not assembled by hand: it is
+    /// the measurement [`RecordSink::finish`] returned when the blob went up,
+    /// carried across whatever interruption the caller survived.
+    ///
+    /// **The blob check is a verdict, not an assertion.** `Ok(false)` means the
+    /// registry does not hold it and nothing was carried, which is a caller's
+    /// cue to build the layer after all. That is the difference from
+    /// [`Registry::adopt_layer`], where the same answer is an error: a
+    /// published manifest that names a reclaimed blob is a stele nobody can
+    /// restore, while a caller's own note that has gone stale costs a rebuild
+    /// and nothing else.
+    ///
+    /// Nothing here checks that the descriptor describes those bytes, for the
+    /// reason [`Registry::adopt_layer`] gives: checking would mean reading
+    /// them, which is the cost being avoided.
+    pub fn adopt_carried(&self, layer: WrittenLayer) -> Result<bool, Error> {
+        if !self.shared.blob_exists(&layer.digests.blob_digest)? {
+            return Ok(false);
+        }
+
+        let mut state = self.shared.locked();
+        state.transfer.layers_reused += 1;
+        state.transfer.bytes_reused += layer.digests.compressed_size;
+        state.pending.push(layer);
+
+        Ok(true)
+    }
+
+    /// The layer this transport is carrying for the next seal under `diff_id`.
+    ///
+    /// What [`SteleWriter::seal`] would put in the manifest, asked for one
+    /// layer at a time — so a caller recording what it has finished records
+    /// the transport's own measurement rather than a reconstruction of it.
+    /// `None` once the layers have been spent by a seal, and for a `diffId`
+    /// this transport never wrote.
+    pub fn carried(&self, diff_id: &Digest) -> Option<WrittenLayer> {
+        self.shared
+            .locked()
+            .pending
+            .iter()
+            .find(|layer| layer.digests.diff_id == *diff_id)
+            .cloned()
     }
 }
 

--- a/crates/stelae/src/transport.rs
+++ b/crates/stelae/src/transport.rs
@@ -50,6 +50,8 @@
 //! needs to ask a repository what is in it is asking a transport-specific
 //! question and should hold the transport-specific type.
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     digest::{LayerDigests, LayerWriter},
     frame::{CanonicalCbor, LayerHeader, Limits, SeqWriter},
@@ -89,7 +91,15 @@ impl LayerSpec {
 
 /// A written layer: the descriptor to put in the inscription, plus the
 /// transport facts that do not belong there.
-#[derive(Debug, Clone)]
+///
+/// Serializable so that a host can *hold one across a process*. Nothing in the
+/// protocol reads such a file — it is not a stele and never becomes one — but a
+/// publisher that wants to carry a layer it already uploaded into a later
+/// attempt has to write down what the transport told it, and writing down a
+/// half of the pair is what makes a descriptor and a blob able to disagree. See
+/// [`crate::oci::Registry::adopt_carried`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WrittenLayer {
     pub descriptor: LayerDescriptor,
     pub digests: LayerDigests,

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -151,6 +151,14 @@ fn to_repository(
         .into_diagnostic()
         .context("opening the repository")?;
 
+    // The resumption record sits beside the stores, so an interrupted publish
+    // restarted against this repository carries forward the epoch layers it
+    // already uploaded instead of rebuilding them. `--rebuild` starts it over
+    // along with everything else.
+    let publishing = registry::Publishing::new(&registry)
+        .recording_in(&config.storage.path)
+        .rebuilding(args.rebuild);
+
     // Before anything is built, and before the dry run too: a publisher asking
     // what a publish would do wants the same answer the publish gives.
     if !standing(&registry, plan, args)? {
@@ -171,7 +179,7 @@ fn to_repository(
         // `None` here and `None` at the `publish` below are one decision: a dry
         // run describes the publish that follows it, so the two calls are
         // handed the same digest records or the number is about something else.
-        let preview = registry::preview(&registry, plan, None, args.rebuild)
+        let preview = registry::preview(publishing, plan, None)
             .into_diagnostic()
             .context("planning the publish")?;
 
@@ -189,13 +197,12 @@ fn to_repository(
     }
 
     let published = registry::publish(
-        &registry,
+        publishing,
         plan,
         &stores.archive,
         &stores.state,
         &stores.indexes,
         None,
-        args.rebuild,
     )
     .into_diagnostic()
     .context("publishing the stele")?;


### PR DESCRIPTION
Plan: [`plans/dolos-stelae-publisher-operability-resume.md`](https://github.com/txpipe/dolos) — third piece of the `dolos-stelae-publisher-operability` family, behind the preflight piece (#1192).

## The problem

A publish that dies part way is resumed by starting over. The blob check makes that retry cheap in *bytes* — nothing already uploaded moves twice — but not in *work*: every layer is rebuilt from the stores to discover its digest, because a `diffId` is the digest of bytes that do not exist until they are built. For an interrupted mainnet publish that is the same hours again. Nothing in the format asks for it: the manifest is written last precisely so an interrupted publish is safe to repeat.

## What changed

A publish writes `<storage.path>/.snapshot-publish.json` beside the stores it reads — the mirror of the restore's `.snapshot-restore.json` — recording each completed **epoch layer** after its upload succeeds, and deleting it once the stele is sealed. A restart against the same repository adopts those layers through `Registry::adopt_carried`: the same move an inherited layer already makes, one `HEAD` and no store read. The sixteen state shards are never recorded, for the reason they are never inherited.

The record is a stand-in for the predecessor manifest an unfinished publish never got to write, and nothing more. Four properties keep it from becoming a second source of truth:

- **a skip is gated on the registry's own blob check**, so the record alone can never place a digest in a manifest the registry cannot serve. Where a manifest naming a reclaimed blob is a refusal, a record naming one is a rebuild;
- **a recorded digest equals a rebuilt one**, because an epoch layer is deterministic for a closed epoch — and the `Origin` guard (repository, network magic, inscription parameters, compression) refuses a record left by a publish this one does not continue;
- **`--rebuild` ignores it wholesale**, exactly as it already ignores inheritance, and overwrites it rather than reading it;
- **the manifest remains the only statement of what the repository holds.** A stale or deleted record costs a rebuild, never a wrong publish.

No change to the format, the manifest, or the history rules.

### Surface

- `crates/stelae/src/oci.rs` — `Registry::adopt_carried` (the record's half of `adopt_layer`, whose missing blob is a verdict rather than an error), `Registry::carried`, `Registry::repository`. `adopt_layer` now delegates its tail, so both paths make one blob check and one push.
- `crates/stelae/src/transport.rs`, `digest.rs` — `WrittenLayer` and `LayerDigests` are serializable, so a host holds the transport's own measurement rather than reassembling the pair by hand.
- `crates/snapshot/src/export.rs` — `Predecessor::landed`, a default-noop seam called once per epoch layer as it lands.
- `crates/snapshot/src/registry.rs` — `PublishRecord`, `Origin`, `Publishing` (which groups the transport, the storage path and `--rebuild`, keeping both entry points inside their signatures), and `publish_into`, the generic half of `publish` that `restore` already has on its side.

## Done criterion

1. **A publish interrupted after N epoch layers and restarted does not rebuild them.** `a_restarted_publish_carries_forward_the_layers_it_finished`: a transport that dies at `logs`/epoch 1 leaves five epoch layers up — two of which no manifest in the repository mentions — and the restart carries all five forward, builds only the sixth and the sixteen shards, and produces a manifest **byte-identical** to an uninterrupted publish's into a second repository.
2. **`--rebuild` ignores the record; a record for another repository is ignored.** `a_rebuild_and_another_repository_both_ignore_the_record`, plus unit tests over the four ways an `Origin` can fail to match.
3. Verification below.

## Verification

| check | result |
| --- | --- |
| `cargo test --workspace --all-targets` | pass |
| `cargo test --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` | pass |
| `cargo test -p dolos-snapshot --features oci --test publish -- --ignored` | 10 passed |
| `cargo test -p dolos-snapshot --features oci --test restore_registry -- --ignored` | 5 passed |
| `cargo test -p stelae --all-features --test oci -- --ignored` | 10 passed |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo +nightly fmt --all -- --check` | clean |
| `cargo deny check advisories` | ok |
| `cargo tree -p stelae -e normal --all-features` | matches nothing `^dolos(-\|$)` |

### Finding, pre-existing and not from this branch

`preflight::tests::a_measured_shortfall_refuses_and_an_unmeasurable_need_does_not` and `needs_sharing_a_volume_are_summed` are flaky on a live machine: each reads `fs4::available_space` and then asserts that a need of `available + 1` (or two needs summing to it) is refused, so free space growing by a byte between the two reads turns the refusal into a pass. Observed once each in ~10 runs here. Untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interrupted snapshot publishing can now resume automatically from recorded progress.
  * Incomplete or missing layers are rebuilt as needed, with an option to force a full rebuild.
  * Preview and publishing now share consistent layer reuse behavior.
  * Publishing progress is cleared after successful completion.
* **Bug Fixes**
  * Missing referenced blobs are now reported instead of being silently accepted.
* **Documentation**
  * Transfer details now distinguish reused layers from skipped uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->