### PR TITLE
chore(minibf): blockfrost-openapi 0.1.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-openapi"
-version = "0.1.90"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0b9855f3d7df80f7fa76403dcc5d1d6b3f6904f349662cd89e71065470a9e2"
+checksum = "baaf3130c1ec8d5680aeda15e847ba6c109cc31a83f2aa293465b160992f9853"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/minibf/Cargo.toml
+++ b/crates/minibf/Cargo.toml
@@ -25,7 +25,7 @@ dolos-cardano = { path = "../cardano" }
 axum = { version = "0.8.4", features = ["macros"] }
 base58 = "0.2.0"
 bech32 = "0.11.0"
-blockfrost-openapi = "=0.1.90"
+blockfrost-openapi = "=0.1.91"
 crc = "3.3.0"
 futures = "0.3.31"
 hex = "0.4.3"


### PR DESCRIPTION
Resolves #1224.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Blockfrost API integration dependency to the latest available patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->