### PR TITLE
refactor(stelae): open every layer through one prologue

### DIFF
--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -52,8 +52,8 @@ use crate::{
     frame::{CanonicalCbor, LayerHeader, Limits, SeqReader, SeqWriter},
     inscription::LayerDescriptor,
     layer::{check_header, check_identity, check_record_count, LayerReader},
-    profile::{checked_layer_media_type, Profile},
-    transport::{RecordSink, SteleReader, SteleWriter},
+    profile::Profile,
+    transport::{open_layer, RecordSink, SteleReader, SteleWriter},
     Digest, Error, Inscription,
 };
 
@@ -340,9 +340,6 @@ impl SteleWriter for SteleDir {
         spec: &LayerSpec,
         level: i32,
     ) -> Result<LayerSink, Error> {
-        let media_type = checked_layer_media_type(profile, &spec.kind)?;
-        let header = LayerHeader::new(profile.name(), &spec.kind, spec.header_scope.clone());
-
         // A layer's file name is its digest, which is not known until the last
         // byte is written, so it is staged first. The counter keeps two writers
         // of the same kind apart — a profile sharding one logical layer into
@@ -359,23 +356,18 @@ impl SteleWriter for SteleDir {
 
         // From here on every `?` unwinds through `staging`, which removes the
         // file it named.
-        let file = fs::File::create(&staging.path)?;
+        let (sequence, media_type) = open_layer(profile, spec, level, || {
+            Ok(fs::File::create(&staging.path)?)
+        })?;
 
-        let mut sink = LayerSink {
-            sequence: SeqWriter::with_max_record(
-                LayerWriter::new(file, level)?,
-                profile.max_record(),
-            ),
+        Ok(LayerSink {
+            sequence,
             staging,
             root: self.root.clone(),
             kind: spec.kind.clone(),
             media_type,
             scope: spec.scope.clone(),
-        };
-
-        sink.write_record(&header.encode()?)?;
-
-        Ok(sink)
+        })
     }
 
     /// Write the inscription in canonical form and return its digest — the

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -136,11 +136,13 @@ pub use oci_client::Reference;
 
 use crate::{
     digest::{LayerDigests, LayerWriter},
-    frame::{CanonicalCbor, LayerHeader, Limits, SeqWriter},
+    frame::{CanonicalCbor, Limits, SeqWriter},
     inscription::{canonical_json, Inscription, LayerDescriptor},
     layer::LayerReader,
-    profile::{checked_layer_media_type, checked_tag_for_sequence, validate_tag, Profile},
-    transport::{BlobIndex, LayerSpec, RecordSink, SteleReader, SteleWriter, WrittenLayer},
+    profile::{checked_tag_for_sequence, validate_tag, Profile},
+    transport::{
+        open_layer, BlobIndex, LayerSpec, RecordSink, SteleReader, SteleWriter, WrittenLayer,
+    },
     Digest, Error, ARTIFACT_TYPE, INSCRIPTION_MEDIA_TYPE, MANIFEST_SIZE_LIMIT,
 };
 
@@ -871,23 +873,15 @@ impl SteleWriter for Registry {
         spec: &LayerSpec,
         level: i32,
     ) -> Result<RegistrySink, Error> {
-        let media_type = checked_layer_media_type(profile, &spec.kind)?;
-        let header = LayerHeader::new(profile.name(), &spec.kind, spec.header_scope.clone());
+        let (sequence, media_type) = open_layer(profile, spec, level, || self.shared.scratch())?;
 
-        let mut sink = RegistrySink {
+        Ok(RegistrySink {
             shared: Arc::clone(&self.shared),
-            sequence: SeqWriter::with_max_record(
-                LayerWriter::new(self.shared.scratch()?, level)?,
-                profile.max_record(),
-            ),
+            sequence,
             kind: spec.kind.clone(),
             media_type,
             scope: spec.scope.clone(),
-        };
-
-        sink.write_record(&header.encode()?)?;
-
-        Ok(sink)
+        })
     }
 
     /// Publish the manifest, and with it the stele.

--- a/crates/stelae/src/transport.rs
+++ b/crates/stelae/src/transport.rs
@@ -237,6 +237,43 @@ pub trait SteleWriter {
     }
 }
 
