### PR TITLE
fix(stelae): a staging directory that cannot be used says which one

### DIFF
--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -283,6 +283,29 @@ pub enum Error {
     #[error("{value:?} is not an OCI repository: {reason}")]
     InvalidRepository { value: String, reason: String },
 
+    /// A staging directory the transport could not use.
+    ///
+    /// Distinct from [`Error::Io`], which is the catch-all every other bare
+    /// `?` in this crate falls through, because this is the one path an
+    /// operator types on a command line — `dolos snapshot publish
+    /// --scratch-dir`, `dolos bootstrap stelae --scratch-dir`, or the default
+    /// the binary derives from `storage.path`. A typo, an unmounted volume, a
+    /// directory owned by somebody else and a path that is already a regular
+    /// file all arrive here, and `std::io::Error` carries none of them: it
+    /// knows the errno and not the path that produced it. So the path is
+    /// captured where it is still in scope, which is the only place it can be.
+    ///
+    /// The message deliberately does *not* repeat what the operating system
+    /// said — that stays on the source, one line further down the chain, so a
+    /// rendered report says each thing once.
+    #[cfg(feature = "oci")]
+    #[error("cannot use {} as the staging directory", dir.display())]
+    Scratch {
+        dir: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     /// Anything the registry client reported.
     #[cfg(feature = "oci")]
     #[error("registry error: {0}")]

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -735,11 +735,9 @@ fn is_absent(error: &oci_client::errors::OciDistributionError) -> bool {
 /// A staged file, created where [`Options::scratch_dir`] said.
 ///
 /// Both calls that can fail against a *named* directory raise
-/// [`Error::Scratch`] rather than falling through `#[from]` into
-/// [`Error::Io`]: this directory came from an operator — `--scratch-dir`, or
-/// the default a host derives for them — and an errno with no path in it
-/// leaves them nothing to correct. The unnamed case keeps the catch-all,
-/// because the platform temporary directory is not a path anybody chose.
+/// [`Error::Scratch`], whose docstring carries the reason. The unnamed case
+/// keeps the catch-all [`Error::Io`], because the platform temporary
+/// directory is not a path anybody chose.
 ///
 /// Creating the directory lazily, here, is load-bearing elsewhere: it is what
 /// makes a staging directory that exists after a run evidence that the run
@@ -1715,9 +1713,6 @@ mod tests {
     }
 
     /// The unnamed case keeps the catch-all, and still works.
-    ///
-    /// `None` is the platform temporary directory — nothing an operator chose,
-    /// so nothing [`Error::Scratch`] could usefully name.
     #[test]
     fn an_unnamed_staging_directory_still_stages() {
         scratch_in(None).expect("the platform temporary directory is unusable");

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -732,6 +732,37 @@ fn is_absent(error: &oci_client::errors::OciDistributionError) -> bool {
     }
 }
 
+/// A staged file, created where [`Options::scratch_dir`] said.
+///
+/// Both calls that can fail against a *named* directory raise
+/// [`Error::Scratch`] rather than falling through `#[from]` into
+/// [`Error::Io`]: this directory came from an operator — `--scratch-dir`, or
+/// the default a host derives for them — and an errno with no path in it
+/// leaves them nothing to correct. The unnamed case keeps the catch-all,
+/// because the platform temporary directory is not a path anybody chose.
+///
+/// Creating the directory lazily, here, is load-bearing elsewhere: it is what
+/// makes a staging directory that exists after a run evidence that the run
+/// staged in it. Nothing else creates it.
+///
+/// A free function rather than a method so it can be tested against an
+/// unusable directory without standing up a registry client — see
+/// `an_unusable_staging_directory_names_itself`.
+fn scratch_in(dir: Option<&Path>) -> Result<File, Error> {
+    let Some(dir) = dir else {
+        return Ok(tempfile::tempfile()?);
+    };
+
+    let staged = |source| Error::Scratch {
+        dir: dir.to_path_buf(),
+        source,
+    };
+
+    std::fs::create_dir_all(dir).map_err(staged)?;
+
+    tempfile::tempfile_in(dir).map_err(staged)
+}
+
 impl Shared {
     fn locked(&self) -> std::sync::MutexGuard<'_, PushState> {
         // A poisoned lock means a push panicked while holding it. The counters
@@ -752,15 +783,7 @@ impl Shared {
     }
 
     fn scratch(&self) -> Result<File, Error> {
-        let file = match &self.scratch_dir {
-            Some(dir) => {
-                std::fs::create_dir_all(dir)?;
-                tempfile::tempfile_in(dir)?
-            }
-            None => tempfile::tempfile()?,
-        };
-
-        Ok(file)
+        scratch_in(self.scratch_dir.as_deref())
     }
 
     fn blob_exists(&self, digest: &Digest) -> Result<bool, Error> {
@@ -1653,5 +1676,50 @@ mod tests {
             }
         );
         assert!(!printed.contains("hunter2"), "{printed}");
+    }
+
+    /// A staging directory that cannot be used says which one, and why.
+    ///
+    /// The registry suite covers the same ground through a real publish, but
+    /// it needs a container and is `#[ignore]`d for it; this is the claim
+    /// under plain `cargo test`. The path names an existing regular file,
+    /// which `create_dir_all` cannot turn into a directory for anybody, `root`
+    /// included — so it is the one unusable directory that reproduces on every
+    /// platform and under every user the suite might run as.
+    #[test]
+    fn an_unusable_staging_directory_names_itself() {
+        let root = tempfile::tempdir().unwrap();
+        let occupied = root.path().join("not-a-directory");
+        std::fs::write(&occupied, b"").unwrap();
+
+        let error = scratch_in(Some(&occupied)).expect_err("staged in a regular file");
+
+        assert!(
+            matches!(&error, Error::Scratch { dir, .. } if dir == &occupied),
+            "fell through to the catch-all: {error:?}",
+        );
+
+        // The two halves the old `io error: File exists (os error 17)` had
+        // neither of: which directory, and that it was the staging one.
+        let message = error.to_string();
+        assert!(
+            message.contains(&occupied.display().to_string()),
+            "{message}",
+        );
+        assert!(message.contains("staging directory"), "{message}");
+
+        // And what the operating system said, exactly once, one line down the
+        // chain rather than repeated into the message above it.
+        let source = std::error::Error::source(&error).expect("no cause to render");
+        assert!(!message.contains(&source.to_string()), "{message}");
+    }
+
+    /// The unnamed case keeps the catch-all, and still works.
+    ///
+    /// `None` is the platform temporary directory — nothing an operator chose,
+    /// so nothing [`Error::Scratch`] could usefully name.
+    #[test]
+    fn an_unnamed_staging_directory_still_stages() {
+        scratch_in(None).expect("the platform temporary directory is unusable");
     }
 }

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1650,6 +1650,84 @@ fn staging_stays_in_the_scratch_directory_and_leaves_nothing() {
     assert!(left.is_empty(), "{left:?}");
 }
 
+/// A staging directory that cannot be used says which one, in both directions.
+///
+/// The operator this is for has just been told, by `--scratch-dir`'s own help,
+/// to point the tool at a volume with room on it — so the paths that arrive
+/// here are typos, unmounted volumes, and directories owned by somebody else.
+/// What they used to get was `io error: File exists (os error 17)`, three
+/// times over and naming neither the path nor what it was for, because
+/// `std::io::Error` carries the errno and not the path that produced it.
+///
+/// Both directions, because one [`Options::scratch_dir`] serves both — a sink
+/// on the way up and a pulled blob on the way down — and fixing the direction
+/// somebody happened to test first is how this defect would come back.
+///
+/// The unusable directory is an existing regular file: `create_dir_all` cannot
+/// turn one into a directory for anybody, `root` included, so it reproduces on
+/// every platform and under whatever user CI runs as.
+/// `an_unusable_staging_directory_names_itself` in `src/oci.rs` makes the same
+/// claim without a container; this one makes it through a real publish and a
+/// real pull.
+#[test]
+#[ignore = "spawns a registry"]
+fn a_staging_directory_that_cannot_be_used_names_itself() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    let root = tempfile::tempdir().unwrap();
+    let occupied = root.path().join("not-a-directory");
+    std::fs::write(&occupied, b"").unwrap();
+
+    let names_it = |err: &Error| {
+        assert!(
+            matches!(err, Error::Scratch { dir, .. } if dir == &occupied),
+            "fell through to the catch-all: {err:?}",
+        );
+
+        let message = err.to_string();
+        assert!(
+            message.contains(&occupied.display().to_string()),
+            "{message}",
+        );
+        assert!(message.contains("staging directory"), "{message}");
+    };
+
+    // Up: the sink stages the layer it is building.
+    let (header_scope, scope) = notes_scope(3);
+    let Err(err) = fixture
+        .registry_staging_in("stelae/occupied", Some(occupied.clone()))
+        .layer_sink(
+            &ToyProfile,
+            &LayerSpec::new("notes", header_scope, scope),
+            COMPRESSION_LEVEL,
+        )
+    else {
+        panic!("staged a layer in a regular file")
+    };
+
+    names_it(&err);
+
+    // Down: the same directory, against a stele that is really there. Published
+    // through a staging directory that works, so what fails below is the pull.
+    let staged = tempfile::tempdir().unwrap();
+    let published = write_stele(
+        &fixture.registry_staging_in("stelae/occupied", Some(staged.path().to_owned())),
+        3,
+    );
+
+    let reader = fixture.registry_staging_in("stelae/occupied", Some(occupied.clone()));
+    let stele = reader.pull_latest(&ToyProfile).unwrap();
+    let index = stele.blob_index().unwrap();
+
+    let err = stele
+        .stream_layer(&index, &ToyProfile, &published.layers[0], Limits::default())
+        .expect_err("staged a pulled blob in a regular file");
+
+    names_it(&err);
+}
+
 /// `latest` tells "this repository holds nothing" apart from "this repository
 /// could not be read", which is the distinction a publisher's history chain
 /// rests on.

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1652,23 +1652,14 @@ fn staging_stays_in_the_scratch_directory_and_leaves_nothing() {
 
 /// A staging directory that cannot be used says which one, in both directions.
 ///
-/// The operator this is for has just been told, by `--scratch-dir`'s own help,
-/// to point the tool at a volume with room on it — so the paths that arrive
-/// here are typos, unmounted volumes, and directories owned by somebody else.
-/// What they used to get was `io error: File exists (os error 17)`, three
-/// times over and naming neither the path nor what it was for, because
-/// `std::io::Error` carries the errno and not the path that produced it.
-///
 /// Both directions, because one [`Options::scratch_dir`] serves both — a sink
 /// on the way up and a pulled blob on the way down — and fixing the direction
 /// somebody happened to test first is how this defect would come back.
 ///
-/// The unusable directory is an existing regular file: `create_dir_all` cannot
-/// turn one into a directory for anybody, `root` included, so it reproduces on
-/// every platform and under whatever user CI runs as.
 /// `an_unusable_staging_directory_names_itself` in `src/oci.rs` makes the same
-/// claim without a container; this one makes it through a real publish and a
-/// real pull.
+/// claim without a container, and says why the unusable directory is an
+/// existing regular file; this one makes it through a real publish and a real
+/// pull.
 #[test]
 #[ignore = "spawns a registry"]
 fn a_staging_directory_that_cannot_be_used_names_itself() {


### PR DESCRIPTION
Plan: `plans/dolos-stelae-scratch-dir-diagnostics.md` (Trellis domain root), filed as residue of #1191.

## What was wrong

`--scratch-dir` on `dolos snapshot publish` and `dolos bootstrap stelae` takes a
filesystem path an operator types, and its default is derived from `storage.path`.
Both are paths people get wrong: a typo, a volume that is not mounted yet, a
directory owned by somebody else, a path that is already a regular file.

Pointed at a regular file, a publish said this and nothing else:

```
Error:   × publishing the stele
  ├─▶ stelae error: io error: File exists (os error 17)
  ├─▶ io error: File exists (os error 17)
  ╰─▶ File exists (os error 17)
```

Three lines saying the same thing three times, and not one of them names the
path, the flag, or the fact that this was a staging directory rather than the
stele, the registry, or a store. `stelae::oci::Shared::scratch` raised both of
its fallible calls — `create_dir_all` and `tempfile_in` — through
`Error::Io`'s `#[from]`, and `std::io::Error` carries the errno without the path
that produced it.

## What changed

`Error::Scratch { dir, source }` in `crates/stelae/src/lib.rs`, raised by the
scratch path for both calls that can fail against a directory somebody named.
The variant belongs in `stelae` because that is where the path is in scope — a
`miette` context on the `dolos` side would name the flag but not the path, since
the binary cannot tell which of the transport's many IO calls failed.

The message names the directory and what it was for and stops there; the
operating system's own words stay on the `#[source]`, one line further down the
chain, so a rendered report says each thing once:

```
  ├─▶ stelae error: cannot use /mnt/fast/scratch as the staging directory
  ╰─▶ File exists (os error 17)
```

The unnamed case (`scratch_dir: None`, the platform temporary directory) keeps
the catch-all — nobody chose that path, so there is nothing useful to name.

**No new check and no new refusal.** The failure already happened; only what it
says changes. Sizing the staging volume before the fact is the preflight's job
(#1192), and a check here would collide with it. The flags, their defaults and
their help are untouched (#1191).

## Tests

- `crates/stelae/src/oci.rs` — `an_unusable_staging_directory_names_itself`
  covers the scratch path directly against a path that is an existing regular
  file, which `create_dir_all` cannot turn into a directory for anybody, `root`
  included. Under plain `cargo test`: no container, no crypto provider. This is
  why `scratch` became a free function rather than staying a method on `Shared`
  — a method needs a registry client to reach.
- `crates/stelae/tests/oci.rs` —
  `a_staging_directory_that_cannot_be_used_names_itself` makes the same claim
  through a real publish and a real pull. Both directions, because one
  `Options::scratch_dir` serves the sink on the way up and the pulled blob on the
  way down, and fixing whichever direction was tested first is how this defect
  comes back. Rides the existing `registry.yml` gate; no new CI wiring.

## Verification

Run against a clean `main` worktree:

- `cargo test -p stelae --all-features` — pass
- `cargo test -p stelae --all-features --test oci -- --ignored a_staging_directory_that_cannot_be_used_names_itself` — pass against a real `registry:2`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo deny check advisories` — ok
- `cargo tree -p stelae -e normal --all-features` — no `^dolos(-|$)` package; the ADR-004 boundary holds

The full-workspace `cargo test` could not be run locally — the host disk filled
mid-build (121 MiB free of 460 GiB), which is a machine condition and not this
change. It is left to CI, which is why this is a draft.

## Note for the reviewer

The plan's done criterion 1 names a CLI test at `tests/stelae_scratch.rs`. That
file never landed on `main` — it existed on `feat/stelae-scratch-dir` and was
dropped from #1191's squash — so there was nothing to amend. The criterion's
substance (a publish and a restore each told to stage at a regular-file path
fail with a message naming the path and identifying it as the staging directory)
is covered in `crates/stelae/tests/oci.rs` instead, which is already Docker-gated
and already wired into `registry.yml`. Recreating the CLI suite would also mean a
new `registry.yml` step and its `AGENTS.md` mirror — scope the plan did not
budget, and adjacent to the flag work it explicitly fences off. Raised as an open
escalation on the plan for `org/founder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when temporary staging directories cannot be created or used.
  * Errors now identify the affected directory and provide clearer staging context.
  * Preserved existing behavior for unnamed temporary files.

* **Tests**
  * Added coverage for staging failures during uploads and downloads.
  * Added validation for successful unnamed temporary-file staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->