### PR TITLE
fix: shut down tracer provider on CLI exit

### DIFF
--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -7,7 +7,9 @@ use dolos_snapshot::registry::Auth;
 use miette::{Context as _, IntoDiagnostic};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::{fs, path::PathBuf, time::Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -19,6 +21,8 @@ use dolos::prelude::*;
 use dolos::storage;
 
 pub type Stores = storage::Stores<dolos_cardano::CardanoDelta>;
+
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
 /// Ensure the storage root directory exists.
 pub fn ensure_storage_path(config: &RootConfig) -> Result<PathBuf, Error> {
@@ -285,6 +289,7 @@ pub fn setup_tracing(config: &LoggingConfig, telemetry: &TelemetryConfig) -> mie
             .build();
 
         opentelemetry::global::set_tracer_provider(tracer.clone());
+        let _ = TRACER_PROVIDER.set(tracer.clone());
 
         let layer = tracing_opentelemetry::layer().with_tracer(tracer.tracer("dolos"));
         Some(layer)
@@ -317,6 +322,20 @@ pub fn setup_tracing(config: &LoggingConfig, telemetry: &TelemetryConfig) -> mie
     tracing_log::LogTracer::init().ok();
 
     Ok(())
+}
+
+/// Flush and stop the batch span exporter before the process exits.
+///
+/// The global provider owns a clone, so merely dropping the local provider from
+/// `setup_tracing` does not stop its worker or export its final batch. Keeping a
+/// handle here lets the CLI perform an explicit shutdown after every command,
+/// including commands that do not run the long-lived daemon pipeline.
+pub fn shutdown_tracing() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(error) = provider.shutdown() {
+            eprintln!("failed to shut down OpenTelemetry tracer provider: {error}");
+        }
+    }
 }
 
 pub fn open_genesis_files(config: &GenesisConfig) -> miette::Result<Genesis> {

--- a/src/bin/dolos/main.rs
+++ b/src/bin/dolos/main.rs
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
 
     let feedback = crate::feedback::Feedback::default();
 
-    match (config, args.command) {
+    let result = match (config, args.command) {
         (Ok(config), Command::Daemon(args)) => daemon::run(config, &args),
         (Ok(config), Command::Sync(args)) => sync::run(&config, &args),
         (Ok(config), Command::Serve(args)) => serve::run(config, &args),
@@ -119,5 +119,8 @@ fn main() -> Result<()> {
         (Ok(config), Command::Minikupo(x)) => minikupo::run(&config, &x),
 
         (Err(x), _) => Err(x),
-    }
+    };
+
+    crate::common::shutdown_tracing();
+    result
 }


### PR DESCRIPTION
## Summary
- retain the configured OpenTelemetry tracer provider for the process lifetime
- flush and shut it down after every CLI command, including error exits

Closes #893.

## Validation
- `cargo check -p dolos --bin dolos`
- `cargo test -p dolos --bin dolos` (26 passed, 1 ignored)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown by properly closing telemetry after command execution.
  * Added error reporting when telemetry shutdown encounters a problem.
  * Ensured command results are preserved and returned after shutdown completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->