+/// Open a layer: everything every [`SteleWriter::layer_sink`] does before its
+/// own sink struct exists.
+///
+/// The media type is resolved through the profile and validated against the
+/// naming rules, the framing is wrapped at the profile's record ceiling, and
+/// the encoded [`LayerHeader`] goes in as the layer's first record. All three
+/// are inside the layer's identity, so a transport that skipped any of them
+/// would produce blobs that hash cleanly and are refused on read — a failure
+/// that would be that transport's alone, invisible to every test exercising
+/// the others. It lives here, once, so the next transport cannot open a layer
+/// wrongly by omission.
+///
+/// The byte destination arrives as a closure rather than a value because the
+/// order matters: a profile claiming a media type it does not own is refused
+/// *before* `sink` runs, so nothing is created — no staging file, no scratch
+/// file — for a layer that was never going to be written.
+pub(crate) fn open_layer<W, F>(
+    profile: &dyn Profile,
+    spec: &LayerSpec,
+    level: i32,
+    sink: F,
+) -> Result<(SeqWriter<LayerWriter<W>>, String), Error>
+where
+    W: std::io::Write,
+    F: FnOnce() -> Result<W, Error>,
+{
+    let media_type = checked_layer_media_type(profile, &spec.kind)?;
+    let header = LayerHeader::new(profile.name(), &spec.kind, spec.header_scope.clone());
+
+    let mut sequence =
+        SeqWriter::with_max_record(LayerWriter::new(sink()?, level)?, profile.max_record());
+
+    sequence.write_record(&header.encode()?)?;
+
+    Ok((sequence, media_type))
+}
+
 /// A stele that computes its identity and stores nothing.
 ///
 /// The write half of the seam with the storing taken out. Every field of a
@@ -345,22 +382,14 @@ impl SteleWriter for Discarding {
         spec: &LayerSpec,
         level: i32,
     ) -> Result<DiscardingSink, Error> {
-        let media_type = checked_layer_media_type(profile, &spec.kind)?;
-        let header = LayerHeader::new(profile.name(), &spec.kind, spec.header_scope.clone());
+        let (sequence, media_type) = open_layer(profile, spec, level, || Ok(std::io::sink()))?;
 
-        let mut sink = DiscardingSink {
-            sequence: SeqWriter::with_max_record(
-                LayerWriter::new(std::io::sink(), level)?,
-                profile.max_record(),
-            ),
+        Ok(DiscardingSink {
+            sequence,
             kind: spec.kind.clone(),
             media_type,
             scope: spec.scope.clone(),
-        };
-
-        sink.write_record(&header.encode()?)?;
-
-        Ok(sink)
+        })
     }
 
     /// Return the stele's identity without writing it down.


### PR DESCRIPTION
Plan: `plans/dolos-stelae-sink-prologue.md` — residue of the publisher-commands work, raised in review of #1188 and deferred there because two of the three copies predate that branch.

## What changed

The three `SteleWriter::layer_sink` implementations in `crates/stelae` — `dir.rs`, `oci.rs` and the `Discarding` writer in `transport.rs` — each opened a layer with the same four statements:

1. resolve the media type through `checked_layer_media_type`;
2. build a `LayerHeader` from the profile name, the kind and the header scope;
3. wrap a `LayerWriter` in a `SeqWriter::with_max_record` at the profile's ceiling;
4. write the encoded header as the layer's first record.

Only the middle varied: where the compressed bytes go (a temp file, a scratch file, `io::sink()`) and what struct holds them.

That prologue is the layer format's opening contract, not boilerplate. A transport that skipped the header record, or wrapped the writer without the record ceiling, would produce blobs that hash cleanly and are refused on read — and the failure would be that transport's alone, invisible to every test exercising the other two.

`transport::open_layer` now holds it, beside the trait it serves. Each `layer_sink` keeps only what is genuinely its own: obtaining its byte destination and assembling its sink struct.

**The byte destination arrives as a closure, not a value.** That is the one shape decision worth naming: it keeps the ordering the old code had, in which the media type is validated *before* anything is created — so a profile claiming a name it does not own is still refused without a staging file or a scratch file having been made. Passing the sink eagerly would have quietly moved that line, and `SteleDir::layer_sink`'s doc comment ("refused before anything is created on disk") would have become false.

No behaviour change; no new coverage owed. The roundtrip, publish and registry suites all read layers back through the format, so a drifted prologue already fails them.

## Out of scope

The sink structs, `finish`/`RecordSink` (already sharing `SeqWriter`), and any change to the header, the ceiling or the framing. This is an extraction; a format change is not.

## Verification

