### PR TITLE
fix(cardano): move the pots when a treasury withdrawal enacts

### DIFF
--- a/crates/cardano/src/estart/reset.rs
+++ b/crates/cardano/src/estart/reset.rs
@@ -32,6 +32,7 @@ pub fn define_new_pots(ctx: &super::WorkContext) -> Pots {
         // Rolling stats contain total from MIR certificates, which includes unregistered accounts
         reserve_mirs: end.reserve_mirs,
         treasury_mirs: end.treasury_mirs,
+        treasury_withdrawals: end.treasury_withdrawals,
         proposal_refunds: end.proposal_refunds,
         proposal_invalid_refunds: end.proposal_invalid_refunds,
         effective_rewards: end.effective_rewards,
@@ -69,6 +70,8 @@ pub fn define_new_pots(ctx: &super::WorkContext) -> Pots {
         effective_treasury_mirs = end.treasury_mirs,
         invalid_reserve_mirs = end.invalid_reserve_mirs,
         invalid_treasury_mirs = end.invalid_treasury_mirs,
+        treasury_withdrawals = end.treasury_withdrawals,
+        invalid_treasury_withdrawals = end.invalid_treasury_withdrawals,
         pool_invalid_refund_count = end.pool_invalid_refund_count,
         proposal_invalid_refunds = end.proposal_invalid_refunds,
         treasury_donations = rolling.treasury_donations,

--- a/crates/cardano/src/ewrap/enactment.rs
+++ b/crates/cardano/src/ewrap/enactment.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
+
 use dolos_core::{ChainError, EntityKey};
-use pallas::ledger::primitives::conway::GovActionId;
+use pallas::ledger::primitives::{conway::GovActionId, StakeCredential};
 
 use crate::{
     ewrap::{BoundaryWork, ProposalId},
@@ -19,8 +21,16 @@ pub struct BoundaryVisitor {
 /// new root.
 ///
 /// Kept apart from the visitor so the mapping is exercisable on its own —
-/// none of it depends on boundary context.
-pub(crate) fn enactment_deltas(id: &ProposalId, proposal: &ProposalState) -> Vec<CardanoDelta> {
+/// none of it depends on boundary context. `deliverable_withdrawal_targets`
+/// is the boundary's ruling on which withdrawal credentials can receive
+/// their credit (registered at the boundary): the ledger's
+/// `applyEnactedWithdrawals` restricts the enacted withdrawal map to the
+/// rewards UMap and discards the rest, so no delta is emitted for them.
+pub(crate) fn enactment_deltas(
+    id: &ProposalId,
+    proposal: &ProposalState,
+    deliverable_withdrawal_targets: &HashSet<StakeCredential>,
+) -> Vec<CardanoDelta> {
     let mut deltas: Vec<CardanoDelta> = Vec::new();
 
     match &proposal.action {
@@ -34,7 +44,9 @@ pub(crate) fn enactment_deltas(id: &ProposalId, proposal: &ProposalState) -> Vec
         }
         ProposalAction::TreasuryWithdrawal(withdrawals) => {
             for (credential, amount) in withdrawals {
-                deltas.push(TreasuryWithdrawal::new(credential.clone(), *amount).into());
+                if deliverable_withdrawal_targets.contains(credential) {
+                    deltas.push(TreasuryWithdrawal::new(credential.clone(), *amount).into());
+                }
             }
         }
         ProposalAction::NoConfidence => {
@@ -100,14 +112,35 @@ pub(crate) fn enactment_deltas(id: &ProposalId, proposal: &ProposalState) -> Vec
 impl super::BoundaryVisitor for BoundaryVisitor {
     fn visit_enacting_proposal(
         &mut self,
-        _: &mut BoundaryWork,
+        ctx: &mut BoundaryWork,
         id: &ProposalId,
         proposal: &ProposalState,
         _: Option<&AccountState>,
     ) -> Result<(), ChainError> {
         tracing::debug!(proposal=%id, "visiting enacted proposal");
 
-        self.deltas.extend(enactment_deltas(id, proposal));
+        if let ProposalAction::TreasuryWithdrawal(withdrawals) = &proposal.action {
+            for (credential, amount) in withdrawals {
+                if ctx.deliverable_withdrawal_targets.contains(credential) {
+                    ctx.effective_treasury_withdrawals += amount;
+                } else {
+                    ctx.invalid_treasury_withdrawals += amount;
+
+                    tracing::warn!(
+                        proposal=%id,
+                        credential=?credential,
+                        %amount,
+                        "treasury withdrawal not applied (unregistered account) - stays in treasury"
+                    );
+                }
+            }
+        }
+
+        self.deltas.extend(enactment_deltas(
+            id,
+            proposal,
+            &ctx.deliverable_withdrawal_targets,
+        ));
 
         Ok(())
     }
@@ -210,7 +243,7 @@ mod tests {
             "the action's shape alone would claim a tree"
         );
 
-        let deltas = enactment_deltas(&id, &legacy);
+        let deltas = enactment_deltas(&id, &legacy, &HashSet::new());
 
         assert!(
             deltas
@@ -229,7 +262,7 @@ mod tests {
         let mut conway = proposal([9u8; 32].into(), 0, action);
         conway.purpose = Some(GovPurpose::PParamUpdate);
 
-        let deltas = enactment_deltas(&id, &conway);
+        let deltas = enactment_deltas(&id, &conway, &HashSet::new());
 
         assert!(
             deltas
@@ -237,6 +270,37 @@ mod tests {
                 .any(|delta| matches!(delta, CardanoDelta::GovRootsUpdate(_))),
             "a Conway action must claim its lineage root"
         );
+    }
+
+    /// A withdrawal credential outside the deliverable set gets no
+    /// per-account delta — the ledger's `applyEnactedWithdrawals` discards
+    /// withdrawals to credentials absent from the rewards UMap, so neither
+    /// the account nor the pots move for them.
+    #[test]
+    fn undeliverable_withdrawal_emits_no_account_delta() {
+        let registered = StakeCredential::AddrKeyhash([1u8; 28].into());
+        let unregistered = StakeCredential::AddrKeyhash([2u8; 28].into());
+
+        let action = ProposalAction::TreasuryWithdrawal(vec![
+            (registered.clone(), 3_000_000),
+            (unregistered.clone(), 5_000_000),
+        ]);
+
+        let id = ProposalId::from(b"withdrawal".to_vec());
+        let row = proposal([3u8; 32].into(), 0, action);
+
+        let deliverable = HashSet::from([registered.clone()]);
+        let deltas = enactment_deltas(&id, &row, &deliverable);
+
+        let credited: Vec<_> = deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                CardanoDelta::TreasuryWithdrawal(w) => Some((w.account.clone(), w.amount)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(credited, vec![(registered, 3_000_000)]);
     }
 
     /// Every governance action a Conway chain can carry has an enactment
@@ -278,12 +342,14 @@ mod tests {
             (ProposalAction::Info, None),
         ];
 
+        let deliverable = HashSet::from([cred.clone()]);
+
         for (action, purpose) in cases {
             let is_info = matches!(action, ProposalAction::Info);
             let id = ProposalId::from(b"proposal".to_vec());
             let mut row = proposal([7u8; 32].into(), 0, action.clone());
             row.purpose = purpose;
-            let deltas = enactment_deltas(&id, &row);
+            let deltas = enactment_deltas(&id, &row, &deliverable);
 
             let roots = deltas
                 .iter()
@@ -358,7 +424,7 @@ mod tests {
             },
         );
         row.purpose = Some(GovPurpose::Constitution);
-        state = apply_gov(state, enactment_deltas(&id, &row));
+        state = apply_gov(state, enactment_deltas(&id, &row, &HashSet::new()));
 
         let id = ProposalId::from(committee_tx.to_vec());
         let mut row = proposal(
@@ -371,7 +437,7 @@ mod tests {
             },
         );
         row.purpose = Some(GovPurpose::Committee);
-        state = apply_gov(state, enactment_deltas(&id, &row));
+        state = apply_gov(state, enactment_deltas(&id, &row, &HashSet::new()));
 
         assert_eq!(state.constitution, Some(enacted_constitution));
         assert_ne!(state.constitution, Some(constitution));

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -30,7 +30,7 @@ use crate::{
     roll::WorkDeltas,
     rupd::credential_to_key,
     AccountState, DRepState, EraProtocol, FixedNamespace as _, PendingMirState, PendingRewardState,
-    PoolHash, PoolState, ProposalOutcome, ProposalState,
+    PoolHash, PoolState, ProposalAction, ProposalOutcome, ProposalState,
 };
 
 impl BoundaryWork {
@@ -76,6 +76,9 @@ impl BoundaryWork {
             logs: Default::default(),
             applied_reward_credentials: Default::default(),
             applied_rewards: Default::default(),
+            deliverable_withdrawal_targets: Default::default(),
+            effective_treasury_withdrawals: 0,
+            invalid_treasury_withdrawals: 0,
             effective_treasury_mirs: 0,
             effective_reserve_mirs: 0,
             invalid_treasury_mirs: 0,
@@ -656,6 +659,29 @@ impl BoundaryWork {
         Ok(account)
     }
 
+    /// Record which target credentials of an enacting treasury withdrawal
+    /// can receive the credit. The ledger's `applyEnactedWithdrawals`
+    /// restricts the enacted withdrawal map to credentials present in the
+    /// rewards UMap — accounts registered at the boundary — and discards
+    /// the rest: no account credit and no pot movement.
+    fn load_withdrawal_targets<D: Domain>(
+        &mut self,
+        state: &D::State,
+        withdrawals: &[(StakeCredential, u64)],
+    ) -> Result<(), ChainError> {
+        for (credential, _) in withdrawals {
+            let account: Option<AccountState> =
+                state.read_entity_typed(AccountState::NS, &credential_to_key(credential))?;
+
+            if account.is_some_and(|account| account.is_registered()) {
+                self.deliverable_withdrawal_targets
+                    .insert(credential.clone());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Split the boundary's removals into the two sets the visitors take:
     /// the accepted actions, whose effects enact, and everything else the
     /// boundary drops. Both refund their deposit; only the first changes
@@ -686,6 +712,10 @@ impl BoundaryWork {
 
             match outcome {
                 ProposalOutcome::Enacted => {
+                    if let ProposalAction::TreasuryWithdrawal(withdrawals) = &proposal.action {
+                        self.load_withdrawal_targets::<D>(state, withdrawals)?;
+                    }
+
                     self.enacting_proposals.insert(id, (proposal, account));
                 }
                 ProposalOutcome::Expired | ProposalOutcome::PrunedSibling => {
@@ -2163,7 +2193,12 @@ mod ratification_tests {
         epoch.number = CLOSING;
         let pparams = conway_pparams(epoch.pparams.unwrap_live());
         epoch.pparams = EpochValue::from_parts(CLOSING, Some(pparams), None, None, None, None);
+        let rolling = epoch.rolling.unwrap_live().clone();
+        epoch.rolling = EpochValue::from_parts(CLOSING, Some(rolling), None, None, None, None);
         epoch.initial_pots.treasury = TREASURY;
+        // every live proposal's deposit is held by the deposits pot, which
+        // funds the refunds the boundary pays out
+        epoch.initial_pots.proposal_deposits = DEPOSIT * proposals.len() as u64;
 
         let mut gov = crate::load_gov::<ToyDomain>(state).unwrap();
         gov.active_since = Some(0);
@@ -2189,6 +2224,44 @@ mod ratification_tests {
         writer
             .write_entity_typed(&GovState::singleton_key(), &gov)
             .unwrap();
+
+        // the devnet bootstrap leaves its accounts and pools positioned at
+        // epoch 0; the boundary under test rotates every entity into
+        // CLOSING + 1 and the strict transition refuses a jump, so reseat
+        // them at the closing epoch
+        let bootstrapped_accounts: Vec<_> = state
+            .iter_entities_typed::<crate::AccountState>(crate::AccountState::NS, None)
+            .unwrap()
+            .map(|record| record.unwrap())
+            .collect();
+
+        for (key, mut row) in bootstrapped_accounts {
+            row.stake =
+                EpochValue::from_parts(CLOSING, row.stake.live().cloned(), None, None, None, None);
+            row.pool =
+                EpochValue::from_parts(CLOSING, row.pool.live().cloned(), None, None, None, None);
+            row.drep =
+                EpochValue::from_parts(CLOSING, row.drep.live().cloned(), None, None, None, None);
+            writer.write_entity_typed(&key, &row).unwrap();
+        }
+
+        let bootstrapped_pools: Vec<_> = state
+            .iter_entities_typed::<PoolState>(PoolState::NS, None)
+            .unwrap()
+            .map(|record| record.unwrap())
+            .collect();
+
+        for (key, mut row) in bootstrapped_pools {
+            row.snapshot = EpochValue::from_parts(
+                CLOSING,
+                row.snapshot.live().cloned(),
+                None,
+                None,
+                None,
+                None,
+            );
+            writer.write_entity_typed(&key, &row).unwrap();
+        }
 
         let drep_row = crate::DRepState {
             registered_at: Some((0, 0)),
@@ -2285,6 +2358,90 @@ mod ratification_tests {
         assert_eq!(live.ratified_epoch, None);
         assert_eq!(live.canceled_epoch, None);
         assert!(live.is_unresolved_at_close(CLOSING + 1));
+    }
+
+    /// An enacted treasury withdrawal moves the pot pair across the
+    /// boundary: `pots.treasury` is debited and `pots.rewards` credited by
+    /// the effective amount — the enacted deposit's refund rides along on
+    /// the rewards side, funded by the deposits pot — and
+    /// `Pots::is_consistent()` holds over the transition. Before the fix
+    /// the per-account credit landed while both pots stood still, leaving
+    /// treasury long and rewards short by exactly the enacted total (the
+    /// mainnet divergence-B signature).
+    #[test]
+    fn enacted_withdrawal_moves_pots_across_the_boundary() {
+        let accepted = withdrawal(0x01, Some(Vote::Yes), CLOSING + 10);
+
+        let domain = seed(&[accepted]);
+
+        let before = crate::load_epoch::<ToyDomain>(domain.state()).unwrap();
+        let max_supply = before.initial_pots.max_supply();
+
+        // EWRAP: the boundary rules, enacts, and stamps the end stats
+        let boundary = finalize(&domain);
+
+        assert_eq!(boundary.effective_treasury_withdrawals, WITHDRAWAL);
+        assert_eq!(boundary.invalid_treasury_withdrawals, 0);
+
+        let wrapped = crate::load_epoch::<ToyDomain>(domain.state()).unwrap();
+        let end = wrapped.end.as_ref().expect("EWRAP stamped end stats");
+        assert_eq!(end.treasury_withdrawals, WITHDRAWAL);
+        assert_eq!(end.invalid_treasury_withdrawals, 0);
+
+        // the beneficiary's live stake got the withdrawal credit (the
+        // deposit refund is scheduled for the opening epoch instead)
+        let account = domain
+            .state()
+            .read_entity_typed::<crate::AccountState>(
+                crate::AccountState::NS,
+                &credential_to_key(&beneficiary()),
+            )
+            .unwrap()
+            .expect("beneficiary row present");
+        assert_eq!(account.stake.unwrap_live().rewards_sum, WITHDRAWAL);
+
+        // ESTART: one account shard, then the finalize pass applying the
+        // epoch transition that carries the new pots
+        let ranges = crate::shard::shard_key_ranges(0, 1);
+        let mut shard = crate::estart::WorkContext::load_shard::<ToyDomain>(
+            domain.state(),
+            domain.genesis(),
+            0,
+            0,
+            1,
+            ranges.clone(),
+        )
+        .unwrap();
+        shard
+            .commit_shard::<ToyDomain>(domain.state(), domain.archive(), ranges)
+            .unwrap();
+
+        let mut estart = crate::estart::WorkContext::load_finalize::<ToyDomain>(
+            domain.state(),
+            domain.genesis(),
+        )
+        .unwrap();
+        let slot = estart.chain_summary.epoch_start(estart.starting_epoch_no());
+        estart
+            .commit_finalize::<ToyDomain>(domain.state(), domain.archive(), slot)
+            .unwrap();
+
+        let after = crate::load_epoch::<ToyDomain>(domain.state()).unwrap();
+
+        assert_eq!(after.number, CLOSING + 1);
+        assert_eq!(
+            after.initial_pots.treasury,
+            before.initial_pots.treasury - WITHDRAWAL
+        );
+        assert_eq!(
+            after.initial_pots.rewards,
+            before.initial_pots.rewards + WITHDRAWAL + DEPOSIT
+        );
+        assert_eq!(
+            after.initial_pots.proposal_deposits,
+            before.initial_pots.proposal_deposits - DEPOSIT
+        );
+        assert!(after.initial_pots.is_consistent(max_supply));
     }
 
     /// An action submitted *during* the closing epoch cannot ratify at

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -248,6 +248,21 @@ pub struct BoundaryWork {
     /// commit so callers can observe what was credited.
     pub applied_rewards: Vec<AppliedReward>,
 
+    /// Withdrawal target credentials of enacting `TreasuryWithdrawal`
+    /// proposals that can receive the credit — registered at the boundary,
+    /// as the ledger's `applyEnactedWithdrawals` restricts the enacted
+    /// withdrawal map to the rewards UMap and discards the rest.
+    pub deliverable_withdrawal_targets: HashSet<StakeCredential>,
+
+    /// Enacted treasury withdrawals delivered to registered accounts
+    /// (moved treasury → rewards at the boundary).
+    pub effective_treasury_withdrawals: u64,
+
+    /// Enacted treasury withdrawals whose target account cannot receive
+    /// them (unregistered at the boundary) — discarded, the value stays
+    /// in treasury.
+    pub invalid_treasury_withdrawals: u64,
+
     /// Effective MIRs from treasury (applied to registered accounts).
     pub effective_treasury_mirs: u64,
 

--- a/crates/cardano/src/ewrap/wrapup.rs
+++ b/crates/cardano/src/ewrap/wrapup.rs
@@ -110,6 +110,8 @@ fn define_end_stats(ctx: &super::BoundaryWork) -> EndStats {
         reserve_mirs,
         invalid_treasury_mirs,
         invalid_reserve_mirs,
+        treasury_withdrawals: ctx.effective_treasury_withdrawals,
+        invalid_treasury_withdrawals: ctx.invalid_treasury_withdrawals,
         proposal_refunds: proposal_valid_refunds,
         proposal_invalid_refunds,
         // TODO: deprecate

--- a/crates/cardano/src/model/epochs.rs
+++ b/crates/cardano/src/model/epochs.rs
@@ -220,6 +220,19 @@ pub struct EndStats {
     #[cbor(default)]
     pub invalid_reserve_mirs: Lovelace,
 
+    /// Treasury withdrawals enacted by governance at the boundary and
+    /// delivered to registered accounts (moved treasury → rewards).
+    #[n(15)]
+    #[cbor(default)]
+    pub treasury_withdrawals: Lovelace,
+
+    /// Enacted treasury withdrawals whose target account cannot receive
+    /// them (unregistered at the boundary) — discarded, the value stays
+    /// in treasury.
+    #[n(16)]
+    #[cbor(default)]
+    pub invalid_treasury_withdrawals: Lovelace,
+
     #[n(6)]
     pub proposal_invalid_refunds: Lovelace,
 
@@ -411,6 +424,8 @@ pub(crate) mod testing {
                 reserve_mirs: 0,
                 invalid_treasury_mirs: 0,
                 invalid_reserve_mirs: 0,
+                treasury_withdrawals: 0,
+                invalid_treasury_withdrawals: 0,
                 proposal_invalid_refunds: 0,
                 proposal_refunds: 0,
                 __drep_deposits: 0,

--- a/crates/cardano/src/pots.rs
+++ b/crates/cardano/src/pots.rs
@@ -183,6 +183,12 @@ pub struct PotDelta {
     #[n(24)]
     #[cbor(default)]
     pub treasury_mirs: Lovelace,
+
+    /// Treasury withdrawals enacted by governance at this boundary,
+    /// restricted to the amounts delivered to registered accounts.
+    #[n(25)]
+    #[cbor(default)]
+    pub treasury_withdrawals: Lovelace,
 }
 
 impl PotDelta {
@@ -213,6 +219,7 @@ impl PotDelta {
             deposit_per_pool: None,
             avvm_reclamation: 0,
             treasury_mirs: 0,
+            treasury_withdrawals: 0,
         }
     }
 
@@ -392,6 +399,7 @@ pub fn apply_shelley_delta(mut pots: Pots, incentives: &EpochIncentives, delta: 
     pots.treasury = add!(pots.treasury, delta.proposal_invalid_refunds);
     pots.treasury = add!(pots.treasury, delta.treasury_donations);
     pots.treasury = sub!(pots.treasury, delta.treasury_mirs);
+    pots.treasury = sub!(pots.treasury, delta.treasury_withdrawals);
 
     // fees pot
     pots.fees = sub!(pots.fees, incentives.used_fees);
@@ -407,6 +415,7 @@ pub fn apply_shelley_delta(mut pots: Pots, incentives: &EpochIncentives, delta: 
     pots.rewards = add!(pots.rewards, delta.proposal_refunds);
     pots.rewards = add!(pots.rewards, delta.reserve_mirs);
     pots.rewards = add!(pots.rewards, delta.treasury_mirs);
+    pots.rewards = add!(pots.rewards, delta.treasury_withdrawals);
 
     // we don't need to return account deposit refunds to the rewards pot because
     // these refunds are returned directly as utxos in the deregistration
@@ -636,6 +645,48 @@ mod tests {
         assert_eq!(pots.obligations(), 1506000000);
         assert_eq!(pots.utxos, 29999998492845396);
         assert_eq!(pots.rewards, 0);
+    }
+
+    /// An enacted treasury withdrawal moves value from the treasury pot to
+    /// the rewards pot — the same pair the treasury MIR moves — and total
+    /// supply is conserved.
+    #[test]
+    fn treasury_withdrawal_moves_treasury_to_rewards() {
+        let pots = Pots {
+            reserves: 8_000_000_000_000_000,
+            treasury: 1_000_000_000_000_000,
+            fees: 0,
+            utxos: 35_999_000_000_000_000,
+            rewards: 1_000_000_000_000,
+            pool_count: 0,
+            account_count: 0,
+            deposit_per_pool: 0,
+            deposit_per_account: 0,
+            nominal_deposits: 0,
+            drep_deposits: 0,
+            proposal_deposits: 0,
+        };
+
+        assert!(pots.is_consistent(MAX_SUPPLY));
+
+        let withdrawal = 649_764_674_000_000;
+
+        let delta = PotDelta {
+            treasury_withdrawals: withdrawal,
+            ..PotDelta::neutral(10, 10)
+        };
+
+        let incentives = EpochIncentives::default();
+
+        let after = apply_delta(pots.clone(), &incentives, &delta);
+
+        assert!(after.is_consistent(MAX_SUPPLY));
+
+        assert_eq!(after.treasury, pots.treasury - withdrawal);
+        assert_eq!(after.rewards, pots.rewards + withdrawal);
+        assert_eq!(after.reserves, pots.reserves);
+        assert_eq!(after.utxos, pots.utxos);
+        assert_eq!(after.fees, pots.fees);
     }
 
     // TODO: add property based testing that ensures that the pots are


### PR DESCRIPTION
## Plan

`plans/dolos-governance-treasury-withdrawal-pots.md` — divergence **B** of the mainnet governance oracle replay (the plan was renamed when divergence **A** was carved into `plans/dolos-governance-drep-snapshot-timing.md`): dolos held in `treasury` what db-sync held in `rewards`, off by exactly 649,764,674,000,000 lovelace — the sum of every `TreasuryWithdrawal` enacted at or before epoch 645.

## Code read: confirmed

The plan's reading holds on `main`:

- `ewrap/enactment.rs` — enacting a `TreasuryWithdrawal` emitted one per-account delta per `(credential, amount)` and nothing else.
- `model/accounts.rs` — that delta's `apply` does exactly one thing: credit `stake.rewards_sum`. Per-account value lands, which is why the 17 mainnet recipients reconcile individually.
- `pots.rs` — `PotDelta` had **no field** for enacted withdrawals, so `apply_shelley_delta` never debited `pots.treasury` nor credited `pots.rewards`. Later transaction withdrawals subtract from `pots.rewards`, so the miss shows as rewards short / treasury long by exactly the enacted total.

Two additions to the read, found while implementing:

1. **The effective split is real, and it is MIR-shaped.** The ledger's `applyEnactedWithdrawals` domain-restricts the enacted withdrawal map to credentials present in the rewards UMap — i.e. registered at the boundary — and **discards** the rest: no account credit and no pot movement. Dolos previously credited any existing account row unconditionally (registered or not) and **panicked** (`expect("existing account")`) on a credential with no account row at all. Both are fixed by the same gate.
2. The enacted proposal's deposit refund is scheduled for the opening epoch (`scheduled_or_default`), while the withdrawal credit lands on the live position — noted here because the harness test pins both.

## What changed

Mirrors the `treasury_mirs` pair in the same four places:

- `ewrap/loading.rs` — the finalize pass records which withdrawal targets are registered at the boundary (`deliverable_withdrawal_targets`), read at proposal-classification time like the MIR registration check.
- `ewrap/enactment.rs` — `enactment_deltas` only emits per-account credits for deliverable targets; the visitor accumulates `effective_treasury_withdrawals` / `invalid_treasury_withdrawals` on the boundary work, warning on each discard.
- `model/epochs.rs` — `EndStats` carries `treasury_withdrawals` (`#[n(15)]`) and `invalid_treasury_withdrawals` (`#[n(16)]`), both `#[cbor(default)]` so pre-fix rows decode.
- `pots.rs` + `estart/reset.rs` — `PotDelta.treasury_withdrawals` (`#[n(25)]`, `#[cbor(default)]`), wired from `EndStats`; `apply_shelley_delta` subtracts it from `pots.treasury` and adds it to `pots.rewards`. Byron is unaffected (`apply_byron_delta` zeroes both pots).

## Tests

- `pots::tests::treasury_withdrawal_moves_pots_across` — unit: the pair moves, supply conserved (uses the mainnet delta figure).
- `ewrap::loading::ratification_tests::enacted_withdrawal_moves_pots_across_the_boundary` — harness (ToyDomain, real EWRAP finalize + ESTART shard/finalize commit path): an enacted withdrawal debits `pots.treasury`, credits `pots.rewards`, the account is credited, and `Pots::is_consistent()` holds across the transition — done criterion 1.
- `ewrap::enactment::tests::undeliverable_withdrawal_emits_no_account_delta` — the discard case.

Verification run: `cargo test --all-features` (all suites green, 253 in `dolos-cardano`), `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo +nightly fmt --all -- --check` clean.

## Consumer-visible surface change

Every Conway-era boundary's `EpochState` treasury and rewards figures change value on a rebuilt/resynced store — `minibf`, the `epochs` log, and Stelae snapshots published pre-fix will disagree with post-fix ones. Flagging here for the v1.7 release notes and the breaking-change sweep.

## Plan criteria

All met. Divergence **A** (DRep voting powers, 14 credentials + `Abstain` bucket) was carved into `plans/dolos-governance-drep-snapshot-timing.md` by owner ruling; this PR ships B alone per the plan's scope decision, and the mainnet re-read below is that plan's baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preprod verification (plan criterion 3) — done

- `dolos doctor rebuild-state --rewrite-logs --force` in place on the governance preprod instance (17G archive, epoch 307), with this PR's binary (824240e7): **3066 s ≈ 51 min** wall-clock, exit 0 — in line with the ~1 h datum.
- Full-width `dolos data check` on the resulting store: **cursors / archive-continuity / account-epochs / epoch-log / totals — 0 issues, "no consistency issues found"**.
- **No-regression proof:** preprod and preview have **zero enacted treasury withdrawals** (Koios: 79 resp. 435 proposed, 0 enacted), so on those networks the fix must move nothing — and it doesn't: the post-fix rebuilt `EpochState` is content-identical to a pre-fix rebuild of the same archive (diff clean up to `HashSet` iteration order). Mainnet is the only network where the pot movement is observable on-chain; the harness test carries the mechanism proof.

## Divergence A — mechanism findings (tracked on the plan, deliberately not fixed here)

Three code-anchored mechanisms, all one class: dolos's distribution accumulation reads live stake in the EWRAP shard passes, **before** the finalize-pass account mutations, while the ledger's pulser snapshots **after** all of them (Conway `Epoch.hs` ordering: `applyEnactedWithdrawals` → `returnProposalDeposits` → pool reap refunds → `setFreshDRepPulsingState`):

1. Same-boundary enacted-withdrawal credits are missing from dolos's snapshot; the mainnet recipients all delegate always-abstain → the `Abstain`-bucket shortfall class.
2. `PoolDepositRefund` lands on the scheduled stake position, so a same-boundary pool-deposit refund misses the snapshot the ledger includes — matches the one dolos-low offset of exactly −500,000,000.
3. A proposal resolved at boundary B still passes `is_active(B+1)` (`was_enacted` requires `current > ratified + 1`), so its deposit stays in the snapshot deposit-set for one extra boundary while its refund already sits in live rewards — a one-epoch double count matching the +100,000,000,000 dolos-high offset exactly.

These have their own blast radius (every boundary's DRep voting powers) and are proposed as a carve into their own plan.

## Mainnet verification (plan criteria 3–4) — done

The retained `mainnet-gov` instance (full genesis replay on shipped `v1.7.0-alpha.0`, `81f7ba7d`) had its state re-derived from its own archive with this PR's binary — `dolos doctor rebuild-state --target … --stop-epoch 646 --force`, no network, no snapshot re-import, no archive rewrite. **26,206 s ≈ 7.28 h**, against the ~23.5 h the original genesis replay cost. Cursor landed on the archive tip, slot 193,535,999. The instance's own stores were not written; the read below is from the rebuilt store.

### Rows 18 and 19 — exact

| field | pre-fix | rebuilt | db-sync/Koios |
|---|---|---|---|
| pot treasury | 2123528392394011 | **1473763718394011** | 1473763718394011 |
| pot rewards | 153772737636833 | **803537411636833** | 803537411636833 |

Both move by exactly **649,764,674,000,000** — the sum of every `TreasuryWithdrawal` enacted at or before epoch 645 — in opposite directions, supply conserved to the lovelace.

### Regression — the fix moves two pots and nothing else

The rebuilt store was diffed against the pre-fix instance store, dump for dump, at the same tip:

| namespace | result |
|---|---|
| `epochs` | **only** `pot treasury` and `pot rewards` differ; reserves, utxos, deposits, fees, gathered fees, pparams count, protocol version and epoch nonce are byte-identical |
| `proposals` | identical |
| `dreps` | identical |
| `gov` (committee, constitution, DRep distribution) | identical |

### Rows 7 and 9 — baseline for the carved plan

Unchanged by this fix, as expected: `Abstain` 9,412,108,368,313,004 and `NoConfidence` 176,451,764,046,729 in the rebuilt store, identical to pre-fix. The oracle's divergences against Koios (14 of 893 DRep powers; `Abstain` short by 5,996,004,893,013) therefore carry over untouched as the baseline for `plans/dolos-governance-drep-snapshot-timing.md`.

### CI note

`cargo deny (advisories, bans)` fails on this branch and equally on `main` — the advisories check flags **RUSTSEC-2026-0258** (`h2`, unbounded empty DATA frames), which reaches the tree transitively as both `h2 0.3.26` and `h2 0.4.9`. This PR touches no dependencies, so the failure is pre-existing and unrelated; clearing it is a dependency-bump of its own. Every other check is green.

*(Corrected: an earlier revision of this note attributed the failure to a toolchain-install error, which is a non-fatal line earlier in the same job log.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Treasury withdrawals to registered accounts are now delivered from the treasury to rewards.
  - Withdrawals to unregistered accounts are rejected and remain in the treasury.
  - Epoch accounting now reports delivered and invalid treasury withdrawals.

- **Bug Fixes**
  - Corrected pot transitions and supply accounting for enacted treasury withdrawals.
  - Improved handling of invalid withdrawal targets during governance enactment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
