### PR TITLE
feat(cardano): governance RATIFY engine in shadow mode

### DIFF
--- a/crates/cardano/src/ewrap/enactment.rs
+++ b/crates/cardano/src/ewrap/enactment.rs
@@ -15,7 +15,8 @@ pub struct BoundaryVisitor {
 }
 
 /// The state effects an enacted proposal carries: the action's own effect
-/// plus, for every action belonging to a lineage tree, that tree's new root.
+/// plus, for every Conway action belonging to a lineage tree, that tree's
+/// new root.
 ///
 /// Kept apart from the visitor so the mapping is exercisable on its own —
 /// none of it depends on boundary context.
@@ -70,7 +71,21 @@ pub(crate) fn enactment_deltas(id: &ProposalId, proposal: &ProposalState) -> Vec
         }
     }
 
-    if let Some(purpose) = proposal.action.purpose() {
+    // `ensPrevGovActionIds` is Conway enact-state: it names Conway
+    // governance actions and nothing else. The tree membership to read is
+    // the recorded `purpose`, written by `parse_gov_action` when the action
+    // was decoded as a Conway action — not `action.purpose()`, which infers
+    // a tree from the action's *shape* and so fires for any row carrying
+    // parameters, a pre-Conway update proposal included.
+    //
+    // Such a proposal still enacts, which is how its parameter change lands,
+    // but claiming a root leaves a phantom parent that no later action can
+    // match: a first-of-purpose action declares no parent, so it fails
+    // `prevActionAsExpected` forever. Observed on a preview replay, where
+    // legacy `Params` proposals auto-ratified by the protocol <= 8 rule
+    // (`hacks::proposals`) held the pparam-update root and the chain's first
+    // ParameterChange (epoch 735) could never ratify.
+    if let Some(purpose) = proposal.purpose {
         let action = GovActionId {
             transaction_id: proposal.tx,
             action_index: proposal.idx,
@@ -173,6 +188,57 @@ mod tests {
         Option::<GovState>::from(entity.unwrap()).unwrap()
     }
 
+    /// A pre-Conway update proposal enacts its parameter change but claims
+    /// no lineage root. Its row carries no recorded `purpose` — it was never
+    /// decoded as a Conway action — while its `action` still looks like a
+    /// parameter change, so gating on the action's shape would hand it the
+    /// pparam-update root. The phantom parent that leaves can never be
+    /// matched by a first-of-purpose action, which declares none: observed
+    /// on a preview replay, where legacy `Params` proposals auto-ratified by
+    /// the protocol <= 8 rule (`hacks::proposals`) held the root and the
+    /// chain's first ParameterChange (epoch 735) could never ratify.
+    #[test]
+    fn enactment_without_recorded_purpose_claims_no_lineage_root() {
+        let action = ProposalAction::ParamChange(PParamsSet::default());
+        let id = ProposalId::from(b"legacy".to_vec());
+
+        let legacy = proposal([9u8; 32].into(), 0, action.clone());
+        assert_eq!(legacy.purpose, None);
+        assert_eq!(
+            legacy.action.purpose(),
+            Some(GovPurpose::PParamUpdate),
+            "the action's shape alone would claim a tree"
+        );
+
+        let deltas = enactment_deltas(&id, &legacy);
+
+        assert!(
+            deltas
+                .iter()
+                .any(|delta| matches!(delta, CardanoDelta::PParamsUpdate(_))),
+            "the parameter change itself must still land"
+        );
+        assert!(
+            !deltas
+                .iter()
+                .any(|delta| matches!(delta, CardanoDelta::GovRootsUpdate(_))),
+            "a row with no recorded purpose must not claim a lineage root"
+        );
+
+        // The same action decoded as a Conway proposal does claim it.
+        let mut conway = proposal([9u8; 32].into(), 0, action);
+        conway.purpose = Some(GovPurpose::PParamUpdate);
+
+        let deltas = enactment_deltas(&id, &conway);
+
+        assert!(
+            deltas
+                .iter()
+                .any(|delta| matches!(delta, CardanoDelta::GovRootsUpdate(_))),
+            "a Conway action must claim its lineage root"
+        );
+    }
+
     /// Every governance action a Conway chain can carry has an enactment
     /// effect — no variant falls through to an error arm. Only the legacy
     /// `Other` catch-all, which never records the action's content, does.
@@ -215,7 +281,9 @@ mod tests {
         for (action, purpose) in cases {
             let is_info = matches!(action, ProposalAction::Info);
             let id = ProposalId::from(b"proposal".to_vec());
-            let deltas = enactment_deltas(&id, &proposal([7u8; 32].into(), 0, action.clone()));
+            let mut row = proposal([7u8; 32].into(), 0, action.clone());
+            row.purpose = purpose;
+            let deltas = enactment_deltas(&id, &row);
 
             let roots = deltas
                 .iter()
@@ -278,37 +346,29 @@ mod tests {
         };
 
         let id = ProposalId::from(constitution_tx.to_vec());
-        state = apply_gov(
-            state,
-            enactment_deltas(
-                &id,
-                &proposal(
-                    constitution_tx,
-                    0,
-                    ProposalAction::NewConstitution {
-                        anchor: enacted_constitution.anchor.clone(),
-                        guardrail_script: enacted_constitution.guardrail_script,
-                    },
-                ),
-            ),
+        let mut row = proposal(
+            constitution_tx,
+            0,
+            ProposalAction::NewConstitution {
+                anchor: enacted_constitution.anchor.clone(),
+                guardrail_script: enacted_constitution.guardrail_script,
+            },
         );
+        row.purpose = Some(GovPurpose::Constitution);
+        state = apply_gov(state, enactment_deltas(&id, &row));
 
         let id = ProposalId::from(committee_tx.to_vec());
-        state = apply_gov(
-            state,
-            enactment_deltas(
-                &id,
-                &proposal(
-                    committee_tx,
-                    0,
-                    ProposalAction::UpdateCommittee {
-                        to_remove: committee.members.keys().cloned().collect(),
-                        to_add: vec![(new_member.clone(), 620)],
-                        threshold: two_thirds(),
-                    },
-                ),
-            ),
+        let mut row = proposal(
+            committee_tx,
+            0,
+            ProposalAction::UpdateCommittee {
+                to_remove: committee.members.keys().cloned().collect(),
+                to_add: vec![(new_member.clone(), 620)],
+                threshold: two_thirds(),
+            },
         );
+        row.purpose = Some(GovPurpose::Committee);
+        state = apply_gov(state, enactment_deltas(&id, &row));
 
         assert_eq!(state.constitution, Some(enacted_constitution));
         assert_ne!(state.constitution, Some(constitution));

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -46,7 +46,7 @@ impl BoundaryWork {
         let gov = load_gov::<D>(state)?;
         let num_dormant_epochs = gov.num_dormant_epochs;
         let gov_active_since = gov.active_since;
-        let gov_distr = gov.distr;
+        let gov_distr = gov.distr.clone();
 
         Ok(BoundaryWork {
             ending_state,
@@ -62,6 +62,10 @@ impl BoundaryWork {
             num_dormant_epochs,
             gov_active_since,
             gov_distr,
+            gov,
+            pv10_migration: false,
+            ratify_dreps: Default::default(),
+            shadow_mismatches: 0,
             proposal_deposits: Default::default(),
             snapshot_registered_dreps: Default::default(),
             enacting_proposals: Default::default(),
@@ -246,6 +250,39 @@ impl BoundaryWork {
         }
     }
 
+    /// Whether this boundary enacts the hard fork into protocol major 10
+    /// — the one that carries the account-delegation repair migration
+    /// (research §5.5 step 9). Under shadow mode the hack-stamped
+    /// enactment is what marks the boundary.
+    fn detect_pv10_migration<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
+        let live_major = self
+            .ending_state
+            .pparams
+            .unwrap_live()
+            .protocol_major_or_default();
+
+        if live_major != 9 {
+            return Ok(());
+        }
+
+        let starting = self.starting_epoch_no();
+
+        let proposals = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
+
+        for record in proposals {
+            let (_, proposal) = record?;
+
+            if proposal.should_enact(starting)
+                && matches!(proposal.action, crate::ProposalAction::HardFork((10, _)))
+            {
+                self.pv10_migration = true;
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Load + compute for a per-shard run of the close half:
     ///   * reload the small classifications that drops.visit_account needs
     ///     (retiring_pools, retiring_dreps, reregistrating_dreps),
@@ -268,6 +305,7 @@ impl BoundaryWork {
         // re-classifying them per shard is cheap.
         boundary.load_pool_data::<D>(state)?;
         boundary.load_drep_data::<D>(state)?;
+        boundary.detect_pv10_migration::<D>(state)?;
 
         if boundary.distr_snapshot_epoch().is_some() {
             boundary.load_proposal_deposits::<D>(state)?;
@@ -294,6 +332,7 @@ impl BoundaryWork {
         let mut drep_distr: BTreeMap<DRep, u64> = BTreeMap::new();
         let mut pool_distr: BTreeMap<PoolHash, u64> = BTreeMap::new();
         let mut pool_total: u64 = 0;
+        let mut migration_drops: Vec<crate::DRepDelegatorDrop> = Vec::new();
 
         for range in ranges {
             let accounts =
@@ -301,6 +340,27 @@ impl BoundaryWork {
 
             for record in accounts {
                 let (account_id, account) = record?;
+
+                // PV10 hard-fork migration (research §5.5 step 9): drop
+                // delegations pointing at DReps that are not registered
+                // at this boundary. Delegations to a DRep unregistering
+                // right now are already dropped by the drops visitor.
+                if self.pv10_migration {
+                    if let Some(drep) = account.delegated_drep_at(self.ending_state.number) {
+                        let dangling = matches!(drep, DRep::Key(_) | DRep::Script(_))
+                            && !self
+                                .snapshot_registered_dreps
+                                .contains(&drep_to_entity_key(drep))
+                            && !self.retiring_dreps.contains(drep);
+
+                        if dangling {
+                            migration_drops.push(crate::DRepDelegatorDrop::new(
+                                account_id.clone(),
+                                self.ending_state.number,
+                            ));
+                        }
+                    }
+                }
                 // HACK: rewards must apply before drops. Rewards update the live
                 // value before the snapshot; drops schedule refunds for after the
                 // snapshot. If reordered, the rewards would be overwritten by the
@@ -341,6 +401,10 @@ impl BoundaryWork {
 
         visitor_rewards.flush(self)?;
         visitor_drops.flush(self)?;
+
+        for drop in migration_drops {
+            self.add_delta(drop);
+        }
 
         // Emitted whenever the accumulation ran, even with empty maps — the
         // shard cursor must advance for the accumulator to report complete.
@@ -509,6 +573,13 @@ impl BoundaryWork {
     pub(crate) fn load_drep_data<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
         let boundary_slot = self.chain_summary.epoch_start(self.ending_state.number + 1);
 
+        // The ratification snapshot sits one boundary back: the pulser
+        // ratified while closing epoch n was created when epoch n opened,
+        // so its registered set and expiries cut off at the start of the
+        // closing epoch.
+        let ratify_slot = self.chain_summary.epoch_start(self.ending_state.number);
+        let ratify_expiry_epoch = self.ending_state.number.saturating_sub(1);
+
         let dreps = state.iter_entities_typed::<DRepState>(DRepState::NS, None)?;
 
         for record in dreps {
@@ -516,6 +587,23 @@ impl BoundaryWork {
 
             if Self::is_drep_registered_as_of(&drep, boundary_slot) {
                 self.snapshot_registered_dreps.insert(id);
+            }
+
+            if Self::is_drep_registered_as_of(&drep, ratify_slot) {
+                let credential = match &drep.identifier {
+                    DRep::Key(hash) => Some(StakeCredential::AddrKeyhash(*hash)),
+                    DRep::Script(hash) => Some(StakeCredential::ScriptHash(*hash)),
+                    DRep::Abstain | DRep::NoConfidence => None,
+                };
+
+                if let Some(credential) = credential {
+                    let expiry = drep
+                        .expiry
+                        .as_ref()
+                        .and_then(|expiry| expiry.as_of(ratify_expiry_epoch));
+
+                    self.ratify_dreps.insert(credential, expiry);
+                }
             }
 
             if self.should_retire_drep(&drep) {
@@ -715,6 +803,284 @@ impl BoundaryWork {
         }
     }
 
+    /// Slot cutoff of the ratification snapshot: the last slot before the
+    /// boundary that opened the closing epoch. Votes, committee
+    /// authorizations, and DRep registrations after it belong to the
+    /// closing epoch and tally at the *next* boundary.
+    fn ratify_cutoff_slot(&self) -> BlockSlot {
+        self.chain_summary
+            .epoch_start(self.ending_state.number)
+            .saturating_sub(1)
+    }
+
+    /// Assemble the pure ratification input for the boundary closing this
+    /// epoch, or `None` when the engine cannot run: governance inactive,
+    /// or the previous boundary's distributions missing/incomplete (the
+    /// degraded case warns and self-heals one boundary later).
+    fn build_ratify_input<D: Domain>(
+        &self,
+        state: &D::State,
+    ) -> Result<Option<super::ratify::RatifyInput>, ChainError> {
+        use super::ratify;
+
+        let closing = self.ending_state.number;
+
+        let gov_active = self.gov_active_since.is_some_and(|since| since <= closing);
+
+        if !gov_active || closing == 0 {
+            return Ok(None);
+        }
+
+        let Some(prev_distr) = self
+            .gov
+            .prev_distr
+            .as_ref()
+            .filter(|distr| distr.is_complete_for(closing - 1))
+        else {
+            tracing::warn!(
+                epoch = closing,
+                "previous boundary's stake distributions missing or incomplete; \
+                 skipping shadow ratification"
+            );
+            return Ok(None);
+        };
+
+        let cutoff = self.ratify_cutoff_slot();
+
+        // committee authorizations as of the snapshot boundary
+        let committee_auths = self
+            .gov
+            .committee_auths
+            .keys()
+            .filter_map(|cold| {
+                self.gov
+                    .committee_auth_as_of(cold, cutoff)
+                    .map(|auth| (cold.clone(), auth.clone()))
+            })
+            .collect();
+
+        // the snapshot proposal set: still in the live forest, submitted
+        // before the closing epoch, with votes resolved as of the boundary
+        let mut proposals = Vec::new();
+
+        let records = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
+
+        for record in records {
+            let (key, proposal) = record?;
+
+            if !proposal.is_unresolved_at_close(closing) {
+                continue;
+            }
+
+            let in_snapshot = proposal
+                .proposed_in
+                .is_some_and(|proposed| proposed < closing);
+
+            if !in_snapshot {
+                continue;
+            }
+
+            if matches!(proposal.action, crate::ProposalAction::Other) {
+                tracing::warn!(
+                    proposal = %key,
+                    "legacy proposal without tracked action content; \
+                     excluded from shadow ratification"
+                );
+                continue;
+            }
+
+            let Some(expires_after) = proposal.max_epoch else {
+                tracing::warn!(
+                    proposal = %key,
+                    "proposal without expiry bound; excluded from shadow ratification"
+                );
+                continue;
+            };
+
+            proposals.push(ratify::RatifyProposal {
+                key,
+                id: proposal.gov_action_id(),
+                action: proposal.action.clone(),
+                parent: proposal.parent.clone(),
+                expires_after,
+                order: (proposal.slot, proposal.tx, proposal.idx),
+                cc_votes: proposal.cc_votes_as_of(cutoff),
+                drep_votes: proposal.drep_votes_as_of(cutoff),
+                spo_votes: proposal.spo_votes_as_of(cutoff),
+            });
+        }
+
+        // per-pool default votes from the reward account's DRep
+        // delegation, read at the snapshot position; only the non-No
+        // defaults are recorded
+        let mut pool_default_votes = BTreeMap::new();
+
+        for pool in prev_distr.pool_distr.keys() {
+            let pool_state: Option<PoolState> =
+                state.read_entity_typed(PoolState::NS, &EntityKey::from(pool.as_slice()))?;
+
+            let Some(pool_state) = pool_state else {
+                continue;
+            };
+
+            let account = match self.load_pool_reward_account::<D>(state, &pool_state) {
+                Ok(account) => account,
+                Err(error) => {
+                    tracing::warn!(
+                        pool = %hex::encode(pool),
+                        %error,
+                        "unreadable pool reward account; default vote falls back to No"
+                    );
+                    continue;
+                }
+            };
+
+            let Some(account) = account else {
+                continue;
+            };
+
+            let default = match account.delegated_drep_at(closing - 1) {
+                Some(DRep::Abstain) => ratify::DefaultVote::Abstain,
+                Some(DRep::NoConfidence) => ratify::DefaultVote::NoConfidence,
+                _ => continue,
+            };
+
+            pool_default_votes.insert(*pool, default);
+        }
+
+        Ok(Some(ratify::RatifyInput {
+            current_epoch: closing,
+            pparams: self.ending_state.pparams.unwrap_live().clone(),
+            treasury: self.ending_state.initial_pots.treasury,
+            committee: self.gov.committee.clone(),
+            roots: self.gov.prev_gov_action_ids.clone(),
+            committee_auths,
+            drep_distr: prev_distr.drep_distr.clone(),
+            pool_distr: prev_distr.pool_distr.clone(),
+            pool_total: prev_distr.pool_total,
+            dreps: self.ratify_dreps.clone(),
+            pool_default_votes,
+            proposals,
+        }))
+    }
+
+    /// Run the ratification engine in shadow mode: compute the verdicts
+    /// for real and log every disagreement with the hack-stamped
+    /// outcomes, which remain authoritative for state effects.
+    fn run_shadow_ratification<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
+        use super::ratify;
+
+        let Some(input) = self.build_ratify_input::<D>(state)? else {
+            return Ok(());
+        };
+
+        if input.proposals.is_empty() {
+            return Ok(());
+        }
+
+        let outcome = ratify::ratify(&input);
+        let pruned = ratify::pruned_by_enactment(&input.proposals, &outcome.enacted);
+
+        let starting = self.starting_epoch_no();
+
+        for verdict in &outcome.verdicts {
+            let proposal: Option<ProposalState> =
+                state.read_entity_typed(ProposalState::NS, &verdict.key)?;
+
+            let Some(proposal) = proposal else {
+                continue;
+            };
+
+            let hack_enacts = proposal.should_enact(starting);
+            let hack_drops = proposal.should_drop(starting);
+
+            let engine_enacts = verdict.verdict == ratify::Verdict::Accepted;
+            let engine_drops = verdict.verdict == ratify::Verdict::Expired
+                || (verdict.verdict == ratify::Verdict::Continuing
+                    && pruned.contains(&verdict.key));
+
+            if engine_enacts == hack_enacts && engine_drops == hack_drops {
+                continue;
+            }
+
+            self.shadow_mismatches += 1;
+
+            tracing::warn!(
+                proposal = %proposal.id_as_string(),
+                epoch = self.ending_state.number,
+                engine = ?verdict.verdict,
+                engine_pruned = pruned.contains(&verdict.key),
+                hack_enacts,
+                hack_drops,
+                ratified_epoch = ?proposal.ratified_epoch,
+                canceled_epoch = ?proposal.canceled_epoch,
+                tallies = ?verdict.tallies,
+                "shadow ratification disagrees with hack-stamped outcome"
+            );
+        }
+
+        tracing::info!(
+            epoch = self.ending_state.number,
+            proposals = outcome.verdicts.len(),
+            enacted = outcome.enacted.len(),
+            mismatches = self.shadow_mismatches,
+            "shadow ratification complete"
+        );
+
+        Ok(())
+    }
+
+    /// Queue the governance bookkeeping the EPOCH rule applies
+    /// unconditionally at every boundary (research §5.5 steps 6–7) plus
+    /// the distribution rotation the next boundary's tally reads. Must
+    /// run after the enactment visitor flushed: the committee GC reads
+    /// the post-enactment committee at apply time.
+    fn emit_governance_boundary_deltas<D: Domain>(
+        &mut self,
+        state: &D::State,
+    ) -> Result<(), ChainError> {
+        let closing = self.ending_state.number;
+
+        if self.gov_active_since.is_none_or(|since| since > closing) {
+            return Ok(());
+        }
+
+        let starting = self.starting_epoch_no();
+
+        // dormancy (step 6): does any proposal survive this boundary's
+        // application still votable in the starting epoch?
+        let mut any_votable_survivor = false;
+
+        let records = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
+
+        for record in records {
+            let (_, proposal) = record?;
+
+            let survives = proposal.is_unresolved_at_close(closing)
+                && !proposal.should_enact(starting)
+                && !proposal.should_drop(starting);
+
+            if survives && proposal.max_epoch.is_some_and(|max| max >= starting) {
+                any_votable_survivor = true;
+                break;
+            }
+        }
+
+        if !any_votable_survivor {
+            self.add_delta(crate::GovDormancyTick::new());
+        }
+
+        // committee-state GC (step 7) — reads the post-enactment
+        // committee when the delta applies
+        self.add_delta(crate::CommitteeGc::new());
+
+        // rotate this boundary's completed distributions where the next
+        // boundary's ratification tally will read them
+        self.add_delta(crate::GovDistrRotate::new(closing));
+
+        Ok(())
+    }
+
     /// Drive the global visitors (enactment / refunds / drops / wrapup)
     /// over pools, dreps, and proposals; the wrapup visitor's flush emits
     /// `EpochWrapUp` carrying the final `EndStats`.
@@ -793,6 +1159,14 @@ impl BoundaryWork {
         visitor_enactment.flush(self)?;
         visitor_drops.flush(self)?;
         visitor_refunds.flush(self)?;
+
+        // Shadow ratification: compute the boundary's outcomes for real
+        // and log disagreements with the hack table, which stays
+        // authoritative for state effects. Then queue the unconditional
+        // governance bookkeeping — after the enactment flush, so the
+        // committee GC applies over the post-enactment committee.
+        self.run_shadow_ratification::<D>(state)?;
+        self.emit_governance_boundary_deltas::<D>(state)?;
 
         // wrapup.flush emits the final `EpochWrapUp` delta carrying the
         // assembled `EndStats` (prepare-time fields + shard accumulators).

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -12,7 +12,7 @@
 //! in the finalize pass).
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -21,12 +21,13 @@ use pallas::ledger::primitives::{conway::DRep, Epoch, StakeCredential};
 
 use crate::{
     eras::ChainSummary, rewards::RewardMap, roll::WorkDeltas, rupd::RupdWork, AccountState,
-    CardanoDelta, CardanoEntity, DRepState, EpochState, EraProtocol, GovDistr, PoolHash, PoolState,
-    ProposalState,
+    CardanoDelta, CardanoEntity, DRepState, EpochState, EraProtocol, GovDistr, GovState, PoolHash,
+    PoolState, ProposalState,
 };
 
 pub mod commit;
 pub mod loading;
+pub mod ratify;
 pub mod work_unit;
 
 // visitors
@@ -167,6 +168,28 @@ pub struct BoundaryWork {
     /// accumulator as of this phase's load. The finalize pass reads the
     /// completed distributions from here to write DRep voting powers.
     pub gov_distr: Option<GovDistr>,
+
+    /// The whole governance singleton as of this phase's load — committee,
+    /// authorization histories, roots, and the previous boundary's
+    /// distributions, all consumed by the shadow ratification run.
+    pub gov: GovState,
+
+    /// Whether this boundary enacts the hard fork into protocol 10, which
+    /// carries the one-shot account migration dropping DRep delegations
+    /// that point at never/no-longer-registered DReps (research §5.5
+    /// step 9). Detected from the hack-stamped enactment during the
+    /// shard loads.
+    pub pv10_migration: bool,
+
+    /// DReps registered as of the boundary that *opened* the closing epoch
+    /// — the ratification snapshot's `reDRepState` — keyed by DRep
+    /// credential, with the stored expiry as of the end of the previous
+    /// epoch (`None` on pre-upgrade rows without the epoch-based field).
+    pub ratify_dreps: BTreeMap<StakeCredential, Option<Epoch>>,
+
+    /// Shadow-mode disagreements between the ratification engine and the
+    /// hack-stamped outcomes found by this finalize pass.
+    pub shadow_mismatches: u64,
 
     /// Deposits of the snapshot proposal set (live, `proposed_in` before the
     /// closing epoch), summed per return credential. Added to the delegated

--- a/crates/cardano/src/ewrap/ratify.rs
+++ b/crates/cardano/src/ewrap/ratify.rs
@@ -1,0 +1,1642 @@
+//! Pure RATIFY engine — the epoch-boundary ratification math.
+//!
+//! A faithful port of the Conway `RATIFY` rule (`Rules/Ratify.hs`,
+//! research doc §5.3): per-proposal acceptance out of the three body
+//! tallies plus the structural checks, applied in priority order over an
+//! evolving enact-state. The entry point [`ratify`] is a pure function
+//! over an explicit [`RatifyInput`] snapshot — no store reads — so the
+//! math is testable section by section against the research doc.
+//!
+//! The engine currently runs in **shadow mode**: `loading.rs` builds the
+//! input at the EWRAP finalize pass, runs the engine, and logs any
+//! disagreement with the hack-stamped outcomes, which remain
+//! authoritative for state effects. Flipping the engine to authoritative
+//! is the hacks-oracle-removal plan.
+//!
+//! Timing model (design doc §2): the boundary closing epoch `c` ratifies
+//! the pulser snapshot created at the `(c-1)/c` boundary with
+//! `currentEpoch = c` — proposals submitted through epoch `c-1`, votes
+//! and committee authorizations as of the `(c-1)/c` boundary slot, and
+//! the stake distributions accumulated by the *previous* boundary's
+//! sharded scan (`GovState::prev_distr`).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use dolos_core::{BlockSlot, EntityKey};
+use pallas::crypto::hash::Hash;
+use pallas::ledger::primitives::{
+    conway::{DRep, DRepVotingThresholds, GovActionId, PoolVotingThresholds, RationalNumber, Vote},
+    Epoch, StakeCredential,
+};
+
+use crate::{
+    Committee, CommitteeAuthorization, GovRoots, PParamKind, PParamsSet, PoolHash, ProposalAction,
+};
+
+/// One proposal of the ratification snapshot, with its votes already
+/// resolved to the effective per-voter vote as of the snapshot boundary.
+#[derive(Debug, Clone)]
+pub struct RatifyProposal {
+    /// Entity key of the backing `ProposalState`, for correlating
+    /// verdicts back to store rows.
+    pub key: EntityKey,
+
+    pub id: GovActionId,
+
+    pub action: ProposalAction,
+
+    /// Lineage parent declared by the action (`None` for tree roots and
+    /// for the lineage-less actions).
+    pub parent: Option<GovActionId>,
+
+    /// Last epoch the proposal can be voted on, inclusive
+    /// (`gasExpiresAfter`; `ProposalState::max_epoch`).
+    pub expires_after: Epoch,
+
+    /// Submission-order key: `(slot, tx, idx)`. Within one transaction
+    /// the index orders proposals exactly; across transactions of one
+    /// block the tx hash stands in for the (untracked) tx order.
+    pub order: (BlockSlot, Hash<32>, u32),
+
+    /// Committee votes as of the boundary, keyed by hot credential.
+    pub cc_votes: BTreeMap<StakeCredential, Vote>,
+
+    /// DRep votes as of the boundary, keyed by DRep credential.
+    pub drep_votes: BTreeMap<StakeCredential, Vote>,
+
+    /// SPO votes as of the boundary, keyed by pool operator hash.
+    pub spo_votes: BTreeMap<PoolHash, Vote>,
+}
+
+/// Default vote of a stake pool whose operator did not vote, derived from
+/// the pool reward-account's DRep delegation (`defaultStakePoolVote`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultVote {
+    No,
+    Abstain,
+    NoConfidence,
+}
+
+/// The explicit snapshot the engine ratifies — the dolos equivalent of
+/// `RatifyEnv` plus the initial `EnactState`.
+#[derive(Debug, Clone)]
+pub struct RatifyInput {
+    /// The epoch being closed (`reCurrentEpoch`).
+    pub current_epoch: Epoch,
+
+    /// Protocol parameters live during the closing epoch. Evolves inside
+    /// the run: enacted `ParameterChange` / `HardForkInitiation` actions
+    /// are visible to later actions of the same run (`ensCurPParams`).
+    pub pparams: PParamsSet,
+
+    /// Treasury at the snapshot boundary (`ensTreasury`); shrinks as
+    /// withdrawals enact within the run.
+    pub treasury: u64,
+
+    /// The enacted committee (`ensCommittee`); evolves inside the run.
+    pub committee: Option<Committee>,
+
+    /// The four per-purpose roots (`ensPrevGovActionIds`); evolve inside
+    /// the run.
+    pub roots: GovRoots,
+
+    /// Effective committee authorization per cold credential as of the
+    /// snapshot boundary (`reCommitteeState`). Resigned entries are kept:
+    /// the tally distinguishes resigned from never-authorized only in
+    /// spirit — both count as abstain.
+    pub committee_auths: BTreeMap<StakeCredential, CommitteeAuthorization>,
+
+    /// DRep stake distribution from the previous boundary's accumulation
+    /// (`reDRepDistr`). `AlwaysAbstain` / `AlwaysNoConfidence` under
+    /// their own keys.
+    pub drep_distr: BTreeMap<DRep, u64>,
+
+    /// Per-pool stake distribution and its total (`reStakePoolDistr`).
+    pub pool_distr: BTreeMap<PoolHash, u64>,
+    pub pool_total: u64,
+
+    /// DReps registered as of the snapshot boundary, with their stored
+    /// expiry epoch as of the end of the previous epoch (`reDRepState`).
+    /// `None` expiry marks a pre-upgrade row without the epoch-based
+    /// field; it is treated as unexpired.
+    pub dreps: BTreeMap<StakeCredential, Option<Epoch>>,
+
+    /// Non-`No` default votes per pool (`defaultStakePoolVote` over the
+    /// snapshot accounts). Pools absent from the map default to `No`.
+    pub pool_default_votes: BTreeMap<PoolHash, DefaultVote>,
+
+    /// The snapshot proposal set (any order; the engine sorts).
+    pub proposals: Vec<RatifyProposal>,
+}
+
+/// Verdict of one ratification run for one proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Accepted by every body and every structural check — enacts at
+    /// this boundary.
+    Accepted,
+
+    /// Not accepted and past its voting lifetime — drops at this
+    /// boundary.
+    Expired,
+
+    /// Not accepted, still votable — stays live for the next boundary.
+    Continuing,
+}
+
+/// The tally numbers and structural checks behind one verdict, kept for
+/// shadow-mode logging.
+#[derive(Debug, Clone)]
+pub struct Tallies {
+    pub prev_action_ok: bool,
+    pub committee_term_ok: bool,
+    pub not_delayed: bool,
+    pub withdrawal_ok: bool,
+
+    /// Committee: (yes members, total non-abstaining members), threshold.
+    pub cc: (u64, u64),
+    pub cc_threshold: Option<RationalNumber>,
+    pub cc_accepted: bool,
+
+    /// DReps: (yes stake, total non-abstaining stake), threshold.
+    pub drep: (u64, u64),
+    pub drep_threshold: Option<RationalNumber>,
+    pub drep_accepted: bool,
+
+    /// SPOs: (yes stake, abstain stake, active-stake denominator),
+    /// threshold. The denominator is `pool_total - abstain`.
+    pub spo: (u64, u64, u64),
+    pub spo_threshold: Option<RationalNumber>,
+    pub spo_accepted: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProposalRatification {
+    pub key: EntityKey,
+    pub id: GovActionId,
+    pub verdict: Verdict,
+    pub tallies: Tallies,
+}
+
+/// Result of one ratification run — the verdicts plus the final
+/// enact-state the run evolved.
+#[derive(Debug, Clone)]
+pub struct RatifyOutcome {
+    pub verdicts: Vec<ProposalRatification>,
+
+    /// Accepted actions in enactment order.
+    pub enacted: Vec<GovActionId>,
+
+    pub roots: GovRoots,
+    pub treasury: u64,
+    pub delayed: bool,
+}
+
+/// Enactment priority (`actionPriority`): lower ratifies first; ties keep
+/// submission order.
+pub fn action_priority(action: &ProposalAction) -> u8 {
+    match action {
+        ProposalAction::NoConfidence => 0,
+        ProposalAction::UpdateCommittee { .. } => 1,
+        ProposalAction::NewConstitution { .. } => 2,
+        ProposalAction::HardFork(_) => 3,
+        ProposalAction::ParamChange(_) => 4,
+        ProposalAction::TreasuryWithdrawal(_) => 5,
+        ProposalAction::Info => 6,
+        ProposalAction::Other => 7,
+    }
+}
+
+/// Whether enacting the action delays every later action of the same run
+/// and the next boundary's (`delayingAction`).
+pub fn delaying_action(action: &ProposalAction) -> bool {
+    matches!(
+        action,
+        ProposalAction::NoConfidence
+            | ProposalAction::UpdateCommittee { .. }
+            | ProposalAction::NewConstitution { .. }
+            | ProposalAction::HardFork(_)
+    )
+}
+
+/// The Conway bootstrap phase (`hardforkConwayBootstrapPhase`): protocol
+/// major 9, between the Chang and Plomin hard forks.
+fn bootstrap_phase(pparams: &PParamsSet) -> bool {
+    pparams.protocol_major_or_default() == 9
+}
+
+/// The DRep voting-threshold group a protocol parameter belongs to
+/// (`ConwayPParams` THKD tags; `None` for parameters outside the Conway
+/// update surface).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DRepGroup {
+    Network,
+    Economic,
+    Technical,
+    Governance,
+}
+
+pub fn pparam_drep_group(kind: PParamKind) -> Option<DRepGroup> {
+    use PParamKind::*;
+
+    match kind {
+        MinFeeA
+        | MinFeeB
+        | KeyDeposit
+        | PoolDeposit
+        | ExpansionRate
+        | TreasuryGrowthRate
+        | MinPoolCost
+        | AdaPerUtxoByte
+        | ExecutionCosts
+        | MinFeeRefScriptCostPerByte => Some(DRepGroup::Economic),
+        MaxBlockBodySize | MaxTransactionSize | MaxBlockHeaderSize | MaxValueSize
+        | MaxTxExUnits | MaxBlockExUnits | MaxCollateralInputs => Some(DRepGroup::Network),
+        MaximumEpoch
+        | DesiredNumberOfStakePools
+        | PoolPledgeInfluence
+        | CollateralPercentage
+        | CostModelsPlutusV1
+        | CostModelsPlutusV2
+        | CostModelsPlutusV3
+        | CostModelsUnknown => Some(DRepGroup::Technical),
+        PoolVotingThresholds
+        | DrepVotingThresholds
+        | MinCommitteeSize
+        | CommitteeTermLimit
+        | GovernanceActionValidityPeriod
+        | GovernanceActionDeposit
+        | DrepDeposit
+        | DrepInactivityPeriod => Some(DRepGroup::Governance),
+        SystemStart
+        | EpochLength
+        | SlotLength
+        | ProtocolVersion
+        | MinUtxoValue
+        | DecentralizationConstant
+        | ExtraEntropy => None,
+    }
+}
+
+/// Whether a protocol parameter belongs to the SPO security group
+/// (`SecurityGroup` THKD tags — research §5.3.1).
+pub fn pparam_is_security(kind: PParamKind) -> bool {
+    use PParamKind::*;
+
+    matches!(
+        kind,
+        MinFeeA
+            | MinFeeB
+            | MaxBlockBodySize
+            | MaxTransactionSize
+            | MaxBlockHeaderSize
+            | AdaPerUtxoByte
+            | MaxBlockExUnits
+            | MaxValueSize
+            | GovernanceActionDeposit
+            | MinFeeRefScriptCostPerByte
+    )
+}
+
+fn zero_threshold() -> RationalNumber {
+    RationalNumber {
+        numerator: 0,
+        denominator: 1,
+    }
+}
+
+/// All-zero DRep thresholds — the bootstrap-phase `def` in the Haskell
+/// threshold resolution.
+fn bootstrap_drep_thresholds() -> DRepVotingThresholds {
+    DRepVotingThresholds {
+        motion_no_confidence: zero_threshold(),
+        committee_normal: zero_threshold(),
+        committee_no_confidence: zero_threshold(),
+        update_constitution: zero_threshold(),
+        hard_fork_initiation: zero_threshold(),
+        pp_network_group: zero_threshold(),
+        pp_economic_group: zero_threshold(),
+        pp_technical_group: zero_threshold(),
+        pp_governance_group: zero_threshold(),
+        treasury_withdrawal: zero_threshold(),
+    }
+}
+
+/// `a >= b` over unit-interval rationals, without floating point.
+fn rational_gte(a: &RationalNumber, b: &RationalNumber) -> bool {
+    (a.numerator as u128) * (b.denominator as u128)
+        >= (b.numerator as u128) * (a.denominator as u128)
+}
+
+/// `yes / total >= threshold`, with the `total == 0 → ratio 0` convention
+/// (`%?` in the Haskell tallies) and the zero-threshold short circuit.
+fn ratio_meets(yes: u64, total: u64, threshold: &RationalNumber) -> bool {
+    if threshold.numerator == 0 {
+        return true;
+    }
+
+    if total == 0 {
+        return false;
+    }
+
+    (yes as u128) * (threshold.denominator as u128)
+        >= (threshold.numerator as u128) * (total as u128)
+}
+
+/// Threshold semantics (`toRatifyVotingThreshold`): `None` — the body
+/// cannot ratify the action at all; `Some(0)` — the body has no say and
+/// auto-accepts; `Some(t)` — accept iff ratio `>= t`.
+type Threshold = Option<RationalNumber>;
+
+/// `votingCommitteeThreshold` over the run's evolving committee and
+/// pparams. Post-bootstrap the committee must have at least
+/// `MinCommitteeSize` active members or it counts as absent.
+fn committee_threshold(input: &RatifyInput, run: &RunState, action: &ProposalAction) -> Threshold {
+    match action {
+        ProposalAction::NoConfidence | ProposalAction::UpdateCommittee { .. } => {
+            Some(zero_threshold())
+        }
+        ProposalAction::Info | ProposalAction::Other => None,
+        _ => {
+            let committee = run.committee.as_ref()?;
+
+            let min_size = run.pparams.min_committee_size_or_default();
+
+            if bootstrap_phase(&run.pparams) || active_committee_size(input, committee) >= min_size
+            {
+                Some(committee.threshold.clone())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Number of committee members with a live (non-resigned) hot-credential
+/// authorization and an unexpired term.
+fn active_committee_size(input: &RatifyInput, committee: &Committee) -> u64 {
+    committee
+        .members
+        .iter()
+        .filter(|(cold, expiry)| {
+            input.current_epoch <= **expiry
+                && matches!(
+                    input.committee_auths.get(*cold),
+                    Some(CommitteeAuthorization::HotCredential(_))
+                )
+        })
+        .count() as u64
+}
+
+/// `votingDRepThreshold` over the run's evolving pparams and committee.
+/// All thresholds collapse to zero during bootstrap.
+fn drep_threshold(run: &RunState, action: &ProposalAction) -> Threshold {
+    let thresholds = if bootstrap_phase(&run.pparams) {
+        bootstrap_drep_thresholds()
+    } else {
+        run.pparams.drep_voting_thresholds_or_default()
+    };
+
+    match action {
+        ProposalAction::NoConfidence => Some(thresholds.motion_no_confidence),
+        ProposalAction::UpdateCommittee { .. } => Some(if run.committee.is_some() {
+            thresholds.committee_normal
+        } else {
+            thresholds.committee_no_confidence
+        }),
+        ProposalAction::NewConstitution { .. } => Some(thresholds.update_constitution),
+        ProposalAction::HardFork(_) => Some(thresholds.hard_fork_initiation),
+        ProposalAction::ParamChange(update) => {
+            Some(pparams_update_drep_threshold(&thresholds, update))
+        }
+        ProposalAction::TreasuryWithdrawal(_) => Some(thresholds.treasury_withdrawal),
+        ProposalAction::Info | ProposalAction::Other => None,
+    }
+}
+
+/// `pparamsUpdateThreshold`: the max over the DRep-group thresholds of
+/// every group the update touches.
+fn pparams_update_drep_threshold(
+    thresholds: &DRepVotingThresholds,
+    update: &PParamsSet,
+) -> RationalNumber {
+    let mut max = zero_threshold();
+
+    for value in update.iter() {
+        let Some(group) = pparam_drep_group(value.kind()) else {
+            continue;
+        };
+
+        let candidate = match group {
+            DRepGroup::Network => &thresholds.pp_network_group,
+            DRepGroup::Economic => &thresholds.pp_economic_group,
+            DRepGroup::Technical => &thresholds.pp_technical_group,
+            DRepGroup::Governance => &thresholds.pp_governance_group,
+        };
+
+        if rational_gte(candidate, &max) {
+            max = candidate.clone();
+        }
+    }
+
+    max
+}
+
+/// `votingStakePoolThreshold` over the run's evolving pparams and
+/// committee.
+fn spo_threshold(run: &RunState, action: &ProposalAction) -> Threshold {
+    let thresholds: PoolVotingThresholds = run.pparams.pool_voting_thresholds_or_default();
+
+    match action {
+        ProposalAction::NoConfidence => Some(thresholds.motion_no_confidence),
+        ProposalAction::UpdateCommittee { .. } => Some(if run.committee.is_some() {
+            thresholds.committee_normal
+        } else {
+            thresholds.committee_no_confidence
+        }),
+        ProposalAction::NewConstitution { .. } => Some(zero_threshold()),
+        ProposalAction::HardFork(_) => Some(thresholds.hard_fork_initiation),
+        ProposalAction::ParamChange(update) => {
+            if update.iter().any(|value| pparam_is_security(value.kind())) {
+                Some(thresholds.security_voting_threshold)
+            } else {
+                Some(zero_threshold())
+            }
+        }
+        ProposalAction::TreasuryWithdrawal(_) => Some(zero_threshold()),
+        ProposalAction::Info | ProposalAction::Other => None,
+    }
+}
+
+/// The committee tally (`committeeAcceptedRatio`, research §5.3.2):
+/// iterate the evolving committee's members, resolve each cold
+/// credential's hot authorization as of the boundary, and look up that
+/// hot credential's vote. Expired, resigned, and unauthorized members
+/// abstain; an authorized member without a vote counts as `No`.
+pub fn committee_tally(
+    current_epoch: Epoch,
+    members: &BTreeMap<StakeCredential, Epoch>,
+    auths: &BTreeMap<StakeCredential, CommitteeAuthorization>,
+    votes: &BTreeMap<StakeCredential, Vote>,
+) -> (u64, u64) {
+    let mut yes = 0u64;
+    let mut total = 0u64;
+
+    for (cold, expiry) in members {
+        if current_epoch > *expiry {
+            continue;
+        }
+
+        let Some(CommitteeAuthorization::HotCredential(hot)) = auths.get(cold) else {
+            continue;
+        };
+
+        match votes.get(hot) {
+            None | Some(Vote::No) => total += 1,
+            Some(Vote::Abstain) => (),
+            Some(Vote::Yes) => {
+                yes += 1;
+                total += 1;
+            }
+        }
+    }
+
+    (yes, total)
+}
+
+/// The DRep tally (`dRepAcceptedRatio`, research §5.3.3): iterate the
+/// stake distribution; skip unregistered and expired DReps entirely;
+/// an active DRep without a vote counts as `No`; `AlwaysNoConfidence`
+/// stake votes yes on `NoConfidence` and no otherwise; `AlwaysAbstain`
+/// stake never counts.
+pub fn drep_tally(
+    current_epoch: Epoch,
+    drep_distr: &BTreeMap<DRep, u64>,
+    dreps: &BTreeMap<StakeCredential, Option<Epoch>>,
+    votes: &BTreeMap<StakeCredential, Vote>,
+    is_no_confidence: bool,
+) -> (u64, u64) {
+    let mut yes = 0u64;
+    let mut total = 0u64;
+
+    for (drep, stake) in drep_distr {
+        let cred = match drep {
+            DRep::Key(hash) => StakeCredential::AddrKeyhash(*hash),
+            DRep::Script(hash) => StakeCredential::ScriptHash(*hash),
+            DRep::Abstain => continue,
+            DRep::NoConfidence => {
+                if is_no_confidence {
+                    yes += stake;
+                }
+                total += stake;
+                continue;
+            }
+        };
+
+        let Some(expiry) = dreps.get(&cred) else {
+            continue;
+        };
+
+        if expiry.is_some_and(|expiry| current_epoch > expiry) {
+            continue;
+        }
+
+        match votes.get(&cred) {
+            None | Some(Vote::No) => total += stake,
+            Some(Vote::Abstain) => (),
+            Some(Vote::Yes) => {
+                yes += stake;
+                total += stake;
+            }
+        }
+    }
+
+    (yes, total)
+}
+
+/// The SPO tally (`spoAcceptedRatio`, research §5.3.4): returns
+/// `(yes, abstain)` stake; the acceptance denominator is
+/// `pool_total - abstain`, not `yes + no`. A pool without a vote
+/// defaults to `No` for `HardForkInitiation` always, to `Abstain`
+/// during bootstrap, and to its reward-account-derived default
+/// otherwise.
+pub fn spo_tally(
+    pool_distr: &BTreeMap<PoolHash, u64>,
+    votes: &BTreeMap<PoolHash, Vote>,
+    default_votes: &BTreeMap<PoolHash, DefaultVote>,
+    action: &ProposalAction,
+    bootstrap: bool,
+) -> (u64, u64) {
+    let is_hard_fork = matches!(action, ProposalAction::HardFork(_));
+    let is_no_confidence = matches!(action, ProposalAction::NoConfidence);
+
+    let mut yes = 0u64;
+    let mut abstain = 0u64;
+
+    for (pool, stake) in pool_distr {
+        match votes.get(pool) {
+            Some(Vote::Yes) => yes += stake,
+            Some(Vote::No) => (),
+            Some(Vote::Abstain) => abstain += stake,
+            None => {
+                if is_hard_fork {
+                    // always a default No
+                } else if bootstrap {
+                    abstain += stake;
+                } else {
+                    match default_votes.get(pool) {
+                        Some(DefaultVote::NoConfidence) if is_no_confidence => yes += stake,
+                        Some(DefaultVote::Abstain) => abstain += stake,
+                        _ => (),
+                    }
+                }
+            }
+        }
+    }
+
+    (yes, abstain)
+}
+
+/// The run's evolving enact-state (`EnactState` residue the checks and
+/// tallies consume).
+struct RunState {
+    pparams: PParamsSet,
+    committee: Option<Committee>,
+    roots: GovRoots,
+    treasury: u64,
+    delayed: bool,
+}
+
+/// `prevActionAsExpected`: the declared parent must equal the run's
+/// current root for the action's purpose. Lineage-less actions pass.
+fn prev_action_as_expected(run: &RunState, proposal: &RatifyProposal) -> bool {
+    match proposal.action.purpose() {
+        None => true,
+        Some(purpose) => proposal.parent == *run.roots.root(purpose),
+    }
+}
+
+/// `validCommitteeTerm`: every member added by an `UpdateCommittee` must
+/// expire within `CommitteeTermLimit` epochs of the current one.
+fn valid_committee_term(run: &RunState, current_epoch: Epoch, action: &ProposalAction) -> bool {
+    match action {
+        ProposalAction::UpdateCommittee { to_add, .. } => {
+            let max_term = run.pparams.committee_term_limit_or_default();
+            to_add
+                .iter()
+                .all(|(_, expiry)| *expiry <= current_epoch + max_term)
+        }
+        _ => true,
+    }
+}
+
+/// `withdrawalCanWithdraw`: the action's withdrawals must fit in the
+/// run's remaining treasury.
+fn withdrawal_can_withdraw(run: &RunState, action: &ProposalAction) -> bool {
+    match action {
+        ProposalAction::TreasuryWithdrawal(withdrawals) => {
+            let sum: u128 = withdrawals.iter().map(|(_, coin)| *coin as u128).sum();
+            sum <= run.treasury as u128
+        }
+        _ => true,
+    }
+}
+
+/// ENACT (research §5.4) restricted to the state the run itself
+/// consumes: pparams (incl. protocol version), committee, treasury, and
+/// the purpose roots. Constitution changes have no in-run consumer.
+fn enact(run: &mut RunState, proposal: &RatifyProposal) {
+    match &proposal.action {
+        ProposalAction::ParamChange(update) => {
+            run.pparams.merge(update.clone());
+        }
+        ProposalAction::HardFork(version) => {
+            run.pparams
+                .set(crate::PParamValue::ProtocolVersion(*version));
+        }
+        ProposalAction::TreasuryWithdrawal(withdrawals) => {
+            let sum: u128 = withdrawals.iter().map(|(_, coin)| *coin as u128).sum();
+            run.treasury = run
+                .treasury
+                .saturating_sub(sum.min(u64::MAX as u128) as u64);
+        }
+        ProposalAction::NoConfidence => {
+            run.committee = None;
+        }
+        ProposalAction::UpdateCommittee {
+            to_remove,
+            to_add,
+            threshold,
+        } => {
+            // an update enacted out of the no-confidence state starts
+            // from an empty member set, as in `CommitteeUpdate::apply`
+            let mut members = run
+                .committee
+                .as_ref()
+                .map(|committee| committee.members.clone())
+                .unwrap_or_default();
+
+            for cold in to_remove {
+                members.remove(cold);
+            }
+
+            for (cold, term) in to_add {
+                members.insert(cold.clone(), *term);
+            }
+
+            run.committee = Some(Committee {
+                members,
+                threshold: threshold.clone(),
+            });
+        }
+        ProposalAction::NewConstitution { .. } | ProposalAction::Info | ProposalAction::Other => (),
+    }
+
+    if let Some(purpose) = proposal.action.purpose() {
+        *run.roots.root_mut(purpose) = Some(proposal.id.clone());
+    }
+}
+
+/// One full ratification run (`ratifyTransition`, research §5.3): sort
+/// the snapshot by action priority (submission order within), evaluate
+/// each action against the evolving enact-state, ENACT the accepted
+/// ones, and expire the rejected ones whose lifetime is over.
+pub fn ratify(input: &RatifyInput) -> RatifyOutcome {
+    let mut ordered: Vec<&RatifyProposal> = input.proposals.iter().collect();
+    ordered.sort_by(|a, b| {
+        action_priority(&a.action)
+            .cmp(&action_priority(&b.action))
+            .then_with(|| a.order.cmp(&b.order))
+    });
+
+    let mut run = RunState {
+        pparams: input.pparams.clone(),
+        committee: input.committee.clone(),
+        roots: input.roots.clone(),
+        treasury: input.treasury,
+        delayed: false,
+    };
+
+    let mut verdicts = Vec::with_capacity(ordered.len());
+    let mut enacted = Vec::new();
+
+    for proposal in ordered {
+        let prev_action_ok = prev_action_as_expected(&run, proposal);
+        let committee_term_ok = valid_committee_term(&run, input.current_epoch, &proposal.action);
+        let not_delayed = !run.delayed;
+        let withdrawal_ok = withdrawal_can_withdraw(&run, &proposal.action);
+
+        let cc_threshold = committee_threshold(input, &run, &proposal.action);
+        let cc = match &run.committee {
+            Some(committee) => committee_tally(
+                input.current_epoch,
+                &committee.members,
+                &input.committee_auths,
+                &proposal.cc_votes,
+            ),
+            None => (0, 0),
+        };
+        let cc_accepted = cc_threshold
+            .as_ref()
+            .is_some_and(|threshold| ratio_meets(cc.0, cc.1, threshold));
+
+        let drep_threshold = drep_threshold(&run, &proposal.action);
+        let is_no_confidence = matches!(proposal.action, ProposalAction::NoConfidence);
+        let drep = drep_tally(
+            input.current_epoch,
+            &input.drep_distr,
+            &input.dreps,
+            &proposal.drep_votes,
+            is_no_confidence,
+        );
+        let drep_accepted = drep_threshold
+            .as_ref()
+            .is_some_and(|threshold| ratio_meets(drep.0, drep.1, threshold));
+
+        let spo_threshold = spo_threshold(&run, &proposal.action);
+        let (spo_yes, spo_abstain) = spo_tally(
+            &input.pool_distr,
+            &proposal.spo_votes,
+            &input.pool_default_votes,
+            &proposal.action,
+            bootstrap_phase(&run.pparams),
+        );
+        let spo_denominator = input.pool_total.saturating_sub(spo_abstain);
+        let spo_accepted = spo_threshold
+            .as_ref()
+            .is_some_and(|threshold| ratio_meets(spo_yes, spo_denominator, threshold));
+
+        let accepted = prev_action_ok
+            && committee_term_ok
+            && not_delayed
+            && withdrawal_ok
+            && cc_accepted
+            && spo_accepted
+            && drep_accepted;
+
+        let verdict = if accepted {
+            enact(&mut run, proposal);
+            run.delayed = delaying_action(&proposal.action);
+            enacted.push(proposal.id.clone());
+            Verdict::Accepted
+        } else if proposal.expires_after < input.current_epoch {
+            Verdict::Expired
+        } else {
+            Verdict::Continuing
+        };
+
+        verdicts.push(ProposalRatification {
+            key: proposal.key.clone(),
+            id: proposal.id.clone(),
+            verdict,
+            tallies: Tallies {
+                prev_action_ok,
+                committee_term_ok,
+                not_delayed,
+                withdrawal_ok,
+                cc,
+                cc_threshold,
+                cc_accepted,
+                drep,
+                drep_threshold,
+                drep_accepted,
+                spo: (spo_yes, spo_abstain, spo_denominator),
+                spo_threshold,
+                spo_accepted,
+            },
+        });
+    }
+
+    RatifyOutcome {
+        verdicts,
+        enacted,
+        roots: run.roots,
+        treasury: run.treasury,
+        delayed: run.delayed,
+    }
+}
+
+/// Snapshot proposals the boundary application would remove as sibling
+/// subtrees of the enacted actions (`removedDueToEnactment`, research
+/// §5.5 step 3): for each purpose with an enacted action, every other
+/// snapshot proposal of that purpose survives only if it descends from
+/// the *last* enacted action of the purpose. Shadow mode uses this to
+/// classify hack-stamped cancellations the pure verdicts call
+/// `Continuing`.
+pub fn pruned_by_enactment(
+    proposals: &[RatifyProposal],
+    enacted: &[GovActionId],
+) -> BTreeSet<EntityKey> {
+    let by_id: BTreeMap<&GovActionId, &RatifyProposal> =
+        proposals.iter().map(|p| (&p.id, p)).collect();
+
+    let enacted_set: BTreeSet<&GovActionId> = enacted.iter().collect();
+
+    // last enacted action per purpose — the surviving subtree's root
+    let mut last_enacted: BTreeMap<crate::GovPurpose, &GovActionId> = BTreeMap::new();
+    for id in enacted {
+        if let Some(proposal) = by_id.get(id) {
+            if let Some(purpose) = proposal.action.purpose() {
+                last_enacted.insert(purpose, id);
+            }
+        }
+    }
+
+    let mut pruned = BTreeSet::new();
+
+    for proposal in proposals {
+        if enacted_set.contains(&proposal.id) {
+            continue;
+        }
+
+        let Some(purpose) = proposal.action.purpose() else {
+            continue;
+        };
+
+        let Some(winner) = last_enacted.get(&purpose) else {
+            continue;
+        };
+
+        // walk the parent chain: reaching the winner means the proposal
+        // sits in the surviving subtree; anything else is pruned
+        let mut cursor = proposal.parent.as_ref();
+        let mut survives = false;
+        let mut steps = 0usize;
+
+        while let Some(parent) = cursor {
+            if parent == *winner {
+                survives = true;
+                break;
+            }
+
+            steps += 1;
+            if steps > proposals.len() {
+                break;
+            }
+
+            cursor = by_id.get(parent).and_then(|p| p.parent.as_ref());
+        }
+
+        if !survives {
+            pruned.insert(proposal.key.clone());
+        }
+    }
+
+    pruned
+}
+
+#[cfg(test)]
+mod tests {
+    use pallas::ledger::primitives::conway::Anchor;
+
+    use super::*;
+    use crate::{PParamValue, ProposalState};
+
+    fn rational(numerator: u64, denominator: u64) -> RationalNumber {
+        RationalNumber {
+            numerator,
+            denominator,
+        }
+    }
+
+    fn cred(byte: u8) -> StakeCredential {
+        StakeCredential::AddrKeyhash([byte; 28].into())
+    }
+
+    fn script_cred(byte: u8) -> StakeCredential {
+        StakeCredential::ScriptHash([byte; 28].into())
+    }
+
+    fn drep_key(byte: u8) -> DRep {
+        DRep::Key([byte; 28].into())
+    }
+
+    fn pool(byte: u8) -> PoolHash {
+        [byte; 28].into()
+    }
+
+    fn action_id(byte: u8) -> GovActionId {
+        GovActionId {
+            transaction_id: [byte; 32].into(),
+            action_index: 0,
+        }
+    }
+
+    fn anchor() -> Anchor {
+        Anchor {
+            url: "ipfs://x".into(),
+            content_hash: [0u8; 32].into(),
+        }
+    }
+
+    /// Conway-shaped pparams: PV10, opinionated thresholds that make the
+    /// bodies distinguishable in tests.
+    fn test_pparams() -> PParamsSet {
+        PParamsSet::default()
+            .with(PParamValue::ProtocolVersion((10, 0)))
+            .with(PParamValue::MinCommitteeSize(1))
+            .with(PParamValue::CommitteeTermLimit(100))
+            .with(PParamValue::DrepVotingThresholds(DRepVotingThresholds {
+                motion_no_confidence: rational(51, 100),
+                committee_normal: rational(52, 100),
+                committee_no_confidence: rational(53, 100),
+                update_constitution: rational(54, 100),
+                hard_fork_initiation: rational(55, 100),
+                pp_network_group: rational(56, 100),
+                pp_economic_group: rational(57, 100),
+                pp_technical_group: rational(58, 100),
+                pp_governance_group: rational(59, 100),
+                treasury_withdrawal: rational(60, 100),
+            }))
+            .with(PParamValue::PoolVotingThresholds(PoolVotingThresholds {
+                motion_no_confidence: rational(61, 100),
+                committee_normal: rational(62, 100),
+                committee_no_confidence: rational(63, 100),
+                hard_fork_initiation: rational(64, 100),
+                security_voting_threshold: rational(65, 100),
+            }))
+    }
+
+    fn committee_of(members: &[(StakeCredential, Epoch)]) -> Committee {
+        Committee {
+            members: members.iter().cloned().collect(),
+            threshold: rational(2, 3),
+        }
+    }
+
+    fn proposal(byte: u8, action: ProposalAction) -> RatifyProposal {
+        RatifyProposal {
+            key: EntityKey::from(vec![byte]),
+            id: action_id(byte),
+            action,
+            parent: None,
+            expires_after: 1_000,
+            order: (byte as u64, [byte; 32].into(), 0),
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        }
+    }
+
+    fn base_input() -> RatifyInput {
+        RatifyInput {
+            current_epoch: 500,
+            pparams: test_pparams(),
+            treasury: 1_000_000,
+            committee: Some(committee_of(&[(script_cred(1), 600)])),
+            roots: GovRoots::default(),
+            committee_auths: [(
+                script_cred(1),
+                CommitteeAuthorization::HotCredential(cred(11)),
+            )]
+            .into_iter()
+            .collect(),
+            drep_distr: Default::default(),
+            pool_distr: Default::default(),
+            pool_total: 0,
+            dreps: Default::default(),
+            pool_default_votes: Default::default(),
+            proposals: vec![],
+        }
+    }
+
+    fn run_state(input: &RatifyInput) -> RunState {
+        RunState {
+            pparams: input.pparams.clone(),
+            committee: input.committee.clone(),
+            roots: input.roots.clone(),
+            treasury: input.treasury,
+            delayed: false,
+        }
+    }
+
+    fn param_change(kind_value: PParamValue) -> ProposalAction {
+        ProposalAction::ParamChange(PParamsSet::default().with(kind_value))
+    }
+
+    // ------------------------------------------------------------------
+    // §5.3.1 — threshold resolution
+    // ------------------------------------------------------------------
+
+    /// Each pparam group resolves to its own DRep threshold; an update
+    /// touching several groups takes the max; the security list drives
+    /// the SPO threshold.
+    #[test]
+    fn threshold_resolution_pparam_groups() {
+        let input = base_input();
+        let run = run_state(&input);
+
+        // one representative per group
+        let network = param_change(PParamValue::MaxBlockBodySize(1));
+        let economic = param_change(PParamValue::MinFeeA(1));
+        let technical = param_change(PParamValue::CollateralPercentage(1));
+        let governance = param_change(PParamValue::DrepDeposit(1));
+
+        assert_eq!(drep_threshold(&run, &network), Some(rational(56, 100)));
+        assert_eq!(drep_threshold(&run, &economic), Some(rational(57, 100)));
+        assert_eq!(drep_threshold(&run, &technical), Some(rational(58, 100)));
+        assert_eq!(drep_threshold(&run, &governance), Some(rational(59, 100)));
+
+        // technical (58) + governance (59) → max = 59
+        let multi = ProposalAction::ParamChange(
+            PParamsSet::default()
+                .with(PParamValue::CollateralPercentage(1))
+                .with(PParamValue::DrepDeposit(1)),
+        );
+        assert_eq!(drep_threshold(&run, &multi), Some(rational(59, 100)));
+
+        // security param → SPO security threshold; non-security → auto-accept
+        assert_eq!(spo_threshold(&run, &network), Some(rational(65, 100)));
+        assert_eq!(spo_threshold(&run, &technical), Some(rational(0, 1)));
+
+        // the security list is exactly the research doc's
+        for kind in [
+            PParamKind::MinFeeA,
+            PParamKind::MinFeeB,
+            PParamKind::MaxBlockBodySize,
+            PParamKind::MaxTransactionSize,
+            PParamKind::MaxBlockHeaderSize,
+            PParamKind::AdaPerUtxoByte,
+            PParamKind::MaxBlockExUnits,
+            PParamKind::MaxValueSize,
+            PParamKind::GovernanceActionDeposit,
+            PParamKind::MinFeeRefScriptCostPerByte,
+        ] {
+            assert!(pparam_is_security(kind), "{kind:?} must be security");
+        }
+        assert!(!pparam_is_security(PParamKind::MaxTxExUnits));
+        assert!(!pparam_is_security(PParamKind::KeyDeposit));
+    }
+
+    /// CC thresholds: no say on committee-purpose actions, none on Info,
+    /// the committee's own threshold otherwise — provided the committee
+    /// exists and (post-bootstrap) has enough active members.
+    #[test]
+    fn threshold_resolution_committee() {
+        let mut input = base_input();
+        let run = run_state(&input);
+
+        let param = param_change(PParamValue::MinFeeA(1));
+
+        assert_eq!(
+            committee_threshold(&input, &run, &ProposalAction::NoConfidence),
+            Some(rational(0, 1))
+        );
+        assert_eq!(
+            committee_threshold(
+                &input,
+                &run,
+                &ProposalAction::UpdateCommittee {
+                    to_remove: vec![],
+                    to_add: vec![],
+                    threshold: rational(1, 2),
+                }
+            ),
+            Some(rational(0, 1))
+        );
+        assert_eq!(
+            committee_threshold(&input, &run, &ProposalAction::Info),
+            None
+        );
+        assert_eq!(
+            committee_threshold(&input, &run, &param),
+            Some(rational(2, 3))
+        );
+
+        // no committee → no threshold
+        let mut no_committee = run_state(&input);
+        no_committee.committee = None;
+        assert_eq!(committee_threshold(&input, &no_committee, &param), None);
+
+        // active size below MinCommitteeSize → treated as no committee
+        input.committee_auths.clear();
+        let run = run_state(&input);
+        assert_eq!(committee_threshold(&input, &run, &param), None);
+
+        // …except during bootstrap, where the min-size check is off
+        let mut bootstrap = run_state(&input);
+        bootstrap.pparams.set(PParamValue::ProtocolVersion((9, 0)));
+        assert_eq!(
+            committee_threshold(&input, &bootstrap, &param),
+            Some(rational(2, 3))
+        );
+    }
+
+    /// DRep thresholds: per-action rows, the committee-existence split
+    /// for UpdateCommittee, all-zero during bootstrap, none for Info.
+    #[test]
+    fn threshold_resolution_drep_rows() {
+        let input = base_input();
+        let run = run_state(&input);
+
+        let update = ProposalAction::UpdateCommittee {
+            to_remove: vec![],
+            to_add: vec![],
+            threshold: rational(1, 2),
+        };
+
+        assert_eq!(
+            drep_threshold(&run, &ProposalAction::NoConfidence),
+            Some(rational(51, 100))
+        );
+        assert_eq!(drep_threshold(&run, &update), Some(rational(52, 100)));
+
+        let mut no_committee = run_state(&input);
+        no_committee.committee = None;
+        assert_eq!(
+            drep_threshold(&no_committee, &update),
+            Some(rational(53, 100))
+        );
+
+        assert_eq!(
+            drep_threshold(
+                &run,
+                &ProposalAction::NewConstitution {
+                    anchor: anchor(),
+                    guardrail_script: None,
+                }
+            ),
+            Some(rational(54, 100))
+        );
+        assert_eq!(
+            drep_threshold(&run, &ProposalAction::HardFork((11, 0))),
+            Some(rational(55, 100))
+        );
+        assert_eq!(
+            drep_threshold(&run, &ProposalAction::TreasuryWithdrawal(vec![])),
+            Some(rational(60, 100))
+        );
+        assert_eq!(drep_threshold(&run, &ProposalAction::Info), None);
+
+        // bootstrap: every resolvable threshold collapses to zero
+        let mut bootstrap = run_state(&input);
+        bootstrap.pparams.set(PParamValue::ProtocolVersion((9, 0)));
+        assert_eq!(
+            drep_threshold(&bootstrap, &ProposalAction::HardFork((10, 0))),
+            Some(rational(0, 1))
+        );
+        assert_eq!(drep_threshold(&bootstrap, &ProposalAction::Info), None);
+    }
+
+    // ------------------------------------------------------------------
+    // §5.3.2 — committee tally
+    // ------------------------------------------------------------------
+
+    /// Expired and resigned members abstain; an authorized member
+    /// without a vote counts as No; Abstain leaves the denominator; two
+    /// cold members sharing a hot credential each count its vote.
+    #[test]
+    fn committee_tally_members() {
+        let current_epoch = 500;
+
+        let members: BTreeMap<StakeCredential, Epoch> = [
+            (script_cred(1), 600), // yes
+            (script_cred(2), 600), // no vote → No
+            (script_cred(3), 600), // abstain
+            (script_cred(4), 499), // expired term → skipped
+            (script_cred(5), 600), // resigned → skipped
+            (script_cred(6), 600), // never authorized → skipped
+            (script_cred(7), 600), // shares hot cred with member 1 → yes
+        ]
+        .into_iter()
+        .collect();
+
+        let auths: BTreeMap<StakeCredential, CommitteeAuthorization> = [
+            (
+                script_cred(1),
+                CommitteeAuthorization::HotCredential(cred(11)),
+            ),
+            (
+                script_cred(2),
+                CommitteeAuthorization::HotCredential(cred(12)),
+            ),
+            (
+                script_cred(3),
+                CommitteeAuthorization::HotCredential(cred(13)),
+            ),
+            (
+                script_cred(4),
+                CommitteeAuthorization::HotCredential(cred(14)),
+            ),
+            (script_cred(5), CommitteeAuthorization::Resigned(None)),
+            (
+                script_cred(7),
+                CommitteeAuthorization::HotCredential(cred(11)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let votes: BTreeMap<StakeCredential, Vote> = [
+            (cred(11), Vote::Yes),
+            (cred(13), Vote::Abstain),
+            (cred(14), Vote::Yes), // expired member's vote must not count
+        ]
+        .into_iter()
+        .collect();
+
+        let (yes, total) = committee_tally(current_epoch, &members, &auths, &votes);
+
+        // yes: members 1 and 7 (shared hot cred); total adds member 2's
+        // default No; members 3–6 all excluded from the denominator
+        assert_eq!((yes, total), (2, 3));
+    }
+
+    // ------------------------------------------------------------------
+    // §5.3.3 — DRep tally
+    // ------------------------------------------------------------------
+
+    /// Unregistered and expired DReps are ignored entirely; absent votes
+    /// default to No; Abstain and AlwaysAbstain never count; the
+    /// AlwaysNoConfidence bucket votes yes exactly on NoConfidence.
+    #[test]
+    fn drep_tally_buckets_and_expiry() {
+        let current_epoch = 500;
+
+        let drep_distr: BTreeMap<DRep, u64> = [
+            (drep_key(1), 100), // yes
+            (drep_key(2), 50),  // no vote → No
+            (drep_key(3), 25),  // abstain
+            (drep_key(4), 10),  // expired → ignored
+            (drep_key(5), 5),   // not registered → ignored
+            (DRep::Abstain, 1_000),
+            (DRep::NoConfidence, 200),
+        ]
+        .into_iter()
+        .collect();
+
+        let dreps: BTreeMap<StakeCredential, Option<Epoch>> = [
+            (cred(1), Some(600)),
+            (cred(2), Some(600)),
+            (cred(3), Some(600)),
+            (cred(4), Some(499)),
+        ]
+        .into_iter()
+        .collect();
+
+        let votes: BTreeMap<StakeCredential, Vote> = [
+            (cred(1), Vote::Yes),
+            (cred(3), Vote::Abstain),
+            (cred(4), Vote::Yes), // expired drep's vote must not count
+        ]
+        .into_iter()
+        .collect();
+
+        // ordinary action: NoConfidence bucket counts as No
+        let (yes, total) = drep_tally(current_epoch, &drep_distr, &dreps, &votes, false);
+        assert_eq!((yes, total), (100, 100 + 50 + 200));
+
+        // NoConfidence action: the bucket flips to yes
+        let (yes, total) = drep_tally(current_epoch, &drep_distr, &dreps, &votes, true);
+        assert_eq!((yes, total), (100 + 200, 100 + 50 + 200));
+    }
+
+    /// A registered DRep whose row predates the epoch-based expiry field
+    /// tallies as active.
+    #[test]
+    fn drep_tally_legacy_expiry_counts_as_active() {
+        let drep_distr: BTreeMap<DRep, u64> = [(drep_key(1), 100)].into_iter().collect();
+        let dreps: BTreeMap<StakeCredential, Option<Epoch>> =
+            [(cred(1), None)].into_iter().collect();
+
+        let (yes, total) = drep_tally(500, &drep_distr, &dreps, &Default::default(), false);
+        assert_eq!((yes, total), (0, 100));
+    }
+
+    // ------------------------------------------------------------------
+    // §5.3.4 — SPO tally
+    // ------------------------------------------------------------------
+
+    /// The denominator is total minus abstain (No stays in it); absent
+    /// votes resolve through the pool's default vote, except HardFork
+    /// (always No).
+    #[test]
+    fn spo_tally_defaults_and_denominator() {
+        let pool_distr: BTreeMap<PoolHash, u64> = [
+            (pool(1), 100), // yes
+            (pool(2), 50),  // no
+            (pool(3), 25),  // abstain
+            (pool(4), 10),  // absent, DefaultAbstain
+            (pool(5), 5),   // absent, DefaultNoConfidence
+            (pool(6), 1),   // absent, no default → No
+        ]
+        .into_iter()
+        .collect();
+        let pool_total: u64 = pool_distr.values().sum();
+
+        let votes: BTreeMap<PoolHash, Vote> = [
+            (pool(1), Vote::Yes),
+            (pool(2), Vote::No),
+            (pool(3), Vote::Abstain),
+        ]
+        .into_iter()
+        .collect();
+
+        let defaults: BTreeMap<PoolHash, DefaultVote> = [
+            (pool(4), DefaultVote::Abstain),
+            (pool(5), DefaultVote::NoConfidence),
+        ]
+        .into_iter()
+        .collect();
+
+        let info = ProposalAction::Info;
+        let (yes, abstain) = spo_tally(&pool_distr, &votes, &defaults, &info, false);
+        assert_eq!((yes, abstain), (100, 25 + 10));
+        assert_eq!(pool_total - abstain, 156);
+
+        // NoConfidence: the DefaultNoConfidence pool flips to yes
+        let (yes, abstain) = spo_tally(
+            &pool_distr,
+            &votes,
+            &defaults,
+            &ProposalAction::NoConfidence,
+            false,
+        );
+        assert_eq!((yes, abstain), (105, 35));
+
+        // HardFork: absent is always No, defaults ignored
+        let (yes, abstain) = spo_tally(
+            &pool_distr,
+            &votes,
+            &defaults,
+            &ProposalAction::HardFork((11, 0)),
+            false,
+        );
+        assert_eq!((yes, abstain), (100, 25));
+
+        // bootstrap: absent defaults to Abstain (except HardFork)
+        let (yes, abstain) = spo_tally(&pool_distr, &votes, &defaults, &info, true);
+        assert_eq!((yes, abstain), (100, 25 + 16));
+        let (yes, abstain) = spo_tally(
+            &pool_distr,
+            &votes,
+            &defaults,
+            &ProposalAction::HardFork((10, 0)),
+            true,
+        );
+        assert_eq!((yes, abstain), (100, 25));
+    }
+
+    // ------------------------------------------------------------------
+    // §5.5 — application order over the evolving enact-state
+    // ------------------------------------------------------------------
+
+    /// An accepted proposal whose votes pass every body. DRep leg: one
+    /// whale votes yes; SPO leg: one pool votes yes; CC: the sole member
+    /// votes yes.
+    fn all_yes_input(proposals: Vec<RatifyProposal>) -> RatifyInput {
+        let mut input = base_input();
+
+        input.drep_distr = [(drep_key(1), 100)].into_iter().collect();
+        input.dreps = [(cred(1), Some(600))].into_iter().collect();
+        input.pool_distr = [(pool(1), 100)].into_iter().collect();
+        input.pool_total = 100;
+
+        input.proposals = proposals
+            .into_iter()
+            .map(|mut p| {
+                p.cc_votes.insert(cred(11), Vote::Yes);
+                p.drep_votes.insert(cred(1), Vote::Yes);
+                p.spo_votes.insert(pool(1), Vote::Yes);
+                p
+            })
+            .collect();
+
+        input
+    }
+
+    /// Evolving roots: a chained pair of same-purpose actions enacts in
+    /// one run — the second's parent is the first — while a competing
+    /// sibling fails the parent check and is pruned by the application.
+    #[test]
+    fn application_order_evolving_roots() {
+        let winner = proposal(1, param_change(PParamValue::MinFeeA(1)));
+
+        let mut child = proposal(2, param_change(PParamValue::MinFeeA(2)));
+        child.parent = Some(action_id(1));
+
+        let mut sibling = proposal(3, param_change(PParamValue::MinFeeA(3)));
+        sibling.parent = None; // competes with `winner` for the root
+
+        let mut input = all_yes_input(vec![winner, child, sibling]);
+        // the sibling casts no yes votes, but it wouldn't matter: its
+        // parent check fails once `winner` enacts
+        input.proposals[2].drep_votes.clear();
+
+        let outcome = ratify(&input);
+
+        assert_eq!(outcome.enacted, vec![action_id(1), action_id(2)]);
+        assert_eq!(
+            outcome.roots.pparam_update,
+            Some(action_id(2)),
+            "the last enacted action of the purpose is the new root"
+        );
+
+        let sibling_verdict = &outcome.verdicts[2];
+        assert_eq!(sibling_verdict.verdict, Verdict::Continuing);
+        assert!(!sibling_verdict.tallies.prev_action_ok);
+
+        // …and the application prunes it as a sibling of the winner
+        let pruned = pruned_by_enactment(&input.proposals, &outcome.enacted);
+        assert_eq!(pruned, [EntityKey::from(vec![3u8])].into_iter().collect());
+    }
+
+    /// Shrinking treasury: two withdrawals compete for a treasury that
+    /// only fits the first (submission order breaks the tie).
+    #[test]
+    fn application_order_shrinking_treasury() {
+        let first = proposal(
+            1,
+            ProposalAction::TreasuryWithdrawal(vec![(cred(20), 700_000)]),
+        );
+        let second = proposal(
+            2,
+            ProposalAction::TreasuryWithdrawal(vec![(cred(21), 700_000)]),
+        );
+
+        let input = all_yes_input(vec![first, second]);
+        let outcome = ratify(&input);
+
+        assert_eq!(outcome.enacted, vec![action_id(1)]);
+        assert_eq!(outcome.treasury, 300_000);
+
+        let second_verdict = &outcome.verdicts[1];
+        assert_eq!(second_verdict.verdict, Verdict::Continuing);
+        assert!(!second_verdict.tallies.withdrawal_ok);
+    }
+
+    /// A delaying action blocks everything after it in the run —
+    /// including actions that would otherwise pass — and priority
+    /// ordering puts committee actions first regardless of submission
+    /// order.
+    #[test]
+    fn application_order_delay_and_priority() {
+        // submitted first, but ParamChange has priority 4
+        let param = proposal(1, param_change(PParamValue::MinFeeA(1)));
+        // submitted later, priority 2 → considered first
+        let constitution = proposal(
+            2,
+            ProposalAction::NewConstitution {
+                anchor: anchor(),
+                guardrail_script: None,
+            },
+        );
+
+        let input = all_yes_input(vec![param, constitution]);
+        let outcome = ratify(&input);
+
+        // the constitution (delaying) enacts first and blocks the param
+        // change despite its passing tallies
+        assert_eq!(outcome.enacted, vec![action_id(2)]);
+        assert!(outcome.delayed);
+
+        assert_eq!(outcome.verdicts[0].id, action_id(2));
+        assert_eq!(outcome.verdicts[0].verdict, Verdict::Accepted);
+
+        let blocked = &outcome.verdicts[1];
+        assert_eq!(blocked.id, action_id(1));
+        assert_eq!(blocked.verdict, Verdict::Continuing);
+        assert!(!blocked.tallies.not_delayed);
+        assert!(blocked.tallies.drep_accepted, "only the delay blocked it");
+    }
+
+    /// A rejected action past its lifetime expires; one still within it
+    /// continues. Info can never be accepted.
+    #[test]
+    fn rejected_actions_expire_by_lifetime() {
+        let mut stale = proposal(1, ProposalAction::Info);
+        stale.expires_after = 499; // current_epoch = 500 → expired
+
+        let mut fresh = proposal(2, ProposalAction::Info);
+        fresh.expires_after = 500;
+
+        let input = all_yes_input(vec![stale, fresh]);
+        let outcome = ratify(&input);
+
+        assert!(outcome.enacted.is_empty());
+        assert_eq!(outcome.verdicts[0].verdict, Verdict::Expired);
+        assert_eq!(outcome.verdicts[1].verdict, Verdict::Continuing);
+    }
+
+    /// UpdateCommittee enacting from the no-confidence state rebuilds
+    /// the committee, and `validCommitteeTerm` rejects terms beyond the
+    /// limit.
+    #[test]
+    fn update_committee_enactment_and_term_check() {
+        let update = proposal(
+            1,
+            ProposalAction::UpdateCommittee {
+                to_remove: vec![script_cred(1)],
+                to_add: vec![(script_cred(9), 550)],
+                threshold: rational(1, 2),
+            },
+        );
+
+        let input = all_yes_input(vec![update]);
+        let outcome = ratify(&input);
+
+        assert_eq!(outcome.enacted, vec![action_id(1)]);
+        assert_eq!(outcome.roots.committee, Some(action_id(1)));
+
+        // term limit: current 500 + limit 100 = 600; a 601 add fails
+        let overlong = proposal(
+            2,
+            ProposalAction::UpdateCommittee {
+                to_remove: vec![],
+                to_add: vec![(script_cred(9), 601)],
+                threshold: rational(1, 2),
+            },
+        );
+
+        let input = all_yes_input(vec![overlong]);
+        let outcome = ratify(&input);
+
+        assert!(outcome.enacted.is_empty());
+        assert!(!outcome.verdicts[0].tallies.committee_term_ok);
+    }
+
+    /// NoConfidence enacting dissolves the committee within the run.
+    #[test]
+    fn no_confidence_dissolves_committee_in_run() {
+        let no_confidence = proposal(1, ProposalAction::NoConfidence);
+
+        // give the AlwaysNoConfidence bucket the majority
+        let mut input = all_yes_input(vec![no_confidence]);
+        input.drep_distr.insert(DRep::NoConfidence, 1_000);
+
+        let outcome = ratify(&input);
+
+        assert_eq!(outcome.enacted, vec![action_id(1)]);
+        assert_eq!(outcome.roots.committee, Some(action_id(1)));
+        assert!(outcome.delayed);
+    }
+
+    /// The engine sorts by priority with submission order within one
+    /// class (stable), and the whole run reads like research §5.3's
+    /// ordering table.
+    #[test]
+    fn priority_order_is_stable_within_class() {
+        let later = proposal(2, ProposalAction::Info);
+        let earlier = proposal(1, ProposalAction::Info);
+
+        let input = all_yes_input(vec![later, earlier]);
+        let outcome = ratify(&input);
+
+        assert_eq!(outcome.verdicts[0].id, action_id(1));
+        assert_eq!(outcome.verdicts[1].id, action_id(2));
+    }
+
+    /// Descendants of the last enacted action survive the pruning;
+    /// unrelated purposes are untouched.
+    #[test]
+    fn pruning_keeps_winner_descendants() {
+        let winner = proposal(1, param_change(PParamValue::MinFeeA(1)));
+
+        let mut grandchild = proposal(2, param_change(PParamValue::MinFeeA(2)));
+        grandchild.parent = Some(action_id(1));
+
+        let mut orphan = proposal(3, param_change(PParamValue::MinFeeA(3)));
+        orphan.parent = Some(action_id(9)); // outside the snapshot
+
+        let unrelated = proposal(4, ProposalAction::TreasuryWithdrawal(vec![]));
+
+        let proposals = vec![winner, grandchild, orphan, unrelated];
+        let pruned = pruned_by_enactment(&proposals, &[action_id(1)]);
+
+        assert_eq!(pruned, [EntityKey::from(vec![3u8])].into_iter().collect());
+    }
+
+    /// `votes_as_of` integration shape: the engine consumes resolved
+    /// votes, so re-votes after the boundary are invisible by
+    /// construction of the input (see `model::proposals` prop tests for
+    /// the accessor itself).
+    #[test]
+    fn vote_resolution_boundary_shape() {
+        let mut state = ProposalState {
+            slot: 0,
+            tx: [1u8; 32].into(),
+            idx: 0,
+            action: ProposalAction::Info,
+            max_epoch: None,
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: None,
+            reward_account: None,
+            proposed_in: Some(1),
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        };
+
+        state
+            .drep_votes
+            .insert(cred(1), vec![(100, Vote::No), (200, Vote::Yes)]);
+
+        assert_eq!(state.drep_votes_as_of(150).get(&cred(1)), Some(&Vote::No));
+        assert_eq!(state.drep_votes_as_of(250).get(&cred(1)), Some(&Vote::Yes));
+        assert!(state.drep_votes_as_of(50).is_empty());
+    }
+}

--- a/crates/cardano/src/ewrap/ratify.rs
+++ b/crates/cardano/src/ewrap/ratify.rs
@@ -1014,9 +1014,7 @@ mod tests {
         ProposalAction::ParamChange(PParamsSet::default().with(kind_value))
     }
 
-    // ------------------------------------------------------------------
     // §5.3.1 — threshold resolution
-    // ------------------------------------------------------------------
 
     /// Each pparam group resolves to its own DRep threshold; an update
     /// touching several groups takes the max; the security list drives
@@ -1178,9 +1176,7 @@ mod tests {
         assert_eq!(drep_threshold(&bootstrap, &ProposalAction::Info), None);
     }
 
-    // ------------------------------------------------------------------
     // §5.3.2 — committee tally
-    // ------------------------------------------------------------------
 
     /// Expired and resigned members abstain; an authorized member
     /// without a vote counts as No; Abstain leaves the denominator; two
@@ -1242,9 +1238,7 @@ mod tests {
         assert_eq!((yes, total), (2, 3));
     }
 
-    // ------------------------------------------------------------------
     // §5.3.3 — DRep tally
-    // ------------------------------------------------------------------
 
     /// Unregistered and expired DReps are ignored entirely; absent votes
     /// default to No; Abstain and AlwaysAbstain never count; the
@@ -1303,9 +1297,7 @@ mod tests {
         assert_eq!((yes, total), (0, 100));
     }
 
-    // ------------------------------------------------------------------
     // §5.3.4 — SPO tally
-    // ------------------------------------------------------------------
 
     /// The denominator is total minus abstain (No stays in it); absent
     /// votes resolve through the pool's default vote, except HardFork
@@ -1377,9 +1369,7 @@ mod tests {
         assert_eq!((yes, abstain), (100, 25));
     }
 
-    // ------------------------------------------------------------------
     // §5.5 — application order over the evolving enact-state
-    // ------------------------------------------------------------------
 
     /// An accepted proposal whose votes pass every body. DRep leg: one
     /// whale votes yes; SPO leg: one pool votes yes; CC: the sole member

--- a/crates/cardano/src/model/gov.rs
+++ b/crates/cardano/src/model/gov.rs
@@ -171,6 +171,17 @@ impl GovRoots {
             GovPurpose::Constitution => &mut self.constitution,
         }
     }
+
+    /// The root of a single lineage tree — the `prevActionAsExpected`
+    /// read during ratification.
+    pub fn root(&self, purpose: GovPurpose) -> &Option<GovActionId> {
+        match purpose {
+            GovPurpose::PParamUpdate => &self.pparam_update,
+            GovPurpose::HardFork => &self.hard_fork,
+            GovPurpose::Committee => &self.committee,
+            GovPurpose::Constitution => &self.constitution,
+        }
+    }
 }
 
 #[derive(Debug, Encode, Decode, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -221,6 +232,20 @@ pub struct GovState {
     #[n(6)]
     #[cbor(default)]
     pub distr: Option<GovDistr>,
+
+    /// The previous boundary's completed stake distributions — the
+    /// pulser-snapshot equivalent the ratification tally at the *current*
+    /// boundary consumes (the distribution accumulated while closing
+    /// epoch `n` governs the ratification that closes epoch `n + 1`).
+    /// Rotated out of `distr` by [`GovDistrRotate`] at each
+    /// governance-active EWRAP finalize, before the next boundary's
+    /// shard 0 replaces `distr` wholesale. `None` when the previous
+    /// boundary's accumulation was missing or incomplete — consumers
+    /// skip rather than read stale data. Index 7 must not be reused for
+    /// anything else.
+    #[n(7)]
+    #[cbor(default)]
+    pub prev_distr: Option<GovDistr>,
 }
 
 entity_boilerplate!(GovState, "gov");
@@ -898,6 +923,157 @@ impl dolos_core::EntityDelta for GovDistrAccumulate {
     }
 }
 
+/// Increment the dormant-epoch counter — the EPOCH rule's step 6
+/// (research §5.5): emitted at a governance-active boundary whose
+/// post-application live set has no proposal still votable in the
+/// starting epoch. The counter is later folded into DRep expiries and
+/// reset by the roll-side [`GovDormancyReset`] fan-out when a proposal
+/// finally shows up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovDormancyTick {
+    // undo
+    pub(crate) prev: u64,
+}
+
+impl GovDormancyTick {
+    pub fn new() -> Self {
+        Self { prev: 0 }
+    }
+}
+
+impl Default for GovDormancyTick {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl dolos_core::EntityDelta for GovDormancyTick {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        self.prev = state.num_dormant_epochs;
+        state.num_dormant_epochs += 1;
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.num_dormant_epochs = self.prev;
+    }
+}
+
+/// Committee-state GC — the EPOCH rule's step 7 (`updateCommitteeState`,
+/// research §5.5): drop the authorization histories of cold credentials
+/// that are not members of the post-enactment committee (everything, if
+/// the committee dissolved into the no-confidence state). Reads the
+/// committee at apply time, so it must be queued after the boundary's
+/// enactment deltas.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitteeGc {
+    // undo — the removed entries, re-inserted wholesale
+    pub(crate) removed: BTreeMap<StakeCredential, AuthHistory>,
+}
+
+impl CommitteeGc {
+    pub fn new() -> Self {
+        Self {
+            removed: BTreeMap::new(),
+        }
+    }
+}
+
+impl Default for CommitteeGc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl dolos_core::EntityDelta for CommitteeGc {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        let auths = std::mem::take(&mut state.committee_auths);
+
+        let (kept, removed) = match state.committee.as_ref() {
+            Some(committee) => auths
+                .into_iter()
+                .partition(|(cold, _)| committee.members.contains_key(cold)),
+            None => (BTreeMap::new(), auths),
+        };
+
+        state.committee_auths = kept;
+        self.removed = removed;
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        for (cold, history) in &self.removed {
+            state.committee_auths.insert(cold.clone(), history.clone());
+        }
+    }
+}
+
+/// Rotate the boundary stake-distribution accumulator into
+/// `prev_distr`, where the *next* boundary's ratification tally reads it
+/// after that boundary's shard 0 has replaced `distr` wholesale. Emitted
+/// at each governance-active EWRAP finalize. An accumulator that is
+/// missing or incomplete for the closing epoch rotates to `None` — a
+/// visible gap the consumer skips, never stale data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovDistrRotate {
+    pub(crate) closing_epoch: Epoch,
+
+    // undo — pre-image of `prev_distr`
+    pub(crate) prev: Option<GovDistr>,
+}
+
+impl GovDistrRotate {
+    pub fn new(closing_epoch: Epoch) -> Self {
+        Self {
+            closing_epoch,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for GovDistrRotate {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        self.prev = state.prev_distr.take();
+
+        state.prev_distr = state
+            .distr
+            .clone()
+            .filter(|distr| distr.is_complete_for(self.closing_epoch));
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.prev_distr = self.prev.clone();
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
@@ -989,6 +1165,7 @@ pub(crate) mod testing {
             num_dormant_epochs in 0u64..32u64,
             active_since in prop::option::of(root::any_epoch()),
             distr in prop::option::of(any_gov_distr()),
+            prev_distr in prop::option::of(any_gov_distr()),
         ) -> GovState {
             GovState {
                 constitution,
@@ -998,6 +1175,7 @@ pub(crate) mod testing {
                 num_dormant_epochs,
                 active_since,
                 distr,
+                prev_distr,
             }
         }
     }
@@ -1058,6 +1236,14 @@ mod tests {
                 ]),
                 pool_distr: BTreeMap::from([([8u8; 28].into(), 6_000_000)]),
                 pool_total: 6_000_000,
+            }),
+            prev_distr: Some(GovDistr {
+                closing_epoch: 508,
+                committed_shards: 32,
+                total_shards: 32,
+                drep_distr: BTreeMap::from([(DRep::Key([7u8; 28].into()), 4_000_000)]),
+                pool_distr: BTreeMap::from([([8u8; 28].into(), 5_000_000)]),
+                pool_total: 5_000_000,
             }),
         };
 
@@ -1231,6 +1417,60 @@ mod prop_tests {
                 pool_distr,
                 pool_total,
             )
+        }
+    }
+
+    prop_compose! {
+        fn any_gov_distr_rotate()(
+            closing_epoch in root::any_epoch(),
+        ) -> GovDistrRotate {
+            GovDistrRotate::new(closing_epoch)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn dormancy_tick_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+        ) {
+            assert_delta_roundtrip(entity, GovDormancyTick::new());
+        }
+
+        #[test]
+        fn dormancy_tick_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, GovDormancyTick::new());
+        }
+
+        #[test]
+        fn committee_gc_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+        ) {
+            assert_delta_roundtrip(entity, CommitteeGc::new());
+        }
+
+        #[test]
+        fn committee_gc_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, CommitteeGc::new());
+        }
+
+        #[test]
+        fn distr_rotate_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_rotate(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn distr_rotate_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_rotate(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
         }
     }
 
@@ -1626,6 +1866,136 @@ mod prop_tests {
         let distr = entity.unwrap().distr.unwrap();
         assert_eq!(distr.closing_epoch, 501);
         assert_eq!(distr.pool_total, 7);
+    }
+
+    /// The GC keeps the authorization histories of sitting members,
+    /// drops everyone else's, and clears the whole map when the
+    /// committee dissolved — with undo restoring the removed entries.
+    #[test]
+    fn committee_gc_intersects_with_members() {
+        use dolos_core::EntityDelta as _;
+
+        let member = StakeCredential::ScriptHash([1u8; 28].into());
+        let stranger = StakeCredential::ScriptHash([2u8; 28].into());
+        let hot = StakeCredential::AddrKeyhash([3u8; 28].into());
+
+        let auths: BTreeMap<StakeCredential, AuthHistory> = BTreeMap::from([
+            (
+                member.clone(),
+                vec![(100, CommitteeAuthorization::HotCredential(hot.clone()))],
+            ),
+            (
+                stranger.clone(),
+                vec![(200, CommitteeAuthorization::HotCredential(hot))],
+            ),
+        ]);
+
+        let mut entity = Some(GovState {
+            committee: Some(Committee {
+                members: BTreeMap::from([(member.clone(), 600)]),
+                threshold: RationalNumber {
+                    numerator: 2,
+                    denominator: 3,
+                },
+            }),
+            committee_auths: auths.clone(),
+            ..Default::default()
+        });
+
+        let mut gc = CommitteeGc::new();
+        gc.apply(&mut entity);
+
+        let state = entity.as_ref().unwrap();
+        assert!(state.committee_auths.contains_key(&member));
+        assert!(!state.committee_auths.contains_key(&stranger));
+
+        gc.undo(&mut entity);
+        assert_eq!(entity.as_ref().unwrap().committee_auths, auths);
+
+        // no-confidence state: everything is dropped
+        let mut entity = Some(GovState {
+            committee: None,
+            committee_auths: auths.clone(),
+            ..Default::default()
+        });
+
+        let mut gc = CommitteeGc::new();
+        gc.apply(&mut entity);
+        assert!(entity.as_ref().unwrap().committee_auths.is_empty());
+
+        gc.undo(&mut entity);
+        assert_eq!(entity.unwrap().committee_auths, auths);
+    }
+
+    /// The rotation moves a complete accumulator into `prev_distr`,
+    /// replaces an incomplete one with `None` (never stale data), and
+    /// leaves `distr` itself alone for the next boundary's shard 0.
+    #[test]
+    fn distr_rotate_moves_completed_accumulator() {
+        use dolos_core::EntityDelta as _;
+
+        let complete = GovDistr {
+            closing_epoch: 500,
+            committed_shards: 2,
+            total_shards: 2,
+            drep_distr: BTreeMap::from([(DRep::Key([1u8; 28].into()), 10)]),
+            pool_distr: BTreeMap::new(),
+            pool_total: 0,
+        };
+
+        let stale_prev = GovDistr {
+            closing_epoch: 499,
+            ..complete.clone()
+        };
+
+        let mut entity = Some(GovState {
+            distr: Some(complete.clone()),
+            prev_distr: Some(stale_prev.clone()),
+            ..Default::default()
+        });
+
+        let mut rotate = GovDistrRotate::new(500);
+        rotate.apply(&mut entity);
+
+        let state = entity.as_ref().unwrap();
+        assert_eq!(state.prev_distr, Some(complete.clone()));
+        assert_eq!(state.distr, Some(complete.clone()));
+
+        rotate.undo(&mut entity);
+        assert_eq!(entity.as_ref().unwrap().prev_distr, Some(stale_prev));
+
+        // an incomplete accumulator rotates to a visible gap
+        let incomplete = GovDistr {
+            committed_shards: 1,
+            ..complete
+        };
+
+        let mut entity = Some(GovState {
+            distr: Some(incomplete),
+            prev_distr: None,
+            ..Default::default()
+        });
+
+        let mut rotate = GovDistrRotate::new(500);
+        rotate.apply(&mut entity);
+        assert_eq!(entity.unwrap().prev_distr, None);
+    }
+
+    #[test]
+    fn dormancy_tick_increments() {
+        use dolos_core::EntityDelta as _;
+
+        let mut entity = Some(GovState {
+            num_dormant_epochs: 3,
+            ..Default::default()
+        });
+
+        let mut tick = GovDormancyTick::new();
+        tick.apply(&mut entity);
+        assert_eq!(entity.as_ref().unwrap().num_dormant_epochs, 4);
+
+        tick.undo(&mut entity);
+        assert_eq!(entity.unwrap().num_dormant_epochs, 3);
     }
 
     #[test]

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -277,6 +277,9 @@ pub enum CardanoDelta {
     GovRootsUpdate(Box<GovRootsUpdate>),
     GovDistrAccumulate(Box<GovDistrAccumulate>),
     DRepPowerUpdate(Box<DRepPowerUpdate>),
+    GovDormancyTick(Box<GovDormancyTick>),
+    CommitteeGc(Box<CommitteeGc>),
+    GovDistrRotate(Box<GovDistrRotate>),
 }
 
 impl CardanoDelta {
@@ -376,6 +379,9 @@ delta_from!(ConstitutionUpdate);
 delta_from!(GovRootsUpdate);
 delta_from!(GovDistrAccumulate);
 delta_from!(DRepPowerUpdate);
+delta_from!(GovDormancyTick);
+delta_from!(CommitteeGc);
+delta_from!(GovDistrRotate);
 
 #[allow(deprecated)]
 impl dolos_core::EntityDelta for CardanoDelta {
@@ -417,6 +423,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovRootsUpdate(x) => x.key(),
             Self::GovDistrAccumulate(x) => x.key(),
             Self::DRepPowerUpdate(x) => x.key(),
+            Self::GovDormancyTick(x) => x.key(),
+            Self::CommitteeGc(x) => x.key(),
+            Self::GovDistrRotate(x) => x.key(),
             Self::AssignRewards(x) => x.key(),
             Self::NonceTransition(x) => x.key(),
             Self::PoolTransition(x) => x.key(),
@@ -481,6 +490,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovRootsUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::GovDistrAccumulate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::DRepPowerUpdate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::GovDormancyTick(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::CommitteeGc(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::GovDistrRotate(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::AssignRewards(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NonceTransition(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::PoolTransition(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -545,6 +557,9 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovRootsUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::GovDistrAccumulate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::DRepPowerUpdate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::GovDormancyTick(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::CommitteeGc(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::GovDistrRotate(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::AssignRewards(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NonceTransition(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::PoolTransition(x) => Self::downcast_undo(x.as_ref(), entity),

--- a/crates/cardano/src/model/pparams.rs
+++ b/crates/cardano/src/model/pparams.rs
@@ -345,6 +345,12 @@ impl PParamsSet {
         self.values.iter().find(|value| value.kind() == kind)
     }
 
+    /// The values present in the set — for consumers that classify an
+    /// update's touched parameters (e.g. ratification threshold groups).
+    pub fn iter(&self) -> impl Iterator<Item = &PParamValue> {
+        self.values.iter()
+    }
+
     pub fn get_mut(&mut self, kind: PParamKind) -> Option<&mut PParamValue> {
         self.values.iter_mut().find(|value| value.kind() == kind)
     }

--- a/crates/cardano/src/model/proposals.rs
+++ b/crates/cardano/src/model/proposals.rs
@@ -84,7 +84,9 @@ impl ProposalAction {
 ///
 /// `TreasuryWithdrawal` and `Info` actions have no lineage (no parent field,
 /// never become a root), so their proposals carry no purpose.
-#[derive(Debug, Encode, Decode, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(
+    Debug, Encode, Decode, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[cbor(index_only)]
 pub enum GovPurpose {
     #[n(0)]
@@ -270,6 +272,26 @@ pub(crate) mod testing {
     }
 }
 
+/// Effective vote per voter considering only entries at or before `slot` —
+/// the as-of read used by boundary tallies, modeled on
+/// `GovState::committee_auth_as_of`. Voters whose whole history postdates
+/// the cutoff are absent from the result.
+pub fn votes_as_of<K: Ord + Clone>(
+    votes: &BTreeMap<K, VoteHistory>,
+    slot: BlockSlot,
+) -> BTreeMap<K, Vote> {
+    votes
+        .iter()
+        .filter_map(|(voter, history)| {
+            history
+                .iter()
+                .rev()
+                .find(|(at, _)| *at <= slot)
+                .map(|(_, vote)| (voter.clone(), vote.clone()))
+        })
+        .collect()
+}
+
 /// Ensures `key` has a (possibly empty) history in `map`, returning whether
 /// the entry had to be created alongside the history itself.
 fn history_or_default<K: Ord>(
@@ -349,6 +371,49 @@ impl ProposalState {
             ),
             Voter::StakePoolKey(hash) => history_pop(&mut self.spo_votes, hash, created),
         }
+    }
+
+    /// Committee votes as of `slot`, keyed by hot credential.
+    pub fn cc_votes_as_of(&self, slot: BlockSlot) -> BTreeMap<StakeCredential, Vote> {
+        votes_as_of(&self.cc_votes, slot)
+    }
+
+    /// DRep votes as of `slot`, keyed by DRep credential.
+    pub fn drep_votes_as_of(&self, slot: BlockSlot) -> BTreeMap<StakeCredential, Vote> {
+        votes_as_of(&self.drep_votes, slot)
+    }
+
+    /// SPO votes as of `slot`, keyed by pool operator hash.
+    pub fn spo_votes_as_of(&self, slot: BlockSlot) -> BTreeMap<PoolHash, Vote> {
+        votes_as_of(&self.spo_votes, slot)
+    }
+
+    /// Whether the proposal is still in the live governance forest when the
+    /// boundary closing `epoch` begins — no earlier boundary enacted or
+    /// dropped it. Distinct from `is_active`, which keeps resolved
+    /// proposals visible one extra epoch for the drop pass: a proposal
+    /// enacted at the previous boundary is `is_active` here but already
+    /// out of the forest.
+    pub fn is_unresolved_at_close(&self, epoch: Epoch) -> bool {
+        // enacted at the boundary closing `ratified_epoch`
+        if self.ratified_epoch.is_some_and(|ratified| ratified < epoch) {
+            return false;
+        }
+
+        // dropped at the boundary closing `canceled_epoch - 1`
+        if self
+            .canceled_epoch
+            .is_some_and(|canceled| canceled <= epoch)
+        {
+            return false;
+        }
+
+        // expiry-dropped at the boundary closing `max_epoch + 1`
+        if self.max_epoch.is_some_and(|max| max + 1 < epoch) {
+            return false;
+        }
+
+        true
     }
 
     /// Build the ID of the proposal in its string form, as found on explorers.
@@ -1031,6 +1096,67 @@ mod prop_tests {
                 }),
         ) {
             assert_delta_roundtrip(Some(entity), delta);
+        }
+    }
+
+    /// A slot-ordered history, as the roll pipeline appends them.
+    fn any_ordered_history() -> impl Strategy<Value = VoteHistory> {
+        prop::collection::vec((root::any_slot(), root::any_vote()), 0..6).prop_map(|mut entries| {
+            entries.sort_by_key(|(slot, _)| *slot);
+            entries
+        })
+    }
+
+    proptest! {
+        /// Done criterion: the as-of read resolves to the last vote cast
+        /// at or before the boundary — the same answer as filtering the
+        /// history and taking the tail.
+        #[test]
+        fn votes_as_of_is_last_vote_at_or_before_boundary(
+            history in any_ordered_history(),
+            cutoff in root::any_slot(),
+        ) {
+            let map: BTreeMap<StakeCredential, VoteHistory> =
+                [(StakeCredential::AddrKeyhash([5u8; 28].into()), history.clone())]
+                    .into_iter()
+                    .collect();
+
+            let resolved = votes_as_of(&map, cutoff);
+
+            let expected = history
+                .iter()
+                .filter(|(slot, _)| *slot <= cutoff)
+                .next_back()
+                .map(|(_, vote)| vote.clone());
+
+            prop_assert_eq!(
+                resolved.get(&StakeCredential::AddrKeyhash([5u8; 28].into())).cloned(),
+                expected
+            );
+        }
+
+        /// Done criterion: votes cast after the boundary are invisible —
+        /// appending later entries never changes the as-of read.
+        #[test]
+        fn votes_after_boundary_are_invisible(
+            history in any_ordered_history(),
+            cutoff in root::any_slot(),
+            later in prop::collection::vec((1u64..1_000u64, root::any_vote()), 1..4),
+        ) {
+            let key = StakeCredential::AddrKeyhash([5u8; 28].into());
+
+            let map: BTreeMap<StakeCredential, VoteHistory> =
+                [(key.clone(), history.clone())].into_iter().collect();
+            let before = votes_as_of(&map, cutoff);
+
+            let mut extended = history;
+            for (offset, vote) in later {
+                extended.push((cutoff + offset, vote));
+            }
+            let map: BTreeMap<StakeCredential, VoteHistory> =
+                [(key, extended)].into_iter().collect();
+
+            prop_assert_eq!(votes_as_of(&map, cutoff), before);
         }
     }
 


### PR DESCRIPTION
Plan: `plans/dolos-governance-ratification-engine.md` (Brain/txpipe) — phase 5 of the dolos-governance-gaps family, sequenced after #1211 (enactment) and #1212 (stake distributions).

## What changed

Proposal outcomes were stamped at creation from the hardcoded `hacks::proposals` table; there was no tally code anywhere. This PR implements the full Conway RATIFY rule as a pure function and runs it in **shadow mode** at every epoch boundary: the engine computes ratification, expiry, and enactment eligibility for real and logs any disagreement with the hack-stamped outcomes — while the hack table remains authoritative for state effects. Flipping the engine to authoritative and deleting the table is the follow-up oracle-removal plan.

### The pure engine (`crates/cardano/src/ewrap/ratify.rs`)

`ratify(RatifyInput) -> RatifyOutcome` — no store reads; a faithful port of `Rules/Ratify.hs` checked line-by-line against the vendored cardano-ledger:

- **Ordering**: stable sort by action priority (`NoConfidence` → … → `Info`), submission order within a class.
- **Structural checks**: `prevActionAsExpected` against the run's evolving roots, `validCommitteeTerm`, the delay flag, `withdrawalCanWithdraw` against the run's shrinking treasury.
- **Threshold resolution** (research §5.3.1): CC/DRep/SPO tables incl. the pparam-group classification for `ParameterChange` (network/economic/technical/governance, groups verified against the `ConwayPParams` THKD tags) and the ten-parameter security list; the `Maybe UnitInterval` semantics (`None` = unratifiable, `0` = auto-accept) are preserved, and all thresholds read the **evolving** enact-state pparams/committee, exactly as the Haskell rule does.
- **Tallies**: CC over committee *members* resolving each cold credential's hot authorization as of the boundary (resigned/expired members abstain, absent votes count No, shared hot credentials count per cold member); DRep over the stake distribution with expiry filtering and the `AlwaysAbstain`/`AlwaysNoConfidence` buckets; SPO with the `totalActiveStake − abstain` denominator and per-pool `defaultVote` derived from the reward account's DRep delegation. Ratios compare via u128 cross-multiplication — no floats.
- **ENACT in-run** (research §5.4): pparams merge (incl. protocol version), committee edits, treasury shrink, per-purpose root updates — later actions in the same run see them.
- **PV9 bootstrap gates** (design §5.4): DRep thresholds all-zero, committee min-size check off, SPO absent-vote default = Abstain except `HardForkInitiation`.

### Snapshot semantics (design §2, the as-of table)

The boundary closing epoch `c` ratifies the pulser snapshot created at the `(c-1)/c` boundary, `currentEpoch = c`:

- proposals still in the live forest with `proposed_in <= c-1` (a new `is_unresolved_at_close` distinguishes forest membership from `is_active`'s drop-epoch grace);
- votes and committee authorizations slot-filtered to the boundary via the new `votes_as_of` accessors (modeled on `committee_auth_as_of`);
- DRep registration and stored expiry as of the boundary (`DRepExpiry::as_of`), with the tally comparing the uncredited value exactly as Haskell does;
- treasury from `EpochState.initial_pots` (the boundary value), pparams live during the closing epoch;
- **stake distributions from the previous boundary's accumulation**: the tally that closes epoch `n+1` needs the distribution accumulated while closing epoch `n`, which shard 0 of the new boundary replaces wholesale — so a new `GovState.prev_distr` (CBOR index 7) retains it, rotated by the appended `GovDistrRotate` delta at each governance-active finalize. A missing/incomplete accumulation rotates to `None` (a visible gap the engine skips with a warning), never stale data.

### Shadow comparison

In EWRAP finalize, after the visitors: per snapshot proposal, engine verdict (enact / expire / continue, with sibling-subtree pruning derived from the enacted set per research §5.5 step 3) vs. the hack-derived classification (`should_enact` / `should_drop`). Mismatches log as structured `tracing::warn!` with proposal id, epoch, both verdicts, and the full tally numbers; a per-boundary `info!` summarizes proposals/enacted/mismatches.

### EPOCH steps that do change state (not shadow-gated, per plan)

- **`GovDormancyTick`** (appended delta): `num_dormant_epochs` increments iff no votable proposal survives the boundary (research §5.5 step 6 — the counter was previously only ever reset). The existing roll-side `DormancyFold`/`GovDormancyReset` fan-out now fires for real when a proposal ends a dormant stretch.
- **`CommitteeGc`** (appended delta): committee authorization histories are intersected with the **post-enactment** member set (`updateCommitteeState`, step 7) — the delta reads the committee at apply time and is queued after the enactment flush. Note: the ledger intersects with membership only; the plan's "or whose term expired" phrasing does not match `Rules/Epoch.hs` and was not implemented (term-expired members stay members — dropping their auths would break a later term extension).
- **PV10 hard-fork migration** (design §5.4): at the boundary enacting protocol major 10, the existing EWRAP account scan additionally drops DRep delegations pointing at never/no-longer-registered DReps, reusing the existing `DRepDelegatorDrop` delta (no new WAL variant; crash-resume covered by the shard cursor). No #4772 stale-delegator repair, per the founder decision recorded in the plan.

### Schema / WAL

`GovState.prev_distr` at unused index 7 (old rows decode with `None`); three appended `CardanoDelta` variants (`GovDormancyTick`, `CommitteeGc`, `GovDistrRotate`), all with full undo pre-images. No existing index or variant touched.

## Done criteria

1. **Unit tests 1:1 with the research doc** — `ewrap::ratify::tests`: `threshold_resolution_pparam_groups` / `_committee` / `_drep_rows` (§5.3.1, all four groups + security list), `committee_tally_members` (§5.3.2 incl. resigned and expired members), `drep_tally_buckets_and_expiry` + `drep_tally_legacy_expiry_counts_as_active` (§5.3.3, both Always* buckets, expiry filtering), `spo_tally_defaults_and_denominator` (§5.3.4 incl. `defaultVote` and the PV9 bootstrap default), `application_order_evolving_roots` / `_shrinking_treasury` / `_delay_and_priority`, `update_committee_enactment_and_term_check`, `no_confidence_dissolves_committee_in_run`, `priority_order_is_stable_within_class`, `rejected_actions_expire_by_lifetime`, `pruning_keeps_winner_descendants` (§5.5). ✅
2. **Property tests for the slot-filtered vote reads** — `votes_as_of_is_last_vote_at_or_before_boundary`, `votes_after_boundary_are_invisible`; plus roundtrip + serde property tests for all three new deltas. ✅
3. **Preview replay with zero shadow-mode mismatches** — in progress (full from-genesis Mithril replay with this branch's binary; results to be posted here before the PR leaves draft).
4. **Replay behavior otherwise unchanged** — stamped outcomes still drive enactment/drops; the full existing suite passes untouched. ✅
5. **Checks** — `cargo test --workspace` (1190 passed, 0 failed), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo +nightly fmt --all -- --check` (clean). ✅

## Notes for review

- Submission order across different transactions of the same block approximates as `(slot, tx_hash, idx)` — the intra-block tx order is not tracked on `ProposalState`. Within a transaction the index orders exactly; cross-tx same-block gov proposals with equal priority are the only affected case.
- `defaultVote` reads the pool's current row via the existing `load_pool_reward_account` helper (scheduled-params preference), per the plan's direction; a pool re-registered with a new reward account mid-epoch could in principle diverge from the Haskell snapshot until the oracle-removal plan revisits.
- The first boundary after an in-place upgrade has no `prev_distr` yet — shadow ratification skips once with a warning and self-heals at the next boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Done criterion 3 — preview replay result (2026-08-15)

**Met.** Full genesis-to-tip preview replay, `dolos bootstrap mithril` on a clean store to slot 120044117:

| | |
|---|---|
| boundaries with shadow ratification | **742** |
| shadow mismatches | **0** |
| skips | 1 (first governance-active boundary, no `prev_distr` yet — self-heals, as documented above) |
| panics / errors | **0** |
| enactments | **engine 14 = chain 14**, one for one |

The engine's ratification epochs — 735, 742, 963, 993, 997, 998, 1012, 1095, 1269, 1290, 1329, 1360, 1366, 1369 — map exactly onto the fourteen enactments Koios reports for preview (each ratification landing the following epoch). So the engine independently reproduces every ratification decision in preview's governance history.

### A real defect this surfaced

The first replay came back with 3 mismatches at epoch 735 — one missed enactment plus the two siblings that its enactment should have pruned. Root cause, confirmed against the store and Koios:

`enactment_deltas` decided lineage-tree membership from `action.purpose()`, which infers the tree from the action's *shape*. Preview's `hacks::proposals` table stamps every unlisted proposal as ratified while protocol ≤ 8 (`_ => match protocol { 0..=8 => RatifiedCurrentEpoch, .. }`), which is how pre-Conway update proposals get applied at all. Those rows carry parameters, so they matched `ParamChange` and claimed the pparam-update root — from epoch 1 onward. `ensPrevGovActionIds` is Conway enact-state and names Conway actions only, so this left a phantom parent, and the chain's first real ParameterChange (`1f47f3cf…`, ratified 735, parent `None`) could never satisfy `prevActionAsExpected`.

Fixed in bd24cebf by reading the recorded `purpose` — written by `parse_gov_action` only when the action was decoded as a Conway governance action — instead of inferring it from the action's shape. The legacy proposal still enacts; it just no longer claims a root. Regression test `enactment_without_recorded_purpose_claims_no_lineage_root` pins both halves, including an assertion that shape-based gating would get it wrong.

Scope note: the hack table's `protocol <= 8` rule is deliberately left alone. It is doing legitimate work — without it a dozen preview parameter changes would stop landing and the replay's pparams would silently drift. The defect was the lineage write, not the outcome. Expanding this plan to cover the fix was `org/founder`'s call (2026-08-15), taken in place of escalating to the enactment plan.

### Checks

`cargo test --workspace` 1191 passed / 0 failed; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo +nightly fmt --all -- --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governance proposal ratification with committee, DRep, and stake pool voting thresholds.
  * Added historical vote resolution, proposal ordering, and shadow-ratification checks.
  * Added governance state tracking for distributions, migration, dormancy, and committee authorization cleanup.
  * Added automatic handling for expired or invalid delegations and proposal outcomes.

* **Bug Fixes**
  * Corrected lineage tracking for legacy parameter proposals.
  * Improved proposal filtering and enactment behavior at epoch boundaries.

* **Tests**
  * Expanded coverage for voting, thresholds, enactment delays, expiries, serialization, and governance state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->