### PR TITLE
feat(cardano): enact the four missing governance action variants

### DIFF
--- a/crates/cardano/src/ewrap/commit.rs
+++ b/crates/cardano/src/ewrap/commit.rs
@@ -18,7 +18,8 @@ use tracing::{debug, instrument, trace, warn};
 
 use crate::{
     ewrap::BoundaryWork, rupd::credential_to_key, AccountState, CardanoEntity, DRepState,
-    EpochState, FixedNamespace, PendingMirState, PendingRewardState, PoolState, ProposalState,
+    EpochState, FixedNamespace, GovState, PendingMirState, PendingRewardState, PoolState,
+    ProposalState,
 };
 
 impl BoundaryWork {
@@ -179,6 +180,11 @@ impl BoundaryWork {
         {
             self.ending_state = applied;
         }
+
+        // Gov isn't streamed by namespace; the enactment deltas on the
+        // governance singleton (committee, constitution, per-purpose lineage
+        // roots) go through the singleton path, as they do in ESTART's commit.
+        self.deltas.apply_singleton::<GovState, _>(state, &writer)?;
 
         // Delete processed pending MIRs.
         debug!(

--- a/crates/cardano/src/ewrap/enactment.rs
+++ b/crates/cardano/src/ewrap/enactment.rs
@@ -228,8 +228,6 @@ mod tests {
                 "unexpected root updates for {action:?}"
             );
 
-            // Info is the one action that ratifies with no state effect at
-            // all; everything else emits at least its own effect.
             let effects = deltas.len() - roots;
 
             if is_info {
@@ -279,7 +277,6 @@ mod tests {
             guardrail_script: Some([2u8; 28].into()),
         };
 
-        // epoch 541: the Cardano Constitution replaces the interim one
         let id = ProposalId::from(constitution_tx.to_vec());
         state = apply_gov(
             state,
@@ -296,7 +293,6 @@ mod tests {
             ),
         );
 
-        // epoch 580: the interim committee is replaced
         let id = ProposalId::from(committee_tx.to_vec());
         state = apply_gov(
             state,
@@ -327,7 +323,6 @@ mod tests {
         );
         assert!(!enacted_committee.members.contains_key(&interim_member));
 
-        // both lineage trees now root at the action that was enacted
         assert_eq!(
             state.prev_gov_action_ids.constitution,
             Some(GovActionId {
@@ -343,7 +338,6 @@ mod tests {
             })
         );
 
-        // untouched purposes stay empty
         assert_eq!(state.prev_gov_action_ids.hard_fork, None);
         assert_eq!(state.prev_gov_action_ids.pparam_update, None);
     }

--- a/crates/cardano/src/ewrap/enactment.rs
+++ b/crates/cardano/src/ewrap/enactment.rs
@@ -1,9 +1,11 @@
 use dolos_core::{ChainError, EntityKey};
+use pallas::ledger::primitives::conway::GovActionId;
 
 use crate::{
     ewrap::{BoundaryWork, ProposalId},
-    AccountState, CardanoDelta, CardanoEntity, PParamValue, PParamsSet, PParamsUpdate,
-    ProposalAction, ProposalState, TreasuryWithdrawal,
+    AccountState, CardanoDelta, CardanoEntity, CommitteeUpdate, Constitution, ConstitutionUpdate,
+    GovRootsUpdate, PParamValue, PParamsSet, PParamsUpdate, ProposalAction, ProposalState,
+    TreasuryWithdrawal,
 };
 
 #[derive(Default)]
@@ -12,10 +14,72 @@ pub struct BoundaryVisitor {
     logs: Vec<(EntityKey, CardanoEntity)>,
 }
 
-impl BoundaryVisitor {
-    fn change(&mut self, delta: impl Into<CardanoDelta>) {
-        self.deltas.push(delta.into());
+/// The state effects an enacted proposal carries: the action's own effect
+/// plus, for every action belonging to a lineage tree, that tree's new root.
+///
+/// Kept apart from the visitor so the mapping is exercisable on its own —
+/// none of it depends on boundary context.
+pub(crate) fn enactment_deltas(id: &ProposalId, proposal: &ProposalState) -> Vec<CardanoDelta> {
+    let mut deltas: Vec<CardanoDelta> = Vec::new();
+
+    match &proposal.action {
+        ProposalAction::HardFork(version) => {
+            let value = PParamValue::ProtocolVersion(*version);
+            let pparams = PParamsSet::default().with(value);
+            deltas.push(PParamsUpdate::new(pparams).into());
+        }
+        ProposalAction::ParamChange(pparams) => {
+            deltas.push(PParamsUpdate::new(pparams.clone()).into());
+        }
+        ProposalAction::TreasuryWithdrawal(withdrawals) => {
+            for (credential, amount) in withdrawals {
+                deltas.push(TreasuryWithdrawal::new(credential.clone(), *amount).into());
+            }
+        }
+        ProposalAction::NoConfidence => {
+            deltas.push(CommitteeUpdate::no_confidence().into());
+        }
+        ProposalAction::UpdateCommittee {
+            to_remove,
+            to_add,
+            threshold,
+        } => {
+            deltas.push(
+                CommitteeUpdate::update(to_remove.clone(), to_add.clone(), threshold.clone())
+                    .into(),
+            );
+        }
+        ProposalAction::NewConstitution {
+            anchor,
+            guardrail_script,
+        } => {
+            deltas.push(
+                ConstitutionUpdate::new(Constitution {
+                    anchor: anchor.clone(),
+                    guardrail_script: *guardrail_script,
+                })
+                .into(),
+            );
+        }
+        // Info actions ratify but carry no state effect.
+        ProposalAction::Info => (),
+        // Only reachable from rows written before the specific variants
+        // existed, where the action's content was never recorded.
+        ProposalAction::Other => {
+            tracing::error!(proposal=%id, "can't enact legacy proposal with untracked action");
+        }
     }
+
+    if let Some(purpose) = proposal.action.purpose() {
+        let action = GovActionId {
+            transaction_id: proposal.tx,
+            action_index: proposal.idx,
+        };
+
+        deltas.push(GovRootsUpdate::new(purpose, action).into());
+    }
+
+    deltas
 }
 
 impl super::BoundaryVisitor for BoundaryVisitor {
@@ -28,26 +92,7 @@ impl super::BoundaryVisitor for BoundaryVisitor {
     ) -> Result<(), ChainError> {
         tracing::debug!(proposal=%id, "visiting enacted proposal");
 
-        // Apply proposal on ending state
-        match &proposal.action {
-            ProposalAction::HardFork(version) => {
-                let value = PParamValue::ProtocolVersion(*version);
-                let pparams = PParamsSet::default().with(value);
-                self.change(PParamsUpdate::new(pparams));
-            }
-            ProposalAction::ParamChange(pparams) => {
-                self.change(PParamsUpdate::new(pparams.clone()));
-            }
-            ProposalAction::TreasuryWithdrawal(withdrawals) => {
-                for (credential, amount) in withdrawals {
-                    self.change(TreasuryWithdrawal::new(credential.clone(), *amount));
-                }
-            }
-            x => {
-                dbg!(x);
-                tracing::error!(proposal=%id, "don't know how to enact proposal action: {:?}", x);
-            }
-        }
+        self.deltas.extend(enactment_deltas(id, proposal));
 
         Ok(())
     }
@@ -62,5 +107,244 @@ impl super::BoundaryVisitor for BoundaryVisitor {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_core::EntityDelta as _;
+    use pallas::{
+        crypto::hash::Hash,
+        ledger::primitives::{conway::Anchor, RationalNumber, StakeCredential},
+    };
+
+    use super::*;
+    use crate::{
+        gov_from_conway_genesis, Committee, Constitution, FixedNamespace as _, GovPurpose, GovState,
+    };
+
+    fn proposal(tx: Hash<32>, idx: u32, action: ProposalAction) -> ProposalState {
+        ProposalState {
+            slot: 0,
+            tx,
+            idx,
+            action,
+            max_epoch: None,
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: None,
+            reward_account: None,
+            proposed_in: None,
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        }
+    }
+
+    fn anchor(byte: u8) -> Anchor {
+        Anchor {
+            url: format!("ipfs://constitution-{byte}"),
+            content_hash: [byte; 32].into(),
+        }
+    }
+
+    fn two_thirds() -> RationalNumber {
+        RationalNumber {
+            numerator: 2,
+            denominator: 3,
+        }
+    }
+
+    /// Apply the governance-singleton share of a delta set to `state`. Deltas
+    /// keyed at another namespace (pparams, treasury) are skipped, as the
+    /// commit path skips them when it streams the `"gov"` singleton.
+    fn apply_gov(state: GovState, deltas: Vec<CardanoDelta>) -> GovState {
+        let mut entity: Option<CardanoEntity> = Some(state.into());
+
+        for mut delta in deltas {
+            if delta.key().0 == GovState::NS {
+                delta.apply(&mut entity);
+            }
+        }
+
+        Option::<GovState>::from(entity.unwrap()).unwrap()
+    }
+
+    /// Every governance action a Conway chain can carry has an enactment
+    /// effect — no variant falls through to an error arm. Only the legacy
+    /// `Other` catch-all, which never records the action's content, does.
+    #[test]
+    fn every_real_action_enacts() {
+        let cred = StakeCredential::AddrKeyhash([1u8; 28].into());
+
+        let cases = [
+            (
+                ProposalAction::ParamChange(PParamsSet::default()),
+                Some(GovPurpose::PParamUpdate),
+            ),
+            (
+                ProposalAction::HardFork((10, 0)),
+                Some(GovPurpose::HardFork),
+            ),
+            (
+                ProposalAction::TreasuryWithdrawal(vec![(cred.clone(), 1_000_000)]),
+                None,
+            ),
+            (ProposalAction::NoConfidence, Some(GovPurpose::Committee)),
+            (
+                ProposalAction::UpdateCommittee {
+                    to_remove: vec![],
+                    to_add: vec![(cred.clone(), 700)],
+                    threshold: two_thirds(),
+                },
+                Some(GovPurpose::Committee),
+            ),
+            (
+                ProposalAction::NewConstitution {
+                    anchor: anchor(9),
+                    guardrail_script: None,
+                },
+                Some(GovPurpose::Constitution),
+            ),
+            (ProposalAction::Info, None),
+        ];
+
+        for (action, purpose) in cases {
+            let is_info = matches!(action, ProposalAction::Info);
+            let id = ProposalId::from(b"proposal".to_vec());
+            let deltas = enactment_deltas(&id, &proposal([7u8; 32].into(), 0, action.clone()));
+
+            let roots = deltas
+                .iter()
+                .filter(|delta| matches!(delta, CardanoDelta::GovRootsUpdate(_)))
+                .count();
+
+            assert_eq!(
+                roots,
+                usize::from(purpose.is_some()),
+                "unexpected root updates for {action:?}"
+            );
+
+            // Info is the one action that ratifies with no state effect at
+            // all; everything else emits at least its own effect.
+            let effects = deltas.len() - roots;
+
+            if is_info {
+                assert_eq!(effects, 0, "Info should carry no state effect");
+            } else {
+                assert!(effects > 0, "no state effect emitted for {action:?}");
+            }
+        }
+    }
+
+    /// The mainnet committee replacement (`47a0e7a4…#0`, ratified at epoch
+    /// 580) and constitution replacement (`8c653ee5…#0`, ratified at epoch
+    /// 541) — the two enactments the hack table stamps on mainnet — move
+    /// `GovState` off its Conway-genesis values and set their lineage roots.
+    ///
+    /// The action ids are the real ones; the enacted content is a fixture,
+    /// since the actions' payloads are not in the repository.
+    #[test]
+    fn mainnet_gov_enactments_replace_genesis_state() {
+        let genesis = crate::load_test_genesis("mainnet");
+        let (constitution, committee) = gov_from_conway_genesis(&genesis.conway).unwrap();
+
+        let mut state = GovState::default();
+        state.seed_genesis(constitution.clone(), committee.clone(), 507);
+
+        let interim_member = committee
+            .members
+            .keys()
+            .next()
+            .expect("mainnet interim committee is not empty")
+            .clone();
+
+        let new_member = StakeCredential::ScriptHash([42u8; 28].into());
+
+        let constitution_tx: Hash<32> =
+            "8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd"
+                .parse()
+                .unwrap();
+
+        let committee_tx: Hash<32> =
+            "47a0e7a4f9383b1afc2192b23b41824d65ac978d7741aca61fc1fa16833d1111"
+                .parse()
+                .unwrap();
+
+        let enacted_constitution = Constitution {
+            anchor: anchor(1),
+            guardrail_script: Some([2u8; 28].into()),
+        };
+
+        // epoch 541: the Cardano Constitution replaces the interim one
+        let id = ProposalId::from(constitution_tx.to_vec());
+        state = apply_gov(
+            state,
+            enactment_deltas(
+                &id,
+                &proposal(
+                    constitution_tx,
+                    0,
+                    ProposalAction::NewConstitution {
+                        anchor: enacted_constitution.anchor.clone(),
+                        guardrail_script: enacted_constitution.guardrail_script,
+                    },
+                ),
+            ),
+        );
+
+        // epoch 580: the interim committee is replaced
+        let id = ProposalId::from(committee_tx.to_vec());
+        state = apply_gov(
+            state,
+            enactment_deltas(
+                &id,
+                &proposal(
+                    committee_tx,
+                    0,
+                    ProposalAction::UpdateCommittee {
+                        to_remove: committee.members.keys().cloned().collect(),
+                        to_add: vec![(new_member.clone(), 620)],
+                        threshold: two_thirds(),
+                    },
+                ),
+            ),
+        );
+
+        assert_eq!(state.constitution, Some(enacted_constitution));
+        assert_ne!(state.constitution, Some(constitution));
+
+        let enacted_committee = state.committee.clone().unwrap();
+        assert_eq!(
+            enacted_committee,
+            Committee {
+                members: [(new_member, 620)].into_iter().collect(),
+                threshold: two_thirds(),
+            }
+        );
+        assert!(!enacted_committee.members.contains_key(&interim_member));
+
+        // both lineage trees now root at the action that was enacted
+        assert_eq!(
+            state.prev_gov_action_ids.constitution,
+            Some(GovActionId {
+                transaction_id: constitution_tx,
+                action_index: 0,
+            })
+        );
+        assert_eq!(
+            state.prev_gov_action_ids.committee,
+            Some(GovActionId {
+                transaction_id: committee_tx,
+                action_index: 0,
+            })
+        );
+
+        // untouched purposes stay empty
+        assert_eq!(state.prev_gov_action_ids.hard_fork, None);
+        assert_eq!(state.prev_gov_action_ids.pparam_update, None);
     }
 }

--- a/crates/cardano/src/model/gov.rs
+++ b/crates/cardano/src/model/gov.rs
@@ -1145,7 +1145,6 @@ mod prop_tests {
             CommitteeUpdate::update(vec![], vec![(fresh.clone(), 700)], threshold.clone());
         rebuild.apply(&mut entity);
 
-        // the dissolved members do not come back
         assert_eq!(
             entity.as_ref().unwrap().committee.as_ref().unwrap().members,
             BTreeMap::from([(fresh, 700)])

--- a/crates/cardano/src/model/gov.rs
+++ b/crates/cardano/src/model/gov.rs
@@ -31,7 +31,7 @@ use pallas::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::SingletonEntity;
+use super::{GovPurpose, SingletonEntity};
 
 /// Key of the single `GovState` entity inside the `"gov"` namespace.
 pub const GOV_STATE_KEY: &[u8] = b"0";
@@ -98,6 +98,19 @@ pub struct GovRoots {
 
     #[n(3)]
     pub constitution: Option<GovActionId>,
+}
+
+impl GovRoots {
+    /// The root slot of a single lineage tree, for read-modify-write by the
+    /// enactment deltas.
+    pub fn root_mut(&mut self, purpose: GovPurpose) -> &mut Option<GovActionId> {
+        match purpose {
+            GovPurpose::PParamUpdate => &mut self.pparam_update,
+            GovPurpose::HardFork => &mut self.hard_fork,
+            GovPurpose::Committee => &mut self.committee,
+            GovPurpose::Constitution => &mut self.constitution,
+        }
+    }
 }
 
 #[derive(Debug, Encode, Decode, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -435,6 +448,193 @@ impl dolos_core::EntityDelta for CommitteeResign {
     }
 }
 
+/// The committee effect an enacted governance action carries.
+///
+/// Variant order is part of the WAL format (bincode positional encoding) —
+/// append only, never reorder.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CommitteeChange {
+    /// `NoConfidence` — the committee is dissolved outright.
+    NoConfidence,
+
+    /// `UpdateCommittee` — the surviving members are the current ones minus
+    /// `to_remove` plus `to_add`, under the new `threshold`.
+    Update {
+        to_remove: Vec<StakeCredential>,
+        to_add: Vec<(StakeCredential, Epoch)>,
+        threshold: RationalNumber,
+    },
+}
+
+/// A ratified committee action reached enactment. Rewrites
+/// `GovState.committee`; undo restores the pre-image wholesale, which also
+/// covers the `None` (no-confidence) pre-state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitteeUpdate {
+    pub(crate) change: CommitteeChange,
+
+    // undo
+    pub(crate) prev: Option<Committee>,
+}
+
+impl CommitteeUpdate {
+    pub fn no_confidence() -> Self {
+        Self {
+            change: CommitteeChange::NoConfidence,
+            prev: None,
+        }
+    }
+
+    pub fn update(
+        to_remove: Vec<StakeCredential>,
+        to_add: Vec<(StakeCredential, Epoch)>,
+        threshold: RationalNumber,
+    ) -> Self {
+        Self {
+            change: CommitteeChange::Update {
+                to_remove,
+                to_add,
+                threshold,
+            },
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for CommitteeUpdate {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        self.prev = state.committee.clone();
+
+        state.committee = match &self.change {
+            CommitteeChange::NoConfidence => None,
+            CommitteeChange::Update {
+                to_remove,
+                to_add,
+                threshold,
+            } => {
+                // An update enacted out of the no-confidence state starts from
+                // an empty member set, as in the Haskell ledger.
+                let mut members = state
+                    .committee
+                    .as_ref()
+                    .map(|committee| committee.members.clone())
+                    .unwrap_or_default();
+
+                for cold in to_remove {
+                    members.remove(cold);
+                }
+
+                for (cold, term) in to_add {
+                    members.insert(cold.clone(), *term);
+                }
+
+                Some(Committee {
+                    members,
+                    threshold: threshold.clone(),
+                })
+            }
+        };
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.committee = self.prev.clone();
+    }
+}
+
+/// A ratified `NewConstitution` action reached enactment. Replaces
+/// `GovState.constitution`; undo restores the pre-image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConstitutionUpdate {
+    pub(crate) constitution: Constitution,
+
+    // undo
+    pub(crate) prev: Option<Constitution>,
+}
+
+impl ConstitutionUpdate {
+    pub fn new(constitution: Constitution) -> Self {
+        Self {
+            constitution,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for ConstitutionUpdate {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        self.prev = state.constitution.clone();
+        state.constitution = Some(self.constitution.clone());
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.constitution = self.prev.clone();
+    }
+}
+
+/// An enacted action becomes the new root of its purpose's lineage tree
+/// (`prevGovActionIds` in the Haskell ledger). Emitted alongside whatever
+/// state effect the action carries, for every action that has a purpose —
+/// `TreasuryWithdrawal` and `Info` have none and emit nothing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovRootsUpdate {
+    pub(crate) purpose: GovPurpose,
+    pub(crate) action: GovActionId,
+
+    // undo
+    pub(crate) prev: Option<GovActionId>,
+}
+
+impl GovRootsUpdate {
+    pub fn new(purpose: GovPurpose, action: GovActionId) -> Self {
+        Self {
+            purpose,
+            action,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for GovRootsUpdate {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+        let root = state.prev_gov_action_ids.root_mut(self.purpose);
+
+        self.prev = root.replace(self.action.clone());
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        *state.prev_gov_action_ids.root_mut(self.purpose) = self.prev.clone();
+    }
+}
+
 /// Reset the dormant-epoch counter to zero. Emitted together with the
 /// per-DRep [`crate::DRepDormancyRelease`] fan-out when the first proposal
 /// after a dormant stretch shows up (research §3.3.1).
@@ -705,6 +905,45 @@ mod prop_tests {
         }
     }
 
+    prop_compose! {
+        fn any_committee_update()(
+            change in prop_oneof![
+                Just(CommitteeChange::NoConfidence),
+                (
+                    prop::collection::vec(root::any_stake_credential(), 0..3),
+                    prop::collection::vec(
+                        (root::any_stake_credential(), root::any_epoch()),
+                        0..3,
+                    ),
+                    root::any_rational(),
+                ).prop_map(|(to_remove, to_add, threshold)| CommitteeChange::Update {
+                    to_remove,
+                    to_add,
+                    threshold,
+                }),
+            ],
+        ) -> CommitteeUpdate {
+            CommitteeUpdate { change, prev: None }
+        }
+    }
+
+    prop_compose! {
+        fn any_constitution_update()(
+            constitution in any_constitution(),
+        ) -> ConstitutionUpdate {
+            ConstitutionUpdate::new(constitution)
+        }
+    }
+
+    prop_compose! {
+        fn any_gov_roots_update()(
+            purpose in crate::model::proposals::testing::any_gov_purpose(),
+            action in root::any_gov_action_id(),
+        ) -> GovRootsUpdate {
+            GovRootsUpdate::new(purpose, action)
+        }
+    }
+
     proptest! {
         #[test]
         fn entity_cbor_roundtrip(entity in any_gov_state()) {
@@ -774,6 +1013,177 @@ mod prop_tests {
         ) {
             root::assert_delta_serde_roundtrip(entity, delta);
         }
+
+        #[test]
+        fn committee_update_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_committee_update(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn committee_update_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_committee_update(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn constitution_update_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_constitution_update(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn constitution_update_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_constitution_update(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn gov_roots_update_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_roots_update(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn gov_roots_update_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_roots_update(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+    }
+
+    /// The member set an `UpdateCommittee` enacts is the current one minus
+    /// `to_remove` plus `to_add`, under the action's threshold — and undo puts
+    /// the previous committee back exactly.
+    #[test]
+    fn committee_update_edits_the_member_set() {
+        use dolos_core::EntityDelta as _;
+
+        let staying = StakeCredential::ScriptHash([1u8; 28].into());
+        let leaving = StakeCredential::ScriptHash([2u8; 28].into());
+        let joining = StakeCredential::AddrKeyhash([3u8; 28].into());
+
+        let before = Committee {
+            members: BTreeMap::from([(staying.clone(), 500), (leaving.clone(), 500)]),
+            threshold: RationalNumber {
+                numerator: 2,
+                denominator: 3,
+            },
+        };
+
+        let mut entity = Some(GovState {
+            committee: Some(before.clone()),
+            ..Default::default()
+        });
+
+        let mut delta = CommitteeUpdate::update(
+            vec![leaving.clone()],
+            vec![(joining.clone(), 620)],
+            RationalNumber {
+                numerator: 3,
+                denominator: 5,
+            },
+        );
+
+        delta.apply(&mut entity);
+
+        let committee = entity.as_ref().unwrap().committee.as_ref().unwrap();
+        assert_eq!(
+            committee.members,
+            BTreeMap::from([(staying, 500), (joining, 620)])
+        );
+        assert_eq!(
+            committee.threshold,
+            RationalNumber {
+                numerator: 3,
+                denominator: 5,
+            }
+        );
+
+        delta.undo(&mut entity);
+        assert_eq!(entity.unwrap().committee, Some(before));
+    }
+
+    /// `NoConfidence` dissolves the committee; a later `UpdateCommittee`
+    /// rebuilds it from an empty member set.
+    #[test]
+    fn no_confidence_dissolves_then_rebuilds() {
+        use dolos_core::EntityDelta as _;
+
+        let sitting = StakeCredential::ScriptHash([1u8; 28].into());
+        let fresh = StakeCredential::AddrKeyhash([2u8; 28].into());
+
+        let threshold = RationalNumber {
+            numerator: 2,
+            denominator: 3,
+        };
+
+        let mut entity = Some(GovState {
+            committee: Some(Committee {
+                members: BTreeMap::from([(sitting.clone(), 500)]),
+                threshold: threshold.clone(),
+            }),
+            ..Default::default()
+        });
+
+        let mut dissolve = CommitteeUpdate::no_confidence();
+        dissolve.apply(&mut entity);
+        assert_eq!(entity.as_ref().unwrap().committee, None);
+
+        let mut rebuild =
+            CommitteeUpdate::update(vec![], vec![(fresh.clone(), 700)], threshold.clone());
+        rebuild.apply(&mut entity);
+
+        // the dissolved members do not come back
+        assert_eq!(
+            entity.as_ref().unwrap().committee.as_ref().unwrap().members,
+            BTreeMap::from([(fresh, 700)])
+        );
+
+        rebuild.undo(&mut entity);
+        assert_eq!(entity.as_ref().unwrap().committee, None);
+
+        dissolve.undo(&mut entity);
+        assert_eq!(
+            entity.unwrap().committee.unwrap().members,
+            BTreeMap::from([(sitting, 500)])
+        );
+    }
+
+    /// Each purpose writes its own root slot and leaves the others alone.
+    #[test]
+    fn gov_roots_update_targets_one_purpose() {
+        use dolos_core::EntityDelta as _;
+
+        let action = GovActionId {
+            transaction_id: [7u8; 32].into(),
+            action_index: 3,
+        };
+
+        let mut entity = Some(GovState::default());
+
+        let mut delta = GovRootsUpdate::new(GovPurpose::Constitution, action.clone());
+        delta.apply(&mut entity);
+
+        let roots = &entity.as_ref().unwrap().prev_gov_action_ids;
+        assert_eq!(roots.constitution, Some(action));
+        assert_eq!(roots.committee, None);
+        assert_eq!(roots.hard_fork, None);
+        assert_eq!(roots.pparam_update, None);
+
+        delta.undo(&mut entity);
+        assert_eq!(entity.unwrap().prev_gov_action_ids, GovRoots::default());
     }
 
     #[test]

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -272,6 +272,9 @@ pub enum CardanoDelta {
     CommitteeAuth(Box<CommitteeAuth>),
     CommitteeResign(Box<CommitteeResign>),
     GovDormancyReset(Box<GovDormancyReset>),
+    CommitteeUpdate(Box<CommitteeUpdate>),
+    ConstitutionUpdate(Box<ConstitutionUpdate>),
+    GovRootsUpdate(Box<GovRootsUpdate>),
 }
 
 impl CardanoDelta {
@@ -366,6 +369,9 @@ delta_from!(GovGenesisInit);
 delta_from!(CommitteeAuth);
 delta_from!(CommitteeResign);
 delta_from!(GovDormancyReset);
+delta_from!(CommitteeUpdate);
+delta_from!(ConstitutionUpdate);
+delta_from!(GovRootsUpdate);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -402,6 +408,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeAuth(x) => x.key(),
             Self::CommitteeResign(x) => x.key(),
             Self::GovDormancyReset(x) => x.key(),
+            Self::CommitteeUpdate(x) => x.key(),
+            Self::ConstitutionUpdate(x) => x.key(),
+            Self::GovRootsUpdate(x) => x.key(),
             Self::AssignRewards(x) => x.key(),
             Self::NonceTransition(x) => x.key(),
             Self::PoolTransition(x) => x.key(),
@@ -461,6 +470,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeAuth(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::CommitteeResign(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::GovDormancyReset(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::CommitteeUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::ConstitutionUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::GovRootsUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::AssignRewards(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NonceTransition(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolTransition(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -520,6 +532,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeAuth(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::CommitteeResign(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::GovDormancyReset(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::CommitteeUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::ConstitutionUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::GovRootsUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::AssignRewards(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NonceTransition(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolTransition(x) => Self::downcast_undo(x.as_ref(), entity),

--- a/crates/cardano/src/model/proposals.rs
+++ b/crates/cardano/src/model/proposals.rs
@@ -63,6 +63,23 @@ pub enum ProposalAction {
     Info,
 }
 
+impl ProposalAction {
+    /// The lineage tree this action belongs to. Derived from the action
+    /// itself rather than read off `ProposalState.purpose`, so rows written
+    /// before the field existed still resolve their purpose at enactment.
+    /// `None` for the actions that have no lineage — `TreasuryWithdrawal`,
+    /// `Info`, and the legacy `Other` catch-all.
+    pub fn purpose(&self) -> Option<GovPurpose> {
+        match self {
+            Self::ParamChange(_) => Some(GovPurpose::PParamUpdate),
+            Self::HardFork(_) => Some(GovPurpose::HardFork),
+            Self::NoConfidence | Self::UpdateCommittee { .. } => Some(GovPurpose::Committee),
+            Self::NewConstitution { .. } => Some(GovPurpose::Constitution),
+            Self::TreasuryWithdrawal(_) | Self::Info | Self::Other => None,
+        }
+    }
+}
+
 /// The four independent lineage trees a governance action can belong to.
 ///
 /// `TreasuryWithdrawal` and `Info` actions have no lineage (no parent field,


### PR DESCRIPTION
Plan: `plans/dolos-governance-enact-missing-actions.md` (Brain/txpipe) — first piece of the remaining `dolos-governance-gaps` work, after phases 1–3 (#1128, #1129, #1130).

## Problem

`ewrap/enactment.rs` handled only `HardFork`, `ParamChange` and `TreasuryWithdrawal`. Every other ratified action — `NoConfidence`, `UpdateCommittee`, `NewConstitution`, `Info` — fell through to `dbg!` + `tracing::error!("don't know how to enact proposal action")`.

That is a live gap: outcomes come from the `hacks::proposals` table, which does mark the mainnet committee and constitution replacements as ratified, so `should_enact` fires, the visitor errors, and `GovState.committee` / `GovState.constitution` never move past their Conway-genesis values. `GovRoots` was likewise never updated on any enactment, including the three variants that did enact.

## What changed

Three new `CardanoDelta` variants, **appended** (bincode positional encoding — order frozen), each stashing its pre-image for `undo`:

- `CommitteeUpdate` — `UpdateCommittee` edits `GovState.committee` (current members minus `to_remove` plus `to_add`, new threshold); `NoConfidence` sets it to `None`. An update enacted out of the no-confidence state starts from an empty member set, as in the Haskell ledger.
- `ConstitutionUpdate` — replaces `GovState.constitution`.
- `GovRootsUpdate` — sets one per-purpose root in `GovState.prev_gov_action_ids` to the enacted `GovActionId`.

In the enactment visitor, the action→delta mapping moved into `enactment_deltas` (pure, no boundary context, so it is testable on its own):

- `NoConfidence` / `UpdateCommittee` → `CommitteeUpdate` + `GovRootsUpdate(committee)`
- `NewConstitution` → `ConstitutionUpdate` + `GovRootsUpdate(constitution)`
- `ParamChange` / `HardFork` → existing behavior **plus** `GovRootsUpdate` for their purpose
- `Info` → explicit no-op arm, no error
- legacy `Other` → keeps the error arm (its rows never recorded the action's content)

The purpose comes from a new `ProposalAction::purpose()` rather than the stored `ProposalState.purpose`, so rows written before that field existed still resolve their lineage at enactment.

Wiring: EWRAP's `commit_finalize` now applies `"gov"` singleton deltas, which only ESTART's commit did before. Same boundary Haskell enacts at — EWRAP commit, before ESTART of the next epoch. No conflict with `GovGenesisInit`: at the Chang boundary no Conway proposal can have been ratified yet, so the two never write the singleton in the same boundary.

Out of scope (per the plan): no tallies, no ratification, no pruning, no committee GC or dormancy tick, no schema change to existing fields.

## Tests

- apply/undo + WAL-serde round-trips (proptest) for all three deltas, plus targeted tests for the member-set arithmetic, the dissolve-then-rebuild path, and per-purpose root isolation.
- `every_real_action_enacts` drives all seven real `GovAction` variants through the mapping: each emits its state effect and exactly the root updates its purpose implies; `Info` emits nothing.
- `mainnet_gov_enactments_replace_genesis_state` seeds `GovState` from the mainnet Conway genesis and enacts the two actions the hack table stamps on mainnet — the constitution replacement `8c653ee5…#0` (epoch 541) and committee replacement `47a0e7a4…#0` (epoch 580) — asserting both fields move off the genesis interim values and both lineage roots point at the enacted action. The action ids are the real ones; the enacted payloads are fixtures, since those payloads are not in the repository. Confirming the values against the real on-chain committee membership still needs a network replay.

## Verification

- `cargo test --workspace` — all green
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enacting governance actions, including committee, constitution, and governance-root updates.
  * Added governance lineage tracking for actions with distinct purposes.
  * Added support for committee changes, including member updates and no-confidence actions.
  * Governance state changes can now be applied and reverted consistently.

* **Bug Fixes**
  * Governance enactments are now correctly applied when finalizing an epoch.
  * Informational and legacy untracked actions are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->