### PR TITLE
test(stelae): preflight margins that do not race the disk

### DIFF
--- a/crates/snapshot/src/preflight.rs
+++ b/crates/snapshot/src/preflight.rs
@@ -272,6 +272,17 @@ fn same_volume(a: &Path, b: &Path) -> bool {
 mod tests {
     use super::*;
 
+    // Every need here is a proportion of the free space the test measured, and
+    // deliberately a coarse one: `check()` takes its own measurement of the
+    // same volume, so an assertion pinned within a few bytes of what the test
+    // read is a race against whatever else the machine is doing — under
+    // `cargo test`'s threads, that includes the other tests in this module
+    // creating and dropping temporary directories. A need asserted to fit
+    // stays a fraction of the pool so a sharp fall still leaves room; a need
+    // asserted to refuse stays well over it so a sharp rise still refuses. A
+    // fixed byte cushion would not do: runner free space differs by orders of
+    // magnitude across hosts, and only a proportion is generous on all of them.
+
     /// The whole of the free-space policy, over needs that share one volume.
     ///
     /// Both halves in one test because they are one rule: what was measured
@@ -283,9 +294,9 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let available = fs4::available_space(temp.path()).unwrap();
 
-        check(&[Need::of("restoring it", temp.path(), available / 2)]).unwrap();
+        check(&[Need::of("restoring it", temp.path(), available / 4)]).unwrap();
 
-        let err = check(&[Need::of("restoring it", temp.path(), available + 1)]).unwrap_err();
+        let err = check(&[Need::of("restoring it", temp.path(), available / 2 * 3)]).unwrap_err();
         assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
 
         // Nothing sized it, so nothing refuses — however impossible the run.
@@ -321,7 +332,9 @@ mod tests {
         std::fs::create_dir(&beside).unwrap();
 
         let available = fs4::available_space(&storage).unwrap();
-        let each = available / 2 + 1;
+        // Three quarters of the pool: one fits with a quarter to spare, and the
+        // pair asks half again as much as the whole of it.
+        let each = available / 4 * 3;
 
         for scratch in [storage.join("scratch"), beside] {
             check(&[Need::of("restoring it", &storage, each)]).unwrap();


### PR DESCRIPTION
Plan: `plans/dolos-stelae-preflight-space-test-race.md` (Trellis, `org/coder`).

## The defect

`crates/snapshot/src/preflight.rs`'s test module measures the real filesystem
once, derives a need from that reading, and hands it to `check()` — which calls
`fs4::available_space` again on its own, at `preflight.rs:129`. Nothing holds
the disk still between the two reads, and under `cargo test`'s threads the
module's own tests are creating and dropping temporary directories throughout.
The assertions were pinned within one or two bytes of the first reading:

- `a_measured_shortfall_refuses_and_an_unmeasurable_need_does_not` asserted that
  `available + 1` refuses — free space rising by **one byte** makes it `Ok` and
  `unwrap_err()` panics.
- `needs_sharing_a_volume_are_summed` used `each = available / 2 + 1`, a summed
  need of `available + 2` — the same at **two bytes**.

Both have failed in CI on `Test (ubuntu-latest)`, on different runs, which is
what identifies one defect rather than one bad test:

| run | commit | failing test |
|---|---|---|
| [31597147613](https://github.com/txpipe/dolos/actions/runs/31597147613) | `main` @ `7a5a6599` | `a_measured_shortfall_refuses_and_an_unmeasurable_need_does_not` |
| [31620016655](https://github.com/txpipe/dolos/actions/runs/31620016655) | #1200 head | `needs_sharing_a_volume_are_summed` |

## The change

Test module only — no production code, no change to the policy, the refusal
wording, or `same_volume`. Every margin becomes a proportion of the measured
free space: a need asserted to fit is at most `available / 4`, a need asserted
to refuse is at least `available / 2 * 3`, and the shared-volume pair uses
`each = available / 4 * 3` (fits alone with a quarter to spare, needs half again
as much as the pool as a pair). A comment states why the margins are
proportional, so a test added here later inherits the constraint instead of
rediscovering it in CI.

`a_path_that_does_not_exist_yet_is_measured_through_its_parent` is untouched:
its need is one byte and its assertions are about `probe_of`.

Injecting a free-space probe seam into `check()` so the tests never touch a real
filesystem is the durable fix and is deliberately out of scope — it widens the
module's public surface to serve its tests, and part of the policy's value is
being exercised against a real volume. If this module flakes again, that seam is
the escalation rather than a second widening.

## Verification

On the pinned toolchain (1.93): `cargo test --workspace` green,
`cargo clippy --all-targets --all-features -- -D warnings` clean,
`cargo +nightly fmt --all -- --check` clean.

A flake's absence is not provable by re-running, so the deliverable is the
structural property — no assertion rests on free space holding within a few
bytes of a prior read — and a green run is corroboration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved free-space test reliability across environments with varying disk capacity.
  * Reduced sensitivity to concurrent activity and host-specific storage conditions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->