### PR TITLE
feat(stelae): one progress seam, watched from both directions

### DIFF
--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -61,14 +61,16 @@ use dolos_core::{
 };
 use stelae::{
     inscription::{HistoryEntry, Inscription, LayerDescriptor},
+    progress::{Observer, Outcome},
     transport::{LayerSpec, RecordSink, SteleWriter},
 };
 
 use crate::{
     layers::{blocks, digests, indexes, logs, state},
     namespaces::NAMESPACES,
+    reporting::Cursor,
     DigestsScope, DolosProfile, EpochScope, Error, Network, Scope, StateScope, BLOCKS,
-    COMPRESSION_LEVEL, DIGESTS, INDEXES, LOGS, STATE, STATE_SHARDS, UTXOS,
+    COMPRESSION_LEVEL, DIGESTS, EPOCH_KINDS, INDEXES, LOGS, STATE, STATE_SHARDS, UTXOS,
 };
 
 /// The slot window one epoch layer covers.
@@ -532,6 +534,15 @@ impl Standing {
 /// A layer it adopts is *attested without being reproduced*: this function
 /// never opens a sink for it and never touches a store on its behalf, which is
 /// the whole saving and the whole risk. See [`Predecessor::adopt`].
+///
+/// `observer` is who hears about it while it happens, and
+/// [`Observer::silent`] is what every caller that does not care passes: a
+/// silent run does exactly what this function did before the seam existed,
+/// byte for byte. The observer is forwarded to `stele` as well as reported
+/// through here, because the two halves of what an operator wants to see live
+/// in two places — this loop knows which layer of how many, and only the
+/// transport knows how much of it has moved.
+#[allow(clippy::too_many_arguments)]
 pub fn export<W, A, S, I>(
     stele: &W,
     plan: &Plan,
@@ -540,6 +551,7 @@ pub fn export<W, A, S, I>(
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     previous: &dyn Predecessor,
+    observer: &Observer,
 ) -> Result<Inscription, Error>
 where
     W: SteleWriter,
@@ -547,11 +559,21 @@ where
     S: StateStore,
     I: IndexStore,
 {
+    stele.observe(observer.clone());
+
+    // The same arithmetic `crate::registry::preview` reports a dry run with, so
+    // "layer 12 of 52" and "build: 52 layers" cannot disagree.
+    let total = plan.epochs.len() * EPOCH_KINDS.len()
+        + STATE_SHARDS as usize
+        + usize::from(digest_records.is_some());
+
+    let mut cursor = Cursor::new(observer, total);
+
     let mut layers = Vec::new();
 
     for window in &plan.epochs {
         landed(
-            write_blocks(stele, plan, archive, window, previous)?,
+            write_blocks(stele, plan, archive, window, previous, &mut cursor)?,
             previous,
             &mut layers,
         )?;
@@ -559,7 +581,7 @@ where
 
     for window in &plan.epochs {
         landed(
-            write_indexes(stele, plan, indexes, window, previous)?,
+            write_indexes(stele, plan, indexes, window, previous, &mut cursor)?,
             previous,
             &mut layers,
         )?;
@@ -567,18 +589,24 @@ where
 
     for window in &plan.epochs {
         landed(
-            write_logs(stele, plan, archive, window, previous)?,
+            write_logs(stele, plan, archive, window, previous, &mut cursor)?,
             previous,
             &mut layers,
         )?;
     }
 
     // Not offered to the predecessor: see [`Predecessor::landed`].
-    layers.extend(write_state(stele, plan, state)?);
+    layers.extend(write_state(stele, plan, state, &mut cursor)?);
 
     if let Some(records) = digest_records {
-        layers.push(write_digests(stele, plan, records)?);
+        layers.push(write_digests(stele, plan, records, &mut cursor)?);
     }
+
+    debug_assert_eq!(
+        cursor.opened(),
+        layers.len(),
+        "every layer this export writes has to have been announced exactly once",
+    );
 
     let mut inscription = Inscription::new(
         &DolosProfile,
@@ -612,6 +640,7 @@ pub fn publish<A, S, I>(
     state: &S,
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
+    observer: &Observer,
 ) -> Result<Inscription, Error>
 where
     A: ArchiveStore,
@@ -628,6 +657,7 @@ where
         indexes,
         digest_records,
         &First,
+        observer,
     )
 }
 
@@ -660,6 +690,11 @@ where
     S: StateStore,
     I: IndexStore,
 {
+    // Silent, and not for want of a caller to thread one through: a
+    // reproduction stores nothing and moves nothing, so the only thing it could
+    // report is the store walk — which `dolos snapshot digest` and `verify`
+    // already print around. The seam is for the two commands that wait on a
+    // network.
     export(
         &stelae::Discarding,
         plan,
@@ -668,6 +703,7 @@ where
         indexes,
         digest_records,
         previous,
+        &Observer::silent(),
     )
 }
 
@@ -732,6 +768,7 @@ where
         indexes,
         digest_records,
         &Attested::of(published),
+        &Observer::silent(),
     )?;
 
     compare(published, &reproduced)?;
@@ -911,17 +948,22 @@ fn write_blocks<W: SteleWriter, A: ArchiveStore>(
     archive: &A,
     window: &EpochWindow,
     previous: &dyn Predecessor,
+    cursor: &mut Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
 
     let (spec, adopted) = inherit(&scope, BLOCKS, previous)?;
+    let at = cursor.open(BLOCKS, &spec.scope);
 
     if let Some(descriptor) = adopted {
+        cursor.close(at, BLOCKS, Outcome::Inherited);
+
         return Ok(descriptor);
     }
 
     let mut sink = sink(stele, &spec)?;
     let mut order = blocks::OrderCheck::default();
+    let mut records = cursor.records();
 
     let slots = window.slots();
 
@@ -935,9 +977,15 @@ fn write_blocks<W: SteleWriter, A: ArchiveStore>(
 
         order.check(&record)?;
         sink.write_record(&blocks::encode(&record)?)?;
+        records.tick();
     }
 
-    Ok(sink.finish()?.descriptor)
+    records.flush();
+
+    let descriptor = sink.finish()?.descriptor;
+    cursor.close(at, BLOCKS, Outcome::Transferred);
+
+    Ok(descriptor)
 }
 
 /// One epoch's ledger logs, ordered by `(ns, log_key)`.
@@ -951,17 +999,22 @@ fn write_logs<W: SteleWriter, A: ArchiveStore>(
     archive: &A,
     window: &EpochWindow,
     previous: &dyn Predecessor,
+    cursor: &mut Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
 
     let (spec, adopted) = inherit(&scope, LOGS, previous)?;
+    let at = cursor.open(LOGS, &spec.scope);
 
     if let Some(descriptor) = adopted {
+        cursor.close(at, LOGS, Outcome::Inherited);
+
         return Ok(descriptor);
     }
 
     let mut sink = sink(stele, &spec)?;
     let mut order = logs::OrderCheck::default();
+    let mut records = cursor.records();
 
     let slots = window.slots();
     let range = log_key_range(&slots);
@@ -977,10 +1030,16 @@ fn write_logs<W: SteleWriter, A: ArchiveStore>(
 
             order.check(&record)?;
             sink.write_record(&logs::encode(&record)?)?;
+            records.tick();
         }
     }
 
-    Ok(sink.finish()?.descriptor)
+    records.flush();
+
+    let descriptor = sink.finish()?.descriptor;
+    cursor.close(at, LOGS, Outcome::Transferred);
+
+    Ok(descriptor)
 }
 
 /// A log key range covering every log whose slot falls in `slots`.
@@ -1012,6 +1071,7 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
     store: &I,
     window: &EpochWindow,
     previous: &dyn Predecessor,
+    cursor: &mut Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
 
@@ -1019,13 +1079,17 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
     // index layer skips a whole pass over the index store, which is the cost
     // the doc comment above measures.
     let (spec, adopted) = inherit(&scope, INDEXES, previous)?;
+    let at = cursor.open(INDEXES, &spec.scope);
 
     if let Some(descriptor) = adopted {
+        cursor.close(at, INDEXES, Outcome::Inherited);
+
         return Ok(descriptor);
     }
 
     let mut sink = sink(stele, &spec)?;
     let mut order = indexes::OrderCheck::default();
+    let mut records = cursor.records();
 
     let slots = window.slots();
 
@@ -1034,6 +1098,7 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
 
         order.check(&record)?;
         sink.write_record(&indexes::encode(&record)?)?;
+        records.tick();
     }
 
     for exact in store.iter_exact_records(slots)? {
@@ -1041,9 +1106,15 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
 
         order.check(&record)?;
         sink.write_record(&indexes::encode(&record)?)?;
+        records.tick();
     }
 
-    Ok(sink.finish()?.descriptor)
+    records.flush();
+
+    let descriptor = sink.finish()?.descriptor;
+    cursor.close(at, INDEXES, Outcome::Transferred);
+
+    Ok(descriptor)
 }
 
 /// The state tip, as sixteen shards written in one pass.
@@ -1072,16 +1143,26 @@ fn write_state<W: SteleWriter, S: StateStore>(
     stele: &W,
     plan: &Plan,
     store: &S,
+    cursor: &mut Cursor<'_>,
 ) -> Result<Vec<LayerDescriptor>, Error> {
     let shards = 0..STATE_SHARDS as u8;
 
     let mut sinks = Vec::with_capacity(shards.len());
     let mut orders = Vec::with_capacity(shards.len());
+    // All sixteen are announced before the walk begins, because all sixteen are
+    // genuinely in flight from that moment: one pass over the store feeds every
+    // one of them, so there is no honest way to report them one at a time.
+    let mut positions = Vec::with_capacity(shards.len());
 
     for shard in shards {
-        sinks.push(sink(stele, &plan.state_scope(shard).layer_spec(STATE)?)?);
+        let spec = plan.state_scope(shard).layer_spec(STATE)?;
+
+        positions.push(cursor.open(STATE, &spec.scope));
+        sinks.push(sink(stele, &spec)?);
         orders.push(state::OrderCheck::for_shard(shard));
     }
+
+    let mut records = cursor.records();
 
     // `NAMESPACES` is sorted and `utxos` is its last entry, so one walk in
     // registry order yields `(ns, key)` ascending within every shard — the
@@ -1102,6 +1183,7 @@ fn write_state<W: SteleWriter, S: StateStore>(
             let (key, value) = entry?;
 
             route(&mut sinks, &mut orders, state::entity(ns, &key, &value)?)?;
+            records.tick();
         }
     }
 
@@ -1109,11 +1191,20 @@ fn write_state<W: SteleWriter, S: StateStore>(
         let (txo, value) = entry?;
 
         route(&mut sinks, &mut orders, state::utxo(&txo, &value)?)?;
+        records.tick();
     }
+
+    records.flush();
 
     sinks
         .into_iter()
-        .map(|sink| Ok(sink.finish()?.descriptor))
+        .zip(positions)
+        .map(|(sink, at)| {
+            let descriptor = sink.finish()?.descriptor;
+            cursor.close(at, STATE, Outcome::Transferred);
+
+            Ok(descriptor)
+        })
         .collect()
 }
 
