### PR TITLE
feat(cardano): compute DRep and SPO stake distributions in the EWRAP pass

### DIFF
--- a/crates/cardano/src/ewrap/commit.rs
+++ b/crates/cardano/src/ewrap/commit.rs
@@ -91,6 +91,11 @@ impl BoundaryWork {
         self.deltas
             .apply_singleton::<EpochState, _>(state, &writer)?;
 
+        // GovState gets the shard's GovDistrAccumulate delta (governance
+        // active only). Committing it in the same transaction as
+        // EWrapProgress keeps the two shard cursors in lockstep.
+        self.deltas.apply_singleton::<GovState, _>(state, &writer)?;
+
         // Delete applied pending rewards.
         debug!(
             count = self.applied_reward_credentials.len(),

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -128,27 +128,36 @@ impl BoundaryWork {
 
     /// The epoch whose end-of-epoch account snapshot the stake-distribution
     /// accumulation reads, or `None` when the accumulation doesn't run
-    /// (governance inactive, or the closing epoch has no previous
-    /// boundary).
+    /// (governance inactive).
     ///
-    /// EWRAP runs before ESTART's rotation, so for an account in lockstep
-    /// (`EpochValue` at the closing epoch) `snapshot_at` of this epoch is
-    /// the `mark` position — the value frozen at the previous boundary's
-    /// rotation, which already includes that boundary's post-enactment
-    /// effects. This is the pulser-snapshot-equivalent read; the timing
-    /// assumption is pinned by `mark_position_is_the_boundary_snapshot`.
+    /// The closing epoch itself. EWRAP runs before ESTART's rotation, so for
+    /// an account in lockstep (`EpochValue` at the closing epoch)
+    /// `snapshot_at` of this epoch is the `live` position — the end-of-epoch
+    /// value that the rotation about to run freezes into `mark`. That is the
+    /// snapshot governing the epoch now opening, and it is the alignment
+    /// db-sync publishes: db-sync writes `drep_distr` for epoch N at the
+    /// boundary *into* N, so the boundary closing epoch n owes the row for
+    /// n + 1.
+    ///
+    /// Reading one rotation further back (`n - 1`, the `mark` position) was
+    /// the original pin; a preview replay measured it a full epoch stale
+    /// against db-sync and the position moved forward (`org/founder`,
+    /// 2026-08-14). The timing assumption is pinned by
+    /// `live_position_is_the_boundary_snapshot`.
     fn distr_snapshot_epoch(&self) -> Option<Epoch> {
         self.gov_active_since?;
 
-        self.ending_state.number.checked_sub(1)
+        Some(self.ending_state.number)
     }
 
     /// Build the proposal-deposit share of the boundary snapshot: deposits
-    /// of the still-live proposals submitted before the closing epoch,
-    /// summed per return credential — the pulser's `proposalDeposits`
-    /// field. Rows missing `proposed_in`, the deposit, or the return
-    /// credential predate the tracking fields and cannot be attributed;
-    /// they are excluded (the accepted design-§6 degradation).
+    /// of the still-live proposals submitted no later than the closing
+    /// epoch, summed per return credential — the pulser's `proposalDeposits`
+    /// field. The snapshot is the end-of-closing-epoch position, so a
+    /// proposal submitted *during* that epoch has its deposit locked in it.
+    /// Rows missing `proposed_in`, the deposit, or the return credential
+    /// predate the tracking fields and cannot be attributed; they are
+    /// excluded (the accepted design-§6 degradation).
     fn load_proposal_deposits<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
         let proposals = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
 
@@ -161,7 +170,7 @@ impl BoundaryWork {
 
             let in_snapshot = proposal
                 .proposed_in
-                .is_some_and(|epoch| epoch < self.ending_state.number);
+                .is_some_and(|epoch| epoch <= self.ending_state.number);
 
             if !in_snapshot {
                 continue;
@@ -183,7 +192,7 @@ impl BoundaryWork {
     }
 
     /// Accumulate one account's contribution to the boundary stake
-    /// distributions, reading the `snapshot_epoch` (mark) position of its
+    /// distributions, reading the `snapshot_epoch` (live) position of its
     /// `EpochValue`s. The delegated weight is the era-correct stake total
     /// plus the account's share of the snapshot proposal deposits. The
     /// DRep leg skips delegations to targets not registered as of the
@@ -458,12 +467,12 @@ impl BoundaryWork {
         None
     }
 
-    /// Whether `drep` was registered as of the previous epoch boundary —
-    /// the boundary the distribution snapshot corresponds to. Events at or
-    /// after `boundary_slot` happened during the closing epoch and postdate
-    /// the snapshot: a DRep unregistered mid-epoch still counts (the
-    /// Haskell snapshot predates the unregistration), one registered
-    /// mid-epoch doesn't yet.
+    /// Whether `drep` was registered as of the boundary the distribution
+    /// snapshot corresponds to — the one closing this epoch. Events at or
+    /// after `boundary_slot` happen in the epoch now opening and postdate the
+    /// snapshot; everything that happened during the closing epoch is in it,
+    /// so a DRep registered mid-epoch counts and one unregistered mid-epoch
+    /// does not.
     fn is_drep_registered_as_of(drep: &DRepState, boundary_slot: BlockSlot) -> bool {
         let registered = drep.registered_at.filter(|(slot, _)| *slot < boundary_slot);
         let unregistered = drep
@@ -478,7 +487,7 @@ impl BoundaryWork {
     }
 
     pub(crate) fn load_drep_data<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
-        let boundary_slot = self.chain_summary.epoch_start(self.ending_state.number);
+        let boundary_slot = self.chain_summary.epoch_start(self.ending_state.number + 1);
 
         let dreps = state.iter_entities_typed::<DRepState>(DRepState::NS, None)?;
 
@@ -667,9 +676,8 @@ impl BoundaryWork {
 
     /// Emit the boundary `DRepPowerUpdate` for one DRep: registered DReps
     /// get the stake the accumulation attributed to them (zero when absent
-    /// from the distribution — including DReps registered during the
-    /// closing epoch, which postdate the snapshot). No-op writes are
-    /// elided.
+    /// from the distribution — including DReps registered after the
+    /// boundary, which postdate the snapshot). No-op writes are elided.
     fn emit_drep_power_update(
         &mut self,
         distr: &BTreeMap<DRep, u64>,
@@ -793,15 +801,21 @@ mod tests {
     /// Pins the rotation-timing assumption behind the distribution snapshot
     /// read: EWRAP runs before ESTART's rotation (ordering pinned by
     /// `epoch_boundary_emits_ewrap_then_estart` in `work.rs`), so during
-    /// EWRAP closing epoch n+1 the account `EpochValue`s still sit at
-    /// live-epoch n+1 and the `mark` position holds the value frozen at the
-    /// n/n+1 rotation — already including EWRAP(n)'s post-enactment effects
-    /// (applied to `live` before that rotation) and excluding every epoch-n+1
-    /// mutation. `snapshot_at(n)`, the read the accumulation performs, must
-    /// resolve to exactly that `mark` value; a boundary reordering that
-    /// rotated first would desynchronize the two and break this test.
+    /// EWRAP closing epoch n the account `EpochValue`s still sit at live-epoch
+    /// n and the `live` position holds the end-of-epoch-n value — every
+    /// epoch-n mutation included, and it is what the rotation about to run
+    /// freezes into `mark`. `snapshot_at(n)`, the read the accumulation
+    /// performs, must resolve to exactly that `live` value: it is the snapshot
+    /// that governs epoch n + 1, which is the epoch db-sync labels the
+    /// resulting `drep_distr` row with. A boundary reordering that rotated
+    /// first would desynchronize the two and break this test.
+    ///
+    /// The `mark` position — one rotation back, governing epoch n rather than
+    /// n + 1 — was the original pin, measured a full epoch stale against
+    /// db-sync on a preview replay (`org/founder`, 2026-08-14). Both positions
+    /// are asserted here so the distinction stays legible.
     #[test]
-    fn mark_position_is_the_boundary_snapshot() {
+    fn live_position_is_the_boundary_snapshot() {
         let credential = StakeCredential::AddrKeyhash([1u8; 28].into());
         let key = credential_to_key(&credential);
 
@@ -832,15 +846,21 @@ mod tests {
 
         let stake = &account.as_ref().unwrap().stake;
 
-        // the EWRAP(n+1) read: end-of-n snapshot == the mark position ==
-        // the post-enactment value at the n/n+1 rotation
+        // the EWRAP(n+1) read: `snapshot_at(n+1)` is the live position, the
+        // end-of-epoch-n+1 value — this is the distribution that governs
+        // epoch n+2, the row db-sync labels n+2
         assert!(stake.is_at_epoch(6));
+        assert_eq!(stake.snapshot_at(6), stake.live());
+        assert_eq!(stake.snapshot_at(6).unwrap().total(), 200);
+
+        // one rotation back is the mark position — the end-of-epoch-n value,
+        // governing epoch n+1. Reading it here is what made the distribution
+        // a full epoch stale against db-sync.
         assert_eq!(stake.snapshot_at(5), stake.mark());
         assert_eq!(stake.snapshot_at(5).unwrap().total(), 125);
-        assert_eq!(stake.unwrap_live().total(), 200);
 
-        // after the n+1/n+2 rotation — which EWRAP(n+1) must precede — the
-        // mark position moves on to the epoch-n+1 value
+        // after the n+1/n+2 rotation — which EWRAP(n+1) must precede — what
+        // this pass read as `live` is exactly what lands in `mark`
         AccountTransition::new(key, 7).apply(&mut account);
         let stake = &account.as_ref().unwrap().stake;
         assert_eq!(stake.mark().unwrap().total(), 200);
@@ -867,24 +887,27 @@ mod tests {
 
     fn snapshot_account(
         byte: u8,
-        mark_utxo: u64,
+        snapshot_utxo: u64,
         drep: Option<DRep>,
         pool: Option<crate::PoolHash>,
     ) -> crate::AccountState {
         let credential = StakeCredential::AddrKeyhash([byte; 28].into());
 
-        // live values differ from mark so a wrong-position read shows up
+        // The accumulation reads the live position — the end-of-closing-epoch
+        // value. `mark` carries a different value and no delegations at all,
+        // so a read that slipped one rotation back shows up as a wrong total
+        // and an empty distribution rather than as a near-miss.
         let live_stake = Stake {
-            utxo_sum: mark_utxo * 10,
+            utxo_sum: snapshot_utxo,
             ..Default::default()
         };
         let mark_stake = Stake {
-            utxo_sum: mark_utxo,
+            utxo_sum: snapshot_utxo * 10,
             ..Default::default()
         };
 
-        let mark_drep = drep.map_or(DRepDelegation::NotDelegated, DRepDelegation::Delegated);
-        let mark_pool = pool.map_or(PoolDelegation::NotDelegated, PoolDelegation::Pool);
+        let live_drep = drep.map_or(DRepDelegation::NotDelegated, DRepDelegation::Delegated);
+        let live_pool = pool.map_or(PoolDelegation::NotDelegated, PoolDelegation::Pool);
 
         crate::AccountState {
             registered_at: Some(0),
@@ -898,17 +921,17 @@ mod tests {
             ),
             pool: EpochValue::from_parts(
                 CLOSING_EPOCH,
-                Some(PoolDelegation::NotDelegated),
+                Some(live_pool),
                 None,
-                Some(mark_pool),
+                Some(PoolDelegation::NotDelegated),
                 None,
                 None,
             ),
             drep: EpochValue::from_parts(
                 CLOSING_EPOCH,
-                Some(DRepDelegation::NotDelegated),
+                Some(live_drep),
                 None,
-                Some(mark_drep),
+                Some(DRepDelegation::NotDelegated),
                 None,
                 None,
             ),
@@ -949,14 +972,16 @@ mod tests {
         epoch.number = CLOSING_EPOCH;
 
         let chain = load_era_summary::<ToyDomain>(state).unwrap();
-        let boundary_slot = chain.epoch_start(CLOSING_EPOCH);
+        // the snapshot boundary is the one closing this epoch, so the
+        // registration cutoff sits at the *start of the next* epoch
+        let boundary_slot = chain.epoch_start(CLOSING_EPOCH + 1);
 
         let writer = state.start_writer().unwrap();
         writer
             .write_entity_typed(&EpochState::singleton_key(), &epoch)
             .unwrap();
 
-        // alice: 100 mark stake + 40 proposal deposit, delegated to the
+        // alice: 100 snapshot stake + 40 proposal deposit, delegated to the
         // registered drep and to pool_a
         let alice = snapshot_account(0xa1, 100, Some(reg_drep()), Some(pool_a()));
         // bob: 50, delegated to AlwaysAbstain, no pool
@@ -981,7 +1006,8 @@ mod tests {
             Some(boundary_slot - 5),
             0,
         );
-        // registered during the closing epoch — postdates the snapshot
+        // registered after the boundary, i.e. in the epoch now opening —
+        // postdates the snapshot
         let fresh = drep_row(fresh_drep(), Some(boundary_slot), None, 500);
 
         for drep in [&registered, &unregistered, &fresh] {
@@ -1011,8 +1037,24 @@ mod tests {
             spo_votes: Default::default(),
         };
 
+        // a second live proposal, submitted *during* the closing epoch: the
+        // snapshot is the end-of-closing-epoch position, so its deposit is
+        // locked in it too
+        let same_epoch_proposal = ProposalState {
+            tx: [8u8; 32].into(),
+            deposit: Some(7),
+            proposed_in: Some(CLOSING_EPOCH),
+            ..proposal.clone()
+        };
+
         writer
             .write_entity_typed(&EntityKey::from(b"proposal-1".to_vec()), &proposal)
+            .unwrap();
+        writer
+            .write_entity_typed(
+                &EntityKey::from(b"proposal-2".to_vec()),
+                &same_epoch_proposal,
+            )
             .unwrap();
 
         writer.commit().unwrap();
@@ -1054,7 +1096,7 @@ mod tests {
     }
 
     /// End-to-end shard pass over a seeded store: the accumulated
-    /// distributions read the mark position, include proposal deposits in
+    /// distributions read the live position, include proposal deposits in
     /// the delegated weight (done criterion 3), track the abstain
     /// pseudo-DRep separately, skip delegations to DReps outside the
     /// snapshot's registered set, survive shard replays unchanged (done
@@ -1071,15 +1113,16 @@ mod tests {
         let distr = read_distr(&domain);
         assert!(distr.is_complete_for(CLOSING_EPOCH));
 
-        // alice: 100 mark stake + 40 proposal deposit; carol's delegation
-        // targets an unregistered drep and stays out; bob tallies under
-        // the abstain key
-        let expected_dreps = BTreeMap::from([(reg_drep(), 140u64), (DRep::Abstain, 50u64)]);
+        // alice: 100 snapshot stake + 40 + 7 proposal deposits (the second
+        // submitted during the closing epoch, still inside the snapshot);
+        // carol's delegation targets an unregistered drep and stays out;
+        // bob tallies under the abstain key
+        let expected_dreps = BTreeMap::from([(reg_drep(), 147u64), (DRep::Abstain, 50u64)]);
         assert_eq!(distr.drep_distr, expected_dreps);
 
         // the pool leg counts alice and carol regardless of drep status
-        assert_eq!(distr.pool_distr, BTreeMap::from([(pool_a(), 210u64)]));
-        assert_eq!(distr.pool_total, 210);
+        assert_eq!(distr.pool_distr, BTreeMap::from([(pool_a(), 217u64)]));
+        assert_eq!(distr.pool_total, 217);
 
         // a crash-resume replay of every shard leaves the accumulator
         // untouched
@@ -1090,15 +1133,15 @@ mod tests {
 
         // finalize writes the accumulated powers: the registered drep gets
         // its delegated stake (replacing the deposit seed), the drep
-        // registered mid-epoch is zeroed (absent from the snapshot), the
-        // unregistered one is left alone
+        // registered after the boundary is zeroed (absent from the
+        // snapshot), the unregistered one is left alone
         let mut boundary =
             BoundaryWork::load_finalize::<ToyDomain>(domain.state(), domain.genesis()).unwrap();
         boundary
             .commit_finalize::<ToyDomain>(domain.state(), domain.archive())
             .unwrap();
 
-        assert_eq!(read_drep_power(&domain, &reg_drep()), 140);
+        assert_eq!(read_drep_power(&domain, &reg_drep()), 147);
         assert_eq!(read_drep_power(&domain, &fresh_drep()), 0);
         assert_eq!(read_drep_power(&domain, &unreg_drep()), 0);
     }

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -193,8 +193,11 @@ impl BoundaryWork {
 
     /// Accumulate one account's contribution to the boundary stake
     /// distributions, reading the `snapshot_epoch` (live) position of its
-    /// `EpochValue`s. The delegated weight is the era-correct stake total
-    /// plus the account's share of the snapshot proposal deposits. The
+    /// `EpochValue`s. The delegated weight is the era-correct stake total,
+    /// plus `boundary_reward` — the reward this same EWRAP pass is assigning
+    /// to the account, which lands in `live` before the rotation and so is
+    /// inside the snapshot even though the copy we hold predates it — plus
+    /// the account's share of the snapshot proposal deposits. The
     /// DRep leg skips delegations to targets not registered as of the
     /// snapshot; `AlwaysAbstain` / `AlwaysNoConfidence` accumulate under
     /// their own keys. The pool leg feeds both the per-pool map and the
@@ -203,6 +206,7 @@ impl BoundaryWork {
         &self,
         snapshot_epoch: Epoch,
         account: &AccountState,
+        boundary_reward: u64,
         drep_distr: &mut BTreeMap<DRep, u64>,
         pool_distr: &mut BTreeMap<PoolHash, u64>,
         pool_total: &mut u64,
@@ -217,7 +221,7 @@ impl BoundaryWork {
             .copied()
             .unwrap_or_default();
 
-        let weight = stake.total_for_era(self.active_protocol) + deposits;
+        let weight = stake.total_for_era(self.active_protocol) + boundary_reward + deposits;
 
         if weight == 0 {
             return;
@@ -304,13 +308,29 @@ impl BoundaryWork {
                 // values with rewards already applied.
                 // TODO: move retires to ESTART (after the snapshot has been taken)
                 // and drop this ordering hack. (#1037)
+                let rewards_before = visitor_rewards.deltas.len();
                 visitor_rewards.visit_account(self, &account_id, &account)?;
                 visitor_drops.visit_account(self, &account_id, &account)?;
 
                 if let Some(epoch) = snapshot_epoch {
+                    // The snapshot is post-reward — that is what the comment
+                    // above means by "rewards update the live value before
+                    // the snapshot". The visitor expresses the update as a
+                    // delta instead of mutating `account`, so the copy we
+                    // hold still predates it; take the assigned amount off
+                    // the delta it just emitted.
+                    let boundary_reward: u64 = visitor_rewards.deltas[rewards_before..]
+                        .iter()
+                        .filter_map(|delta| match delta {
+                            crate::CardanoDelta::AssignRewards(x) => Some(x.reward),
+                            _ => None,
+                        })
+                        .sum();
+
                     self.accumulate_gov_distr(
                         epoch,
                         &account,
+                        boundary_reward,
                         &mut drep_distr,
                         &mut pool_distr,
                         &mut pool_total,
@@ -996,6 +1016,20 @@ mod tests {
                 .unwrap();
         }
 
+        // a pending reward for bob, which this same EWRAP pass assigns: it
+        // lands in `live` before the rotation, so the snapshot includes it
+        // even though the account copy the accumulation reads predates it
+        let bob_reward = crate::PendingRewardState {
+            credential: bob.credential.clone(),
+            is_spendable: true,
+            as_leader: vec![],
+            as_delegator: vec![(pool_a(), 11)],
+        };
+
+        writer
+            .write_entity_typed(&credential_to_key(&bob.credential), &bob_reward)
+            .unwrap();
+
         // registered before the boundary; power seeded with the deposit,
         // to be overwritten by the accumulated stake
         let registered = drep_row(reg_drep(), Some(boundary_slot - 10), None, 500);
@@ -1115,12 +1149,13 @@ mod tests {
 
         // alice: 100 snapshot stake + 40 + 7 proposal deposits (the second
         // submitted during the closing epoch, still inside the snapshot);
-        // carol's delegation targets an unregistered drep and stays out;
-        // bob tallies under the abstain key
-        let expected_dreps = BTreeMap::from([(reg_drep(), 147u64), (DRep::Abstain, 50u64)]);
+        // bob: 50 + the 11 reward this pass assigns him, under the abstain
+        // key; carol's delegation targets an unregistered drep and stays out
+        let expected_dreps = BTreeMap::from([(reg_drep(), 147u64), (DRep::Abstain, 61u64)]);
         assert_eq!(distr.drep_distr, expected_dreps);
 
-        // the pool leg counts alice and carol regardless of drep status
+        // the pool leg counts alice and carol regardless of drep status;
+        // bob has no pool, so his reward shows up only on the drep leg
         assert_eq!(distr.pool_distr, BTreeMap::from([(pool_a(), 217u64)]));
         assert_eq!(distr.pool_total, 217);
 

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -8,20 +8,26 @@
 //! state (ending_state + chain summary + active protocol + genesis +
 //! incentives) is built by `new_empty`.
 
-use std::{collections::HashMap, ops::Range, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Range,
+    sync::Arc,
+};
 
 use dolos_core::{BlockSlot, ChainError, Domain, EntityKey, Genesis, StateStore, TxOrder};
 use pallas::codec::minicbor;
-use pallas::ledger::primitives::StakeCredential;
+use pallas::ledger::primitives::{conway::DRep, Epoch, StakeCredential};
 
 use crate::{
     ewrap::{BoundaryVisitor as _, BoundaryWork},
-    load_era_summary, load_gov, pallas_extras,
+    load_era_summary, load_gov,
+    model::drep_to_entity_key,
+    pallas_extras,
     rewards::{Reward, RewardMap},
     roll::WorkDeltas,
     rupd::credential_to_key,
     AccountState, DRepState, EraProtocol, FixedNamespace as _, PendingMirState, PendingRewardState,
-    PoolState, ProposalState,
+    PoolHash, PoolState, ProposalState,
 };
 
 impl BoundaryWork {
@@ -37,7 +43,10 @@ impl BoundaryWork {
         let active_protocol = EraProtocol::from(chain_summary.edge().protocol);
         let incentives = ending_state.incentives.clone().unwrap_or_default();
 
-        let num_dormant_epochs = load_gov::<D>(state)?.num_dormant_epochs;
+        let gov = load_gov::<D>(state)?;
+        let num_dormant_epochs = gov.num_dormant_epochs;
+        let gov_active_since = gov.active_since;
+        let gov_distr = gov.distr;
 
         Ok(BoundaryWork {
             ending_state,
@@ -51,6 +60,10 @@ impl BoundaryWork {
             retiring_dreps: Default::default(),
             reregistrating_dreps: Default::default(),
             num_dormant_epochs,
+            gov_active_since,
+            gov_distr,
+            proposal_deposits: Default::default(),
+            snapshot_registered_dreps: Default::default(),
             enacting_proposals: Default::default(),
             dropping_proposals: Default::default(),
             deltas: WorkDeltas::default(),
@@ -113,13 +126,121 @@ impl BoundaryWork {
         Ok(())
     }
 
+    /// The epoch whose end-of-epoch account snapshot the stake-distribution
+    /// accumulation reads, or `None` when the accumulation doesn't run
+    /// (governance inactive, or the closing epoch has no previous
+    /// boundary).
+    ///
+    /// EWRAP runs before ESTART's rotation, so for an account in lockstep
+    /// (`EpochValue` at the closing epoch) `snapshot_at` of this epoch is
+    /// the `mark` position — the value frozen at the previous boundary's
+    /// rotation, which already includes that boundary's post-enactment
+    /// effects. This is the pulser-snapshot-equivalent read; the timing
+    /// assumption is pinned by `mark_position_is_the_boundary_snapshot`.
+    fn distr_snapshot_epoch(&self) -> Option<Epoch> {
+        self.gov_active_since?;
+
+        self.ending_state.number.checked_sub(1)
+    }
+
+    /// Build the proposal-deposit share of the boundary snapshot: deposits
+    /// of the still-live proposals submitted before the closing epoch,
+    /// summed per return credential — the pulser's `proposalDeposits`
+    /// field. Rows missing `proposed_in`, the deposit, or the return
+    /// credential predate the tracking fields and cannot be attributed;
+    /// they are excluded (the accepted design-§6 degradation).
+    fn load_proposal_deposits<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
+        let proposals = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
+
+        for record in proposals {
+            let (_, proposal) = record?;
+
+            if !proposal.is_active(self.ending_state.number) {
+                continue;
+            }
+
+            let in_snapshot = proposal
+                .proposed_in
+                .is_some_and(|epoch| epoch < self.ending_state.number);
+
+            if !in_snapshot {
+                continue;
+            }
+
+            let (Some(deposit), Some(credential)) =
+                (proposal.deposit, proposal.reward_account.as_ref())
+            else {
+                continue;
+            };
+
+            *self
+                .proposal_deposits
+                .entry(credential.clone())
+                .or_default() += deposit;
+        }
+
+        Ok(())
+    }
+
+    /// Accumulate one account's contribution to the boundary stake
+    /// distributions, reading the `snapshot_epoch` (mark) position of its
+    /// `EpochValue`s. The delegated weight is the era-correct stake total
+    /// plus the account's share of the snapshot proposal deposits. The
+    /// DRep leg skips delegations to targets not registered as of the
+    /// snapshot; `AlwaysAbstain` / `AlwaysNoConfidence` accumulate under
+    /// their own keys. The pool leg feeds both the per-pool map and the
+    /// running total.
+    fn accumulate_gov_distr(
+        &self,
+        snapshot_epoch: Epoch,
+        account: &AccountState,
+        drep_distr: &mut BTreeMap<DRep, u64>,
+        pool_distr: &mut BTreeMap<PoolHash, u64>,
+        pool_total: &mut u64,
+    ) {
+        let Some(stake) = account.stake.snapshot_at(snapshot_epoch) else {
+            return;
+        };
+
+        let deposits = self
+            .proposal_deposits
+            .get(&account.credential)
+            .copied()
+            .unwrap_or_default();
+
+        let weight = stake.total_for_era(self.active_protocol) + deposits;
+
+        if weight == 0 {
+            return;
+        }
+
+        if let Some(drep) = account.delegated_drep_at(snapshot_epoch) {
+            let in_snapshot = match drep {
+                DRep::Abstain | DRep::NoConfidence => true,
+                _ => self
+                    .snapshot_registered_dreps
+                    .contains(&drep_to_entity_key(drep)),
+            };
+
+            if in_snapshot {
+                *drep_distr.entry(drep.clone()).or_default() += weight;
+            }
+        }
+
+        if let Some(pool) = account.delegated_pool_at(snapshot_epoch) {
+            *pool_distr.entry(*pool).or_default() += weight;
+            *pool_total += weight;
+        }
+    }
+
     /// Load + compute for a per-shard run of the close half:
     ///   * reload the small classifications that drops.visit_account needs
     ///     (retiring_pools, retiring_dreps, reregistrating_dreps),
     ///   * range-load pending rewards for this shard's key range,
-    ///   * iterate accounts in range, applying rewards+drops visitors, and
-    ///   * emit an `EWrapProgress` delta carrying the shard's reward
-    ///     contribution.
+    ///   * iterate accounts in range, applying rewards+drops visitors and
+    ///     accumulating the boundary stake distributions, and
+    ///   * emit `EWrapProgress` and (governance active) `GovDistrAccumulate`
+    ///     deltas carrying the shard's contributions.
     pub fn load_shard<D: Domain>(
         state: &D::State,
         genesis: Arc<Genesis>,
@@ -134,6 +255,10 @@ impl BoundaryWork {
         // re-classifying them per shard is cheap.
         boundary.load_pool_data::<D>(state)?;
         boundary.load_drep_data::<D>(state)?;
+
+        if boundary.distr_snapshot_epoch().is_some() {
+            boundary.load_proposal_deposits::<D>(state)?;
+        }
 
         boundary.load_pending_rewards_ranges::<D>(state, ranges.clone())?;
 
@@ -152,6 +277,11 @@ impl BoundaryWork {
         let mut visitor_rewards = super::rewards::BoundaryVisitor::default();
         let mut visitor_drops = super::drops::BoundaryVisitor::default();
 
+        let snapshot_epoch = self.distr_snapshot_epoch();
+        let mut drep_distr: BTreeMap<DRep, u64> = BTreeMap::new();
+        let mut pool_distr: BTreeMap<PoolHash, u64> = BTreeMap::new();
+        let mut pool_total: u64 = 0;
+
         for range in ranges {
             let accounts =
                 state.iter_entities_typed::<AccountState>(AccountState::NS, Some(range))?;
@@ -167,11 +297,34 @@ impl BoundaryWork {
                 // and drop this ordering hack. (#1037)
                 visitor_rewards.visit_account(self, &account_id, &account)?;
                 visitor_drops.visit_account(self, &account_id, &account)?;
+
+                if let Some(epoch) = snapshot_epoch {
+                    self.accumulate_gov_distr(
+                        epoch,
+                        &account,
+                        &mut drep_distr,
+                        &mut pool_distr,
+                        &mut pool_total,
+                    );
+                }
             }
         }
 
         visitor_rewards.flush(self)?;
         visitor_drops.flush(self)?;
+
+        // Emitted whenever the accumulation ran, even with empty maps — the
+        // shard cursor must advance for the accumulator to report complete.
+        if snapshot_epoch.is_some() {
+            self.add_delta(crate::GovDistrAccumulate::new(
+                self.ending_state.number,
+                shard_index,
+                total_shards,
+                drep_distr,
+                pool_distr,
+                pool_total,
+            ));
+        }
 
         // Snapshot the reward-map counters for this shard and emit the
         // accumulator delta. The RewardMap's applied_* counters reflect only
@@ -305,11 +458,36 @@ impl BoundaryWork {
         None
     }
 
+    /// Whether `drep` was registered as of the previous epoch boundary —
+    /// the boundary the distribution snapshot corresponds to. Events at or
+    /// after `boundary_slot` happened during the closing epoch and postdate
+    /// the snapshot: a DRep unregistered mid-epoch still counts (the
+    /// Haskell snapshot predates the unregistration), one registered
+    /// mid-epoch doesn't yet.
+    fn is_drep_registered_as_of(drep: &DRepState, boundary_slot: BlockSlot) -> bool {
+        let registered = drep.registered_at.filter(|(slot, _)| *slot < boundary_slot);
+        let unregistered = drep
+            .unregistered_at
+            .filter(|(slot, _)| *slot < boundary_slot);
+
+        match (registered, unregistered) {
+            (Some(registered), Some(unregistered)) => registered > unregistered,
+            (Some(_), None) => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn load_drep_data<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
+        let boundary_slot = self.chain_summary.epoch_start(self.ending_state.number);
+
         let dreps = state.iter_entities_typed::<DRepState>(DRepState::NS, None)?;
 
         for record in dreps {
-            let (_, drep) = record?;
+            let (id, drep) = record?;
+
+            if Self::is_drep_registered_as_of(&drep, boundary_slot) {
+                self.snapshot_registered_dreps.insert(id);
+            }
 
             if self.should_retire_drep(&drep) {
                 self.retiring_dreps.push(drep.identifier);
@@ -463,6 +641,52 @@ impl BoundaryWork {
         Ok(boundary)
     }
 
+    /// The completed DRep distribution for the boundary being closed, or
+    /// `None` when there is nothing sound to write: governance inactive, no
+    /// snapshot epoch, or an accumulator that is missing, incomplete, or
+    /// belongs to another boundary (e.g. earlier shards ran under a binary
+    /// that didn't accumulate). The degraded cases warn and self-heal at
+    /// the next boundary.
+    fn completed_drep_distr(&self) -> Option<BTreeMap<DRep, u64>> {
+        self.distr_snapshot_epoch()?;
+
+        match self.gov_distr.as_ref() {
+            Some(distr) if distr.is_complete_for(self.ending_state.number) => {
+                Some(distr.drep_distr.clone())
+            }
+            _ => {
+                tracing::warn!(
+                    epoch = self.ending_state.number,
+                    "boundary stake distributions missing or incomplete; \
+                     skipping DRep voting-power updates"
+                );
+                None
+            }
+        }
+    }
+
+    /// Emit the boundary `DRepPowerUpdate` for one DRep: registered DReps
+    /// get the stake the accumulation attributed to them (zero when absent
+    /// from the distribution — including DReps registered during the
+    /// closing epoch, which postdate the snapshot). No-op writes are
+    /// elided.
+    fn emit_drep_power_update(
+        &mut self,
+        distr: &BTreeMap<DRep, u64>,
+        id: &EntityKey,
+        drep: &DRepState,
+    ) {
+        if drep.registered_at.is_none() || drep.is_unregistered() {
+            return;
+        }
+
+        let power = distr.get(&drep.identifier).copied().unwrap_or_default();
+
+        if power != drep.voting_power {
+            self.add_delta(crate::DRepPowerUpdate::new(id.clone(), power));
+        }
+    }
+
     /// Drive the global visitors (enactment / refunds / drops / wrapup)
     /// over pools, dreps, and proposals; the wrapup visitor's flush emits
     /// `EpochWrapUp` carrying the final `EndStats`.
@@ -492,7 +716,11 @@ impl BoundaryWork {
             visitor_wrapup.visit_retiring_pool(self, pool_hash, &pool, account.as_ref())?;
         }
 
-        // DReps — drops.visit_drep emits DRepExpiration for expiring dreps.
+        // DReps — drops.visit_drep emits DRepExpiration for expiring dreps;
+        // registered dreps additionally get their boundary voting power
+        // written from the completed distribution accumulator.
+        let drep_power = self.completed_drep_distr();
+
         let dreps = state.iter_entities_typed::<DRepState>(DRepState::NS, None)?;
         for record in dreps {
             let (drep_id, drep) = record?;
@@ -500,6 +728,10 @@ impl BoundaryWork {
             visitor_drops.visit_drep(self, &drep_id, &drep)?;
             visitor_refunds.visit_drep(self, &drep_id, &drep)?;
             visitor_wrapup.visit_drep(self, &drep_id, &drep)?;
+
+            if let Some(distr) = drep_power.as_ref() {
+                self.emit_drep_power_update(distr, &drep_id, &drep);
+            }
         }
 
         // Active proposals + enacting + dropping.
@@ -539,5 +771,335 @@ impl BoundaryWork {
         visitor_wrapup.flush(self)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use dolos_core::{Domain as _, EntityDelta as _, StateStore as _, StateWriter as _};
+    use dolos_testing::toy_domain::ToyDomain;
+    use pallas::ledger::primitives::StakeCredential;
+
+    use super::*;
+    use crate::{
+        model::{credential_to_key, drep_to_entity_key},
+        shard::shard_key_ranges,
+        AccountTransition, AssignRewards, ControlledAmountInc, DRepDelegation, EpochState,
+        EpochValue, PoolDelegation, SingletonEntity as _, Stake,
+    };
+
+    /// Pins the rotation-timing assumption behind the distribution snapshot
+    /// read: EWRAP runs before ESTART's rotation (ordering pinned by
+    /// `epoch_boundary_emits_ewrap_then_estart` in `work.rs`), so during
+    /// EWRAP closing epoch n+1 the account `EpochValue`s still sit at
+    /// live-epoch n+1 and the `mark` position holds the value frozen at the
+    /// n/n+1 rotation — already including EWRAP(n)'s post-enactment effects
+    /// (applied to `live` before that rotation) and excluding every epoch-n+1
+    /// mutation. `snapshot_at(n)`, the read the accumulation performs, must
+    /// resolve to exactly that `mark` value; a boundary reordering that
+    /// rotated first would desynchronize the two and break this test.
+    #[test]
+    fn mark_position_is_the_boundary_snapshot() {
+        let credential = StakeCredential::AddrKeyhash([1u8; 28].into());
+        let key = credential_to_key(&credential);
+
+        // epoch n = 5: account holds 100 lovelace of live stake
+        let mut account = Some(crate::AccountState {
+            registered_at: Some(0),
+            stake: EpochValue::with_live(5, Stake::default()),
+            pool: EpochValue::new(5),
+            drep: EpochValue::new(5),
+            vote_delegated_at: None,
+            deregistered_at: None,
+            credential: credential.clone(),
+            retired_pool: None,
+        });
+
+        ControlledAmountInc::new(credential.clone(), false, 100, 5).apply(&mut account);
+
+        // EWRAP(n) applies a reward — a post-enactment effect of the n/n+1
+        // boundary, mutating `live` before the rotation
+        AssignRewards::new(key.clone(), 25).apply(&mut account);
+
+        // ESTART's rotation into epoch n+1 = 6 freezes the post-enactment
+        // value in `mark`
+        AccountTransition::new(key.clone(), 6).apply(&mut account);
+
+        // activity during epoch n+1 mutates `live` only
+        ControlledAmountInc::new(credential.clone(), false, 75, 6).apply(&mut account);
+
+        let stake = &account.as_ref().unwrap().stake;
+
+        // the EWRAP(n+1) read: end-of-n snapshot == the mark position ==
+        // the post-enactment value at the n/n+1 rotation
+        assert!(stake.is_at_epoch(6));
+        assert_eq!(stake.snapshot_at(5), stake.mark());
+        assert_eq!(stake.snapshot_at(5).unwrap().total(), 125);
+        assert_eq!(stake.unwrap_live().total(), 200);
+
+        // after the n+1/n+2 rotation — which EWRAP(n+1) must precede — the
+        // mark position moves on to the epoch-n+1 value
+        AccountTransition::new(key, 7).apply(&mut account);
+        let stake = &account.as_ref().unwrap().stake;
+        assert_eq!(stake.mark().unwrap().total(), 200);
+    }
+
+    const CLOSING_EPOCH: u64 = 5;
+    const TOTAL_SHARDS: u32 = 2;
+
+    fn reg_drep() -> DRep {
+        DRep::Key([1u8; 28].into())
+    }
+
+    fn unreg_drep() -> DRep {
+        DRep::Key([2u8; 28].into())
+    }
+
+    fn fresh_drep() -> DRep {
+        DRep::Key([3u8; 28].into())
+    }
+
+    fn pool_a() -> crate::PoolHash {
+        [9u8; 28].into()
+    }
+
+    fn snapshot_account(
+        byte: u8,
+        mark_utxo: u64,
+        drep: Option<DRep>,
+        pool: Option<crate::PoolHash>,
+    ) -> crate::AccountState {
+        let credential = StakeCredential::AddrKeyhash([byte; 28].into());
+
+        // live values differ from mark so a wrong-position read shows up
+        let live_stake = Stake {
+            utxo_sum: mark_utxo * 10,
+            ..Default::default()
+        };
+        let mark_stake = Stake {
+            utxo_sum: mark_utxo,
+            ..Default::default()
+        };
+
+        let mark_drep = drep.map_or(DRepDelegation::NotDelegated, DRepDelegation::Delegated);
+        let mark_pool = pool.map_or(PoolDelegation::NotDelegated, PoolDelegation::Pool);
+
+        crate::AccountState {
+            registered_at: Some(0),
+            stake: EpochValue::from_parts(
+                CLOSING_EPOCH,
+                Some(live_stake),
+                None,
+                Some(mark_stake),
+                None,
+                None,
+            ),
+            pool: EpochValue::from_parts(
+                CLOSING_EPOCH,
+                Some(PoolDelegation::NotDelegated),
+                None,
+                Some(mark_pool),
+                None,
+                None,
+            ),
+            drep: EpochValue::from_parts(
+                CLOSING_EPOCH,
+                Some(DRepDelegation::NotDelegated),
+                None,
+                Some(mark_drep),
+                None,
+                None,
+            ),
+            vote_delegated_at: None,
+            deregistered_at: None,
+            credential,
+            retired_pool: None,
+        }
+    }
+
+    fn drep_row(
+        identifier: DRep,
+        registered_at: Option<u64>,
+        unregistered_at: Option<u64>,
+        voting_power: u64,
+    ) -> crate::DRepState {
+        crate::DRepState {
+            registered_at: registered_at.map(|slot| (slot, 0)),
+            voting_power,
+            last_active_slot: None,
+            unregistered_at: unregistered_at.map(|slot| (slot, 0)),
+            expired: false,
+            deposit: voting_power,
+            identifier,
+            anchor: None,
+            expiry: None,
+        }
+    }
+
+    /// Seed a ToyDomain (devnet: governance active since epoch 0) with a
+    /// closing-epoch EpochState, snapshot-position accounts, DRep rows and
+    /// a live proposal whose deposit returns to the first account.
+    fn seed_domain() -> ToyDomain {
+        let domain = ToyDomain::new(None, None);
+        let state = domain.state();
+
+        let mut epoch = crate::load_epoch::<ToyDomain>(state).unwrap();
+        epoch.number = CLOSING_EPOCH;
+
+        let chain = load_era_summary::<ToyDomain>(state).unwrap();
+        let boundary_slot = chain.epoch_start(CLOSING_EPOCH);
+
+        let writer = state.start_writer().unwrap();
+        writer
+            .write_entity_typed(&EpochState::singleton_key(), &epoch)
+            .unwrap();
+
+        // alice: 100 mark stake + 40 proposal deposit, delegated to the
+        // registered drep and to pool_a
+        let alice = snapshot_account(0xa1, 100, Some(reg_drep()), Some(pool_a()));
+        // bob: 50, delegated to AlwaysAbstain, no pool
+        let bob = snapshot_account(0xb2, 50, Some(DRep::Abstain), None);
+        // carol: 70, delegated to a drep unregistered before the boundary,
+        // and to pool_a
+        let carol = snapshot_account(0xc3, 70, Some(unreg_drep()), Some(pool_a()));
+
+        for account in [&alice, &bob, &carol] {
+            writer
+                .write_entity_typed(&credential_to_key(&account.credential), account)
+                .unwrap();
+        }
+
+        // registered before the boundary; power seeded with the deposit,
+        // to be overwritten by the accumulated stake
+        let registered = drep_row(reg_drep(), Some(boundary_slot - 10), None, 500);
+        // registered then unregistered before the boundary
+        let unregistered = drep_row(
+            unreg_drep(),
+            Some(boundary_slot - 10),
+            Some(boundary_slot - 5),
+            0,
+        );
+        // registered during the closing epoch — postdates the snapshot
+        let fresh = drep_row(fresh_drep(), Some(boundary_slot), None, 500);
+
+        for drep in [&registered, &unregistered, &fresh] {
+            writer
+                .write_entity_typed(&drep_to_entity_key(&drep.identifier), drep)
+                .unwrap();
+        }
+
+        // live proposal submitted before the closing epoch; its deposit
+        // returns to alice's credential
+        let proposal = ProposalState {
+            slot: 0,
+            tx: [7u8; 32].into(),
+            idx: 0,
+            action: crate::ProposalAction::Info,
+            max_epoch: None,
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: Some(40),
+            reward_account: Some(alice.credential.clone()),
+            proposed_in: Some(CLOSING_EPOCH - 2),
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        };
+
+        writer
+            .write_entity_typed(&EntityKey::from(b"proposal-1".to_vec()), &proposal)
+            .unwrap();
+
+        writer.commit().unwrap();
+
+        domain
+    }
+
+    fn run_shard(domain: &ToyDomain, shard: u32) {
+        let ranges = shard_key_ranges(shard, TOTAL_SHARDS);
+
+        let mut boundary = BoundaryWork::load_shard::<ToyDomain>(
+            domain.state(),
+            domain.genesis(),
+            shard,
+            TOTAL_SHARDS,
+            ranges.clone(),
+        )
+        .unwrap();
+
+        boundary
+            .commit_shard::<ToyDomain>(domain.state(), domain.archive(), ranges)
+            .unwrap();
+    }
+
+    fn read_distr(domain: &ToyDomain) -> crate::GovDistr {
+        crate::load_gov::<ToyDomain>(domain.state())
+            .unwrap()
+            .distr
+            .expect("accumulator present")
+    }
+
+    fn read_drep_power(domain: &ToyDomain, drep: &DRep) -> u64 {
+        domain
+            .state()
+            .read_entity_typed::<crate::DRepState>(crate::DRepState::NS, &drep_to_entity_key(drep))
+            .unwrap()
+            .expect("drep row present")
+            .voting_power
+    }
+
+    /// End-to-end shard pass over a seeded store: the accumulated
+    /// distributions read the mark position, include proposal deposits in
+    /// the delegated weight (done criterion 3), track the abstain
+    /// pseudo-DRep separately, skip delegations to DReps outside the
+    /// snapshot's registered set, survive shard replays unchanged (done
+    /// criterion 1 through the real commit path), and land on
+    /// `DRepState.voting_power` at finalize.
+    #[test]
+    fn shard_accumulation_builds_boundary_distributions() {
+        let domain = seed_domain();
+
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+
+        let distr = read_distr(&domain);
+        assert!(distr.is_complete_for(CLOSING_EPOCH));
+
+        // alice: 100 mark stake + 40 proposal deposit; carol's delegation
+        // targets an unregistered drep and stays out; bob tallies under
+        // the abstain key
+        let expected_dreps = BTreeMap::from([(reg_drep(), 140u64), (DRep::Abstain, 50u64)]);
+        assert_eq!(distr.drep_distr, expected_dreps);
+
+        // the pool leg counts alice and carol regardless of drep status
+        assert_eq!(distr.pool_distr, BTreeMap::from([(pool_a(), 210u64)]));
+        assert_eq!(distr.pool_total, 210);
+
+        // a crash-resume replay of every shard leaves the accumulator
+        // untouched
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+        assert_eq!(read_distr(&domain), distr);
+
+        // finalize writes the accumulated powers: the registered drep gets
+        // its delegated stake (replacing the deposit seed), the drep
+        // registered mid-epoch is zeroed (absent from the snapshot), the
+        // unregistered one is left alone
+        let mut boundary =
+            BoundaryWork::load_finalize::<ToyDomain>(domain.state(), domain.genesis()).unwrap();
+        boundary
+            .commit_finalize::<ToyDomain>(domain.state(), domain.archive())
+            .unwrap();
+
+        assert_eq!(read_drep_power(&domain, &reg_drep()), 140);
+        assert_eq!(read_drep_power(&domain, &fresh_drep()), 0);
+        assert_eq!(read_drep_power(&domain, &unreg_drep()), 0);
     }
 }

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -17,11 +17,11 @@ use std::{
 };
 
 use dolos_core::{BlockSlot, ChainError, EntityKey, Genesis, TxOrder};
-use pallas::ledger::primitives::{conway::DRep, StakeCredential};
+use pallas::ledger::primitives::{conway::DRep, Epoch, StakeCredential};
 
 use crate::{
     eras::ChainSummary, rewards::RewardMap, roll::WorkDeltas, rupd::RupdWork, AccountState,
-    CardanoDelta, CardanoEntity, DRepState, EpochState, EraProtocol, PoolHash, PoolState,
+    CardanoDelta, CardanoEntity, DRepState, EpochState, EraProtocol, GovDistr, PoolHash, PoolState,
     ProposalState,
 };
 
@@ -158,6 +158,26 @@ pub struct BoundaryWork {
     /// carry no dormancy credit, so the expiry check adds the counter back
     /// (`actual = stored + dormant`, Haskell-style).
     pub num_dormant_epochs: u64,
+
+    /// `GovState::active_since` at the boundary. The stake-distribution
+    /// accumulation only runs while governance is active.
+    pub gov_active_since: Option<Epoch>,
+
+    /// `GovState::distr` at the boundary — the stake-distribution
+    /// accumulator as of this phase's load. The finalize pass reads the
+    /// completed distributions from here to write DRep voting powers.
+    pub gov_distr: Option<GovDistr>,
+
+    /// Deposits of the snapshot proposal set (live, `proposed_in` before the
+    /// closing epoch), summed per return credential. Added to the delegated
+    /// weight of the matching account during the distribution accumulation,
+    /// as the pulser's `proposalDeposits` snapshot field is.
+    pub proposal_deposits: HashMap<StakeCredential, u64>,
+
+    /// Entity keys of the DReps registered as of the previous boundary — the
+    /// distribution accumulation skips delegations to any other target
+    /// (`AlwaysAbstain` / `AlwaysNoConfidence` excepted).
+    pub snapshot_registered_dreps: HashSet<EntityKey>,
 
     // computed via visitors
     pub deltas: WorkDeltas,

--- a/crates/cardano/src/model/dreps.rs
+++ b/crates/cardano/src/model/dreps.rs
@@ -638,6 +638,54 @@ impl dolos_core::EntityDelta for DRepDormancyRelease {
     }
 }
 
+/// Write a DRep's computed voting power — the delegated stake accumulated by
+/// the EWRAP boundary scan (`GovState.distr.drep_distr`) — into
+/// `voting_power`. Emitted at EWRAP finalize for every registered DRep whose
+/// stored value differs from the accumulated one.
+///
+/// The field stays `u64` at its existing CBOR index — its type is frozen; a
+/// per-epoch history, if APIs ever want one, is a new field at a higher
+/// index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DRepPowerUpdate {
+    pub(crate) drep_id: EntityKey,
+    pub(crate) power: u64,
+
+    // undo
+    pub(crate) prev_power: u64,
+}
+
+impl DRepPowerUpdate {
+    pub fn new(drep_id: EntityKey, power: u64) -> Self {
+        Self {
+            drep_id,
+            power,
+            prev_power: 0,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for DRepPowerUpdate {
+    type Entity = DRepState;
+
+    fn key(&self) -> NsKey {
+        NsKey::from((DRepState::NS, self.drep_id.clone()))
+    }
+
+    fn apply(&mut self, entity: &mut Option<DRepState>) {
+        let entity = entity.as_mut().expect("existing drep");
+
+        self.prev_power = entity.voting_power;
+        entity.voting_power = self.power;
+    }
+
+    fn undo(&self, entity: &mut Option<DRepState>) {
+        let entity = entity.as_mut().expect("existing drep");
+
+        entity.voting_power = self.prev_power;
+    }
+}
+
 #[cfg(test)]
 mod prop_tests {
     use super::testing::any_drep_state;
@@ -705,6 +753,15 @@ mod prop_tests {
     }
 
     prop_compose! {
+        fn any_drep_power_update()(
+            drep in root::any_drep(),
+            power in root::any_lovelace(),
+        ) -> DRepPowerUpdate {
+            DRepPowerUpdate::new(drep_to_entity_key(&drep), power)
+        }
+    }
+
+    prop_compose! {
         fn any_drep_dormancy_release()(
             drep in root::any_drep(),
             dormant_epochs in 1u64..32u64,
@@ -761,6 +818,22 @@ mod prop_tests {
             delta in any_drep_expiration(),
         ) {
             assert_delta_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn drep_power_update_roundtrip(
+            entity in any_drep_state(),
+            delta in any_drep_power_update(),
+        ) {
+            assert_delta_roundtrip(Some(entity), delta);
+        }
+
+        #[test]
+        fn drep_power_update_serde_roundtrip(
+            entity in any_drep_state(),
+            delta in any_drep_power_update(),
+        ) {
+            root::assert_delta_serde_roundtrip(Some(entity), delta);
         }
 
         #[test]

--- a/crates/cardano/src/model/gov.rs
+++ b/crates/cardano/src/model/gov.rs
@@ -25,13 +25,13 @@ use dolos_core::{BlockSlot, NsKey};
 use pallas::{
     codec::minicbor::{self, Decode, Encode},
     ledger::primitives::{
-        conway::{Anchor, GovActionId, RationalNumber},
+        conway::{Anchor, DRep, GovActionId, RationalNumber},
         Epoch, ScriptHash, StakeCredential,
     },
 };
 use serde::{Deserialize, Serialize};
 
-use super::{GovPurpose, SingletonEntity};
+use super::{GovPurpose, PoolHash, SingletonEntity};
 
 /// Key of the single `GovState` entity inside the `"gov"` namespace.
 pub const GOV_STATE_KEY: &[u8] = b"0";
@@ -81,6 +81,66 @@ pub enum CommitteeAuthorization {
 /// boundary even if the member re-authorized since. Committee events are
 /// rare, so histories stay tiny.
 pub type AuthHistory = Vec<(BlockSlot, CommitteeAuthorization)>;
+
+/// Crash-safe accumulator for the epoch-boundary stake distributions: the
+/// DRep voting-power distribution (`drepDistr` in the Haskell ledger) and the
+/// per-pool stake distribution (SPO tally denominator), both computed by the
+/// EWRAP sharded account scan from the `mark`-position account state — the
+/// pulser-snapshot-equivalent read at the boundary.
+///
+/// Shards merge their contribution through [`GovDistrAccumulate`], which is
+/// idempotent per `(closing_epoch, shard)` so a resumed mid-scan EWRAP cannot
+/// double-count. The accumulator is keyed by the epoch being closed and is
+/// replaced wholesale when the next boundary's shard 0 arrives — which is
+/// also what prunes the previous epoch's maps.
+#[derive(Debug, Encode, Decode, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GovDistr {
+    /// The epoch the accumulating EWRAP pass is closing.
+    #[n(0)]
+    pub closing_epoch: Epoch,
+
+    /// Shards `0..committed_shards` have merged their contribution;
+    /// `committed_shards == total_shards` means the distributions are
+    /// complete.
+    #[n(1)]
+    pub committed_shards: u32,
+
+    /// Shard plan of the accumulating boundary.
+    #[n(2)]
+    pub total_shards: u32,
+
+    /// Delegated stake per DRep. `AlwaysAbstain` / `AlwaysNoConfidence`
+    /// accumulate under their own keys — the ratification tallies need both.
+    #[n(3)]
+    pub drep_distr: BTreeMap<DRep, u64>,
+
+    /// Delegated stake per pool.
+    #[n(4)]
+    pub pool_distr: BTreeMap<PoolHash, u64>,
+
+    /// Total pool-delegated stake (SPO tally denominator input).
+    #[n(5)]
+    pub pool_total: u64,
+}
+
+impl GovDistr {
+    pub fn new(closing_epoch: Epoch, total_shards: u32) -> Self {
+        Self {
+            closing_epoch,
+            committed_shards: 0,
+            total_shards,
+            drep_distr: BTreeMap::new(),
+            pool_distr: BTreeMap::new(),
+            pool_total: 0,
+        }
+    }
+
+    /// Whether every shard of the boundary closing `epoch` has merged its
+    /// contribution.
+    pub fn is_complete_for(&self, epoch: Epoch) -> bool {
+        self.closing_epoch == epoch && self.committed_shards == self.total_shards
+    }
+}
 
 /// The four per-purpose previous-governance-action roots (`prevGovActionIds`
 /// in the Haskell ledger). Updated on enactment; consumed by the
@@ -152,6 +212,15 @@ pub struct GovState {
     #[n(5)]
     #[cbor(default)]
     pub active_since: Option<Epoch>,
+
+    /// The boundary stake-distribution accumulator. `None` until the first
+    /// governance-active boundary accumulates; afterwards holds the most
+    /// recent boundary's distributions (in progress while its shards run,
+    /// complete after the last one) until the next boundary's shard 0
+    /// replaces it. Index 6 must not be reused for anything else.
+    #[n(6)]
+    #[cbor(default)]
+    pub distr: Option<GovDistr>,
 }
 
 entity_boilerplate!(GovState, "gov");
@@ -677,6 +746,158 @@ impl dolos_core::EntityDelta for GovDormancyReset {
     }
 }
 
+/// Merge one EWRAP shard's stake-distribution contribution into
+/// `GovState.distr`. Emitted once per shard by the boundary account scan.
+///
+/// Idempotent per `(closing_epoch, shard)` and ordered, mirroring the
+/// `EWrapProgress` guard discipline: a shard whose merge already landed is
+/// skipped (crash-resume replay), an out-of-order shard is skipped as a
+/// broken invariant, and a `total_shards` mismatch against the in-flight
+/// accumulator is skipped as corruption. Shard 0 of a new closing epoch
+/// replaces the previous epoch's accumulator wholesale (the pruning step);
+/// undo restores the full pre-image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovDistrAccumulate {
+    pub(crate) closing_epoch: Epoch,
+    pub(crate) shard: u32,
+    pub(crate) total_shards: u32,
+    pub(crate) drep_distr: BTreeMap<DRep, u64>,
+    pub(crate) pool_distr: BTreeMap<PoolHash, u64>,
+    pub(crate) pool_total: u64,
+
+    // undo — captured by `apply` only when state was actually mutated
+    // (i.e. the idempotency / ordering / consistency guards all passed).
+    // When `applied = false`, `undo` is a no-op so a rolled-back skip
+    // can't clobber the accumulator.
+    pub(crate) applied: bool,
+    pub(crate) prev: Option<GovDistr>,
+}
+
+impl GovDistrAccumulate {
+    pub fn new(
+        closing_epoch: Epoch,
+        shard: u32,
+        total_shards: u32,
+        drep_distr: BTreeMap<DRep, u64>,
+        pool_distr: BTreeMap<PoolHash, u64>,
+        pool_total: u64,
+    ) -> Self {
+        Self {
+            closing_epoch,
+            shard,
+            total_shards,
+            drep_distr,
+            pool_distr,
+            pool_total,
+            applied: false,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for GovDistrAccumulate {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        // Idempotency + ordering guards, per accumulating epoch.
+        match state.distr.as_ref() {
+            Some(distr) if distr.closing_epoch == self.closing_epoch => {
+                if distr.committed_shards > self.shard {
+                    // Already merged (crash-recovery replay of a shard whose
+                    // state commit landed). Skip to preserve idempotency.
+                    tracing::debug!(
+                        closing_epoch = self.closing_epoch,
+                        shard = self.shard,
+                        committed = distr.committed_shards,
+                        "GovDistrAccumulate already applied — skipping (idempotent)"
+                    );
+                    return;
+                }
+                if distr.committed_shards < self.shard {
+                    tracing::error!(
+                        closing_epoch = self.closing_epoch,
+                        shard = self.shard,
+                        committed = distr.committed_shards,
+                        "GovDistrAccumulate applied out of order — skipping to avoid corruption"
+                    );
+                    return;
+                }
+                if distr.total_shards != self.total_shards {
+                    tracing::error!(
+                        closing_epoch = self.closing_epoch,
+                        shard = self.shard,
+                        stored_total = distr.total_shards,
+                        delta_total = self.total_shards,
+                        "GovDistrAccumulate total_shards disagrees with in-flight \
+                         accumulator — skipping to avoid corruption"
+                    );
+                    return;
+                }
+            }
+            Some(distr) if distr.closing_epoch > self.closing_epoch => {
+                // Replay of a boundary that a newer one already replaced.
+                tracing::debug!(
+                    closing_epoch = self.closing_epoch,
+                    stored_epoch = distr.closing_epoch,
+                    "GovDistrAccumulate for a superseded boundary — skipping (idempotent)"
+                );
+                return;
+            }
+            _ => {
+                // Fresh boundary (no accumulator yet, or a previous epoch's
+                // residue about to be pruned). Only shard 0 may open it.
+                if self.shard != 0 {
+                    tracing::error!(
+                        closing_epoch = self.closing_epoch,
+                        shard = self.shard,
+                        "GovDistrAccumulate opening a boundary at shard != 0 — \
+                         skipping to avoid corruption"
+                    );
+                    return;
+                }
+            }
+        }
+
+        self.prev = state.distr.clone();
+
+        let distr = match state.distr.as_mut() {
+            Some(distr) if distr.closing_epoch == self.closing_epoch => distr,
+            _ => state
+                .distr
+                .insert(GovDistr::new(self.closing_epoch, self.total_shards)),
+        };
+
+        for (drep, weight) in &self.drep_distr {
+            *distr.drep_distr.entry(drep.clone()).or_default() += weight;
+        }
+
+        for (pool, weight) in &self.pool_distr {
+            *distr.pool_distr.entry(*pool).or_default() += weight;
+        }
+
+        distr.pool_total += self.pool_total;
+        distr.committed_shards = self.shard + 1;
+
+        self.applied = true;
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        if !self.applied {
+            return;
+        }
+
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.distr = self.prev.clone();
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
@@ -728,6 +949,34 @@ pub(crate) mod testing {
     }
 
     prop_compose! {
+        pub fn any_gov_distr()(
+            closing_epoch in root::any_epoch(),
+            committed_shards in 0u32..8u32,
+            total_shards in 8u32..16u32,
+            drep_distr in prop::collection::btree_map(
+                root::any_drep(),
+                root::any_lovelace(),
+                0..4,
+            ),
+            pool_distr in prop::collection::btree_map(
+                root::any_pool_hash(),
+                root::any_lovelace(),
+                0..4,
+            ),
+            pool_total in root::any_lovelace(),
+        ) -> GovDistr {
+            GovDistr {
+                closing_epoch,
+                committed_shards,
+                total_shards,
+                drep_distr,
+                pool_distr,
+                pool_total,
+            }
+        }
+    }
+
+    prop_compose! {
         pub fn any_gov_state()(
             constitution in prop::option::of(any_constitution()),
             committee in prop::option::of(any_committee()),
@@ -739,6 +988,7 @@ pub(crate) mod testing {
             prev_gov_action_ids in any_gov_roots(),
             num_dormant_epochs in 0u64..32u64,
             active_since in prop::option::of(root::any_epoch()),
+            distr in prop::option::of(any_gov_distr()),
         ) -> GovState {
             GovState {
                 constitution,
@@ -747,6 +997,7 @@ pub(crate) mod testing {
                 prev_gov_action_ids,
                 num_dormant_epochs,
                 active_since,
+                distr,
             }
         }
     }
@@ -797,6 +1048,17 @@ mod tests {
             },
             num_dormant_epochs: 3,
             active_since: Some(507),
+            distr: Some(GovDistr {
+                closing_epoch: 509,
+                committed_shards: 2,
+                total_shards: 32,
+                drep_distr: BTreeMap::from([
+                    (DRep::Key([7u8; 28].into()), 5_000_000),
+                    (DRep::Abstain, 1_000_000),
+                ]),
+                pool_distr: BTreeMap::from([([8u8; 28].into(), 6_000_000)]),
+                pool_total: 6_000_000,
+            }),
         };
 
         let bytes = minicbor::to_vec(&state).unwrap();
@@ -944,6 +1206,34 @@ mod prop_tests {
         }
     }
 
+    prop_compose! {
+        fn any_gov_distr_accumulate()(
+            closing_epoch in root::any_epoch(),
+            shard in 0u32..4u32,
+            total_shards in 4u32..8u32,
+            drep_distr in prop::collection::btree_map(
+                root::any_drep(),
+                root::any_lovelace(),
+                0..4,
+            ),
+            pool_distr in prop::collection::btree_map(
+                root::any_pool_hash(),
+                root::any_lovelace(),
+                0..4,
+            ),
+            pool_total in root::any_lovelace(),
+        ) -> GovDistrAccumulate {
+            GovDistrAccumulate::new(
+                closing_epoch,
+                shard,
+                total_shards,
+                drep_distr,
+                pool_distr,
+                pool_total,
+            )
+        }
+    }
+
     proptest! {
         #[test]
         fn entity_cbor_roundtrip(entity in any_gov_state()) {
@@ -997,6 +1287,22 @@ mod prop_tests {
             entity in any_gov_state().prop_map(Some),
         ) {
             assert_delta_roundtrip(entity, GovDormancyReset::new());
+        }
+
+        #[test]
+        fn distr_accumulate_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_accumulate(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn distr_accumulate_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_accumulate(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
         }
 
         #[test]
@@ -1183,6 +1489,143 @@ mod prop_tests {
 
         delta.undo(&mut entity);
         assert_eq!(entity.unwrap().prev_gov_action_ids, GovRoots::default());
+    }
+
+    fn shard_delta(
+        closing_epoch: Epoch,
+        shard: u32,
+        total: u32,
+        weight: u64,
+    ) -> GovDistrAccumulate {
+        let drep = DRep::Key([1u8; 28].into());
+        let pool: crate::PoolHash = [2u8; 28].into();
+
+        GovDistrAccumulate::new(
+            closing_epoch,
+            shard,
+            total,
+            BTreeMap::from([(drep, weight)]),
+            BTreeMap::from([(pool, weight)]),
+            weight,
+        )
+    }
+
+    fn apply_to(state: &mut Option<GovState>, delta: &GovDistrAccumulate) {
+        use dolos_core::EntityDelta as _;
+
+        // fresh instance so replays behave like WAL replays (no undo state)
+        let mut delta = GovDistrAccumulate::new(
+            delta.closing_epoch,
+            delta.shard,
+            delta.total_shards,
+            delta.drep_distr.clone(),
+            delta.pool_distr.clone(),
+            delta.pool_total,
+        );
+
+        delta.apply(state);
+    }
+
+    /// Shards merge in order and the accumulator reports completeness once
+    /// the last one lands.
+    #[test]
+    fn distr_shards_merge_to_completion() {
+        let mut entity = Some(GovState::default());
+
+        for shard in 0..3 {
+            apply_to(&mut entity, &shard_delta(500, shard, 3, 10));
+        }
+
+        let distr = entity.unwrap().distr.unwrap();
+        let pool: crate::PoolHash = [2u8; 28].into();
+        assert!(distr.is_complete_for(500));
+        assert_eq!(distr.drep_distr[&DRep::Key([1u8; 28].into())], 30);
+        assert_eq!(distr.pool_distr[&pool], 30);
+        assert_eq!(distr.pool_total, 30);
+    }
+
+    /// Done criterion: `GovDistrAccumulate` re-applied for an
+    /// already-committed `(epoch, shard)` is a no-op, and a resumed mid-scan
+    /// accumulation (with replayed shards) produces the same distributions
+    /// as an uninterrupted one.
+    #[test]
+    fn distr_resumed_scan_equals_uninterrupted() {
+        let mut uninterrupted = Some(GovState::default());
+        for shard in 0..3 {
+            apply_to(&mut uninterrupted, &shard_delta(500, shard, 3, 10));
+        }
+
+        // crash after shard 1 committed; the restart replays shards 0 and 1
+        // before resuming at shard 2
+        let mut resumed = Some(GovState::default());
+        apply_to(&mut resumed, &shard_delta(500, 0, 3, 10));
+        apply_to(&mut resumed, &shard_delta(500, 1, 3, 10));
+        apply_to(&mut resumed, &shard_delta(500, 0, 3, 10));
+        apply_to(&mut resumed, &shard_delta(500, 1, 3, 10));
+        apply_to(&mut resumed, &shard_delta(500, 2, 3, 10));
+
+        assert_eq!(resumed, uninterrupted);
+    }
+
+    /// A shard arriving ahead of its predecessor is skipped instead of
+    /// corrupting the accumulator, and so is a shard opening a fresh
+    /// boundary at an index other than 0.
+    #[test]
+    fn distr_out_of_order_shards_are_skipped() {
+        let mut entity = Some(GovState::default());
+
+        apply_to(&mut entity, &shard_delta(500, 1, 3, 10));
+        assert_eq!(entity.as_ref().unwrap().distr, None);
+
+        apply_to(&mut entity, &shard_delta(500, 0, 3, 10));
+        apply_to(&mut entity, &shard_delta(500, 2, 3, 10));
+
+        let distr = entity.unwrap().distr.unwrap();
+        assert_eq!(distr.committed_shards, 1);
+        assert_eq!(distr.pool_total, 10);
+    }
+
+    /// Shard 0 of the next boundary replaces the previous epoch's
+    /// accumulator wholesale — the pruning step — and undo restores it.
+    #[test]
+    fn distr_new_boundary_prunes_previous_epoch() {
+        use dolos_core::EntityDelta as _;
+
+        let mut entity = Some(GovState::default());
+
+        for shard in 0..2 {
+            apply_to(&mut entity, &shard_delta(500, shard, 2, 10));
+        }
+
+        let previous = entity.as_ref().unwrap().distr.clone();
+        assert!(previous.as_ref().unwrap().is_complete_for(500));
+
+        let mut opener = shard_delta(501, 0, 2, 7);
+        opener.apply(&mut entity);
+
+        let distr = entity.as_ref().unwrap().distr.as_ref().unwrap();
+        assert_eq!(distr.closing_epoch, 501);
+        assert_eq!(distr.committed_shards, 1);
+        assert_eq!(distr.pool_total, 7);
+
+        opener.undo(&mut entity);
+        assert_eq!(entity.unwrap().distr, previous);
+    }
+
+    /// A replayed shard for a boundary that a newer accumulator already
+    /// replaced is a no-op — it must not resurrect the pruned epoch.
+    #[test]
+    fn distr_superseded_boundary_replay_is_noop() {
+        let mut entity = Some(GovState::default());
+
+        apply_to(&mut entity, &shard_delta(500, 0, 1, 10));
+        apply_to(&mut entity, &shard_delta(501, 0, 1, 7));
+
+        apply_to(&mut entity, &shard_delta(500, 0, 1, 10));
+
+        let distr = entity.unwrap().distr.unwrap();
+        assert_eq!(distr.closing_epoch, 501);
+        assert_eq!(distr.pool_total, 7);
     }
 
     #[test]

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -275,6 +275,8 @@ pub enum CardanoDelta {
     CommitteeUpdate(Box<CommitteeUpdate>),
     ConstitutionUpdate(Box<ConstitutionUpdate>),
     GovRootsUpdate(Box<GovRootsUpdate>),
+    GovDistrAccumulate(Box<GovDistrAccumulate>),
+    DRepPowerUpdate(Box<DRepPowerUpdate>),
 }
 
 impl CardanoDelta {
@@ -372,6 +374,8 @@ delta_from!(GovDormancyReset);
 delta_from!(CommitteeUpdate);
 delta_from!(ConstitutionUpdate);
 delta_from!(GovRootsUpdate);
+delta_from!(GovDistrAccumulate);
+delta_from!(DRepPowerUpdate);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -411,6 +415,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeUpdate(x) => x.key(),
             Self::ConstitutionUpdate(x) => x.key(),
             Self::GovRootsUpdate(x) => x.key(),
+            Self::GovDistrAccumulate(x) => x.key(),
+            Self::DRepPowerUpdate(x) => x.key(),
             Self::AssignRewards(x) => x.key(),
             Self::NonceTransition(x) => x.key(),
             Self::PoolTransition(x) => x.key(),
@@ -473,6 +479,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::ConstitutionUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::GovRootsUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::GovDistrAccumulate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::DRepPowerUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::AssignRewards(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NonceTransition(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolTransition(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -535,6 +543,8 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::CommitteeUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::ConstitutionUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::GovRootsUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::GovDistrAccumulate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::DRepPowerUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::AssignRewards(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NonceTransition(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolTransition(x) => Self::downcast_undo(x.as_ref(), entity),


### PR DESCRIPTION
Plan: `plans/dolos-governance-stake-distributions.md` (Brain/txpipe) — phase 4 of the dolos-governance-gaps family, sequenced after #1211.

## What changed

`DRepState.voting_power` held the registration deposit — the minibf DRep endpoint served it as the Blockfrost `amount`, wrong on every network — and the ratification engine had no per-pool stake distribution to use as its SPO tally denominator. This PR computes both at every epoch boundary, inside the existing EWRAP sharded account scan.

- **Snapshot read**: the accumulation reads `snapshot_at(closing_epoch)` — the `live` position during EWRAP, the end-of-closing-epoch value that ESTART's rotation is about to freeze into `mark`. That is the snapshot governing the epoch now opening, which is the alignment db-sync publishes: it writes `drep_distr` for epoch N at the boundary *into* N, so the boundary closing epoch n owes the row for n+1. Pinned by `live_position_is_the_boundary_snapshot`, which asserts both positions so the distinction stays legible.
- **Weight**: era-correct stake total (`total_for_era`), **plus the reward this same EWRAP pass assigns to the account** — the ledger's snapshot is post-reward, and the rewards visitor expresses the update as a delta rather than mutating the copy the scan holds — plus the account's share of the snapshot proposal deposits (live proposals with `proposed_in <= n`, summed per return credential; rows predating the tracking fields are excluded — the accepted design-§6 degradation).
- **DRep leg**: accumulates per delegated DRep; `AlwaysAbstain`/`AlwaysNoConfidence` under their own keys; delegations to DReps not registered as of the n/n+1 boundary are skipped.
- **Pool leg**: per-pool stake plus a running `pool_total`, independent of RUPD's reward-purposed snapshot (untouched).
- **Crash-safe persistence**: new `GovDistr` accumulator on `GovState` (new field at CBOR index 6), merged per shard via the appended `GovDistrAccumulate` delta — idempotent per (closing epoch, shard) with the `EWrapProgress` guard discipline, committed in the same transaction as `EWrapProgress` so the two cursors stay in lockstep. Shard 0 of the next boundary replaces the accumulator wholesale (the pruning step).
- **Finalize**: the appended `DRepPowerUpdate` delta writes the accumulated stake into `voting_power` for every registered DRep (zero when absent from the distribution, including DReps registered after the boundary). The field stays `u64` at its frozen index.

Out of scope per the plan: tallies/thresholds (ratification engine plan), `EpochValue` history on `DRepState`/`ProposalState`, RUPD changes, PV10 delegation cleanup.

## Done criteria

1. **Idempotent / resume-safe accumulation** — `distr_resumed_scan_equals_uninterrupted`, `distr_shards_merge_to_completion`, `distr_out_of_order_shards_are_skipped`, `distr_new_boundary_prunes_previous_epoch`, `distr_superseded_boundary_replay_is_noop` (delta level) and `shard_accumulation_builds_boundary_distributions` (replaying every shard through the real `load_shard`/`commit_shard` path leaves the accumulator unchanged). ✅
2. **Rotation-timing pin** — `live_position_is_the_boundary_snapshot`. ✅
3. **Proposal deposits in the delegated weight** — covered by the known deposit/return-credential fixture in `shard_accumulation_builds_boundary_distributions`, including a proposal submitted *during* the closing epoch (100 stake + 40 + 7 → 147). ✅
4. **Preview replay comparison** — ✅, detail below.
5. **Checks** — `cargo test --workspace` (all green), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo +nightly fmt --all -- --check` (clean). ✅

## Criterion 4 — preview replay vs Koios

**Setup.** Preview (magic 2) bootstrapped from the published `v3/2/ledger/latest` dolos snapshot (tip slot 114478854, epoch 1325), then replayed forward on this branch across an epoch boundary. `DRepState.voting_power` read through minibf `GET /governance/dreps/{drep_id}`; the independent source is Koios preview `drep_history` (db-sync `drep_distr`), fetched per epoch and paginated in full (~3000 DReps/epoch). The comparison covers **every** DRep in the distribution, not a sample.

Read twice, right after each of two boundaries — once standing in epoch 1326 (boundary 1325→1326) and again standing in 1327 (boundary 1326→1327).

**Exact-match rate, all 2997 non-pseudo DReps:**

| Koios epoch | dolos read at start of 1326 | dolos read at start of 1327 |
|---|---|---|
| 1324 | 95.13 % | 95.06 % |
| 1325 | 95.20 % | 95.13 % |
| 1326 | **99.20 %** | 95.26 % |
| 1327 | 95.26 % | **99.20 %** |

The ~95 % floor is the DReps whose stake did not move between those epochs; the peak is the real alignment. It sits on the epoch the node is in — the label db-sync uses — and steps forward with the boundary.

**The named references** (the criterion asks for at least three; the first four change every epoch, so they pin the alignment rather than merely agreeing):

| DRep | dolos @1326 | Koios 1326 | |
|---|---:|---:|---|
| `drep1y2m6rysrd42afh25zshgaa4hm9ha2des3z8k9uzcgk2e60g46tpuk` | 115,244,851,675,461 | 115,244,851,675,461 | ✅ |
| `drep1ygcqw6sge0y7anenpjz7xm692cqpys4z6j55t3ewcspj94gjsftj3` | 14,980,619,289,036 | 14,980,619,289,036 | ✅ |
| `drep1ygv58mrmlrye9vu0tussycey3vm2rva2c5djx0e66r3wzuqq5w275` | 13,733,154,135,552 | 13,733,154,135,552 | ✅ |
| `drep1y2qn0rf74zdk3u8upx2yk8un7tlts5f33uvklx96gq5a32qmwj3xg` | 12,189,572,246,982 | 12,189,572,246,982 | ✅ |
| `drep1yglgx9tzudmq7mazv2q4f5w8msshnrkmyyq4902jvk0zq8c27qszh` | 29,964,833,322,945 | 29,964,833,322,945 | ✅ |
| `drep1ygqqupvw653m83jgv5yftq83vp8px9u0thetaefcuxukyqcdjrjaa` | 296,313,592,949 | 296,313,592,949 | ✅ |

### How this criterion was reached

The first replay of this branch failed it, and the two fixes it forced are commits 2 and 3 here.

**Round 1 — the distribution was a full epoch stale.** Standing at the start of epoch 1326 the node reproduced Koios's epoch-**1325** numbers byte-exactly (99.20 %), and standing at the start of 1327 it reproduced epoch-1326 — a stable lag that stepped forward with the boundary. The arithmetic was right; the snapshot position was not. Per the plan's risk section this was escalated rather than papered over with an offset, and `org/founder` moved the pin one rotation forward (2026-08-14).

**Round 2 — moving the position was necessary but not sufficient.** It shifted only 5 of 2997 DReps and the alignment did not move, because for most accounts the epoch-to-epoch delta is reward accrual, not UTxO movement. `compute_shard_deltas` already carried the note that "rewards update the live value before the snapshot", but the rewards visitor emits an `AssignRewards` delta instead of mutating the `AccountState` the scan holds — so the accumulation read a pre-reward `live` while the ledger's snapshot is post-reward, and since `Stake::total` counts `rewards_sum`, the entire reward assignment was missing from every weight. Adding it is commit 3, and that is what moved the alignment.

### Known gap — 24 DReps, missing vote delegations (out of scope, `org/founder` 2026-08-14)

24 of 2997 DReps mismatch, the same set before and after the fixes, so they are unaffected by it; 18 are exactly zero in dolos. Total shortfall 24,079,380,599,933 lovelace.

The cause is in the account records, not the accumulation: for e.g. `drep1y23y32wq2047y59509qyvjutk7dmqdgv09kkvegrh8r6elczx5rwf`, Koios lists `stake_test1ur34vgj0kk338wlfsdf7fnxs9uukh24047lc2wfmm0mgptgq7849c` as a 20,008,617,294,336-lovelace delegator since epoch 736, while dolos's own `GET /accounts/{stake_address}` reports `"drep_id": null` for that account. The vote delegation is missing from dolos's state, so nothing can attribute it. This predates this PR and wants a plan of its own; the founder ruled it out of this criterion.

## Incidental findings (not touched here)

- `src/bin/dolos/init.rs:62` points preview at `preview-node.world.dev.cardano.org:30002`, which no longer resolves — a generated preview `dolos.toml` cannot sync. `preview-node.play.dev.cardano.org:3001` works.
- `dolos doctor rollback` to a slot inside the previous epoch does not undo the epoch-boundary work: after rolling back ~2800 slots into epoch 1326, `EpochState.number` still read 1327 and the boundary's `DRepPowerUpdate` writes were still in place. Pre-existing and not specific to this PR's deltas — but reachable on preview, where `max_rollback` (129600 slots) exceeds the 86400-slot epoch. It is not reachable on mainnet or preprod, whose epochs are longer than the rollback window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added epoch-boundary governance stake distribution processing for DReps and stake pools.
  * DRep voting power now updates from completed governance distributions.
  * Proposal deposits and registered DRep snapshots are incorporated into governance accounting.
  * Governance distribution updates support reliable shard processing, replay, ordering, and recovery.

* **Bug Fixes**
  * Ensured governance and epoch progress updates are committed together for consistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->