### PR TITLE
fix(cardano): clear a vote delegation only when the ledger cleared it

### DIFF
--- a/crates/cardano/src/ewrap/drops.rs
+++ b/crates/cardano/src/ewrap/drops.rs
@@ -36,22 +36,7 @@ impl super::BoundaryVisitor for BoundaryVisitor {
         }
 
         if let Some(drep) = account.delegated_drep_at(current_epoch) {
-            let mut should_drop = ctx.retiring_dreps.contains(drep);
-
-            // Check for reregistrations
-            if !should_drop {
-                if let Some((_, registered_at)) =
-                    ctx.reregistrating_dreps.iter().find(|(x, _)| x == drep)
-                {
-                    if let Some(vote_delegated_at) = account.vote_delegated_at {
-                        if vote_delegated_at < *registered_at {
-                            should_drop = true;
-                        }
-                    }
-                }
-            }
-
-            if should_drop {
+            if ctx.clears_drep_delegation(drep, account) {
                 self.change(DRepDelegatorDrop::new(id.clone(), current_epoch));
             }
         }

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -1637,8 +1637,8 @@ mod tests {
         match stored.drep.next() {
             Some(DRepDelegation::NotDelegated) => true,
             None => {
-                // not dropped: the live delegation is intact, which is what
-                // the account endpoint serves as `drep_id`
+                // the delegation this asserts intact is what the account
+                // endpoint serves as `drep_id`
                 assert_eq!(
                     stored.delegated_drep_at(CLOSING_EPOCH),
                     account.delegated_drep_at(CLOSING_EPOCH)
@@ -1669,7 +1669,6 @@ mod tests {
         let unregistered_at = closing_epoch_slot(&domain, 100);
         let reregistered_at = closing_epoch_slot(&domain, 200);
 
-        // deregistered and re-registered inside the closing epoch
         let cycled = replay_drep_certs(
             reg_drep(),
             &[
@@ -1679,7 +1678,6 @@ mod tests {
             ],
         );
 
-        // registered inside the closing epoch and never deregistered
         let registered = replay_drep_certs(fresh_drep(), &[Cert::Reg(reregistered_at, 0)]);
 
         // delegated before the unregistration: the ledger cleared it

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -58,7 +58,6 @@ impl BoundaryWork {
             retiring_pools: Default::default(),
             expiring_dreps: Default::default(),
             retiring_dreps: Default::default(),
-            reregistrating_dreps: Default::default(),
             num_dormant_epochs,
             gov_active_since,
             gov_distr,
@@ -285,7 +284,7 @@ impl BoundaryWork {
 
     /// Load + compute for a per-shard run of the close half:
     ///   * reload the small classifications that drops.visit_account needs
-    ///     (retiring_pools, retiring_dreps, reregistrating_dreps),
+    ///     (retiring_pools, retiring_dreps),
     ///   * range-load pending rewards for this shard's key range,
     ///   * iterate accounts in range, applying rewards+drops visitors and
     ///     accumulating the boundary stake distributions, and
@@ -300,9 +299,9 @@ impl BoundaryWork {
     ) -> Result<BoundaryWork, ChainError> {
         let mut boundary = Self::new_empty::<D>(state, genesis)?;
 
-        // drops.visit_account needs retiring_pools + retiring_dreps +
-        // reregistrating_dreps. These sets are small (handful per epoch) so
-        // re-classifying them per shard is cheap.
+        // drops.visit_account needs retiring_pools + retiring_dreps. These
+        // sets are small (handful per epoch) so re-classifying them per shard
+        // is cheap.
         boundary.load_pool_data::<D>(state)?;
         boundary.load_drep_data::<D>(state)?;
         boundary.detect_pv10_migration::<D>(state)?;
@@ -343,15 +342,17 @@ impl BoundaryWork {
 
                 // PV10 hard-fork migration (research §5.5 step 9): drop
                 // delegations pointing at DReps that are not registered
-                // at this boundary. Delegations to a DRep unregistering
-                // right now are already dropped by the drops visitor.
+                // at this boundary, unless the drops visitor is already
+                // dropping this one. A delegation made *after* the DRep's
+                // unregistration survives that visitor but is still dangling
+                // — the migration is what clears it.
                 if self.pv10_migration {
                     if let Some(drep) = account.delegated_drep_at(self.ending_state.number) {
                         let dangling = matches!(drep, DRep::Key(_) | DRep::Script(_))
                             && !self
                                 .snapshot_registered_dreps
                                 .contains(&drep_to_entity_key(drep))
-                            && !self.retiring_dreps.contains(drep);
+                            && !self.clears_drep_delegation(drep, &account);
 
                         if dangling {
                             migration_drops.push(crate::DRepDelegatorDrop::new(
@@ -496,14 +497,16 @@ impl BoundaryWork {
         Ok(())
     }
 
-    fn should_retire_drep(&self, drep: &DRepState) -> bool {
-        let Some((unregistered_at, _)) = drep.unregistered_at else {
-            return false;
-        };
+    /// The unregistration certificate this boundary acts on: the DRep's
+    /// latest one, when it falls in the closing epoch. Carried into
+    /// `retiring_dreps` so the drops visitor can tell which delegations
+    /// predate it — see [`BoundaryWork::clears_drep_delegation`].
+    fn is_retiring_drep(&self, drep: &DRepState) -> Option<(BlockSlot, TxOrder)> {
+        let unregistered_at = drep.unregistered_at?;
 
-        let (unregistered_epoch, _) = self.chain_summary.slot_epoch(unregistered_at);
+        let (unregistered_epoch, _) = self.chain_summary.slot_epoch(unregistered_at.0);
 
-        self.starting_epoch_no() == unregistered_epoch + 1
+        (self.starting_epoch_no() == unregistered_epoch + 1).then_some(unregistered_at)
     }
 
     fn should_expire_drep(&self, drep: &DRepState) -> Result<bool, ChainError> {
@@ -539,16 +542,6 @@ impl BoundaryWork {
         let expiring_epoch = last_activity_epoch + pparams.ensure_drep_inactivity_period()?;
 
         Ok(expiring_epoch <= self.starting_epoch_no())
-    }
-
-    fn is_reregistering_drep(&self, drep: &DRepState) -> Option<(BlockSlot, TxOrder)> {
-        let registered_at = drep.registered_at?;
-        let (registered_epoch, _) = self.chain_summary.slot_epoch(registered_at.0);
-
-        if self.starting_epoch_no() == registered_epoch + 1 {
-            return Some(registered_at);
-        }
-        None
     }
 
     /// Whether `drep` was registered as of the boundary the distribution
@@ -606,13 +599,10 @@ impl BoundaryWork {
                 }
             }
 
-            if self.should_retire_drep(&drep) {
-                self.retiring_dreps.push(drep.identifier);
+            if let Some(unregistered_at) = self.is_retiring_drep(&drep) {
+                self.retiring_dreps.push((drep.identifier, unregistered_at));
             } else if self.should_expire_drep(&drep)? {
-                self.expiring_dreps.push(drep.identifier.clone());
-            } else if let Some(registered_at) = self.is_reregistering_drep(&drep) {
-                self.reregistrating_dreps
-                    .push((drep.identifier.clone(), registered_at));
+                self.expiring_dreps.push(drep.identifier);
             }
         }
 
@@ -1188,8 +1178,8 @@ mod tests {
     use crate::{
         model::{credential_to_key, drep_to_entity_key},
         shard::shard_key_ranges,
-        AccountTransition, AssignRewards, ControlledAmountInc, DRepDelegation, EpochState,
-        EpochValue, PoolDelegation, SingletonEntity as _, Stake,
+        AccountTransition, AssignRewards, ControlledAmountInc, DRepDelegation, DRepRegistration,
+        DRepUnRegistration, EpochState, EpochValue, PoolDelegation, SingletonEntity as _, Stake,
     };
 
     /// Pins the rotation-timing assumption behind the distribution snapshot
@@ -1553,5 +1543,211 @@ mod tests {
         assert_eq!(read_drep_power(&domain, &reg_drep()), 147);
         assert_eq!(read_drep_power(&domain, &fresh_drep()), 0);
         assert_eq!(read_drep_power(&domain, &unreg_drep()), 0);
+    }
+
+    /// A DRep certificate, as the tests below replay it: the position it
+    /// lands at, and whether it registers or unregisters.
+    enum Cert {
+        Reg(BlockSlot, TxOrder),
+        UnReg(BlockSlot, TxOrder),
+    }
+
+    /// Build a DRep row by replaying `certs` through the real registration
+    /// deltas, so the stored `registered_at` / `unregistered_at` pair is
+    /// exactly what a chain replay leaves behind — in particular, each field
+    /// holding only the *latest* certificate of its kind.
+    fn replay_drep_certs(identifier: DRep, certs: &[Cert]) -> crate::DRepState {
+        let mut entity: Option<crate::DRepState> = None;
+
+        for cert in certs {
+            match cert {
+                Cert::Reg(slot, order) => {
+                    DRepRegistration::new(identifier.clone(), *slot, *order, 500, None)
+                        .apply(&mut entity)
+                }
+                Cert::UnReg(slot, order) => {
+                    DRepUnRegistration::new(identifier.clone(), *slot, *order).apply(&mut entity)
+                }
+            }
+        }
+
+        entity.expect("certs registered the drep")
+    }
+
+    fn delegator(
+        byte: u8,
+        drep: DRep,
+        vote_delegated_at: (BlockSlot, TxOrder),
+    ) -> crate::AccountState {
+        crate::AccountState {
+            vote_delegated_at: Some(vote_delegated_at),
+            ..snapshot_account(byte, 100, Some(drep), None)
+        }
+    }
+
+    /// Seed a ToyDomain standing at the closing epoch with nothing but the
+    /// given DRep rows and delegator accounts — no proposals, no rewards, so
+    /// the only deltas the shard pass produces for these accounts are the
+    /// delegation drops under test.
+    fn seed_delegation_domain(
+        dreps: &[crate::DRepState],
+        accounts: &[crate::AccountState],
+    ) -> ToyDomain {
+        let domain = ToyDomain::new(None, None);
+        let state = domain.state();
+
+        let mut epoch = crate::load_epoch::<ToyDomain>(state).unwrap();
+        epoch.number = CLOSING_EPOCH;
+
+        let writer = state.start_writer().unwrap();
+        writer
+            .write_entity_typed(&EpochState::singleton_key(), &epoch)
+            .unwrap();
+
+        for drep in dreps {
+            writer
+                .write_entity_typed(&drep_to_entity_key(&drep.identifier), drep)
+                .unwrap();
+        }
+
+        for account in accounts {
+            writer
+                .write_entity_typed(&credential_to_key(&account.credential), account)
+                .unwrap();
+        }
+
+        writer.commit().unwrap();
+
+        domain
+    }
+
+    /// Whether the boundary scheduled the account's delegation away. A drop
+    /// schedules `NotDelegated` for the opening epoch; an untouched account
+    /// has nothing scheduled and keeps serving its DRep.
+    fn delegation_dropped(domain: &ToyDomain, account: &crate::AccountState) -> bool {
+        let stored = domain
+            .state()
+            .read_entity_typed::<crate::AccountState>(
+                crate::AccountState::NS,
+                &credential_to_key(&account.credential),
+            )
+            .unwrap()
+            .expect("account row present");
+
+        match stored.drep.next() {
+            Some(DRepDelegation::NotDelegated) => true,
+            None => {
+                // not dropped: the live delegation is intact, which is what
+                // the account endpoint serves as `drep_id`
+                assert_eq!(
+                    stored.delegated_drep_at(CLOSING_EPOCH),
+                    account.delegated_drep_at(CLOSING_EPOCH)
+                );
+                false
+            }
+            other => panic!("unexpected scheduled delegation: {other:?}"),
+        }
+    }
+
+    fn closing_epoch_slot(domain: &ToyDomain, offset: BlockSlot) -> BlockSlot {
+        load_era_summary::<ToyDomain>(domain.state())
+            .unwrap()
+            .epoch_start(CLOSING_EPOCH)
+            + offset
+    }
+
+    /// The boundary sweep stands in for the ledger's `clearDRepDelegations`,
+    /// which runs at the unregistration certificate over the delegator set the
+    /// DRep holds *at that moment* (`ConwayUnRegDRep`, GovCert rule). So the
+    /// sweep must clear exactly the delegations that predate the certificate:
+    /// a later one was never in the set the ledger folded over, and a
+    /// registration — which starts the DRep over with an empty set — clears
+    /// nothing at all.
+    #[test]
+    fn boundary_clears_only_delegations_predating_the_unregistration() {
+        let domain = ToyDomain::new(None, None);
+        let unregistered_at = closing_epoch_slot(&domain, 100);
+        let reregistered_at = closing_epoch_slot(&domain, 200);
+
+        // deregistered and re-registered inside the closing epoch
+        let cycled = replay_drep_certs(
+            reg_drep(),
+            &[
+                Cert::Reg(closing_epoch_slot(&domain, 10), 0),
+                Cert::UnReg(unregistered_at, 0),
+                Cert::Reg(reregistered_at, 0),
+            ],
+        );
+
+        // registered inside the closing epoch and never deregistered
+        let registered = replay_drep_certs(fresh_drep(), &[Cert::Reg(reregistered_at, 0)]);
+
+        // delegated before the unregistration: the ledger cleared it
+        let before = delegator(0xa1, reg_drep(), (closing_epoch_slot(&domain, 50), 0));
+        // delegated after it, in a later block: the ledger never saw it
+        let after = delegator(0xb2, reg_drep(), (closing_epoch_slot(&domain, 300), 0));
+        // delegated in the very transaction that re-registered the DRep — the
+        // shape two of the four preprod cases have
+        let same_tx = delegator(0xc3, reg_drep(), (reregistered_at, 0));
+        // delegated long before a DRep that only ever registered: a
+        // registration clears no account state
+        let predates_registration =
+            delegator(0xd4, fresh_drep(), (closing_epoch_slot(&domain, 5), 0));
+
+        let accounts = [&before, &after, &same_tx, &predates_registration];
+        let domain = seed_delegation_domain(&[cycled, registered], &accounts.map(|x| x.clone()));
+
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+
+        assert!(delegation_dropped(&domain, &before));
+        assert!(!delegation_dropped(&domain, &after));
+        assert!(!delegation_dropped(&domain, &same_tx));
+        assert!(!delegation_dropped(&domain, &predates_registration));
+    }
+
+    /// `DRepState` keeps only the latest certificate of each kind, so a DRep
+    /// that cycles through registration several times inside one epoch is
+    /// indistinguishable from one that cycled once — and the predicate must
+    /// still cut at the *last* unregistration. The shape is the preprod
+    /// `drep1y2v8w5…` case: reg, dereg, reg, dereg, reg, then a delegation.
+    #[test]
+    fn repeated_registration_cycles_cut_at_the_last_unregistration() {
+        let domain = ToyDomain::new(None, None);
+        let first_unregistration = closing_epoch_slot(&domain, 20);
+        let last_unregistration = closing_epoch_slot(&domain, 40);
+
+        let cycled = replay_drep_certs(
+            reg_drep(),
+            &[
+                Cert::Reg(closing_epoch_slot(&domain, 10), 0),
+                Cert::UnReg(first_unregistration, 0),
+                Cert::Reg(closing_epoch_slot(&domain, 30), 0),
+                Cert::UnReg(last_unregistration, 0),
+                Cert::Reg(closing_epoch_slot(&domain, 50), 0),
+            ],
+        );
+
+        assert_eq!(cycled.unregistered_at, Some((last_unregistration, 0)));
+
+        // delegated before the first cycle
+        let oldest = delegator(0xa1, reg_drep(), (closing_epoch_slot(&domain, 5), 0));
+        // delegated between the two unregistrations: still in the set the
+        // last certificate folded over
+        let mid_cycle = delegator(0xb2, reg_drep(), (closing_epoch_slot(&domain, 35), 0));
+        // delegated after the last unregistration
+        let newest = delegator(0xc3, reg_drep(), (closing_epoch_slot(&domain, 60), 0));
+
+        let accounts = [&oldest, &mid_cycle, &newest];
+        let domain = seed_delegation_domain(&[cycled], &accounts.map(|x| x.clone()));
+
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+
+        assert!(delegation_dropped(&domain, &oldest));
+        assert!(delegation_dropped(&domain, &mid_cycle));
+        assert!(!delegation_dropped(&domain, &newest));
     }
 }

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -152,8 +152,14 @@ pub struct BoundaryWork {
     // TODO: we use a vec instead of a HashSet because the Pallas struct doesn't implement Hash. We
     // should turn it into a HashSet once we have the update in Pallas.
     pub expiring_dreps: Vec<DRep>,
-    pub retiring_dreps: Vec<DRep>,
-    pub reregistrating_dreps: Vec<(DRep, (BlockSlot, TxOrder))>,
+
+    /// DReps whose latest unregistration certificate falls in the closing
+    /// epoch, each carrying the position of that certificate. The boundary
+    /// sweep runs the ledger's `clearDRepDelegations` late, so it needs the
+    /// certificate's position to reconstruct the delegator set the ledger
+    /// would have seen at cert time — see
+    /// [`BoundaryWork::clears_drep_delegation`].
+    pub retiring_dreps: Vec<(DRep, (BlockSlot, TxOrder))>,
 
     /// `GovState::num_dormant_epochs` at the boundary. Stored DRep expiries
     /// carry no dormancy credit, so the expiry check adds the counter back
@@ -259,5 +265,29 @@ impl BoundaryWork {
 
     pub fn add_delta(&mut self, delta: impl Into<CardanoDelta>) {
         self.deltas.add_for_entity(delta);
+    }
+
+    /// Whether this boundary clears `account`'s vote delegation to `drep`.
+    ///
+    /// The ledger clears delegations at the unregistration certificate
+    /// (`ConwayUnRegDRep` folding `clearDRepDelegations` over the delegator
+    /// set the DRep holds at that moment), and a later re-registration starts
+    /// the DRep over with an empty set, clearing nothing. Dolos has no reverse
+    /// delegator index on `DRepState`, so it cannot enumerate that set at cert
+    /// time and defers the clear to this boundary; comparing the delegation's
+    /// position against the certificate's reproduces the set the ledger saw.
+    ///
+    /// `unregistered_at` always holds the *latest* unregistration, so this is
+    /// correct under repeated dereg/rereg cycles inside one epoch: only
+    /// delegations predating the last certificate are cleared. A registration
+    /// on its own never clears anything.
+    pub fn clears_drep_delegation(&self, drep: &DRep, account: &AccountState) -> bool {
+        let Some((_, unregistered_at)) = self.retiring_dreps.iter().find(|(x, _)| x == drep) else {
+            return false;
+        };
+
+        account
+            .vote_delegated_at
+            .is_some_and(|delegated_at| delegated_at < *unregistered_at)
     }
 }


### PR DESCRIPTION
Repairs the defect surfaced as Finding 2 on #1212: a vote delegation is
destroyed when its target DRep re-registers. Plan:
`plans/dolos-governance-drep-delegation-drops.md`.

## The defect

The ledger clears vote delegations **at the unregistration certificate**, over
the delegator set the DRep holds *at that moment*
(`ConwayUnRegDRep` folding `clearDRepDelegations` over `drepDelegs`,
`Cardano/Ledger/Conway/Rules/GovCert.hs`). A subsequent `ConwayRegDRep` starts
the DRep over with `drepDelegs = mempty` and clears nothing on any account.

Dolos cannot enumerate delegators at cert time — `DRepState` carries no reverse
`drepDelegs` index — so it defers the clear to the next epoch boundary and
applied it to whoever was delegating *then*. Two consequences, both live:

1. Any delegation made after the unregistration certificate but before the
   epoch boundary was swept up, though the ledger never touched it.
2. `should_retire_drep` read `unregistered_at` alone, with no check for a later
   `registered_at`, so a DRep that deregisters and re-registers inside one
   epoch was classified as retiring and `DRepDelegatorDrop` fired for every one
   of its delegators. That delta schedules `NotDelegated`, **erasing the
   delegation record** rather than suppressing its weight — which is why the
   affected accounts also served `drep_id: null`.

A second branch, `is_reregistering_drep`, dropped delegators whose
`vote_delegated_at` predated a *registration*. It has no counterpart in the
ledger at all — registration clears no account state — and is removed here.

## The fix

Keep the boundary sweep, but make its predicate reproduce the cert-time set.
`retiring_dreps` now carries the unregistration's `(BlockSlot, TxOrder)`
alongside the DRep, and `BoundaryWork::clears_drep_delegation` drops an account
only when `vote_delegated_at < unregistered_at`. Because
`DRepUnRegistration::apply` overwrites `unregistered_at` with the latest
certificate, this is correct under repeated dereg/rereg cycles inside one
epoch, which makes the missing supersession check in (2) unnecessary rather
than merely fixed. Both fields are `(BlockSlot, TxOrder)`, so the comparison is
exact within a block; an account with no `vote_delegated_at` is never dropped.

A reverse `drepDelegs` index on `DRepState` would be the faithful model, but it
is a new field, a new delta per delegation, and unbounded per-DRep growth —
out of proportion to the defect. The cert-time predicate is observationally
equivalent for every case reachable on chain, because `vote_delegated_at`
records the delegation's exact position.

`expiring_dreps` is untouched: expiry does not clear delegations in the ledger
either, and dolos already models it as a `DRepState`-only effect. The pool leg
(`PoolDelegatorRetire` / `should_retire_pool`) looks symmetric but is not —
pool retirement genuinely is a boundary operation (POOLREAP) — and is left
alone.

The PV10 migration guard moves from "is this DRep retiring" to the same
predicate: a delegation made *after* the DRep's unregistration now survives the
drops visitor, but it is still dangling, so the migration is what clears it.

## Verification

Unit tests (both fail against the previous predicate):

- `boundary_clears_only_delegations_predating_the_unregistration` — a
  delegation recorded after the unregistration in the same closing epoch
  survives, one recorded before it does not, one recorded in the very
  transaction that re-registered survives, and a DRep registration alone drops
  nothing.
- `repeated_registration_cycles_cut_at_the_last_unregistration` — reg, dereg,
  reg, dereg, reg inside one epoch (the preprod `drep1y2v8w5…` shape), replayed
  through the real `DRepRegistration` / `DRepUnRegistration` deltas so the
  stored row is what a chain replay leaves.

`cargo test`, `cargo clippy --all-targets --all-features -- -D warnings` and
`cargo +nightly fmt --all -- --check` all pass.

### Preprod re-sync from scratch

A preprod instance was synced from genesis on this branch — every block
replayed from the Mithril immutable DB (raw blocks, no ledger snapshot), so
every boundary that wiped these accounts, back to epoch 176, is re-processed.
The node stands in **epoch 307** (slot 131047178; wal, archive, state and index
all at that tip).

**Every DRep matches db-sync.** All 183 non-pseudo DReps in Koios preprod
`drep_history` for epoch 307 match `DRepState.voting_power` exactly — 183/183,
no mismatches, no residue. On the same comparison before this change the rate
was 176/180 (97.78 %).

The four DReps traced in the plan, all previously short:

| DRep | before | now = Koios 307 |
|---|---:|---:|
| `drep1y2v8w544v5teexvycd6zqgh2686yz7050tdv834yegpt0gsnampev` | 229,080,329,181 | 3,164,339,145,336 |
| `drep1ytett72fzlmudmq55sn95lm5qcks3ekmwpzq5czfswtustqkxs77v` | 0 | 9,497,460,993 |
| `drep1yf58yyq70kh5pwnmll80pcgyjzml45az4n2c7pfffd7gxng24wp2s` | 0 | 8,614,076,283 |
| `drep1yf4gftmrr8kjk5l2vk7kh5lumy66ck54ru7az0klmmgg77qfp67se` | 19,985,949,310 | 20,382,867,204 |

(The "before" column is the plan's measurement against Koios epoch 306; the
"now" column is epoch 307, so the totals differ by ordinary epoch drift as well
as by the repair.)

**The delegation records are back.** Every delegator Koios lists for those four
DReps now serves the right `drep_id` through `GET /accounts/{stake_address}` —
including the accounts whose record used to be erased, e.g.
`stake_test1ur8k3jnuy9dgmptlzl73g6u5yeax2yh79s8wmdyk0rt4lygf5yrq7`
(2,935,121,946,254, the bulk of the first DRep's shortfall) and
`stake_test1urpwxtn2k7r6v3nkpjehverz2mde8cgkuwp5p8njruneewgzlf4t8`, whose
delegation was recorded in the very transaction that re-registered its DRep.

**`dolos data check` is clean** on that instance — cursors, archive-continuity,
account-epochs, epoch-log and totals (the delegation-referent scan): 0 issues.

## Known limitation

Existing state cannot be repaired forward: the delegation record is destroyed,
not mis-read, so no forward pass recovers it. Every already-synced instance —
and every published v3 snapshot restored from one — carries accounts whose
delegation was erased, and only a replay of the affected boundary corrects
them. Whether the published stelae are re-cut, and on what schedule, is a
separate operational call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DRep delegations during unregistration and re-registration cycles.
  * Delegations are now cleared consistently based on certificate timing.
  * Improved migration behavior for delegations affected by DRep status changes.
  * Prevented outdated delegations from persisting after relevant DRep status changes.

* **Tests**
  * Added coverage for delegation clearing before, after, and across repeated DRep registration cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->