@@ -1145,6 +1236,7 @@ fn write_digests<W: SteleWriter>(
     stele: &W,
     plan: &Plan,
     records: &[digests::ImmutableDigests],
+    cursor: &mut Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let mut order = digests::OrderCheck::default();
 
@@ -1168,13 +1260,23 @@ fn write_digests<W: SteleWriter>(
         last_immutable,
     };
 
-    let mut sink = sink(stele, &scope.layer_spec(DIGESTS)?)?;
+    let spec = scope.layer_spec(DIGESTS)?;
+    let at = cursor.open(DIGESTS, &spec.scope);
+
+    let mut sink = sink(stele, &spec)?;
+    let mut ticks = cursor.records();
 
     for record in records {
         sink.write_record(&digests::encode(record)?)?;
+        ticks.tick();
     }
 
-    Ok(sink.finish()?.descriptor)
+    ticks.flush();
+
+    let descriptor = sink.finish()?.descriptor;
+    cursor.close(at, DIGESTS, Outcome::Transferred);
+
+    Ok(descriptor)
 }
 
 #[cfg(test)]

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -1149,9 +1149,6 @@ fn write_state<W: SteleWriter, S: StateStore>(
 
     let mut sinks = Vec::with_capacity(shards.len());
     let mut orders = Vec::with_capacity(shards.len());
-    // All sixteen are announced before the walk begins, because all sixteen are
-    // genuinely in flight from that moment: one pass over the store feeds every
-    // one of them, so there is no honest way to report them one at a time.
     let mut positions = Vec::with_capacity(shards.len());
 
     for shard in shards {

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -58,7 +58,13 @@ pub mod namespaces;
 pub mod preflight;
 #[cfg(feature = "oci")]
 pub mod registry;
+mod reporting;
 pub mod restore;
+
+/// The observer seam both drivers report through, re-exported so a binary
+/// rendering one never has to name the protocol crate — the same property
+/// [`export::publish`] and [`restore::restore_dir`] hold for the transports.
+pub use stelae::progress;
 
 use dolos_core::ChainPoint;
 use serde_json::json;

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -147,6 +147,7 @@ use stelae::{
     frame::Limits,
     inscription::{Compression, HistoryEntry, Inscription, LayerDescriptor},
     oci::{Options, Stele, Transfer},
+    progress::Observer,
     transport::{BlobIndex, WrittenLayer},
     Digest, SteleReader as _, SteleWriter,
 };
@@ -259,6 +260,7 @@ pub fn restore_registry<A, S, I>(
     point: Point,
     node: Restoring<'_>,
     target: Target<'_, A, S, I>,
+    observer: &Observer,
 ) -> Result<(crate::restore::Plan, Outlook, Summary), Error>
 where
     A: ArchiveStore,
@@ -267,7 +269,7 @@ where
 {
     let stele = point.pull(registry)?;
 
-    crate::restore::restore_stele(&stele, node, registry.scratch_dir(), target)
+    crate::restore::restore_stele(&stele, node, registry.scratch_dir(), target, observer)
 }
 
 /// Open a repository in a registry.
@@ -940,6 +942,9 @@ fn staging_need(
 /// layer instead of inheriting the ones whose scope is unchanged, and
 /// [`Publishing::storage_path`] is where the resumption record lives — see the
 /// module documentation for both.
+///
+/// `observer` is who hears about it while it runs, and [`Observer::silent`] is
+/// what a caller with nothing to render passes.
 pub fn publish<A, S, I>(
     publishing: Publishing<'_>,
     plan: &Plan,
@@ -947,6 +952,7 @@ pub fn publish<A, S, I>(
     state: &S,
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
+    observer: &Observer,
 ) -> Result<Published, Error>
 where
     A: ArchiveStore,
@@ -961,6 +967,7 @@ where
         state,
         indexes,
         digest_records,
+        observer,
     )
 }
 
@@ -976,6 +983,7 @@ where
 /// from what that transport is carrying, so a writer that puts the layers
 /// somewhere else would seal a manifest with holes in it. A decorator over the
 /// registry is the shape this takes; anything else is a caller misusing it.
+#[allow(clippy::too_many_arguments)]
 pub fn publish_into<W, A, S, I>(
     stele: &W,
     publishing: Publishing<'_>,
@@ -984,6 +992,7 @@ pub fn publish_into<W, A, S, I>(
     state: &S,
     indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
+    observer: &Observer,
 ) -> Result<Published, Error>
 where
     W: SteleWriter,
@@ -1007,6 +1016,7 @@ where
         indexes,
         digest_records,
         &previous,
+        observer,
     )?;
 
     // Only here: the stele is sealed, so the note about what was uploaded on the

--- a/crates/snapshot/src/reporting.rs
+++ b/crates/snapshot/src/reporting.rs
@@ -1,0 +1,191 @@
+//! Counting layers and records for the two drivers to report.
+//!
+//! Nothing here is protocol: [`stelae::progress`] defines the seam and the
+//! events, and this is the small amount of arithmetic a *driver* has to do to
+//! fill one in — which layer of how many is in flight, and how often a long
+//! scan is worth mentioning.
+//!
+//! Shared by [`crate::export`] and [`crate::restore`] because the two count the
+//! same thing and a second copy would be a second answer to "how far along is
+//! this". Both types are call-scoped: they live on a stack frame for the length
+//! of one publish or one restore, and neither outlives it.
+
+use stelae::progress::{Event, Observer, Outcome};
+
+/// Records reported in one go.
+///
+/// Not one event per record. A mainnet state shard is tens of millions of them,
+/// and a bar redrawn per record is resolution nobody can see bought at a
+/// virtual call per record; this is fine enough that a bar still moves several
+/// times a second on the slowest layer in the profile.
+const RECORD_CADENCE: u64 = 4096;
+
+/// Where a driver is in its run of layers.
+///
+/// Positions are handed out by [`Cursor::open`] and quoted back to
+/// [`Cursor::close`] rather than tracked as "the current layer", because a
+/// driver may hold several open at once — the export's state pass keeps all
+/// sixteen shard sinks open across one walk of the store — and a single cursor
+/// would report the last one opened as the one that finished.
+pub(crate) struct Cursor<'a> {
+    observer: &'a Observer,
+    next: usize,
+    total: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub(crate) fn new(observer: &'a Observer, total: usize) -> Self {
+        Self {
+            observer,
+            next: 0,
+            total,
+        }
+    }
+
+    /// Announce a layer and take its position in the run.
+    pub(crate) fn open(&mut self, kind: &str, scope: &serde_json::Value) -> usize {
+        let index = self.next;
+        self.next += 1;
+
+        self.observer.emit(Event::LayerStarted {
+            index,
+            total: self.total,
+            kind,
+            scope,
+        });
+
+        index
+    }
+
+    /// Close the layer `index` was handed out for.
+    pub(crate) fn close(&self, index: usize, kind: &str, outcome: Outcome) {
+        self.observer.emit(Event::LayerFinished {
+            index,
+            total: self.total,
+            kind,
+            outcome,
+        });
+    }
+
+    /// A record counter reporting to the same place.
+    pub(crate) fn records(&self) -> Records<'a> {
+        Records {
+            observer: self.observer,
+            pending: 0,
+        }
+    }
+
+    /// Layers announced so far — what a caller cross-checks its own total
+    /// against once the run is over.
+    pub(crate) fn opened(&self) -> usize {
+        self.next
+    }
+}
+
+/// Records counted since the last time anyone was told about them.
+///
+/// [`Records::flush`] is explicit rather than a `Drop`, because the moment that
+/// matters is *before* the layer closes: an observer that saw a layer finish
+/// and then received records for it would have to know which layer they
+/// belonged to, and the seam deliberately does not carry that.
+pub(crate) struct Records<'a> {
+    observer: &'a Observer,
+    pending: u64,
+}
+
+impl Records<'_> {
+    pub(crate) fn tick(&mut self) {
+        self.pending += 1;
+
+        if self.pending >= RECORD_CADENCE {
+            self.flush();
+        }
+    }
+
+    pub(crate) fn flush(&mut self) {
+        if self.pending > 0 {
+            self.observer.emit(Event::Records(self.pending));
+            self.pending = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use stelae::progress::Progress;
+
+    #[derive(Default)]
+    struct Recorder(Mutex<Vec<String>>);
+
+    impl Progress for Recorder {
+        fn on(&self, event: Event<'_>) {
+            let line = match event {
+                Event::LayerStarted { index, kind, .. } => format!("open {index} {kind}"),
+                Event::LayerFinished {
+                    index,
+                    kind,
+                    outcome,
+                    ..
+                } => format!("close {index} {kind} {outcome:?}"),
+                Event::Records(n) => format!("records {n}"),
+                other => format!("{other:?}"),
+            };
+
+            self.0.lock().unwrap().push(line);
+        }
+    }
+
+    /// The shape the state pass needs: positions handed out up front, closed in
+    /// whatever order the sinks finish, and never confused with each other.
+    #[test]
+    fn positions_survive_layers_held_open_together() {
+        let recorder = Arc::new(Recorder::default());
+        let observer = Observer::new(recorder.clone());
+        let mut cursor = Cursor::new(&observer, 2);
+
+        let scope = serde_json::json!({});
+        let first = cursor.open("state", &scope);
+        let second = cursor.open("state", &scope);
+
+        cursor.close(second, "state", Outcome::Transferred);
+        cursor.close(first, "state", Outcome::Transferred);
+
+        assert_eq!(cursor.opened(), 2);
+        assert_eq!(
+            *recorder.0.lock().unwrap(),
+            vec![
+                "open 0 state",
+                "open 1 state",
+                "close 1 state Transferred",
+                "close 0 state Transferred",
+            ]
+        );
+    }
+
+    /// A cadence that reported nothing until a layer ended would leave the bar
+    /// still for exactly the layers it exists for, and one that reported a
+    /// trailing zero would tell a renderer records moved when none did.
+    #[test]
+    fn records_report_on_the_cadence_and_once_at_the_end() {
+        let recorder = Arc::new(Recorder::default());
+        let observer = Observer::new(recorder.clone());
+        let cursor = Cursor::new(&observer, 1);
+
+        let mut records = cursor.records();
+
+        for _ in 0..RECORD_CADENCE + 3 {
+            records.tick();
+        }
+
+        records.flush();
+        records.flush();
+
+        assert_eq!(
+            *recorder.0.lock().unwrap(),
+            vec![format!("records {RECORD_CADENCE}"), "records 3".to_owned()]
+        );
+    }
+}

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -118,6 +118,7 @@ use stelae::{
     frame::Limits,
     inscription::{Inscription, LayerDescriptor},
     plan::{Remaining, RestoreProgress, Resume},
+    progress::{Event, Observer, Outcome},
     transport::{BlobIndex, SteleReader},
     Digest, LayerHeader,
 };
@@ -125,8 +126,9 @@ use tracing::info;
 
 use crate::{
     layers::{blocks, indexes, logs, state},
-    preflight, read_position, DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, LOGS, STATE,
-    STATE_SHARDS, UTXOS,
+    preflight, read_position,
+    reporting::Cursor,
+    DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, LOGS, STATE, STATE_SHARDS, UTXOS,
 };
 
 /// What a restore holds at once.
@@ -236,8 +238,9 @@ impl Plan {
     /// of the original total. The tip is always in it; the epoch layers a
     /// `resume` accounts for are not.
     ///
-    /// Numbers only. Rendering them is a caller's, and belongs with the
-    /// observer seam the export and restore commands are going to share.
+    /// Numbers only. Rendering them is a caller's, and belongs with
+    /// [`stelae::progress`] — the seam the export and restore commands share,
+    /// and the one [`restore`] reports this run's own byte deltas through.
     pub fn remaining<R: SteleReader>(
         &self,
         stele: &R,
@@ -616,12 +619,16 @@ impl Checkpoint {
     /// per-kind driver below commits before it returns — and only then is the
     /// layer recorded, which is what makes the record mean "committed" rather
     /// than "attempted".
+    /// Returns the outcome alongside the count, rather than leaving a caller to
+    /// ask the resume the same question a second time: this method is the one
+    /// place a layer is decided about, and what an observer reports has to be
+    /// that decision and not a re-derivation of it.
     fn fetch<T: Default>(
         &mut self,
         descriptor: &LayerDescriptor,
         summary: &mut Summary,
         fetch: impl FnOnce() -> Result<T, Error>,
-    ) -> Result<T, Error> {
+    ) -> Result<(T, Outcome), Error> {
         if self.resume.is_done(&descriptor.diff_id) {
             info!(
                 kind = descriptor.kind,
@@ -631,7 +638,7 @@ impl Checkpoint {
 
             summary.layers_skipped += 1;
 
-            return Ok(T::default());
+            return Ok((T::default(), Outcome::Skipped));
         }
 
         let out = fetch()?;
@@ -639,7 +646,7 @@ impl Checkpoint {
         summary.layers_fetched += 1;
         self.record(descriptor.diff_id)?;
 
-        Ok(out)
+        Ok((out, Outcome::Transferred))
     }
 
     fn record(&mut self, diff_id: Digest) -> Result<(), Error> {
@@ -719,6 +726,12 @@ pub struct Restoring<'a> {
 /// is, and one carrying what an interrupted attempt left behind is exactly what
 /// a [`Checkpoint`] opened with `resume` describes. Deciding between them is
 /// `bootstrap`'s, and it already owns `--force` and `--continue`.
+///
+/// `observer` hears about it as it happens, and is forwarded to `stele`:
+/// this loop knows which layer of how many and whether the resume skipped it,
+/// while the download that dominates a registry restore is only visible to the
+/// transport. [`Observer::silent`] is what a caller with nothing to render
+/// passes, and a silent run is byte-for-byte the run this was before the seam.
 pub fn restore<R, A, S, I>(
     stele: &R,
     index: &BlobIndex,
@@ -726,6 +739,7 @@ pub fn restore<R, A, S, I>(
     target: Target<'_, A, S, I>,
     budget: Budget,
     checkpoint: &mut Checkpoint,
+    observer: &Observer,
 ) -> Result<Summary, Error>
 where
     R: SteleReader,
@@ -739,13 +753,17 @@ where
         indexes,
     } = target;
 
+    stele.observe(observer.clone());
+
     let reader = Reader {
         stele,
         index,
         magic: plan.position.network.magic(),
         budget,
+        observer,
     };
 
+    let mut cursor = Cursor::new(observer, plan.layers().count());
     let mut summary = Summary::default();
 
     indexes.initialize_schema()?;
@@ -758,26 +776,35 @@ where
         );
 
         if let Some(descriptor) = &epoch.blocks {
-            let count = checkpoint.fetch(descriptor, &mut summary, || {
+            let at = cursor.open(BLOCKS, &descriptor.scope);
+
+            let (count, outcome) = checkpoint.fetch(descriptor, &mut summary, || {
                 restore_blocks(&reader, descriptor, archive)
             })?;
 
+            cursor.close(at, BLOCKS, outcome);
             summary.blocks += count;
         }
 
         if let Some(descriptor) = &epoch.logs {
-            let count = checkpoint.fetch(descriptor, &mut summary, || {
+            let at = cursor.open(LOGS, &descriptor.scope);
+
+            let (count, outcome) = checkpoint.fetch(descriptor, &mut summary, || {
                 restore_logs(&reader, descriptor, archive)
             })?;
 
+            cursor.close(at, LOGS, outcome);
             summary.logs += count;
         }
 
         if let Some(descriptor) = &epoch.indexes {
-            let count = checkpoint.fetch(descriptor, &mut summary, || {
+            let at = cursor.open(INDEXES, &descriptor.scope);
+
+            let (count, outcome) = checkpoint.fetch(descriptor, &mut summary, || {
                 restore_indexes(&reader, descriptor, indexes)
             })?;
 
+            cursor.close(at, INDEXES, outcome);
             summary.index_records += count;
         }
     }
@@ -785,7 +812,11 @@ where
     info!(shards = plan.state.len(), "restoring the state tip");
 
     for descriptor in &plan.state {
+        let at = cursor.open(STATE, &descriptor.scope);
+
         let (entities, utxos) = restore_state(&reader, descriptor, state)?;
+
+        cursor.close(at, STATE, Outcome::Transferred);
 
         summary.entities += entities;
         summary.utxos += utxos;
@@ -843,6 +874,7 @@ pub(crate) fn restore_stele<R, A, S, I>(
     node: Restoring<'_>,
     scratch_dir: Option<&Path>,
     target: Target<'_, A, S, I>,
+    observer: &Observer,
 ) -> Result<(Plan, Outlook, Summary), Error>
 where
     R: SteleReader,
@@ -884,6 +916,7 @@ where
         target,
         Budget::default(),
         &mut checkpoint,
+        observer,
     )?;
 
     Ok((plan, outlook, summary))
@@ -899,6 +932,7 @@ pub fn restore_dir<A, S, I>(
     root: impl Into<std::path::PathBuf>,
     node: Restoring<'_>,
     target: Target<'_, A, S, I>,
+    observer: &Observer,
 ) -> Result<(Plan, Outlook, Summary), Error>
 where
     A: ArchiveStore,
@@ -907,7 +941,7 @@ where
 {
     let stele = stelae::dir::SteleDir::open(root)?;
 
-    restore_stele(&stele, node, None, target)
+    restore_stele(&stele, node, None, target, observer)
 }
 
 /// The stele a restore is reading, and the terms it reads under.
@@ -923,6 +957,7 @@ struct Reader<'a, R: SteleReader> {
     /// checking a layer against it checks the layer against the node.
     magic: u64,
     budget: Budget,
+    observer: &'a Observer,
 }
 
 impl<R: SteleReader> Reader<'_, R> {
@@ -958,15 +993,25 @@ impl<R: SteleReader> Reader<'_, R> {
             chunk.push(record);
 
             if chunk.len() >= self.budget.commit_records || bytes >= self.budget.commit_bytes {
+                let committed = chunk.len() as u64;
+
                 flush(std::mem::take(&mut chunk))?;
                 bytes = 0;
+
+                // On the commit boundary rather than on a cadence of its own:
+                // what a watcher of a restore wants to see move is records that
+                // have reached a store, and this is where they do.
+                self.observer.emit(Event::Records(committed));
             }
         }
 
         layer.finish()?;
 
         if !chunk.is_empty() {
+            let committed = chunk.len() as u64;
+
             flush(chunk)?;
+            self.observer.emit(Event::Records(committed));
         }
 
         Ok(count)

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -27,6 +27,7 @@
 
 mod common;
 mod node;
+mod watcher;
 
 use common::read_both_ways;
 use dolos_cardano::{
@@ -45,7 +46,13 @@ use dolos_snapshot::{
 };
 use dolos_testing::toy_domain::{FjallStores, MemoryStores, ToyDomain, ToyStores};
 use node::{export_to, harness, plan_for};
-use stelae::{dir::SteleDir, Discarding, SteleReader};
+use stelae::{
+    dir::SteleDir,
+    progress::{Observer, Outcome},
+    Discarding, SteleReader,
+};
+
+use watcher::Watcher;
 
 /// The identity of an export over an empty store set at [`SKELETON_POINT`].
 const GOLDEN_SKELETON: &str =
@@ -134,6 +141,7 @@ fn an_empty_store_set_exports_the_pinned_skeleton() {
         &index,
         None,
         &export::First,
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -610,6 +618,7 @@ fn a_discarding_export_reproduces_what_a_publish_stores() {
         domain.indexes(),
         None,
         &export::First,
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -663,6 +672,7 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         domain.state(),
         domain.indexes(),
         None,
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -674,6 +684,7 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         domain.indexes(),
         None,
         &export::First,
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -696,6 +707,7 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         domain.indexes(),
         None,
         &export::First,
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -711,4 +723,123 @@ fn distinct_layers(inscription: &stelae::Inscription) -> usize {
         .map(|layer| layer.diff_id)
         .collect::<std::collections::BTreeSet<_>>()
         .len()
+}
+
+// --------------------------------------------------------------------------
+// The progress seam
+// --------------------------------------------------------------------------
+
+/// Every layer a publish writes is announced once and closed once, and the
+/// records it reports are the records the document says it wrote.
+///
+/// Cross-checked against the inscription rather than against the stream: the
+/// descriptor's `records` counts the header record the protocol writes and the
+/// driver never sees, so the arithmetic below is a claim about two independent
+/// counts agreeing and not a recording compared with itself.
+///
+/// A directory is the interesting transport for this half precisely because it
+/// implements none of the byte reporting: `SteleDir` inherits the default no-op
+/// attach, so what comes back here is exactly the profile driver's own stream,
+/// with nothing from a transport mixed into it.
+#[test]
+fn a_directory_publish_reports_every_layer_and_record() {
+    let domain: ToyDomain = harness();
+    let plan = plan_for(&domain);
+
+    let temp = tempfile::tempdir().unwrap();
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let inscription = export::publish(
+        temp.path(),
+        &plan,
+        domain.archive(),
+        domain.state(),
+        domain.indexes(),
+        None,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    watcher.assert_well_formed(inscription.layers.len());
+
+    // A directory publish has no predecessor to inherit from and no registry to
+    // find a blob already in, so every layer is built.
+    assert_eq!(
+        watcher.ended(Outcome::Transferred),
+        inscription.layers.len(),
+        "every layer of a directory publish is built"
+    );
+    assert_eq!(watcher.ended(Outcome::Inherited), 0);
+    assert_eq!(watcher.ended(Outcome::Skipped), 0);
+
+    // One header record per layer is the protocol's, written by `open_layer`
+    // before the driver has a record of its own to write.
+    let content: u64 = inscription
+        .layers
+        .iter()
+        .map(|layer| layer.records - 1)
+        .sum();
+
+    assert!(
+        content > 0,
+        "the fixture has to carry records for this to prove anything"
+    );
+
+    assert_eq!(
+        watcher.records(),
+        content,
+        "records reported, against what the document says was written"
+    );
+
+    // And nothing was invented on the transport's behalf: the default no-op
+    // attach is what keeps the seam an offer rather than a tax, and this is the
+    // assertion that it stayed one.
+    assert_eq!(watcher.bytes(), 0);
+    assert!(watcher.blobs(true).is_empty());
+    assert!(watcher.blobs(false).is_empty());
+}
+
+/// A run nobody is watching is the run this crate has always made.
+///
+/// The seam's whole claim of being free when unused, checked where it can be:
+/// the same plan exported twice, once watched and once silent, has to produce
+/// the same document byte for byte.
+#[test]
+fn a_silent_publish_writes_exactly_what_a_watched_one_does() {
+    let domain: ToyDomain = harness();
+    let plan = plan_for(&domain);
+
+    let watched = tempfile::tempdir().unwrap();
+    let silent = tempfile::tempdir().unwrap();
+
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let with = export::publish(
+        watched.path(),
+        &plan,
+        domain.archive(),
+        domain.state(),
+        domain.indexes(),
+        None,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    let without = export::publish(
+        silent.path(),
+        &plan,
+        domain.archive(),
+        domain.state(),
+        domain.indexes(),
+        None,
+        &Observer::silent(),
+    )
+    .unwrap();
+
+    assert!(watcher.layers() > 0, "the watched run reported nothing");
+
+    assert_eq!(
+        with.canonicalize().unwrap(),
+        without.canonicalize().unwrap(),
+    );
 }

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -725,10 +725,6 @@ fn distinct_layers(inscription: &stelae::Inscription) -> usize {
         .len()
 }
 
-// --------------------------------------------------------------------------
-// The progress seam
-// --------------------------------------------------------------------------
-
 /// Every layer a publish writes is announced once and closed once, and the
 /// records it reports are the records the document says it wrote.
 ///

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -20,7 +20,7 @@ use dolos_testing::{
     synthetic::{build_synthetic_blocks, seed_epoch_logs, seed_reward_logs, SyntheticBlockConfig},
     toy_domain::{ToyDomain, ToyStores},
 };
-use stelae::{dir::SteleDir, inscription::Inscription};
+use stelae::{dir::SteleDir, inscription::Inscription, progress::Observer};
 
 /// Preview genesis, synthetic blocks and seeded logs, all inside epoch zero.
 ///
@@ -125,6 +125,7 @@ mod registry_node {
         Error, Network,
     };
     use dolos_testing::toy_domain::{MemoryStores, ToyDomain};
+    use stelae::progress::Observer;
 
     use super::harness;
 
@@ -188,6 +189,20 @@ mod registry_node {
             publishing: Publishing<'_>,
             plan: &Plan,
         ) -> Result<Published, Error> {
+            self.publish_watched(publishing, plan, &Observer::silent())
+        }
+
+        /// The same publish, with somebody listening.
+        ///
+        /// Separate from [`Node::publish_as`] so the suites that are not about
+        /// progress stay unchanged and keep proving what they proved: an
+        /// observer is meant to change nothing but what is said.
+        pub fn publish_watched(
+            &self,
+            publishing: Publishing<'_>,
+            plan: &Plan,
+            observer: &Observer,
+        ) -> Result<Published, Error> {
             registry::publish(
                 publishing,
                 plan,
@@ -195,6 +210,7 @@ mod registry_node {
                 self.domain.state(),
                 self.domain.indexes(),
                 None,
+                observer,
             )
         }
 
@@ -214,6 +230,7 @@ mod registry_node {
                 self.domain.state(),
                 self.domain.indexes(),
                 None,
+                &Observer::silent(),
             )
         }
 
@@ -239,6 +256,7 @@ pub fn export_to<B: ToyStores>(root: &std::path::Path, domain: &ToyDomain<B>) ->
         domain.indexes(),
         None,
         &First,
+        &Observer::silent(),
     )
     .unwrap()
 }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -885,10 +885,6 @@ impl stelae::SteleWriter for Interrupted<'_> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// The progress seam
-// ---------------------------------------------------------------------------
-
 /// The publish half of the observer's cross-check: what the stream said moved,
 /// against what the transport counted.
 ///
@@ -916,7 +912,6 @@ fn a_publish_reports_what_the_transfer_counted() {
     let node = Node::build();
     let repository = fixture.repository("dolos/progress");
 
-    // The first stele: nothing to inherit, nothing already in the registry.
     let watcher = std::sync::Arc::new(Watcher::default());
     let first = node
         .publish_watched(
@@ -955,7 +950,6 @@ fn a_publish_reports_what_the_transfer_counted() {
         "a publish that moved nothing proves nothing about byte reporting"
     );
 
-    // The second stele: three layers inherited from the first.
     let watcher = std::sync::Arc::new(Watcher::default());
     let second = node
         .publish_watched(
@@ -986,9 +980,6 @@ fn a_publish_reports_what_the_transfer_counted() {
         second.inscription.layers.len(),
     );
 
-    // A second repository, one sequence behind, so the third stele can be a
-    // rebuild rather than a republish: `--rebuild` suppresses inheritance, it
-    // does not suspend the chain.
     let rebuilt_into = fixture.repository("dolos/progress-rebuild");
     node.publish(&rebuilt_into, &node.first, false);
 
@@ -1003,10 +994,6 @@ fn a_publish_reports_what_the_transfer_counted() {
 
     watcher.assert_well_formed(again.inscription.layers.len());
 
-    // Nothing carried forward, and epoch 0's three layers built out of the
-    // stores a second time — at which point the registry answers that it has
-    // them. That is the skip, and it is a different fact from the inheritance
-    // above: the publisher paid for these layers and saved only the upload.
     assert_eq!(
         watcher.ended(Outcome::Inherited),
         0,

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -59,6 +59,7 @@
 
 mod node;
 mod registry_fixture;
+mod watcher;
 
 use dolos_core::Domain as _;
 use dolos_snapshot::{
@@ -66,7 +67,9 @@ use dolos_snapshot::{
     registry::{self, Publishing},
     DolosProfile, Error, BLOCKS, INDEXES, LOGS, STATE_SHARDS,
 };
-use stelae::SteleReader as _;
+use stelae::{progress::Outcome, SteleReader as _};
+
+use watcher::Watcher;
 
 use node::Node;
 use registry_fixture::Fixture;
@@ -880,4 +883,152 @@ impl stelae::SteleWriter for Interrupted<'_> {
     ) -> Result<stelae::Digest, stelae::Error> {
         self.inner.seal(profile, inscription)
     }
+}
+
+// ---------------------------------------------------------------------------
+// The progress seam
+// ---------------------------------------------------------------------------
+
+/// The publish half of the observer's cross-check: what the stream said moved,
+/// against what the transport counted.
+///
+/// Three publishes rather than one, because a single publish into an empty
+/// repository produces only one of the three things a layer can end as, and the
+/// third takes a second repository to reach:
+///
+/// 1. **built and uploaded** — every layer of a first stele;
+/// 2. **inherited** — epoch 0's three layers when the second stele chains onto
+///    the first;
+/// 3. **built and then skipped** — the same three layers under `--rebuild`,
+///    which suppresses inheritance and so builds them, at which point the
+///    registry turns out to hold their blobs already. It needs its own
+///    repository: `--rebuild` does not let a publisher republish a sequence the
+///    chain has already reached, so the skip has to come from a repository
+///    standing one sequence back.
+///
+/// Every tally is held against `Transfer`, which the transport keeps for the
+/// publisher's report and not for this test, so nothing here is the recording
+/// agreeing with itself.
+#[test]
+#[ignore]
+fn a_publish_reports_what_the_transfer_counted() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/progress");
+
+    // The first stele: nothing to inherit, nothing already in the registry.
+    let watcher = std::sync::Arc::new(Watcher::default());
+    let first = node
+        .publish_watched(
+            Publishing::new(&repository),
+            &node.first,
+            &watcher.observer(),
+        )
+        .unwrap();
+
+    watcher.assert_well_formed(first.inscription.layers.len());
+
+    assert_eq!(
+        watcher.ended(Outcome::Transferred),
+        PER_PUBLISH,
+        "every layer of a first publish is built"
+    );
+    assert_eq!(watcher.ended(Outcome::Inherited), 0);
+
+    assert_eq!(
+        watcher.blobs(true).len() as u64,
+        first.transfer.layers_uploaded,
+        "blobs announced as moving, against the uploads the transport counted"
+    );
+    assert_eq!(
+        watcher.blobs(false).len() as u64,
+        first.transfer.layers_skipped,
+        "blobs announced as already present, against the skips the transport counted"
+    );
+    assert_eq!(
+        watcher.bytes(),
+        first.transfer.bytes_uploaded,
+        "byte deltas summed, against the bytes the transport counted"
+    );
+    assert!(
+        first.transfer.bytes_uploaded > 0,
+        "a publish that moved nothing proves nothing about byte reporting"
+    );
+
+    // The second stele: three layers inherited from the first.
+    let watcher = std::sync::Arc::new(Watcher::default());
+    let second = node
+        .publish_watched(
+            Publishing::new(&repository),
+            &node.second,
+            &watcher.observer(),
+        )
+        .unwrap();
+
+    watcher.assert_well_formed(second.inscription.layers.len());
+
+    assert_eq!(
+        watcher.ended(Outcome::Inherited) as u64,
+        second.transfer.layers_reused,
+        "layers announced as carried forward, against the transport's count"
+    );
+    assert_eq!(
+        watcher.blobs(true).len() as u64,
+        second.transfer.layers_uploaded,
+    );
+    assert_eq!(watcher.bytes(), second.transfer.bytes_uploaded);
+
+    // An inherited layer moves no blob at all — it is not built, so nothing is
+    // staged and nothing is offered to the registry. That is what makes it a
+    // different outcome from a skip rather than a spelling of one.
+    assert_eq!(
+        watcher.blobs(true).len() + watcher.blobs(false).len() + watcher.ended(Outcome::Inherited),
+        second.inscription.layers.len(),
+    );
+
+    // A second repository, one sequence behind, so the third stele can be a
+    // rebuild rather than a republish: `--rebuild` suppresses inheritance, it
+    // does not suspend the chain.
+    let rebuilt_into = fixture.repository("dolos/progress-rebuild");
+    node.publish(&rebuilt_into, &node.first, false);
+
+    let watcher = std::sync::Arc::new(Watcher::default());
+    let again = node
+        .publish_watched(
+            Publishing::new(&rebuilt_into).rebuilding(true),
+            &node.second,
+            &watcher.observer(),
+        )
+        .unwrap();
+
+    watcher.assert_well_formed(again.inscription.layers.len());
+
+    // Nothing carried forward, and epoch 0's three layers built out of the
+    // stores a second time — at which point the registry answers that it has
+    // them. That is the skip, and it is a different fact from the inheritance
+    // above: the publisher paid for these layers and saved only the upload.
+    assert_eq!(
+        watcher.ended(Outcome::Inherited),
+        0,
+        "a rebuild carries nothing forward"
+    );
+    assert_eq!(
+        watcher.blobs(false).len() as u64,
+        again.transfer.layers_skipped,
+        "blobs announced as already present, against the skips the transport counted"
+    );
+    assert!(
+        again.transfer.layers_skipped > 0,
+        "a rebuild over a repository that already holds those blobs has to skip some"
+    );
+    assert_eq!(
+        watcher.blob_bytes(false),
+        again.transfer.bytes_skipped,
+        "the sizes of the skipped blobs, against what the transport counted them as"
+    );
+    assert_eq!(
+        watcher.blobs(true).len() as u64,
+        again.transfer.layers_uploaded,
+    );
+    assert_eq!(watcher.bytes(), again.transfer.bytes_uploaded);
 }

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -1114,10 +1114,6 @@ fn max_history_selects_epochs_and_never_the_tip() {
     }
 }
 
-// --------------------------------------------------------------------------
-// The progress seam
-// --------------------------------------------------------------------------
-
 /// A restore announces every layer its plan names, and says which of them a
 /// resume skipped.
 ///

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -38,6 +38,7 @@
 //! the resume has left to do is known before it runs.
 
 mod node;
+mod watcher;
 
 use dolos_cardano::indexes::{archive_dimensions, index_delta_from_utxo_delta};
 use dolos_core::{
@@ -55,9 +56,12 @@ use stelae::{
     frame::Limits,
     inscription::{Inscription, LayerDescriptor},
     plan::RestoreProgress,
+    progress::{Observer, Outcome},
     transport::BlobIndex,
     Digest, LayerReader, Profile, SteleReader,
 };
+
+use watcher::Watcher;
 
 /// Every layer read through a window far below one record and every write
 /// batch committed after a single record.
@@ -121,6 +125,7 @@ fn restore_into<B: ToyStores>(
         target(blank),
         budget,
         &mut Checkpoint::none(),
+        &Observer::silent(),
     )
 }
 
@@ -303,6 +308,7 @@ fn roundtrip<B: ToyStores>() {
             blank.indexes(),
             None,
             &dolos_snapshot::export::First,
+            &Observer::silent(),
         )
         .unwrap()
     };
@@ -591,6 +597,32 @@ fn restore_checkpointed<B: ToyStores>(
     resume: bool,
     stop_at: Option<Digest>,
 ) -> Result<restore::Summary, Error> {
+    restore_watched(
+        root,
+        storage,
+        magic,
+        blank,
+        resume,
+        stop_at,
+        &Observer::silent(),
+    )
+}
+
+/// The same restore, with somebody listening.
+///
+/// Separate so every suite above stays exactly as it was: an observer is meant
+/// to change nothing but what is said, and the tests that prove a restore
+/// correct should not be the ones that prove it talks.
+#[allow(clippy::too_many_arguments)]
+fn restore_watched<B: ToyStores>(
+    root: &std::path::Path,
+    storage: &std::path::Path,
+    magic: u64,
+    blank: &Blank<B>,
+    resume: bool,
+    stop_at: Option<Digest>,
+    observer: &Observer,
+) -> Result<restore::Summary, Error> {
     let stele = SteleDir::open(root)?;
     let identity = stele.read_inscription()?.digest()?;
 
@@ -610,6 +642,7 @@ fn restore_checkpointed<B: ToyStores>(
             target(blank),
             Budget::default(),
             &mut checkpoint,
+            observer,
         ),
         None => restore::restore(
             &stele,
@@ -618,6 +651,7 @@ fn restore_checkpointed<B: ToyStores>(
             target(blank),
             Budget::default(),
             &mut checkpoint,
+            observer,
         ),
     }
 }
@@ -902,6 +936,7 @@ fn export_standing_at<B: ToyStores>(
         domain.indexes(),
         None,
         &dolos_snapshot::export::First,
+        &Observer::silent(),
     )
     .unwrap()
 }
@@ -1077,4 +1112,149 @@ fn max_history_selects_epochs_and_never_the_tip() {
         assert_eq!(plan.skipped_epochs, 0, "{max_history:?}");
         assert_eq!(plan.epochs.len(), 1, "{max_history:?}");
     }
+}
+
+// --------------------------------------------------------------------------
+// The progress seam
+// --------------------------------------------------------------------------
+
+/// A restore announces every layer its plan names, and says which of them a
+/// resume skipped.
+///
+/// The scenario is [`kill_and_resume`]'s, because that is the only one in which
+/// the two outcomes a restore can report both occur — and the tallies are held
+/// against `Summary`'s own counters, which the driver keeps for its report and
+/// not for this. A stream asserted against itself would pass with the skip
+/// reported as a fetch.
+fn a_resumed_restore_reports_what_it_skipped<B: ToyStores>() {
+    let domain: ToyDomain<B> = harness();
+    let magic = magic_of(&domain);
+
+    let stele = tempfile::tempdir().unwrap();
+    let inscription = export_to(stele.path(), &domain);
+
+    let (epoch_layers, _) = layers_in_driver_order(stele.path(), magic);
+
+    let storage = tempfile::tempdir().unwrap();
+    let blank = Blank::<B>::open();
+
+    restore_checkpointed(
+        stele.path(),
+        storage.path(),
+        magic,
+        &blank,
+        false,
+        Some(epoch_layers[1]),
+    )
+    .unwrap_err();
+
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let resumed = restore_watched(
+        stele.path(),
+        storage.path(),
+        magic,
+        &blank,
+        true,
+        None,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    // The plan is every layer the restore will consider, skipped ones included,
+    // and it is what a bar's length has to be for the bar to be honest.
+    watcher.assert_well_formed(inscription.layers.len());
+
+    assert_eq!(
+        watcher.ended(Outcome::Skipped),
+        resumed.layers_skipped,
+        "layers reported as skipped, against the driver's own count"
+    );
+    assert_eq!(
+        watcher.ended(Outcome::Transferred),
+        resumed.layers_fetched,
+        "layers reported as fetched, against the driver's own count"
+    );
+    assert_eq!(
+        watcher.ended(Outcome::Inherited),
+        0,
+        "a restore inherits nothing; that is the publish side's word"
+    );
+
+    assert_eq!(
+        resumed.layers_skipped, 1,
+        "the scenario has to produce a skip, or the tally above proves nothing"
+    );
+
+    // Records are the ones that reached a store, so a skipped layer contributes
+    // none of them — which is what makes the total below smaller than the
+    // document's and not equal to it.
+    let content: u64 = inscription
+        .layers
+        .iter()
+        .map(|layer| layer.records - 1)
+        .sum();
+
+    assert!(watcher.records() > 0);
+    assert!(
+        watcher.records() < content,
+        "a resumed restore reported as many records as a whole one"
+    );
+
+    // A directory reader stages nothing and reports no bytes: it inherits the
+    // default no-op attach, exactly as the writer half does.
+    assert_eq!(watcher.bytes(), 0);
+    assert!(watcher.blobs(true).is_empty());
+}
+
+#[test]
+fn a_resumed_restore_reports_what_it_skipped_on_memory() {
+    a_resumed_restore_reports_what_it_skipped::<MemoryStores>();
+}
+
+/// A whole restore reports every record the stele carries.
+///
+/// The unresumed half of the pair above, and the one that pins the record
+/// stream exactly rather than as an inequality: nothing is skipped, so the
+/// records that reach the stores are the records the document says the layers
+/// hold.
+#[test]
+fn a_whole_restore_reports_every_record_the_document_carries() {
+    let domain: ToyDomain<MemoryStores> = harness();
+    let magic = magic_of(&domain);
+
+    let stele = tempfile::tempdir().unwrap();
+    let inscription = export_to(stele.path(), &domain);
+
+    let storage = tempfile::tempdir().unwrap();
+    let blank = Blank::<MemoryStores>::open();
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let summary = restore_watched(
+        stele.path(),
+        storage.path(),
+        magic,
+        &blank,
+        false,
+        None,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    watcher.assert_well_formed(inscription.layers.len());
+
+    assert_eq!(watcher.ended(Outcome::Transferred), summary.layers_fetched);
+    assert_eq!(watcher.ended(Outcome::Skipped), 0);
+
+    let content: u64 = inscription
+        .layers
+        .iter()
+        .map(|layer| layer.records - 1)
+        .sum();
+
+    assert_eq!(
+        watcher.records(),
+        content,
+        "records reported, against what the document says the layers hold"
+    );
 }

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -45,6 +45,7 @@
 
 mod node;
 mod registry_fixture;
+mod watcher;
 
 use dolos_cardano::indexes::{archive_dimensions, index_delta_from_utxo_delta};
 use dolos_core::{
@@ -65,9 +66,12 @@ use stelae::{
     inscription::LayerDescriptor,
     oci::{Auth, Registry, Stele},
     plan::RestoreProgress,
+    progress::{Observer, Outcome},
     transport::BlobIndex,
     Digest, LayerReader, Profile, SteleReader,
 };
+
+use watcher::Watcher;
 
 /// Layers a publish of one epoch writes: three epoch kinds plus the state tip.
 const PER_PUBLISH: usize = 3 + STATE_SHARDS as usize;
@@ -124,6 +128,7 @@ impl Node {
             self.domain.state(),
             self.domain.indexes(),
             None,
+            &Observer::silent(),
         )
         .unwrap();
     }
@@ -138,13 +143,40 @@ fn restore_from(
     blank: &Blank<MemoryStores>,
     resume: bool,
 ) -> Result<restore::Summary, Error> {
+    restore_watched(
+        repository,
+        point,
+        storage,
+        magic,
+        blank,
+        resume,
+        &Observer::silent(),
+    )
+    .map(|(_, _, summary)| summary)
+}
+
+/// The same restore, with somebody listening, and the outlook the summary alone
+/// does not carry.
+///
+/// Separate so every suite above stays exactly as it was: an observer is meant
+/// to change nothing but what is said.
+#[allow(clippy::too_many_arguments)]
+fn restore_watched(
+    repository: &Registry,
+    point: Point,
+    storage: &std::path::Path,
+    magic: u64,
+    blank: &Blank<MemoryStores>,
+    resume: bool,
+    observer: &Observer,
+) -> Result<(restore::Plan, restore::Outlook, restore::Summary), Error> {
     registry::restore_registry(
         repository,
         point,
         restoring(storage, magic, resume),
         target(blank),
+        observer,
     )
-    .map(|(_, _, summary)| summary)
 }
 
 /// What the node reading a stele knows about itself.
@@ -200,6 +232,7 @@ fn a_registry_restore_is_a_directory_restore() {
             node.domain.indexes(),
             None,
             &dolos_snapshot::export::First,
+            &Observer::silent(),
         )
         .unwrap();
     }
@@ -210,6 +243,7 @@ fn a_registry_restore_is_a_directory_restore() {
         dir.path(),
         restoring(dir_storage.path(), node.magic, false),
         target(&from_dir),
+        &Observer::silent(),
     )
     .unwrap();
 
@@ -315,6 +349,7 @@ fn a_killed_registry_restore_resumes_where_it_stopped() {
         target(&blank),
         Budget::default(),
         &mut checkpoint,
+        &Observer::silent(),
     )
     .unwrap_err();
 
@@ -425,6 +460,7 @@ fn a_pre_seeded_node_fetches_only_what_it_lacks() {
         target(&blank),
         Budget::default(),
         &mut checkpoint,
+        &Observer::silent(),
     )
     .unwrap_err();
 
@@ -786,4 +822,163 @@ fn exact_of<I: IndexStore>(store: &I) -> Vec<ExactRecord> {
 
     found.sort_by_key(|record| (record.kind, record.key().to_vec()));
     found
+}
+
+// ---------------------------------------------------------------------------
+// The progress seam
+// ---------------------------------------------------------------------------
+
+/// The restore half of the observer's cross-check: what the stream said came
+/// down, against what the manifest says the layers weigh.
+///
+/// This is the direction the seam exists for. A registry reader pulls a whole
+/// blob into scratch before `stream_layer` yields its first record, so an
+/// observer wired only to the profile driver would report nothing for the
+/// entire download — which on a restore is the entire operation. What proves
+/// the bytes are genuinely being reported *during* the pull, rather than
+/// announced once at the end, is that the deltas sum to the same number the
+/// manifest states independently.
+#[test]
+#[ignore]
+fn a_registry_restore_reports_every_byte_it_pulls() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/progress-restore");
+
+    node.publish(&repository, &node.first);
+
+    let storage = tempfile::tempdir().unwrap();
+    let blank = Blank::<MemoryStores>::open();
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let (plan, outlook, summary) = restore_watched(
+        &repository,
+        Point::Latest,
+        storage.path(),
+        node.magic,
+        &blank,
+        false,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    watcher.assert_well_formed(plan.layers().count());
+
+    assert_eq!(watcher.ended(Outcome::Transferred), summary.layers_fetched);
+    assert_eq!(watcher.ended(Outcome::Skipped), summary.layers_skipped);
+    assert_eq!(watcher.ended(Outcome::Skipped), 0, "nothing to resume here");
+
+    // Every layer the plan names was pulled, and each was announced with the
+    // size the manifest states for it.
+    assert_eq!(watcher.blobs(true).len(), summary.layers_fetched);
+    assert!(watcher.blobs(false).is_empty(), "a pull never skips a blob");
+
+    assert_eq!(
+        watcher.blob_bytes(true),
+        outlook.remaining.compressed_bytes,
+        "the blobs announced, against what the plan said was left to fetch"
+    );
+
+    // And the deltas — reported as the bytes were written, one `poll_write` at a
+    // time — sum to the same total.
+    assert_eq!(
+        watcher.bytes(),
+        outlook.remaining.compressed_bytes,
+        "byte deltas summed, against the compressed total the manifest states"
+    );
+
+    assert!(
+        outlook.remaining.compressed_bytes > 0,
+        "a restore that moved nothing proves nothing about byte reporting"
+    );
+    assert_eq!(outlook.remaining.unsized_layers, 0);
+
+    eprintln!(
+        "restored {} layers, {} compressed bytes reported in {} blob(s)",
+        summary.layers_fetched,
+        watcher.bytes(),
+        watcher.blobs(true).len(),
+    );
+}
+
+/// A resumed restore over the wire reports the layers it did not have to pull.
+///
+/// The skip is the driver's, decided before the transport is asked for
+/// anything, so what this pins is that the two emitters do not disagree: a
+/// layer the resume skipped contributes no blob and no bytes, and the counts
+/// still add up to the plan's.
+#[test]
+#[ignore]
+fn a_resumed_registry_restore_reports_what_it_skipped() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let repository = fixture.repository("dolos/progress-resume");
+
+    node.publish(&repository, &node.first);
+
+    let storage = tempfile::tempdir().unwrap();
+    let blank = Blank::<MemoryStores>::open();
+
+    // The interruption, at the second epoch layer the driver reaches — the same
+    // deterministic placement `a_killed_registry_restore_resumes_where_it_stopped`
+    // uses, and for the same reason: a wall-clock kill against a loopback
+    // registry holding a kilobyte-scale stele interrupts nothing.
+    {
+        let stele = Point::Latest.pull(&repository).unwrap();
+        let identity = stele.read_inscription().unwrap().digest().unwrap();
+        let plan = restore::plan(&stele, node.magic, None).unwrap();
+        let index = stele.blob_index().unwrap();
+
+        let epoch_layers: Vec<Digest> = plan.immutable_layers().map(|l| l.diff_id).collect();
+        assert!(epoch_layers.len() >= 2);
+
+        let mut checkpoint = Checkpoint::open(storage.path(), identity, false).unwrap();
+
+        restore::restore(
+            &Interrupted {
+                inner: &stele,
+                stop_at: epoch_layers[1],
+            },
+            &index,
+            &plan,
+            target(&blank),
+            Budget::default(),
+            &mut checkpoint,
+            &Observer::silent(),
+        )
+        .unwrap_err();
+    }
+
+    let watcher = std::sync::Arc::new(Watcher::default());
+
+    let (plan, outlook, summary) = restore_watched(
+        &repository,
+        Point::Latest,
+        storage.path(),
+        node.magic,
+        &blank,
+        true,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    watcher.assert_well_formed(plan.layers().count());
+
+    assert!(
+        summary.layers_skipped > 0,
+        "the scenario has to produce a skip, or the tallies below prove nothing"
+    );
+
+    assert_eq!(watcher.ended(Outcome::Skipped), summary.layers_skipped);
+    assert_eq!(watcher.ended(Outcome::Transferred), summary.layers_fetched);
+
+    // A skipped layer is never asked of the transport, so it contributes no
+    // blob — which is why the blob count is the fetch count and not the plan's.
+    assert_eq!(watcher.blobs(true).len(), summary.layers_fetched);
+
+    assert_eq!(
+        watcher.bytes(),
+        outlook.remaining.compressed_bytes,
+        "a resumed run reports the bytes it still had to move, not the original total"
+    );
 }

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -824,10 +824,6 @@ fn exact_of<I: IndexStore>(store: &I) -> Vec<ExactRecord> {
     found
 }
 
-// ---------------------------------------------------------------------------
-// The progress seam
-// ---------------------------------------------------------------------------
-
 /// The restore half of the observer's cross-check: what the stream said came
 /// down, against what the manifest says the layers weigh.
 ///

--- a/crates/snapshot/tests/watcher/mod.rs
+++ b/crates/snapshot/tests/watcher/mod.rs
@@ -1,0 +1,240 @@
+//! A recording observer, and the invariants every event stream owes.
+//!
+//! What makes this worth having rather than a `Vec` per test: the assertions
+//! below are about the stream's *shape* — every layer opens once and closes
+//! once, the positions are exactly `0..total`, nothing is reported after the
+//! last layer closes — and those hold for a publish and a restore alike. A
+//! suite that only checked the numbers it happened to care about would let a
+//! second emitter added later report a layer twice without anything noticing.
+//!
+//! The numbers themselves are cross-checked against counters that already
+//! exist — `Transfer` on the publish side, `Summary` on the restore side — and
+//! never against the stream itself. An event stream asserted only against its
+//! own recording is a test of the recorder.
+
+// Each integration test binary compiles this module in full, so the parts one
+// binary does not reach look dead to it. They are not.
+#![allow(dead_code)]
+
+use std::sync::Mutex;
+
+use stelae::progress::{Event, Observer, Outcome, Progress};
+
+/// One layer, as the stream described it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layer {
+    pub index: usize,
+    pub total: usize,
+    pub kind: String,
+    pub scope: String,
+}
+
+/// One layer's end, as the stream reported it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Closed {
+    pub index: usize,
+    pub total: usize,
+    pub kind: String,
+    pub outcome: Outcome,
+}
+
+/// One blob, as the transport announced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Blob {
+    pub moved: bool,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Default)]
+struct Stream {
+    opened: Vec<Layer>,
+    closed: Vec<Closed>,
+    records: u64,
+    blobs: Vec<Blob>,
+    bytes: u64,
+    /// Anything reported after the last layer closed — which is nothing, and
+    /// checking it is how a byte delta escaping into the gap between layers
+    /// gets caught.
+    trailing: usize,
+}
+
+/// Everything a run said about itself.
+#[derive(Debug, Default)]
+pub struct Watcher(Mutex<Stream>);
+
+impl Progress for Watcher {
+    fn on(&self, event: Event<'_>) {
+        let mut stream = self.0.lock().unwrap();
+
+        let layer = |index, total, kind: &str, scope: &serde_json::Value| Layer {
+            index,
+            total,
+            kind: kind.to_owned(),
+            scope: scope.to_string(),
+        };
+
+        match event {
+            Event::LayerStarted {
+                index,
+                total,
+                kind,
+                scope,
+            } => stream.opened.push(layer(index, total, kind, scope)),
+
+            Event::LayerFinished {
+                index,
+                total,
+                kind,
+                outcome,
+            } => stream.closed.push(Closed {
+                index,
+                total,
+                kind: kind.to_owned(),
+                outcome,
+            }),
+
+            Event::Records(moved) => {
+                if stream.settled() {
+                    stream.trailing += 1;
+                }
+
+                stream.records += moved;
+            }
+
+            Event::Blob { moved, bytes } => {
+                if stream.settled() {
+                    stream.trailing += 1;
+                }
+
+                stream.blobs.push(Blob { moved, bytes });
+            }
+
+            Event::Bytes(moved) => {
+                if stream.settled() {
+                    stream.trailing += 1;
+                }
+
+                stream.bytes += moved;
+            }
+        }
+    }
+}
+
+impl Stream {
+    /// Whether every layer announced has already been closed, which for a
+    /// well-formed run means the transfer is over.
+    fn settled(&self) -> bool {
+        !self.opened.is_empty()
+            && self.opened.len() == self.closed.len()
+            && self.opened.len() == self.opened[0].total
+    }
+}
+
+impl Watcher {
+    pub fn observer(self: &std::sync::Arc<Self>) -> Observer {
+        Observer::new(self.clone())
+    }
+
+    /// Layers the run announced.
+    pub fn layers(&self) -> usize {
+        self.0.lock().unwrap().opened.len()
+    }
+
+    /// How many layers ended each way.
+    pub fn ended(&self, outcome: Outcome) -> usize {
+        self.0
+            .lock()
+            .unwrap()
+            .closed
+            .iter()
+            .filter(|closed| closed.outcome == outcome)
+            .count()
+    }
+
+    pub fn records(&self) -> u64 {
+        self.0.lock().unwrap().records
+    }
+
+    /// Compressed bytes the transport said crossed the wire.
+    pub fn bytes(&self) -> u64 {
+        self.0.lock().unwrap().bytes
+    }
+
+    /// Blobs the transport handled, by whether anything moved for them.
+    pub fn blobs(&self, moved: bool) -> Vec<Blob> {
+        self.0
+            .lock()
+            .unwrap()
+            .blobs
+            .iter()
+            .copied()
+            .filter(|blob| blob.moved == moved)
+            .collect()
+    }
+
+    /// What the blobs of one kind weigh, as the transport stated their sizes.
+    pub fn blob_bytes(&self, moved: bool) -> u64 {
+        self.blobs(moved).iter().map(|blob| blob.bytes).sum()
+    }
+
+    /// The invariants a well-formed stream owes, whichever direction produced
+    /// it.
+    ///
+    /// `expected` is the layer count from somewhere other than the stream — the
+    /// inscription on a publish, the plan on a restore — because "the stream
+    /// counted what the stream counted" proves nothing.
+    pub fn assert_well_formed(&self, expected: usize) {
+        let stream = self.0.lock().unwrap();
+
+        assert_eq!(
+            stream.opened.len(),
+            expected,
+            "layers announced, against the count the document carries"
+        );
+
+        assert_eq!(
+            stream.closed.len(),
+            expected,
+            "layers closed, against the count the document carries"
+        );
+
+        let positions: Vec<usize> = {
+            let mut positions: Vec<usize> = stream.opened.iter().map(|l| l.index).collect();
+            positions.sort_unstable();
+            positions
+        };
+
+        assert_eq!(
+            positions,
+            (0..expected).collect::<Vec<_>>(),
+            "every position from 0 announced exactly once"
+        );
+
+        let closed: Vec<usize> = {
+            let mut closed: Vec<usize> = stream.closed.iter().map(|c| c.index).collect();
+            closed.sort_unstable();
+            closed
+        };
+
+        assert_eq!(
+            closed,
+            (0..expected).collect::<Vec<_>>(),
+            "every position closed exactly once"
+        );
+
+        for layer in &stream.opened {
+            assert_eq!(layer.total, expected, "a layer reported a different total");
+            assert!(!layer.kind.is_empty(), "a layer reported no kind");
+            assert_ne!(layer.scope, "null", "a layer reported no scope");
+        }
+
+        for closed in &stream.closed {
+            assert_eq!(closed.total, expected, "a layer reported a different total");
+        }
+
+        assert_eq!(
+            stream.trailing, 0,
+            "records or bytes were reported after the last layer closed"
+        );
+    }
+}

--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -35,6 +35,9 @@
 //!   identity without storing it.
 //! - [`plan`] — what a restore has already done and what it has left to fetch:
 //!   the progress file, the resume rule, and remaining-bytes accounting.
+//! - [`progress`] — the one seam a publish and a restore report through while
+//!   they run: an observer a caller passes in, callbacks only, silent by
+//!   default.
 //! - [`dir`] — a minimal on-disk stele: the first implementation of that seam,
 //!   and the one a stele is inspectable by hand through.
 //! - [`oci`] — (feature `oci`) an OCI registry as the other implementation:
@@ -58,6 +61,7 @@ pub mod layer;
 pub mod oci;
 pub mod plan;
 pub mod profile;
+pub mod progress;
 pub mod transport;
 
 pub use digest::{Digest, LayerDigests, LayerWriter};
@@ -68,6 +72,7 @@ pub use inscription::{
 pub use layer::LayerReader;
 pub use plan::{Remaining, RestoreProgress, Resume};
 pub use profile::{MediaType, Profile};
+pub use progress::{Event, Observer, Outcome, Progress};
 pub use transport::{
     BlobIndex, Discarding, DiscardingSink, LayerSpec, RecordSink, SteleReader, SteleWriter,
     WrittenLayer,

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -140,6 +140,7 @@ use crate::{
     inscription::{canonical_json, Inscription, LayerDescriptor},
     layer::LayerReader,
     profile::{checked_tag_for_sequence, validate_tag, Profile},
+    progress::{Event, Observer},
     transport::{
         open_layer, BlobIndex, LayerSpec, RecordSink, SteleReader, SteleWriter, WrittenLayer,
     },
@@ -436,6 +437,14 @@ struct Shared {
     auth: RegistryAuth,
     scratch_dir: Option<PathBuf>,
     state: Mutex<PushState>,
+    /// Who is watching this connection, in either direction.
+    ///
+    /// Beside the push state rather than inside it, because a [`Stele`] shares
+    /// this value and only ever reads: attaching an observer to the
+    /// [`Registry`] is what makes the pull it resolves report too, which is the
+    /// property a restore depends on — the reader is created inside the driver
+    /// and there is no other moment to wire it.
+    observer: Mutex<Observer>,
 }
 
 #[derive(Default)]
@@ -508,6 +517,7 @@ impl Registry {
                 auth,
                 scratch_dir: options.scratch_dir,
                 state: Mutex::new(PushState::default()),
+                observer: Mutex::new(Observer::silent()),
             }),
         })
     }
@@ -841,6 +851,26 @@ impl Shared {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    /// A handle on whoever is watching, taken once per operation.
+    ///
+    /// Cloned out from under the lock rather than emitted through it: a blob
+    /// download reports a delta per write, and holding a mutex across a
+    /// renderer's call would put this transport's byte loop behind whatever the
+    /// binary does with the event.
+    fn observer(&self) -> Observer {
+        self.observer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn watch(&self, observer: Observer) {
+        *self
+            .observer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = observer;
+    }
+
     fn tagged(&self, tag: &str) -> Reference {
         Reference::with_tag(
             self.repository.registry().to_owned(),
@@ -867,8 +897,18 @@ impl Shared {
     fn put_layer(&self, layer: &WrittenLayer, staged: File) -> Result<(), Error> {
         let digest = layer.digests.blob_digest;
         let size = layer.digests.compressed_size;
+        let observer = self.observer();
 
         if self.blob_exists(&digest)? {
+            // Announced even though nothing moves: "the registry already had
+            // this one" is the blob-skip working, and a watcher that only heard
+            // about uploads would read the whole point of a content-addressed
+            // registry as a stall.
+            observer.emit(Event::Blob {
+                moved: false,
+                bytes: size,
+            });
+
             let mut state = self.locked();
             state.transfer.layers_skipped += 1;
             state.transfer.bytes_skipped += size;
@@ -877,9 +917,16 @@ impl Shared {
             return Ok(());
         }
 
+        // Before the upload rather than after it, so a watcher knows how big
+        // the transfer it is about to see is while it is still happening.
+        observer.emit(Event::Blob {
+            moved: true,
+            bytes: size,
+        });
+
         self.runtime.block_on(self.client.push_blob_stream(
             &self.repository,
-            blob_stream(staged),
+            blob_stream(staged, observer),
             &digest.to_string(),
         ))?;
 
@@ -919,10 +966,18 @@ impl Shared {
     ) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::with_capacity(descriptor.size.max(0) as usize);
 
+        // No observer: the config blob is the inscription, not a layer, and a
+        // watcher summing byte deltas against a layer total would find them
+        // disagreeing by however large the document is.
         self.runtime.block_on(self.client.pull_blob(
             reference,
             descriptor,
-            Blocking::new(&mut buffer, descriptor.size, &descriptor.digest),
+            Blocking::new(
+                &mut buffer,
+                descriptor.size,
+                &descriptor.digest,
+                Observer::silent(),
+            ),
         ))?;
 
         Ok(buffer)
@@ -939,11 +994,20 @@ impl Shared {
         descriptor: &OciDescriptor,
     ) -> Result<File, Error> {
         let mut file = self.scratch()?;
+        let observer = self.observer();
+
+        // The whole layer lands here before `stream_layer` yields one record,
+        // so this loop is where a restore spends nearly all of its time and the
+        // only place it can report from.
+        observer.emit(Event::Blob {
+            moved: true,
+            bytes: descriptor.size.max(0) as u64,
+        });
 
         self.runtime.block_on(self.client.pull_blob(
             reference,
             descriptor,
-            Blocking::new(&mut file, descriptor.size, &descriptor.digest),
+            Blocking::new(&mut file, descriptor.size, &descriptor.digest, observer),
         ))?;
 
         file.seek(SeekFrom::Start(0))?;
@@ -1024,6 +1088,15 @@ impl SteleWriter for Registry {
         self.shared.locked().pending.clear();
 
         Ok(identity)
+    }
+
+    /// Report every blob this connection uploads.
+    ///
+    /// One of the two implementations that override the default — the other is
+    /// [`Stele`], and it shares this connection's state, so an observer
+    /// attached here is also attached to whatever this registry pulls.
+    fn observe(&self, observer: Observer) {
+        self.shared.watch(observer);
     }
 }
 
@@ -1212,6 +1285,16 @@ impl SteleReader for Stele {
         let file = self.shared.pull_blob_file(&self.reference, oci)?;
 
         LayerReader::new(file, profile, descriptor, limits)
+    }
+
+    /// Report every blob this connection pulls.
+    ///
+    /// A restore resolves its [`Stele`] inside the driver, so this is the
+    /// spelling a caller reaches when it holds the reader; attaching to the
+    /// [`Registry`] the stele came from does the same thing, because both write
+    /// the same connection state.
+    fn observe(&self, observer: Observer) {
+        self.shared.watch(observer);
     }
 }
 
@@ -1447,27 +1530,38 @@ pub fn read_manifest(
 ///
 /// One chunk is allocated at a time and handed over, so what the upload holds
 /// is [`UPLOAD_CHUNK`] and not the layer.
-fn blob_stream(file: File) -> impl Stream<Item = oci_client::errors::Result<bytes::Bytes>> {
-    futures_util::stream::unfold(Some(file), |state| async move {
-        let mut file = state?;
-        let mut chunk = vec![0u8; UPLOAD_CHUNK];
-        let mut filled = 0usize;
+/// Each chunk is reported as it is handed over, which is the only resolution
+/// this loop has: a `PATCH` either went out or it did not, and the client does
+/// not say how much of one has reached the wire.
+fn blob_stream(
+    file: File,
+    observer: Observer,
+) -> impl Stream<Item = oci_client::errors::Result<bytes::Bytes>> {
+    futures_util::stream::unfold(Some(file), move |state| {
+        let observer = observer.clone();
 
-        while filled < chunk.len() {
-            match file.read(&mut chunk[filled..]) {
-                Ok(0) => break,
-                Ok(read) => filled += read,
-                Err(e) => return Some((Err(e.into()), None)),
+        async move {
+            let mut file = state?;
+            let mut chunk = vec![0u8; UPLOAD_CHUNK];
+            let mut filled = 0usize;
+
+            while filled < chunk.len() {
+                match file.read(&mut chunk[filled..]) {
+                    Ok(0) => break,
+                    Ok(read) => filled += read,
+                    Err(e) => return Some((Err(e.into()), None)),
+                }
             }
+
+            if filled == 0 {
+                return None;
+            }
+
+            chunk.truncate(filled);
+            observer.emit(Event::Bytes(filled as u64));
+
+            Some((Ok(bytes::Bytes::from(chunk)), Some(file)))
         }
-
-        if filled == 0 {
-            return None;
-        }
-
-        chunk.truncate(filled);
-
-        Some((Ok(bytes::Bytes::from(chunk)), Some(file)))
     })
 }
 
@@ -1495,15 +1589,17 @@ struct Blocking<'a, W: Write> {
     written: u64,
     limit: u64,
     digest: String,
+    observer: Observer,
 }
 
 impl<'a, W: Write> Blocking<'a, W> {
-    fn new(inner: &'a mut W, limit: i64, digest: &str) -> Self {
+    fn new(inner: &'a mut W, limit: i64, digest: &str, observer: Observer) -> Self {
         Self {
             inner,
             written: 0,
             limit: limit.max(0) as u64,
             digest: digest.to_owned(),
+            observer,
         }
     }
 }
@@ -1535,6 +1631,10 @@ impl<W: Write + Unpin> tokio::io::AsyncWrite for Blocking<'_, W> {
         match this.inner.write(&buf[..buf.len().min(room)]) {
             Ok(written) => {
                 this.written += written as u64;
+                // On what was written, for the same reason the ceiling is: a
+                // partial write's remainder is offered again, and reporting the
+                // offer would count those bytes twice.
+                this.observer.emit(Event::Bytes(written as u64));
                 Poll::Ready(Ok(written))
             }
             Err(e) => Poll::Ready(Err(e)),

--- a/crates/stelae/src/plan.rs
+++ b/crates/stelae/src/plan.rs
@@ -43,9 +43,9 @@
 //! profile knows which epochs a node wants.
 //!
 //! Not a renderer either. [`Remaining`] is a pair of numbers. Turning them into
-//! a progress bar is a caller's business, and adding an observer here would put
-//! a second one beside the seam the export and restore commands are going to
-//! share.
+//! a progress bar is a caller's business, and an observer here would be a
+//! second one beside [`crate::progress`], which is the seam the export and
+//! restore commands share and the only one either of them reports through.
 
 use std::{
     collections::BTreeSet,

--- a/crates/stelae/src/progress.rs
+++ b/crates/stelae/src/progress.rs
@@ -1,0 +1,234 @@
+//! What a transfer says about itself while it is still running.
+//!
+//! A publish and a restore are the two operations in this protocol that take
+//! hours, and until this module existed both were silent for every one of them:
+//! a caller learned what happened when it was over, from an [`Inscription`] or
+//! a summary. This is the seam that makes the middle visible, and it is
+//! deliberately the *only* one — there is no second observer on the profile
+//! side and no `tracing` subscriber standing in for one.
+//!
+//! [`Inscription`]: crate::Inscription
+//!
+//! ## It carries callbacks, never counters
+//!
+//! Nothing here accumulates. [`Observer`] holds a handle and forwards; an
+//! [`Event`] carries values the code emitting it already had in hand — the
+//! layer it is on, the size the manifest states, the bytes a chunk moved. A
+//! number this module would have to compute for itself is a number that does
+//! not belong in it, because a transport that keeps a tally the caller does not
+//! ask for is a transport whose cost nobody chose.
+//!
+//! ## Two emitters, because the numbers live in two places
+//!
+//! Neither half is honest alone:
+//!
+//! - the **profile driver** owns the layer loops, so it is the only code that
+//!   knows *n* of *m*, a layer's kind and scope, and whether it was produced,
+//!   inherited or skipped;
+//! - the **transport** owns the bytes. A publish stages a layer and then
+//!   uploads it in chunks, and a restore pulls a whole blob to scratch before
+//!   the first record comes back out of it — so an observer wired only to the
+//!   driver reports nothing for the entire duration of a download, which on the
+//!   restore side is the entire operation.
+//!
+//! The transports answer through [`SteleWriter::observe`] and
+//! [`SteleReader::observe`], which have default no-op bodies: reporting is
+//! something a transport *may* do, not a tax every implementation pays.
+//!
+//! [`SteleWriter::observe`]: crate::SteleWriter::observe
+//! [`SteleReader::observe`]: crate::SteleReader::observe
+//!
+//! ## Rendering is nobody's business here
+//!
+//! An [`Event`] is a fact, not a line of output. Which bar moves, whether
+//! anything is drawn at all, and what a human reads is the binary's, which is
+//! why the default is silence and why the handle is passed as an argument
+//! rather than installed globally.
+
+use std::sync::Arc;
+
+/// Somewhere to report a transfer's progress to.
+///
+/// One method, taking one enum, for a reason worth stating: a trait with a
+/// method per event kind would make every new fact a breaking change for every
+/// implementor, and the implementors are renderers — the least interesting code
+/// to have to revisit. Matching an enum, a renderer that does not care about a
+/// variant writes one arm.
+///
+/// `Send + Sync` because a transport holds it behind an [`Arc`] and calls it
+/// from wherever the bytes happen to be moving.
+pub trait Progress: Send + Sync {
+    fn on(&self, event: Event<'_>);
+}
+
+/// A handle on whatever is watching, and silence by default.
+///
+/// Cheap to clone — an [`Arc`] bump — because both a driver and a transport
+/// hold one for the same run. [`Observer::silent`] is the whole of "a caller
+/// that passes nothing": every emission becomes a branch on `None`, and the
+/// output is byte-for-byte what it was before this seam existed.
+#[derive(Clone, Default)]
+pub struct Observer(Option<Arc<dyn Progress>>);
+
+impl Observer {
+    /// An observer nobody is listening to.
+    pub fn silent() -> Self {
+        Self(None)
+    }
+
+    /// Report to `progress`.
+    pub fn new(progress: Arc<dyn Progress>) -> Self {
+        Self(Some(progress))
+    }
+
+    /// Whether anything is listening.
+    ///
+    /// For an emitter deciding whether a *costly* event is worth assembling —
+    /// never for deciding whether to do the work, which must not depend on who
+    /// is watching.
+    pub fn is_silent(&self) -> bool {
+        self.0.is_none()
+    }
+
+    pub fn emit(&self, event: Event<'_>) {
+        if let Some(progress) = &self.0 {
+            progress.on(event);
+        }
+    }
+}
+
+/// What was resolved, and nothing about who is listening.
+impl std::fmt::Debug for Observer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.is_silent() {
+            true => f.write_str("Observer(silent)"),
+            false => f.write_str("Observer(watching)"),
+        }
+    }
+}
+
+/// How a driver was done with a layer.
+///
+/// Three outcomes rather than a boolean because the two ways of *not* moving a
+/// layer cost different things and mean different things to whoever is
+/// watching: an inherited layer was never read out of a store at all, while a
+/// skipped one is work an earlier attempt already paid for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The driver read the layer end to end: built out of the stores on a
+    /// publish, streamed into them on a restore.
+    ///
+    /// Whether its blob then crossed the wire is a separate question, and the
+    /// transport answers it with [`Event::Blob`] — a layer a publisher builds
+    /// and a registry turns out to already hold is `Transferred` here and
+    /// `Blob { moved: false, .. }` there.
+    Transferred,
+
+    /// Nothing was done for it, because it was already done: a layer an
+    /// interrupted restore had committed before it died.
+    Skipped,
+
+    /// Adopted whole from the stele before it, and never read out of a store.
+    Inherited,
+}
+
+/// One thing that happened, as the code that did it saw it.
+///
+/// Deltas rather than running totals throughout ([`Event::Records`],
+/// [`Event::Bytes`]): a total is state, and state is what this seam does not
+/// keep. A renderer that wants one adds them up, which is what a renderer is
+/// for.
+#[derive(Debug, Clone, Copy)]
+pub enum Event<'a> {
+    /// A layer is now in flight: the `index`-th of `total`, counting from zero.
+    ///
+    /// `scope` is the profile's own opaque description of what the layer covers
+    /// — the epoch, the shard — carried so a watcher can name the layer the way
+    /// the inscription does rather than by its position alone.
+    LayerStarted {
+        index: usize,
+        total: usize,
+        kind: &'a str,
+        scope: &'a serde_json::Value,
+    },
+
+    /// The layer at `index` is done, one way or another.
+    ///
+    /// Carries the index rather than relying on the last
+    /// [`Event::LayerStarted`] because a profile may hold several layers
+    /// open at once — this one's sixteen state shards are written in a
+    /// single pass over the store — so "the layer in flight" is not always
+    /// a single thing.
+    LayerFinished {
+        index: usize,
+        total: usize,
+        kind: &'a str,
+        outcome: Outcome,
+    },
+
+    /// Records that went past since the last one of these.
+    ///
+    /// Batched at the emitter's own cadence rather than one per record: the
+    /// point is a bar that moves inside a layer that takes minutes, and a
+    /// virtual call per record on a mainnet store would be paying for
+    /// resolution nobody can see.
+    Records(u64),
+
+    /// One layer's blob, announced before the transport handles it.
+    ///
+    /// `bytes` is its compressed size, which the transport knows up front in
+    /// both directions — from the digest pipeline on the way up, from the
+    /// manifest on the way down — so a watcher can size the transfer it is
+    /// about to see. `moved` is false when nothing will cross the wire because
+    /// the far side already holds it, and no [`Event::Bytes`] follows.
+    Blob { moved: bool, bytes: u64 },
+
+    /// Compressed bytes that crossed the wire since the last one of these,
+    /// for the blob the most recent [`Event::Blob`] announced.
+    Bytes(u64),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct Recorder(Mutex<Vec<u64>>);
+
+    impl Progress for Recorder {
+        fn on(&self, event: Event<'_>) {
+            if let Event::Bytes(n) = event {
+                self.0.lock().unwrap().push(n);
+            }
+        }
+    }
+
+    /// The property every silent call site depends on: emitting into silence
+    /// does nothing and costs a branch.
+    #[test]
+    fn a_silent_observer_swallows_everything() {
+        let observer = Observer::silent();
+
+        assert!(observer.is_silent());
+        observer.emit(Event::Bytes(1));
+        observer.emit(Event::Records(1));
+
+        assert!(Observer::default().is_silent());
+    }
+
+    /// And a clone reports to the same place, which is what lets a driver and a
+    /// transport share one run's observer.
+    #[test]
+    fn a_clone_reports_to_the_same_place() {
+        let recorder = Arc::new(Recorder::default());
+        let observer = Observer::new(recorder.clone());
+
+        assert!(!observer.is_silent());
+
+        observer.emit(Event::Bytes(1));
+        observer.clone().emit(Event::Bytes(2));
+
+        assert_eq!(*recorder.0.lock().unwrap(), vec![1, 2]);
+    }
+}

--- a/crates/stelae/src/transport.rs
+++ b/crates/stelae/src/transport.rs
@@ -58,6 +58,7 @@ use crate::{
     inscription::{Inscription, LayerDescriptor},
     layer::LayerReader,
     profile::{checked_layer_media_type, Profile},
+    progress::Observer,
     Digest, Error,
 };
 
@@ -245,6 +246,22 @@ pub trait SteleWriter {
 
         sink.finish()
     }
+
+    /// Report what this transport moves to `observer`, for as long as it is
+    /// attached.
+    ///
+    /// **The default body does nothing, and that is the point.** A transport
+    /// that has no bytes of its own to report — [`crate::dir::SteleDir`] writes
+    /// straight to files a caller can watch, [`Discarding`] moves nothing —
+    /// implements nothing and loses nothing; only [`crate::oci::Registry`],
+    /// whose uploads are the hours a publisher waits through, overrides it. A
+    /// method every implementor must answer would be a tax on every future
+    /// transport for a capability most of them do not have.
+    ///
+    /// The profile driver is what calls this — it is handed the observer as an
+    /// argument and passes it on — so a caller wires one observer once and both
+    /// halves of the stream come back through it.
+    fn observe(&self, _observer: Observer) {}
 }
 
 /// Open a layer: everything every [`SteleWriter::layer_sink`] does before its
@@ -474,4 +491,14 @@ pub trait SteleReader {
         descriptor: &LayerDescriptor,
         limits: Limits,
     ) -> Result<LayerReader<Self::Blob>, Error>;
+
+    /// Report what this transport moves to `observer`, for as long as it is
+    /// attached.
+    ///
+    /// The read half of [`SteleWriter::observe`], with the same default and the
+    /// same reason for it. It matters more here than there: a registry reader
+    /// pulls a whole blob to scratch before it yields its first record, so a
+    /// restore that reported only what the profile driver sees would be silent
+    /// for the download — and on a restore the download *is* the work.
+    fn observe(&self, _observer: Observer) {}
 }

--- a/src/bin/dolos/bootstrap/mod.rs
+++ b/src/bin/dolos/bootstrap/mod.rs
@@ -175,16 +175,13 @@ fn dispatch(
         Command::Relay(args) => relay::run(config, args, feedback),
         Command::Mithril(args) => mithril::run(config, args, feedback),
         Command::Snapshot(args) => snapshot::run(config, args, feedback),
-        // No `feedback`: a stele restore has no progress reporting yet, which
-        // is a stated gap rather than an oversight — see the follow-up plan.
-        //
         // `resume` is `--continue`, and this is the only subcommand that does
         // anything with it. For the others it has always meant no more than
         // "proceed even though there is data here"; for a stele restore it is
         // also the instruction to read the progress file an interrupted attempt
         // left behind. Passing it rather than re-reading `args` keeps that one
         // flag with one meaning per subcommand instead of two spellings.
-        Command::Stelae(args) => stelae::run(config, args, resume),
+        Command::Stelae(args) => stelae::run(config, args, feedback, resume),
     }
 }
 

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -467,7 +467,6 @@ mod progress_tests {
         assert_eq!(progress.layers_position(), PER_RESTORE as u64);
         assert_eq!(progress.layers_length(), Some(PER_RESTORE as u64));
 
-        // The last blob came down whole.
         assert_eq!(progress.blob_position(), 8_192);
         assert_eq!(progress.blob_length(), Some(8_192));
 

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -41,6 +41,8 @@ use miette::{Context as _, IntoDiagnostic as _};
 
 use dolos_snapshot::registry::{self, Point, Repository};
 
+use crate::feedback::{Feedback, SteleProgress};
+
 #[derive(Debug, clap::Args, Clone)]
 pub struct Args {
     /// Where to restore from, as a URL: `file://DIR` naming a stele directory,
@@ -190,13 +192,25 @@ impl Node {
     }
 }
 
-fn restore_dir(config: &RootConfig, dir: &std::path::Path, resume: bool) -> miette::Result<()> {
+fn restore_dir(
+    config: &RootConfig,
+    dir: &std::path::Path,
+    feedback: &Feedback,
+    resume: bool,
+) -> miette::Result<()> {
     let node = Node::open(config)?;
+    let progress = SteleProgress::restoring(feedback);
 
-    let (plan, outlook, summary) =
-        dolos_snapshot::restore::restore_dir(dir, node.restoring(resume), node.target())
-            .into_diagnostic()
-            .context("restoring the stele")?;
+    let (plan, outlook, summary) = dolos_snapshot::restore::restore_dir(
+        dir,
+        node.restoring(resume),
+        node.target(),
+        &progress.observer(),
+    )
+    .into_diagnostic()
+    .context("restoring the stele")?;
+
+    progress.finish();
 
     report(&plan, &outlook, &summary);
 
@@ -209,6 +223,7 @@ fn restore_repo(
     point: Point,
     insecure: bool,
     scratch_dir: Option<&std::path::Path>,
+    feedback: &Feedback,
     resume: bool,
 ) -> miette::Result<()> {
     // First: `Node::open` runs `ensure_storage_path`, so the default of
@@ -229,10 +244,19 @@ fn restore_repo(
 
     println!("source:   {repo} ({point})");
 
-    let (plan, outlook, summary) =
-        registry::restore_registry(&registry, point, node.restoring(resume), node.target())
-            .into_diagnostic()
-            .context("restoring the stele")?;
+    let progress = SteleProgress::restoring(feedback);
+
+    let (plan, outlook, summary) = registry::restore_registry(
+        &registry,
+        point,
+        node.restoring(resume),
+        node.target(),
+        &progress.observer(),
+    )
+    .into_diagnostic()
+    .context("restoring the stele")?;
+
+    progress.finish();
 
     report(&plan, &outlook, &summary);
 
@@ -241,12 +265,11 @@ fn restore_repo(
 
 /// What the run did, in the numbers an operator checks.
 ///
-/// The remaining-download figures are printed *after* the restore rather than
-/// before it, and that is a gap rather than a choice: rendering progress while
-/// it runs is the observer seam this command shares with `snapshot publish`,
-/// and it belongs to whichever of the two follow-up slices lands first. What is
-/// here is the arithmetic that seam will read, and a report that at least says
-/// what a resumed run cost rather than what an unresumed one would have.
+/// Still printed after the restore, and now that is a choice rather than a gap:
+/// the run itself is drawn while it happens, through the observer seam this
+/// command shares with `snapshot publish`, so what is left for the end is the
+/// arithmetic a bar cannot carry — what a resumed run cost rather than what an
+/// unresumed one would have.
 fn report(
     plan: &dolos_snapshot::restore::Plan,
     outlook: &dolos_snapshot::restore::Outlook,
@@ -288,15 +311,21 @@ fn report(
     );
 }
 
-pub fn run(config: &RootConfig, args: &Args, resume: bool) -> miette::Result<()> {
+pub fn run(
+    config: &RootConfig,
+    args: &Args,
+    feedback: &Feedback,
+    resume: bool,
+) -> miette::Result<()> {
     match &args.source {
-        Source::Dir(dir) => restore_dir(config, dir, resume),
+        Source::Dir(dir) => restore_dir(config, dir, feedback, resume),
         Source::Repo(repo) => restore_repo(
             config,
             repo,
             args.point,
             args.insecure,
             args.scratch_dir.as_deref(),
+            feedback,
             resume,
         ),
     }
@@ -356,5 +385,98 @@ mod tests {
         ] {
             assert!(raw.parse::<Source>().is_err(), "{raw:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use dolos_snapshot::progress::{Event, Outcome, Progress as _};
+
+    use crate::feedback::{Feedback, SteleProgress};
+
+    const PER_RESTORE: usize = 3 + 16;
+
+    /// The wiring `restore_dir` and `restore_repo` use, driven over a
+    /// fixture-scale restore that resumes.
+    ///
+    /// The resume is the case worth rendering and the one worth testing: a
+    /// skipped layer moves no blob and no bytes, so a bar that advanced only on
+    /// bytes would stall on exactly the layers a resumed run gets for free.
+    #[test]
+    fn the_restore_renderer_tracks_a_resumed_fixture_scale_run() {
+        let progress = SteleProgress::restoring(&Feedback::hidden());
+
+        let epoch = serde_json::json!({"networkMagic": 2, "epoch": 0});
+        let shard = serde_json::json!({"networkMagic": 2, "epoch": 0, "shard": 0});
+
+        // The layer an earlier attempt had already committed: announced, closed,
+        // nothing pulled for it.
+        progress.on(Event::LayerStarted {
+            index: 0,
+            total: PER_RESTORE,
+            kind: "blocks",
+            scope: &epoch,
+        });
+
+        progress.on(Event::LayerFinished {
+            index: 0,
+            total: PER_RESTORE,
+            kind: "blocks",
+            outcome: Outcome::Skipped,
+        });
+
+        assert_eq!(
+            progress.layers_position(),
+            1,
+            "a skip still advances the run"
+        );
+        assert_eq!(progress.blob_position(), 0);
+
+        for index in 1..PER_RESTORE {
+            let kind = if index < 3 { "logs" } else { "state" };
+            let scope = if index < 3 { &epoch } else { &shard };
+
+            progress.on(Event::LayerStarted {
+                index,
+                total: PER_RESTORE,
+                kind,
+                scope,
+            });
+
+            // A registry reader pulls the whole blob before a record comes back
+            // out of it, which is the stretch this bar exists for.
+            progress.on(Event::Blob {
+                moved: true,
+                bytes: 8_192,
+            });
+
+            for _ in 0..8 {
+                progress.on(Event::Bytes(1_024));
+            }
+
+            progress.on(Event::Records(2_000));
+
+            progress.on(Event::LayerFinished {
+                index,
+                total: PER_RESTORE,
+                kind,
+                outcome: Outcome::Transferred,
+            });
+        }
+
+        assert_eq!(progress.layers_position(), PER_RESTORE as u64);
+        assert_eq!(progress.layers_length(), Some(PER_RESTORE as u64));
+
+        // The last blob came down whole.
+        assert_eq!(progress.blob_position(), 8_192);
+        assert_eq!(progress.blob_length(), Some(8_192));
+
+        assert_eq!(
+            progress.records_position(),
+            2_000 * (PER_RESTORE as u64 - 1),
+            "the skipped layer contributed no records"
+        );
+
+        progress.finish();
     }
 }

--- a/src/bin/dolos/feedback.rs
+++ b/src/bin/dolos/feedback.rs
@@ -1,6 +1,8 @@
 pub use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::Arc;
 
+use dolos_snapshot::progress::{Event, Observer, Outcome, Progress};
+
 pub struct ProgressReader<R> {
     inner: R,
     progress: ProgressBar,
@@ -68,10 +70,299 @@ impl Feedback {
     }
 }
 
+impl Feedback {
+    /// A feedback surface that draws nothing.
+    ///
+    /// For the tests over the renderers built on it, which assert on the state
+    /// a bar holds rather than on a terminal — and which would otherwise
+    /// scribble over the test harness's own output.
+    #[cfg(test)]
+    pub fn hidden() -> Self {
+        Self {
+            multi: Arc::new(MultiProgress::with_draw_target(
+                indicatif::ProgressDrawTarget::hidden(),
+            )),
+        }
+    }
+}
+
 impl Default for Feedback {
     fn default() -> Self {
         let multi = Arc::new(MultiProgress::new());
 
         Self { multi }
+    }
+}
+
+/// A stele transfer, drawn while it happens.
+///
+/// The one renderer for both directions, because both report through one seam
+/// and an operator watching a publish and an operator watching a restore want
+/// the same three things: which layer of how many, how much of the blob in
+/// flight has moved, and that records are still going past. What differs
+/// between the two commands is the words, which is
+/// [`SteleProgress::publishing`] and [`SteleProgress::restoring`].
+///
+/// Three bars rather than one because the three move on entirely different
+/// clocks: a layer boundary can be a minute apart on mainnet, a blob's bytes
+/// tick continuously, and the record counter is the only thing that moves at
+/// all during the epoch scan that dominates a publish.
+pub struct SteleProgress {
+    verb: &'static str,
+    layers: ProgressBar,
+    blob: ProgressBar,
+    records: ProgressBar,
+}
+
+impl SteleProgress {
+    /// The renderer `dolos snapshot publish` reports through.
+    pub fn publishing(feedback: &Feedback) -> Arc<Self> {
+        Self::new(feedback, "publishing")
+    }
+
+    /// The renderer `dolos bootstrap stelae` reports through.
+    pub fn restoring(feedback: &Feedback) -> Arc<Self> {
+        Self::new(feedback, "restoring")
+    }
+
+    fn new(feedback: &Feedback, verb: &'static str) -> Arc<Self> {
+        let multi = feedback.multi_progress();
+
+        let layers = multi.add(ProgressBar::new(0));
+        layers.set_style(
+            ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos:>4}/{len:4} layers {msg}",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+        );
+
+        let blob = multi.add(ProgressBar::new(0));
+        blob.set_style(
+            ProgressStyle::with_template(
+                "  {bar:40.cyan/blue} {bytes}/{total_bytes} {binary_bytes_per_sec} (eta: {eta}) {msg}",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+        );
+
+        let records = multi.add(ProgressBar::new_spinner());
+        records.set_style(
+            ProgressStyle::with_template("  {spinner:.green} {human_pos} records").unwrap(),
+        );
+
+        Arc::new(Self {
+            verb,
+            layers,
+            blob,
+            records,
+        })
+    }
+
+    /// The handle a driver takes.
+    pub fn observer(self: &Arc<Self>) -> Observer {
+        Observer::new(self.clone())
+    }
+
+    /// Leave the bars saying what the run ended as.
+    ///
+    /// Called by the command once the driver returns, so that the summary it
+    /// prints is not interleaved with a bar still claiming to be drawing.
+    pub fn finish(&self) {
+        self.blob.finish_and_clear();
+        self.records.finish_and_clear();
+        self.layers.finish_and_clear();
+    }
+
+    /// Where the bars ended up.
+    ///
+    /// The renderer's whole output is terminal state, so a test over it has to
+    /// read that state; these are the accessors it reads. Test-only, because
+    /// nothing in the program has a reason to ask a bar what it says.
+    #[cfg(test)]
+    pub fn layers_position(&self) -> u64 {
+        self.layers.position()
+    }
+
+    #[cfg(test)]
+    pub fn layers_length(&self) -> Option<u64> {
+        self.layers.length()
+    }
+
+    #[cfg(test)]
+    pub fn blob_position(&self) -> u64 {
+        self.blob.position()
+    }
+
+    #[cfg(test)]
+    pub fn blob_length(&self) -> Option<u64> {
+        self.blob.length()
+    }
+
+    #[cfg(test)]
+    pub fn records_position(&self) -> u64 {
+        self.records.position()
+    }
+
+    /// How a layer is named to an operator: its kind, and whatever of the
+    /// profile's scope identifies it.
+    ///
+    /// The scope is opaque to everything below the binary, so this reads the
+    /// two keys this profile actually uses and falls back to the compact JSON
+    /// rather than inventing a vocabulary the inscription does not have.
+    fn describe(kind: &str, scope: &serde_json::Value) -> String {
+        let field = |name: &str| scope.get(name).and_then(|v| v.as_u64());
+
+        match (field("epoch"), field("shard")) {
+            (Some(epoch), Some(shard)) => format!("{kind} epoch {epoch} shard {shard}"),
+            (Some(epoch), None) => format!("{kind} epoch {epoch}"),
+            (None, Some(shard)) => format!("{kind} shard {shard}"),
+            (None, None) => format!("{kind} {scope}"),
+        }
+    }
+}
+
+impl Progress for SteleProgress {
+    fn on(&self, event: Event<'_>) {
+        match event {
+            Event::LayerStarted {
+                total, kind, scope, ..
+            } => {
+                self.layers.set_length(total as u64);
+                self.layers
+                    .set_message(format!("{} {}", self.verb, Self::describe(kind, scope)));
+            }
+
+            // Counted rather than positioned from the index: a driver may hold
+            // several layers open at once and close them in whatever order its
+            // sinks finish — the export's sixteen state shards do exactly that —
+            // and a bar placed at `index + 1` would run backwards when it did.
+            Event::LayerFinished {
+                total,
+                kind,
+                outcome,
+                ..
+            } => {
+                self.layers.set_length(total as u64);
+                self.layers.inc(1);
+
+                match outcome {
+                    Outcome::Transferred => {}
+                    Outcome::Skipped => self
+                        .layers
+                        .set_message(format!("skipped {kind}, already restored")),
+                    Outcome::Inherited => self
+                        .layers
+                        .set_message(format!("carried forward {kind}, not rebuilt")),
+                }
+            }
+
+            Event::Records(moved) => self.records.inc(moved),
+
+            // Per blob, not per run: the total a run will move is not knowable
+            // up front on the publish side — a layer's compressed size exists
+            // only once it has been compressed — so a cumulative bar would show
+            // a length that grew as it filled.
+            Event::Blob { moved, bytes } => {
+                self.blob.set_position(0);
+                self.blob.set_length(bytes);
+
+                match moved {
+                    true => self.blob.set_message(""),
+                    false => self.blob.set_message("already in the registry"),
+                }
+            }
+
+            Event::Bytes(moved) => self.blob.inc(moved),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hidden(verb: &'static str) -> Arc<SteleProgress> {
+        SteleProgress::new(&Feedback::hidden(), verb)
+    }
+
+    #[test]
+    fn a_layer_names_itself_by_scope() {
+        let epoch = serde_json::json!({"networkMagic": 764824073, "epoch": 512});
+        let shard = serde_json::json!({"networkMagic": 764824073, "epoch": 512, "shard": 3});
+        let neither = serde_json::json!({"lastImmutable": 9});
+
+        assert_eq!(
+            SteleProgress::describe("blocks", &epoch),
+            "blocks epoch 512"
+        );
+        assert_eq!(
+            SteleProgress::describe("state", &shard),
+            "state epoch 512 shard 3"
+        );
+        assert_eq!(
+            SteleProgress::describe("digests", &neither),
+            "digests {\"lastImmutable\":9}"
+        );
+    }
+
+    /// Layers held open together and closed in whatever order their sinks
+    /// finish — the shape the export's state pass produces — leave the bar at
+    /// the run's real position and never run it backwards.
+    #[test]
+    fn closing_out_of_order_does_not_overshoot() {
+        let progress = hidden("publishing");
+        let scope = serde_json::json!({"shard": 0});
+
+        for index in 0..4 {
+            progress.on(Event::LayerStarted {
+                index,
+                total: 4,
+                kind: "state",
+                scope: &scope,
+            });
+        }
+
+        for index in (0..4).rev() {
+            let before = progress.layers.position();
+
+            progress.on(Event::LayerFinished {
+                index,
+                total: 4,
+                kind: "state",
+                outcome: Outcome::Transferred,
+            });
+
+            assert!(
+                progress.layers.position() > before,
+                "the bar went backwards"
+            );
+        }
+
+        assert_eq!(progress.layers.position(), 4);
+        assert_eq!(progress.layers.length(), Some(4));
+    }
+
+    #[test]
+    fn a_blob_bar_is_per_blob_and_a_skip_moves_nothing() {
+        let progress = hidden("publishing");
+
+        progress.on(Event::Blob {
+            moved: true,
+            bytes: 300,
+        });
+        progress.on(Event::Bytes(120));
+        progress.on(Event::Bytes(180));
+
+        assert_eq!(progress.blob.position(), 300);
+        assert_eq!(progress.blob.length(), Some(300));
+
+        progress.on(Event::Blob {
+            moved: false,
+            bytes: 50,
+        });
+
+        assert_eq!(progress.blob.position(), 0);
+        assert_eq!(progress.blob.length(), Some(50));
     }
 }

--- a/src/bin/dolos/main.rs
+++ b/src/bin/dolos/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
         (Ok(config), Command::Serve(args)) => serve::run(config, &args),
         (Ok(config), Command::Eval(args)) => eval::run(&config, &args),
         (Ok(config), Command::Doctor(args)) => doctor::run(&config, &args, &feedback),
-        (Ok(config), Command::Snapshot(args)) => snapshot::run(&config, &args),
+        (Ok(config), Command::Snapshot(args)) => snapshot::run(&config, &args, &feedback),
 
         // the init command is special because it knows how to execute with or without a valid
         // configuration, that is why we pass the whole result and let the command logic decide what

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -25,6 +25,8 @@ use dolos_core::config::RootConfig;
 use dolos_snapshot::export::Plan;
 use miette::IntoDiagnostic as _;
 
+use crate::feedback::Feedback;
+
 mod digest;
 mod inspect;
 mod publish;
@@ -53,9 +55,12 @@ pub struct Args {
     command: Command,
 }
 
-pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {
     match &args.command {
-        Command::Publish(x) => publish::run(config, x),
+        // `feedback` reaches `publish` alone: it is the only one of the four
+        // that waits on a store walk and a network, and the other three are
+        // over in the time it takes to print what they found.
+        Command::Publish(x) => publish::run(config, x, feedback),
         Command::Digest(x) => digest::run(config, x),
         Command::Verify(x) => verify::run(config, x),
         Command::Inspect(x) => inspect::run(config, x),

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -11,6 +11,7 @@ use dolos_snapshot::{
 };
 
 use super::EpochRange;
+use crate::feedback::{Feedback, SteleProgress};
 
 /// Where a stele goes, and it goes to exactly one place.
 ///
@@ -68,7 +69,7 @@ pub struct Args {
     require_new: bool,
 }
 
-pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {
     let stores = crate::common::open_data_stores(config)
         .into_diagnostic()
         .context("opening the data stores")?;
@@ -84,8 +85,8 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     super::report_plan(&plan)?;
 
     match (&args.repo, &args.output_dir) {
-        (Some(repo), _) => to_repository(config, args, repo, &plan, &stores),
-        (None, Some(dir)) => to_directory(args, dir, &plan, &stores),
+        (Some(repo), _) => to_repository(config, args, repo, &plan, &stores, feedback),
+        (None, Some(dir)) => to_directory(args, dir, &plan, &stores, feedback),
         // The required `destination` group already refuses this.
         (None, None) => unreachable!("one of --output-dir and --repo is required"),
     }
@@ -96,11 +97,17 @@ fn to_directory(
     dir: &std::path::Path,
     plan: &export::Plan,
     stores: &crate::common::Stores,
+    feedback: &Feedback,
 ) -> miette::Result<()> {
     if args.dry_run {
         println!("dry run: nothing written to {}", dir.display());
         return Ok(());
     }
+
+    // A directory publish moves no bytes over a network, so the blob bar stays
+    // empty here — but the layer and record bars are the same hours of store
+    // walking a repository publish pays, and they are what this reports.
+    let progress = SteleProgress::publishing(feedback);
 
     let inscription = export::publish(
         dir,
@@ -109,9 +116,12 @@ fn to_directory(
         &stores.state,
         &stores.indexes,
         None,
+        &progress.observer(),
     )
     .into_diagnostic()
     .context("exporting the stele")?;
+
+    progress.finish();
 
     let digest = inscription.digest().into_diagnostic()?;
 
@@ -137,6 +147,7 @@ fn to_repository(
     repo: &Repository,
     plan: &export::Plan,
     stores: &crate::common::Stores,
+    feedback: &Feedback,
 ) -> miette::Result<()> {
     // A publisher's credentials come from `STELAE_REGISTRY_USER` /
     // `STELAE_REGISTRY_PASSWORD`, which override anything configured. The
@@ -196,6 +207,11 @@ fn to_repository(
         return Ok(());
     }
 
+    // Built here rather than above the dry run: the dry run prints and returns,
+    // and a renderer for a publish that never happens would draw an empty bar
+    // under the report.
+    let progress = SteleProgress::publishing(feedback);
+
     let published = registry::publish(
         publishing,
         plan,
@@ -203,9 +219,12 @@ fn to_repository(
         &stores.state,
         &stores.indexes,
         None,
+        &progress.observer(),
     )
     .into_diagnostic()
     .context("publishing the stele")?;
+
+    progress.finish();
 
     let transfer = published.transfer;
 
@@ -284,5 +303,106 @@ fn standing(registry: &Registry, plan: &export::Plan, args: &Args) -> miette::Re
              stele, and this one would leave a gap no later stele could close",
             plan.sequence,
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_snapshot::progress::{Event, Outcome, Progress as _};
+
+    use crate::feedback::{Feedback, SteleProgress};
+
+    /// One epoch's three layers plus the sixteen state shards — the fixture
+    /// suites' `PER_PUBLISH`, and the smallest publish this profile makes.
+    const PER_PUBLISH: usize = 3 + 16;
+
+    /// The wiring `run` uses, driven over a fixture-scale publish.
+    ///
+    /// Named for what it is protecting: [#1191]'s squash dropped the CLI's
+    /// rendering layer outright and nothing noticed, because nothing under
+    /// `src/bin/dolos/` had anything to say about it. This exercises the same
+    /// constructor `to_repository` and `to_directory` call, feeds it the event
+    /// stream a one-epoch publish produces, and holds the bars to where that
+    /// run actually ended.
+    ///
+    /// [#1191]: https://github.com/txpipe/dolos/pull/1191
+    #[test]
+    fn the_publish_renderer_tracks_a_fixture_scale_run() {
+        let progress = SteleProgress::publishing(&Feedback::hidden());
+
+        let epoch = serde_json::json!({"networkMagic": 2, "epoch": 0});
+        let shard = serde_json::json!({"networkMagic": 2, "epoch": 0, "shard": 0});
+
+        let mut moved = 0u64;
+
+        for (index, kind) in ["blocks", "indexes", "logs"].into_iter().enumerate() {
+            progress.on(Event::LayerStarted {
+                index,
+                total: PER_PUBLISH,
+                kind,
+                scope: &epoch,
+            });
+
+            progress.on(Event::Records(1_000));
+
+            // The transport's half: staged, then uploaded in chunks.
+            progress.on(Event::Blob {
+                moved: true,
+                bytes: 4_096,
+            });
+
+            for _ in 0..4 {
+                progress.on(Event::Bytes(1_024));
+                moved += 1_024;
+            }
+
+            progress.on(Event::LayerFinished {
+                index,
+                total: PER_PUBLISH,
+                kind,
+                outcome: Outcome::Transferred,
+            });
+        }
+
+        // The state pass: sixteen layers open at once, closed in order, with one
+        // record stream feeding all of them.
+        for index in 3..PER_PUBLISH {
+            progress.on(Event::LayerStarted {
+                index,
+                total: PER_PUBLISH,
+                kind: "state",
+                scope: &shard,
+            });
+        }
+
+        progress.on(Event::Records(50_000));
+
+        for index in 3..PER_PUBLISH {
+            progress.on(Event::Blob {
+                moved: false,
+                bytes: 512,
+            });
+
+            progress.on(Event::LayerFinished {
+                index,
+                total: PER_PUBLISH,
+                kind: "state",
+                outcome: Outcome::Transferred,
+            });
+        }
+
+        assert_eq!(progress.layers_position(), PER_PUBLISH as u64);
+        assert_eq!(progress.layers_length(), Some(PER_PUBLISH as u64));
+        assert_eq!(progress.records_position(), 53_000);
+
+        // The last blob was one the registry already held, so the byte bar sits
+        // at zero over its stated size rather than carrying the previous
+        // layer's total forward.
+        assert_eq!(progress.blob_position(), 0);
+        assert_eq!(progress.blob_length(), Some(512));
+
+        assert_eq!(moved, 3 * 4_096);
+
+        progress.finish();
     }
 }


### PR DESCRIPTION
Implements [`plans/dolos-stelae-progress-observer.md`](https://github.com/txpipe/dolos) — "Stelae — one progress seam, watched from both directions".

Every stelae command that runs for hours is silent while it does. `dolos snapshot publish` prints its plan and then nothing until the digest; `dolos bootstrap stelae` computes what is left and then goes quiet until the summary. Four plans named the gap and each deferred it to another. This closes it for both directions, through one seam neither direction owns alone.

## What changed

**`crates/stelae/src/progress.rs` — the seam.** A `Progress` trait with one method taking one `Event` enum, and an `Observer` handle that is silent by default and cheap to clone. It carries callbacks and nothing else: no new counter, no field on `Transfer`, `Remaining` or `Published`, no state outliving a call. Every event carries values the emitting code already had in hand.

**`SteleWriter::observe` / `SteleReader::observe` — one method each, default no-op.** `SteleDir` (`dir.rs`) and `Discarding` (`transport.rs`) compile unchanged and implement nothing; `oci::Registry` and `oci::Stele` override it. That default is what keeps the trait an offer rather than a tax on every future transport.

**Two emitters.**

- `crates/snapshot` emits the layer level as an explicit parameter. `export()` and the restore driver each take an `&Observer` and report, per layer, its index of the total, its kind and scope, and its outcome — `Transferred`, `Inherited` or `Skipped` — plus a record-level cadence (batched at 4096) over the store scan, which is where a publish spends most of its hours and where a layer boundary alone leaves a bar still for minutes at a time. The state pass holds all sixteen shard sinks open at once, so positions are handed out up front and quoted back at close rather than tracked as "the current layer".
- `oci` emits the bytes. A `Blob { moved, bytes }` event announces each layer's blob before the transport handles it — including the ones the registry already holds, where `moved` is false and nothing follows — then `Bytes` deltas from the upload chunk loop (`blob_stream`) and from the blob download (`Blocking::poll_write`). Without this half a restore reports nothing for its entire duration: `pull_blob_file` lands the whole blob in scratch before `stream_layer` yields one record.

**The CLI is the only renderer.** `feedback.rs` grows `SteleProgress` — a layer bar, a per-blob byte bar and a record spinner over the existing `MultiProgress` — built the way `bootstrap mithril` already builds its own. `snapshot publish` and `bootstrap stelae` each construct one and hand its observer to the driver. A library consumer passes `Observer::silent()` and gets today's output byte for byte.

Nothing reports through `tracing` and nothing is installed globally; the parameter is the only path in.

## Verification

`cargo +nightly fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` (clean), `cargo test --workspace --all-targets`, and `cargo test --workspace --all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` — all green.

A recording observer (`crates/snapshot/tests/watcher/`) pins both streams and asserts their shape — every position in `0..total` opened exactly once and closed exactly once, every event carrying the same total, nothing reported after the last layer closes — then cross-checks the numbers against counters that already exist, never against the recording itself:

| suite | cross-checked against |
|---|---|
| `tests/export.rs` | the inscription's layer count and per-layer `records`; a watched and a silent publish produce identical documents |
| `tests/restore.rs` | `Summary::layers_fetched` / `layers_skipped`, whole and resumed |
| `tests/publish.rs` (Docker) | `Transfer::layers_uploaded` / `layers_skipped` / `layers_reused` / `bytes_uploaded` / `bytes_skipped` |
| `tests/restore_registry.rs` (Docker) | `Outlook::remaining.compressed_bytes`, and the blob sizes the manifest states |

Each command also has a test under `src/bin/dolos/` driving its own renderer constructor over a fixture-scale event stream — named explicitly because #1191's squash dropped exactly that layer and the loss stayed invisible until someone went looking. The restore one covers the resumed case, where a skipped layer moves no blob and no bytes.

## Not run locally

The two `#[ignore]`d Docker suites (`tests/publish.rs`, `tests/restore_registry.rs`) compile and their new tests are written, but the Docker daemon on the machine this was developed on is unresponsive, so the registry-backed cross-checks — the `Transfer` half of done criterion 4 — were **not executed locally**. The `Registry` workflow runs them here, across `registry:2`, `registry:3` and `zot`, so that gate is this PR's rather than a manual step; the result on this PR is the evidence, not my local run.

To reproduce by hand with a working daemon:

```
cargo test -p dolos-snapshot --features oci --test publish -- --ignored --test-threads=1
cargo test -p dolos-snapshot --features oci --test restore_registry -- --ignored --test-threads=1
```

## One finding for the plan's owner

Done criterion 4 asks the outcome tallies to equal `Transfer`'s `layers_uploaded` / `layers_skipped` / `layers_reused` three ways. The publish-side skip — a layer the publisher built and the registry turned out to already hold — is decided inside `put_layer`, which `export()` cannot see, and surfacing it on `LayerFinished` would have meant either a field on `WrittenLayer` or a second required trait method, both of which the plan's scope decision rules out. It is reported instead as `Blob { moved: false }` from the transport, which is a callback over a number the transport already counts. The tallies therefore land as: `Blob{moved:true}` == `layers_uploaded`, `Blob{moved:false}` == `layers_skipped`, `Outcome::Inherited` == `layers_reused` — the same three-way split, split across the two emitters rather than carried on one event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live progress reporting for snapshot publishing and restoring.
  * Progress now displays layers, records, blobs, transferred bytes, and outcomes such as skipped or inherited data.
  * Added progress support for directory and registry operations.
* **Bug Fixes**
  * Improved progress accuracy for resumed operations and out-of-order layer completion.
  * Dry runs remain free of progress rendering.
* **Tests**
  * Added coverage for transfer totals, skipped layers, inherited data, records, blobs, and byte movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