Run at the repository's pinned toolchain (`1.93`).

`cargo test` — whole workspace, all green:

```
test result: ok. 41 passed; 0 failed; 1 ignored
test result: ok. 26 passed; 0 failed; 1 ignored
test result: ok. 24 passed; 0 failed; 0 ignored
test result: ok. 16 passed; 0 failed; 1 ignored
test result: ok. 15 passed; 0 failed; 0 ignored
test result: ok. 10 passed; 0 failed; 0 ignored
test result: ok.  9 passed; 0 failed; 0 ignored    (stelae_restore)
test result: ok.  6 passed; 0 failed; 0 ignored    (x2)
test result: ok.  6 passed; 0 failed; 6 ignored    (e2e/sync)
test result: ok.  4 passed; 0 failed; 0 ignored
test result: ok.  1 passed; 0 failed; 0 ignored
test result: ok.  0 passed; 0 failed; 2 ignored
```

`cargo clippy --all-targets --all-features -- -D warnings` — clean.
`cargo +nightly fmt --all -- --check` — clean.
`cargo deny check advisories` — `advisories ok`.

### The `#[ignore]`d registry suites, against a spawned registry

An extraction that changed a published byte would show up nowhere else, so these were run rather than trusted.

`cargo test -p stelae --all-features --test oci -- --ignored`:

```
running 10 tests
test a_layer_whose_blob_is_not_there_cannot_be_carried_forward ... ok
test a_layer_that_is_not_the_one_described_is_refused ... ok
test a_second_push_uploads_only_what_is_missing ... ok
test a_same_kind_blob_is_refused_when_the_layer_ends ... ok
test the_read_only_pair_pulls_and_cannot_push ... ok
test latest_is_absent_until_something_is_published ... ok
test neither_direction_holds_a_layer ... ok
test a_stele_survives_the_round_trip ... ok
test staging_stays_in_the_scratch_directory_and_leaves_nothing ... ok
test credentials_are_required ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 15.17s
```

`cargo test -p dolos-snapshot --features oci --test publish --test restore_registry --test snapshot_verify -- --ignored`:

```
running 8 tests   (publish.rs)
test a_publish_sizes_its_staging_off_the_stele_before_it ... ok
test a_publisher_can_ask_where_it_stands ... ok
test a_second_publish_builds_and_uploads_only_what_is_new ... ok
test a_publish_that_does_not_follow_latest_is_refused ... ok
test a_dry_run_agrees_with_the_publish_that_follows_it ... ok
test a_stele_published_with_reuse_is_reproduced_from_the_stores ... ok
test a_different_predecessor_is_a_different_digest ... ok
test reuse_and_a_forced_rebuild_agree_on_the_digest ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.99s

running 5 tests   (restore_registry.rs)
test a_point_that_names_no_stele_is_refused ... ok
test a_node_authenticates_with_the_credentials_it_was_given ... ok
test a_registry_restore_is_a_directory_restore ... ok
test a_killed_registry_restore_resumes_where_it_stopped ... ok
test a_pre_seeded_node_fetches_only_what_it_lacks ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.80s

running 6 tests   (snapshot_verify.rs)
test a_diff_id_annotation_that_disagrees_is_refused ... ok
test a_blob_that_is_not_the_layer_is_refused_with_the_layer_named ... ok
test a_history_that_skips_a_sequence_is_refused ... ok
test an_inspection_reports_the_manifest_and_its_json_chains_a_digest ... ok
test a_reproduction_passes_at_the_published_epoch_and_fails_at_another ... ok
test a_freshly_published_stele_verifies_clean ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.97s
```

`reuse_and_a_forced_rebuild_agree_on_the_digest` and `a_stele_published_with_reuse_is_reproduced_from_the_stores` are the ones that would have caught a moved byte. No digest moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## A CI flake, not a finding of this branch

The first `Test (ubuntu-latest)` run failed on two tests in `crates/snapshot/src/preflight.rs` — `a_measured_shortfall_refuses_and_an_unmeasurable_need_does_not` and `needs_sharing_a_volume_are_summed`. Neither is in a file this branch touches. Both read the runner's live free space and then assert that a need of `available + 1` is refused, so a runner that frees a byte between the two calls turns the refusal into a pass and `unwrap_err` panics. A re-run of the same commit was green.

Worth its own fix eventually — the tests should pin the measurement they assert against rather than re-reading a moving one — but that is not this branch's concern.
