### PR TITLE
style(snapshot): normalize the preflight test comments

### DIFF
--- a/crates/snapshot/src/preflight.rs
+++ b/crates/snapshot/src/preflight.rs
@@ -268,20 +268,17 @@ fn same_volume(a: &Path, b: &Path) -> bool {
     }
 }
 
+/// Every need here is a proportion of the free space the test measured, and
+/// deliberately a coarse one: `check()` takes its own measurement of the same
+/// volume, so an assertion pinned within a few bytes of what the test read is a
+/// race against whatever else the machine is doing — under `cargo test`'s
+/// threads, that includes the other tests in this module creating and dropping
+/// temporary directories. A fixed byte cushion would not do: runner free space
+/// differs by orders of magnitude across hosts, and only a proportion is
+/// generous on all of them.
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // Every need here is a proportion of the free space the test measured, and
-    // deliberately a coarse one: `check()` takes its own measurement of the
-    // same volume, so an assertion pinned within a few bytes of what the test
-    // read is a race against whatever else the machine is doing — under
-    // `cargo test`'s threads, that includes the other tests in this module
-    // creating and dropping temporary directories. A need asserted to fit
-    // stays a fraction of the pool so a sharp fall still leaves room; a need
-    // asserted to refuse stays well over it so a sharp rise still refuses. A
-    // fixed byte cushion would not do: runner free space differs by orders of
-    // magnitude across hosts, and only a proportion is generous on all of them.
 
     /// The whole of the free-space policy, over needs that share one volume.
     ///
@@ -332,8 +329,8 @@ mod tests {
         std::fs::create_dir(&beside).unwrap();
 
         let available = fs4::available_space(&storage).unwrap();
-        // Three quarters of the pool: one fits with a quarter to spare, and the
-        // pair asks half again as much as the whole of it.
+        // One of these fits with a quarter of the pool to spare; the pair asks
+        // half again as much as the whole of it.
         let each = available / 4 * 3;
 
         for scratch in [storage.join("scratch"), beside] {


### PR DESCRIPTION
Residue from PR #1203, which merged before the code-quality sweep reached its branch.

#1203 fixed the free-space race in `crates/snapshot/src/preflight.rs`'s test module and, in doing so, added a ten-line inline preamble explaining why every need is asserted as a *proportion* of measured free space rather than a fixed byte cushion. That rationale describes the module, so it belongs in the module's docstring rather than floating as a comment block inside it.

Comment-only: no test, assertion, or threshold changes.

- Promotes the margin rationale to a docstring on `mod tests`.
- Trims two sentences that restated the fit/refuse directions already evident from the assertions themselves.
- Rewrites the `each = available / 4 * 3` comment to say what the value buys rather than restate the arithmetic.

Verified on this branch against current `main`: `cargo +nightly fmt --all -- --check` and `cargo test -p dolos-snapshot --lib preflight` (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test documentation for proportional free-space sizing.
  * Simplified the shared-volume test comment.
  * No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->