### PR TITLE
fix(cardano): align the boundary DRep distribution with the ledger's post-enactment snapshot

### DIFF
--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -77,6 +77,7 @@ impl BoundaryWork {
             applied_reward_credentials: Default::default(),
             applied_rewards: Default::default(),
             deliverable_withdrawal_targets: Default::default(),
+            boundary_drep_credits: Default::default(),
             effective_treasury_withdrawals: 0,
             invalid_treasury_withdrawals: 0,
             effective_treasury_mirs: 0,
@@ -159,6 +160,27 @@ impl BoundaryWork {
         Some(self.ending_state.number)
     }
 
+    /// The DRep an account's weight counts toward in the boundary stake
+    /// distribution, or `None` when it counts toward none: accumulation
+    /// inactive, the account not delegated as of the snapshot, or the
+    /// target a key/script DRep outside the snapshot's registered set.
+    /// `AlwaysAbstain` / `AlwaysNoConfidence` are always in — the
+    /// ratification tallies need both.
+    fn snapshot_drep_of(&self, account: &AccountState) -> Option<DRep> {
+        let snapshot_epoch = self.distr_snapshot_epoch()?;
+
+        let drep = account.delegated_drep_at(snapshot_epoch)?;
+
+        let in_snapshot = match drep {
+            DRep::Abstain | DRep::NoConfidence => true,
+            _ => self
+                .snapshot_registered_dreps
+                .contains(&drep_to_entity_key(drep)),
+        };
+
+        in_snapshot.then(|| drep.clone())
+    }
+
     /// Build the proposal-deposit share of the boundary snapshot: deposits
     /// of the still-live proposals submitted no later than the closing
     /// epoch, summed per return credential — the pulser's `proposalDeposits`
@@ -167,13 +189,22 @@ impl BoundaryWork {
     /// Rows missing `proposed_in`, the deposit, or the return credential
     /// predate the tracking fields and cannot be attributed; they are
     /// excluded (the accepted design-§6 degradation).
+    ///
+    /// The gate is `is_unresolved_at_close`, not `is_active`: a proposal
+    /// resolved at the *previous* boundary is out of the ledger's live
+    /// forest and its deposit already refunded into the return account's
+    /// live stake, so counting it here again double-counts the deposit for
+    /// one epoch — the mainnet epoch-645 `+100e9` DRep offset. A proposal
+    /// resolved at *this* boundary stays counted: its refund is scheduled
+    /// for the opening epoch, so the deposit is this snapshot's only
+    /// carrier of that value, matching the ledger's pre-snapshot refund.
     fn load_proposal_deposits<D: Domain>(&mut self, state: &D::State) -> Result<(), ChainError> {
         let proposals = state.iter_entities_typed::<ProposalState>(ProposalState::NS, None)?;
 
         for record in proposals {
             let (_, proposal) = record?;
 
-            if !proposal.is_active(self.ending_state.number) {
+            if !proposal.is_unresolved_at_close(self.ending_state.number) {
                 continue;
             }
 
@@ -236,17 +267,8 @@ impl BoundaryWork {
             return;
         }
 
-        if let Some(drep) = account.delegated_drep_at(snapshot_epoch) {
-            let in_snapshot = match drep {
-                DRep::Abstain | DRep::NoConfidence => true,
-                _ => self
-                    .snapshot_registered_dreps
-                    .contains(&drep_to_entity_key(drep)),
-            };
-
-            if in_snapshot {
-                *drep_distr.entry(drep.clone()).or_default() += weight;
-            }
+        if let Some(drep) = self.snapshot_drep_of(account) {
+            *drep_distr.entry(drep).or_default() += weight;
         }
 
         if let Some(pool) = account.delegated_pool_at(snapshot_epoch) {
@@ -664,18 +686,30 @@ impl BoundaryWork {
     /// restricts the enacted withdrawal map to credentials present in the
     /// rewards UMap — accounts registered at the boundary — and discards
     /// the rest: no account credit and no pot movement.
+    ///
+    /// Each deliverable amount also counts toward the recipient's snapshot
+    /// DRep in this boundary's stake distribution — the ledger enacts
+    /// before it takes the fresh pulser snapshot, and the shard
+    /// accumulation ran on pre-enactment positions (the mainnet epoch-645
+    /// `Abstain` shortfall).
     fn load_withdrawal_targets<D: Domain>(
         &mut self,
         state: &D::State,
         withdrawals: &[(StakeCredential, u64)],
     ) -> Result<(), ChainError> {
-        for (credential, _) in withdrawals {
+        for (credential, amount) in withdrawals {
             let account: Option<AccountState> =
                 state.read_entity_typed(AccountState::NS, &credential_to_key(credential))?;
 
-            if account.is_some_and(|account| account.is_registered()) {
-                self.deliverable_withdrawal_targets
-                    .insert(credential.clone());
+            let Some(account) = account.filter(|account| account.is_registered()) else {
+                continue;
+            };
+
+            self.deliverable_withdrawal_targets
+                .insert(credential.clone());
+
+            if let Some(drep) = self.snapshot_drep_of(&account) {
+                *self.boundary_drep_credits.entry(drep).or_default() += amount;
             }
         }
 
@@ -819,6 +853,7 @@ impl BoundaryWork {
 
         boundary.load_pool_data::<D>(state)?;
         boundary.load_drep_data::<D>(state)?;
+        boundary.load_pool_refund_credits()?;
 
         // The ruling first: the proposal classification below, the
         // `ProposalResolved` stamping it emits, and the dormancy check all
@@ -830,6 +865,46 @@ impl BoundaryWork {
         boundary.compute_ewrap_deltas::<D>(state)?;
 
         Ok(boundary)
+    }
+
+    /// Count each retiring pool's deposit refund toward its reward
+    /// account's snapshot DRep in this boundary's stake distribution. The
+    /// ledger pays POOLREAP refunds into the rewards UMap before it takes
+    /// the fresh DRep pulser snapshot, while dolos schedules the refund
+    /// for the opening epoch — after the shard accumulation read its
+    /// positions (the mainnet epoch-645 `-500e6` DRep offset). The pool
+    /// leg is untouched: the ledger's pool snapshot (SNAP) precedes
+    /// POOLREAP. Runs after `load_pool_data` (the retiring set) and
+    /// `load_drep_data` (the registered-DRep gate).
+    fn load_pool_refund_credits(&mut self) -> Result<(), ChainError> {
+        if self.distr_snapshot_epoch().is_none() {
+            return Ok(());
+        }
+
+        let refunded: Vec<_> = self
+            .retiring_pools
+            .values()
+            .filter_map(|(_, account)| account.clone())
+            .filter(|account| account.is_registered())
+            .collect();
+
+        if refunded.is_empty() {
+            return Ok(());
+        }
+
+        let deposit = self
+            .ending_state
+            .pparams
+            .unwrap_live()
+            .ensure_pool_deposit()?;
+
+        for account in refunded {
+            if let Some(drep) = self.snapshot_drep_of(&account) {
+                *self.boundary_drep_credits.entry(drep).or_default() += deposit;
+            }
+        }
+
+        Ok(())
     }
 
     /// The completed DRep distribution for the boundary being closed, or
@@ -1327,6 +1402,17 @@ impl BoundaryWork {
         // committee when the delta applies
         self.add_delta(crate::CommitteeGc::new());
 
+        // fold the boundary-paid credits (enacted withdrawals,
+        // pool-deposit refunds) into the completed accumulator before it
+        // rotates, so the persisted row and the next boundary's tally
+        // both carry them
+        if !self.boundary_drep_credits.is_empty() {
+            self.add_delta(crate::GovDistrBoundaryCredit::new(
+                closing,
+                self.boundary_drep_credits.clone(),
+            ));
+        }
+
         // rotate this boundary's completed distributions where the next
         // boundary's ratification tally will read them
         self.add_delta(crate::GovDistrRotate::new(closing));
@@ -1365,8 +1451,16 @@ impl BoundaryWork {
 
         // DReps — drops.visit_drep emits DRepExpiration for expiring dreps;
         // registered dreps additionally get their boundary voting power
-        // written from the completed distribution accumulator.
-        let drep_power = self.completed_drep_distr();
+        // written from the completed distribution accumulator, with the
+        // boundary-paid credits folded in — the same amounts
+        // `GovDistrBoundaryCredit` persists into the accumulator itself.
+        let drep_power = self.completed_drep_distr().map(|mut distr| {
+            for (drep, credit) in &self.boundary_drep_credits {
+                *distr.entry(drep.clone()).or_default() += credit;
+            }
+
+            distr
+        });
 
         let dreps = state.iter_entities_typed::<DRepState>(DRepState::NS, None)?;
         for record in dreps {
@@ -1810,6 +1904,180 @@ mod tests {
         assert_eq!(read_drep_power(&domain, &reg_drep()), 147);
         assert_eq!(read_drep_power(&domain, &fresh_drep()), 0);
         assert_eq!(read_drep_power(&domain, &unreg_drep()), 0);
+    }
+
+    /// Deposit weight follows the ledger's live forest, not the drop-pass
+    /// grace: a proposal resolved at the *previous* boundary already had
+    /// its deposit refunded into the return account's live stake, so
+    /// counting it again double-counts the deposit for one epoch — the
+    /// mainnet epoch-645 `+100e9` DRep offset. A proposal resolved at
+    /// *this* boundary stays counted: its refund is scheduled for the
+    /// opening epoch, so the deposit is this snapshot's only carrier of
+    /// that value.
+    #[test]
+    fn resolved_proposal_deposit_leaves_the_snapshot() {
+        let domain = seed_domain();
+        let state = domain.state();
+
+        let alice_credential = StakeCredential::AddrKeyhash([0xa1; 28].into());
+
+        let base = ProposalState {
+            slot: 0,
+            tx: [0u8; 32].into(),
+            idx: 0,
+            action: crate::ProposalAction::Info,
+            max_epoch: None,
+            ratified_epoch: None,
+            canceled_epoch: None,
+            deposit: None,
+            reward_account: Some(alice_credential),
+            proposed_in: Some(CLOSING_EPOCH - 2),
+            parent: None,
+            purpose: None,
+            anchor: None,
+            cc_votes: Default::default(),
+            drep_votes: Default::default(),
+            spo_votes: Default::default(),
+        };
+
+        // ratified at the previous boundary: out of the forest, refunded
+        let enacted_prior = ProposalState {
+            tx: [0xe1u8; 32].into(),
+            deposit: Some(900),
+            ratified_epoch: Some(CLOSING_EPOCH - 1),
+            ..base.clone()
+        };
+
+        // dropped at the previous boundary: same
+        let dropped_prior = ProposalState {
+            tx: [0xe2u8; 32].into(),
+            deposit: Some(300),
+            canceled_epoch: Some(CLOSING_EPOCH),
+            ..base.clone()
+        };
+
+        // ratified at *this* boundary: still counted — its refund is
+        // scheduled for the opening epoch, past the snapshot
+        let enacted_here = ProposalState {
+            tx: [0xe3u8; 32].into(),
+            deposit: Some(70),
+            ratified_epoch: Some(CLOSING_EPOCH),
+            ..base.clone()
+        };
+
+        let writer = state.start_writer().unwrap();
+        for (key, proposal) in [
+            (b"proposal-3".to_vec(), &enacted_prior),
+            (b"proposal-4".to_vec(), &dropped_prior),
+            (b"proposal-5".to_vec(), &enacted_here),
+        ] {
+            writer
+                .write_entity_typed(&EntityKey::from(key), proposal)
+                .unwrap();
+        }
+        writer.commit().unwrap();
+
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+
+        let distr = read_distr(&domain);
+        assert!(distr.is_complete_for(CLOSING_EPOCH));
+
+        // alice: 100 stake + 40 + 7 live deposits + 70 resolved-here
+        // deposit; the 900 and 300 resolved-prior deposits stay out
+        let expected_dreps = BTreeMap::from([(reg_drep(), 217u64), (DRep::Abstain, 61u64)]);
+        assert_eq!(distr.drep_distr, expected_dreps);
+    }
+
+    /// A pool retiring at this boundary has its deposit refund counted
+    /// toward the reward account's snapshot DRep: the ledger pays POOLREAP
+    /// refunds into the rewards UMap before it takes the fresh pulser
+    /// snapshot, while dolos schedules the refund for the opening epoch —
+    /// the mainnet epoch-645 `-500e6` DRep offset. The pool leg stays
+    /// untouched (SNAP precedes POOLREAP).
+    #[test]
+    fn retiring_pool_refund_credits_the_boundary_drep_distr() {
+        let domain = seed_domain();
+        let state = domain.state();
+
+        // pool_a retires into the opening epoch; its declared reward
+        // account is alice, delegated to the registered drep
+        let params = crate::PoolParams {
+            vrf_keyhash: [0u8; 32].into(),
+            pledge: 0,
+            cost: 0,
+            margin: crate::pallas_extras::default_rational_number(),
+            reward_account: [&[0xe1u8][..], &[0xa1u8; 28][..]].concat(),
+            pool_owners: vec![],
+            relays: vec![],
+            pool_metadata: None,
+        };
+
+        let pool = crate::PoolState {
+            operator: pool_a(),
+            snapshot: EpochValue::from_parts(
+                CLOSING_EPOCH,
+                Some(crate::PoolSnapshot {
+                    is_retired: false,
+                    blocks_minted: 0,
+                    params,
+                    is_new: false,
+                }),
+                None,
+                None,
+                None,
+                None,
+            ),
+            blocks_minted_total: 0,
+            register_slot: 0,
+            retiring_epoch: Some(CLOSING_EPOCH + 1),
+            deposit: 0,
+        };
+
+        let writer = state.start_writer().unwrap();
+        writer
+            .write_entity_typed(&EntityKey::from(pool_a().as_slice()), &pool)
+            .unwrap();
+        writer.commit().unwrap();
+
+        for shard in 0..TOTAL_SHARDS {
+            run_shard(&domain, shard);
+        }
+
+        let accumulated = read_distr(&domain);
+        assert!(accumulated.is_complete_for(CLOSING_EPOCH));
+        assert_eq!(accumulated.drep_distr.get(&reg_drep()), Some(&147));
+
+        let mut boundary =
+            BoundaryWork::load_finalize::<ToyDomain>(domain.state(), domain.genesis()).unwrap();
+        boundary
+            .commit_finalize::<ToyDomain>(domain.state(), domain.archive())
+            .unwrap();
+
+        let pool_deposit = crate::load_epoch::<ToyDomain>(state)
+            .unwrap()
+            .pparams
+            .unwrap_live()
+            .ensure_pool_deposit()
+            .unwrap();
+
+        assert_eq!(
+            boundary.boundary_drep_credits,
+            BTreeMap::from([(reg_drep(), pool_deposit)])
+        );
+
+        let distr = read_distr(&domain);
+        assert_eq!(
+            distr.drep_distr.get(&reg_drep()),
+            Some(&(147 + pool_deposit))
+        );
+
+        // the pool leg is not credited
+        assert_eq!(distr.pool_distr, accumulated.pool_distr);
+        assert_eq!(distr.pool_total, accumulated.pool_total);
+
+        assert_eq!(read_drep_power(&domain, &reg_drep()), 147 + pool_deposit);
     }
 
     /// A DRep certificate, as the tests below replay it: the position it
@@ -2442,6 +2710,94 @@ mod ratification_tests {
             before.initial_pots.proposal_deposits - DEPOSIT
         );
         assert!(after.initial_pots.is_consistent(max_supply));
+    }
+
+    /// An enacted treasury withdrawal counts toward the recipient's
+    /// snapshot DRep in the distribution this boundary publishes: the
+    /// ledger enacts before it takes the fresh pulser snapshot, while the
+    /// shard accumulation ran on pre-enactment positions — on mainnet the
+    /// 644→645 boundary's six items left the `Abstain` bucket short by
+    /// exactly their deliverable total. The finalize pass folds the credit
+    /// into the accumulator, the rotated copy the next boundary ratifies
+    /// with, and the published `DRepState.voting_power`.
+    #[test]
+    fn enacted_withdrawal_credits_the_boundary_drep_distr() {
+        let accepted = withdrawal(0x01, Some(Vote::Yes), CLOSING + 10);
+
+        let domain = seed(&[accepted]);
+
+        // delegate the beneficiary to the registered drep as of the
+        // snapshot position
+        let key = credential_to_key(&beneficiary());
+        let mut row = domain
+            .state()
+            .read_entity_typed::<crate::AccountState>(crate::AccountState::NS, &key)
+            .unwrap()
+            .expect("beneficiary row present");
+        row.drep = EpochValue::from_parts(
+            CLOSING,
+            Some(crate::DRepDelegation::Delegated(drep())),
+            None,
+            None,
+            None,
+            None,
+        );
+        let writer = domain.state().start_writer().unwrap();
+        writer.write_entity_typed(&key, &row).unwrap();
+        writer.commit().unwrap();
+
+        // EWRAP shard pass: the accumulation reads pre-enactment
+        // positions, so the drep carries only the deposit weight of the
+        // live proposal returning to the beneficiary
+        let ranges = crate::shard::shard_key_ranges(0, 1);
+        let mut shard = BoundaryWork::load_shard::<ToyDomain>(
+            domain.state(),
+            domain.genesis(),
+            0,
+            1,
+            ranges.clone(),
+        )
+        .unwrap();
+        shard
+            .commit_shard::<ToyDomain>(domain.state(), domain.archive(), ranges)
+            .unwrap();
+
+        let accumulated = crate::load_gov::<ToyDomain>(domain.state())
+            .unwrap()
+            .distr
+            .expect("accumulator present");
+        assert!(accumulated.is_complete_for(CLOSING));
+        assert_eq!(accumulated.drep_distr.get(&drep()), Some(&DEPOSIT));
+
+        // EWRAP finalize: enacts the withdrawal and folds the credit in
+        let boundary = finalize(&domain);
+
+        assert_eq!(
+            boundary.boundary_drep_credits,
+            BTreeMap::from([(drep(), WITHDRAWAL)])
+        );
+
+        let gov = crate::load_gov::<ToyDomain>(domain.state()).unwrap();
+
+        let distr = gov.distr.expect("accumulator present");
+        assert_eq!(distr.drep_distr.get(&drep()), Some(&(DEPOSIT + WITHDRAWAL)));
+
+        let rotated = gov.prev_distr.expect("rotated distribution present");
+        assert!(rotated.is_complete_for(CLOSING));
+        assert_eq!(
+            rotated.drep_distr.get(&drep()),
+            Some(&(DEPOSIT + WITHDRAWAL))
+        );
+
+        let drep_row = domain
+            .state()
+            .read_entity_typed::<crate::DRepState>(
+                crate::DRepState::NS,
+                &crate::model::drep_to_entity_key(&drep()),
+            )
+            .unwrap()
+            .expect("drep row present");
+        assert_eq!(drep_row.voting_power, DEPOSIT + WITHDRAWAL);
     }
 
     /// An action submitted *during* the closing epoch cannot ratify at

--- a/crates/cardano/src/ewrap/mod.rs
+++ b/crates/cardano/src/ewrap/mod.rs
@@ -254,6 +254,15 @@ pub struct BoundaryWork {
     /// withdrawal map to the rewards UMap and discards the rest.
     pub deliverable_withdrawal_targets: HashSet<StakeCredential>,
 
+    /// Boundary-paid amounts that count toward each recipient's snapshot
+    /// DRep in this boundary's stake distribution: enacted treasury
+    /// withdrawals and pool-deposit refunds, both landing in the rewards
+    /// UMap before the ledger takes the fresh DRep pulser snapshot. The
+    /// shard accumulation predates them, so the finalize pass folds them
+    /// in via `GovDistrBoundaryCredit`. The pool leg is unaffected — the
+    /// ledger's pool snapshot (SNAP) is taken before POOLREAP and ENACT.
+    pub boundary_drep_credits: BTreeMap<DRep, u64>,
+
     /// Enacted treasury withdrawals delivered to registered accounts
     /// (moved treasury → rewards at the boundary).
     pub effective_treasury_withdrawals: u64,

--- a/crates/cardano/src/model/gov.rs
+++ b/crates/cardano/src/model/gov.rs
@@ -1074,6 +1074,81 @@ impl dolos_core::EntityDelta for GovDistrRotate {
     }
 }
 
+/// Fold the boundary-paid credits into the completed DRep-distribution
+/// accumulator: enacted treasury withdrawals and pool-deposit refunds land
+/// in the rewards UMap before the ledger takes the fresh DRep pulser
+/// snapshot at the same boundary, so their amounts count toward each
+/// recipient's snapshot DRep in the distribution this boundary publishes.
+/// Emitted at a governance-active EWRAP finalize, before [`GovDistrRotate`],
+/// so the rotated copy the next boundary ratifies with carries them. An
+/// accumulator that is missing, incomplete, or belongs to another boundary
+/// is left alone — the same degraded case the rotation turns into a gap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovDistrBoundaryCredit {
+    pub(crate) closing_epoch: Epoch,
+    pub(crate) credits: BTreeMap<DRep, u64>,
+
+    // undo — pre-image of `distr`, captured by `apply` only when state
+    // was actually mutated.
+    pub(crate) applied: bool,
+    pub(crate) prev: Option<GovDistr>,
+}
+
+impl GovDistrBoundaryCredit {
+    pub fn new(closing_epoch: Epoch, credits: BTreeMap<DRep, u64>) -> Self {
+        Self {
+            closing_epoch,
+            credits,
+            applied: false,
+            prev: None,
+        }
+    }
+}
+
+impl dolos_core::EntityDelta for GovDistrBoundaryCredit {
+    type Entity = GovState;
+
+    fn key(&self) -> NsKey {
+        GovState::ns_key()
+    }
+
+    fn apply(&mut self, entity: &mut Option<GovState>) {
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        if !state
+            .distr
+            .as_ref()
+            .is_some_and(|distr| distr.is_complete_for(self.closing_epoch))
+        {
+            tracing::warn!(
+                closing_epoch = self.closing_epoch,
+                "GovDistrBoundaryCredit without a completed accumulator — skipping"
+            );
+            return;
+        }
+
+        self.prev = state.distr.clone();
+
+        let distr = state.distr.as_mut().expect("checked above");
+
+        for (drep, credit) in &self.credits {
+            *distr.drep_distr.entry(drep.clone()).or_default() += credit;
+        }
+
+        self.applied = true;
+    }
+
+    fn undo(&self, entity: &mut Option<GovState>) {
+        if !self.applied {
+            return;
+        }
+
+        let state = entity.as_mut().expect(GOV_MUST_EXIST);
+
+        state.distr = self.prev.clone();
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
@@ -1428,6 +1503,19 @@ mod prop_tests {
         }
     }
 
+    prop_compose! {
+        fn any_gov_distr_boundary_credit()(
+            closing_epoch in root::any_epoch(),
+            credits in prop::collection::btree_map(
+                root::any_drep(),
+                root::any_lovelace(),
+                0..4,
+            ),
+        ) -> GovDistrBoundaryCredit {
+            GovDistrBoundaryCredit::new(closing_epoch, credits)
+        }
+    }
+
     proptest! {
         #[test]
         fn dormancy_tick_roundtrip(
@@ -1469,6 +1557,22 @@ mod prop_tests {
         fn distr_rotate_serde_roundtrip(
             entity in any_gov_state().prop_map(Some),
             delta in any_gov_distr_rotate(),
+        ) {
+            root::assert_delta_serde_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn distr_boundary_credit_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_boundary_credit(),
+        ) {
+            assert_delta_roundtrip(entity, delta);
+        }
+
+        #[test]
+        fn distr_boundary_credit_serde_roundtrip(
+            entity in any_gov_state().prop_map(Some),
+            delta in any_gov_distr_boundary_credit(),
         ) {
             root::assert_delta_serde_roundtrip(entity, delta);
         }

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -280,6 +280,7 @@ pub enum CardanoDelta {
     GovDormancyTick(Box<GovDormancyTick>),
     CommitteeGc(Box<CommitteeGc>),
     GovDistrRotate(Box<GovDistrRotate>),
+    GovDistrBoundaryCredit(Box<GovDistrBoundaryCredit>),
     ProposalResolved(Box<ProposalResolved>),
 }
 
@@ -383,6 +384,7 @@ delta_from!(DRepPowerUpdate);
 delta_from!(GovDormancyTick);
 delta_from!(CommitteeGc);
 delta_from!(GovDistrRotate);
+delta_from!(GovDistrBoundaryCredit);
 delta_from!(ProposalResolved);
 
 #[allow(deprecated)]
@@ -428,6 +430,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovDormancyTick(x) => x.key(),
             Self::CommitteeGc(x) => x.key(),
             Self::GovDistrRotate(x) => x.key(),
+            Self::GovDistrBoundaryCredit(x) => x.key(),
             Self::ProposalResolved(x) => x.key(),
             Self::AssignRewards(x) => x.key(),
             Self::NonceTransition(x) => x.key(),
@@ -496,6 +499,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovDormancyTick(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::CommitteeGc(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::GovDistrRotate(x) => Self::downcast_apply(x.as_mut(), entity),
+            Self::GovDistrBoundaryCredit(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::ProposalResolved(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::AssignRewards(x) => Self::downcast_apply(x.as_mut(), entity),
             Self::NonceTransition(x) => Self::downcast_apply(x.as_mut(), entity),
@@ -564,6 +568,7 @@ impl dolos_core::EntityDelta for CardanoDelta {
             Self::GovDormancyTick(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::CommitteeGc(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::GovDistrRotate(x) => Self::downcast_undo(x.as_ref(), entity),
+            Self::GovDistrBoundaryCredit(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::ProposalResolved(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::AssignRewards(x) => Self::downcast_undo(x.as_ref(), entity),
             Self::NonceTransition(x) => Self::downcast_undo(x.as_ref(), entity),

--- a/crates/cardano/src/model/mod.rs
+++ b/crates/cardano/src/model/mod.rs
@@ -209,9 +209,10 @@ pub fn build_schema() -> StateSchema {
 // --- CardanoDelta ---
 
 // Variant order is part of the on-disk WAL format: bincode encodes enum
-// variants by positional index (no name tags). Indices 0..=38 are frozen
-// to match pre-PR `main` so existing WAL rows decode correctly. New
-// variants must be appended to the end. The `EpochTransition` and
+// variants by positional index (no name tags). The index of every variant
+// a released binary has written is frozen (0..=63 as of v1.7.0-alpha.0)
+// so existing WAL rows decode correctly. New variants must be appended to
+// the end. The `EpochTransition` and
 // `EpochWrapUp` variants point at the *legacy* (deprecated) struct
 // shapes for the same reason; `EpochTransitionV2` / `EpochWrapUpV2` are
 // the live shapes used by all new commit paths.
@@ -280,8 +281,8 @@ pub enum CardanoDelta {
     GovDormancyTick(Box<GovDormancyTick>),
     CommitteeGc(Box<CommitteeGc>),
     GovDistrRotate(Box<GovDistrRotate>),
-    GovDistrBoundaryCredit(Box<GovDistrBoundaryCredit>),
     ProposalResolved(Box<ProposalResolved>),
+    GovDistrBoundaryCredit(Box<GovDistrBoundaryCredit>),
 }
 
 impl CardanoDelta {


### PR DESCRIPTION
## Plan

`plans/dolos-governance-drep-snapshot-timing.md` — divergence **A** of the mainnet governance oracle replay: DRep voting powers off on 14 of 893 credentials plus the `Abstain` bucket, net −5,648,950,777,614 lovelace against Koios/db-sync at epoch 645. Carved out of the pot plan (divergence B, delivered on #1227, now merged — this PR sits directly on `main`).

## Mechanism, established per the plan before touching anything

The ledger takes the fresh DRep pulser snapshot at the very end of the boundary — after ENACT and POOLREAP — while dolos accumulated the distribution from pre-boundary account positions during the EWRAP shard passes. Three boundary effects were missing, each matched exactly to a measured mainnet offset from the retained `mainnet-gov` store joined against Koios pinned at epoch 645:

1. **Enacted treasury withdrawals** — the six items enacted at the 644→645 boundary (2,350,000,000,000 to `549fe090…`, 3,847,050,000,000 across five items to script `eb06997a…`, total 6,197,050,000,000; both recipients registered and delegated `AlwaysAbstain` at the snapshot) land in the ledger's snapshot but after dolos's accumulation.
2. **Proposal-deposit one-epoch double count** — `is_active()` keeps a resolved proposal visible one extra epoch for the drop pass, so `load_proposal_deposits` still counted its deposit in the same epoch its refund already sat in the return account's live stake. The three proposals resolved at the 643→644 boundary map exactly: `d52a4917…` returns to `eb48b727…`, delegated to DRep `b3c2a80e…` — the credential dolos-high by **exactly 100,000,000,000**; the other two return to Abstain-delegated credentials (+200e9 inside `Abstain`).
3. **Pool-deposit refund timing** — the one pool retiring at the 644→645 boundary (`9b922e2f…`) refunds 500,000,000 to reward account `e6bf21e2…`, delegated at the snapshot to DRep `27757135…` — the single dolos-low credential, by **exactly −500,000,000**. The ledger pays POOLREAP refunds before the pulser snapshot; dolos schedules them for the opening epoch.

Arithmetic check on `Abstain`: −6,197,050,000,000 + 200,000,000,000 = −5,997,050,000,000 predicted vs −5,996,004,893,013 measured — closed to a +1,045,106,987 residual, which belongs to the family below.

**The residual small offsets are db-sync's own.** For every one of the 12 non-mechanism differing DReps, dolos's row equals **exactly** the sum of per-account boundary instant stake over db-sync's **own** delegator list, computed from db-sync's **own raw tables** (`delegation_vote`, `tx_out`/`tx_in`, `reward`, `reward_rest`, `withdrawal`, `gov_action_proposal` — pinned to boundary tx 122,721,644, the last tx before slot 193,276,800): db-sync's `drep_distr` aggregation disagrees with its own source data. All twelve, dolos-high delta vs `drep_distr@645`:

| DRep (Key) | delegators | Σ db-sync raw tables | verdict |
|---|---|---|---|
| `8af81c6e…` | 31 | = dolos exactly | db-sync artefact (+1,031,457) |
| `426d5a97…` | 46 | = dolos exactly | db-sync artefact (+102,618,126,820) |
| `a4d8e2b7…` | 125 | = dolos exactly | db-sync artefact (+709,317,863) |
| `0ec943dc…` | 165 | = dolos exactly | db-sync artefact (+78,018,220,396) |
| `43d159af…` | 251 | = dolos exactly | db-sync artefact (+225,339,630) |
| `a4a01438…` | 659 | = dolos exactly | db-sync artefact (+3,149,880,808) |
| `0dd84c5b…` | 909 | = dolos exactly | db-sync artefact (+170,762,927) |
| `b102197e…` | 1,424 | = dolos exactly | db-sync artefact (+529,770,792) |
| `55215f98…` | 1,690 | = dolos exactly | db-sync artefact (+1,561,620,397) |
| `d2e0ed6a…` | 3,065 | = dolos exactly | db-sync artefact (+2,674,373,806) |
| `b6f4547a…` | 1,875 kept of 1,890 | = dolos exactly | db-sync artefact (+2,862,499,183) |
| `8b75035882…` | 9,779 | = dolos exactly | db-sync artefact (+55,033,171,320) |

`b6f4547a…` is the one that needed a second rule and settles a standing question: it has a dereg/re-reg cycle (epoch 507), and 15 accounts whose latest vote delegation predates the deregistration. dolos marks exactly those 15 `NotDelegated`; filtering them, Σ = dolos's row to the lovelace, and the 15 sum exactly to the 422,932,052,927 the naive cert replay overshoots by. **This is the mainnet answer to the PV9 #4772 stale-delegator question: a DRep deregistration voids existing vote delegations and re-registration does not resurrect them** — dolos and db-sync's aggregation independently agree on the same 15-account set.

## What changed

- `ewrap/loading.rs` — `load_proposal_deposits` gates on `is_unresolved_at_close` (the ledger's live forest) instead of `is_active` (the drop-pass grace); a proposal resolved at *this* boundary stays counted, matching the ledger's pre-snapshot refund. New `snapshot_drep_of` helper shared by the accumulation, `load_withdrawal_targets` (which now also accumulates each deliverable amount onto the recipient's snapshot DRep), and the new `load_pool_refund_credits` (retiring pools' deposits onto their reward accounts' snapshot DReps; the pool leg untouched — SNAP precedes POOLREAP).
- `ewrap/mod.rs` — `BoundaryWork.boundary_drep_credits` carries the boundary-paid credits.
- `model/gov.rs` + `model/mod.rs` — new `GovDistrBoundaryCredit` delta folds the credits into the completed accumulator at finalize, emitted **before** `GovDistrRotate` so the persisted row, the rotated copy the next boundary ratifies with, and the published `DRepState.voting_power` all agree. The variant is appended at the **tail** of `CardanoDelta` — variant order is the on-disk WAL format, and every index a released binary has written (0..=63 as of v1.7.0-alpha.0) is frozen.

Ratification is unaffected at the crediting boundary: the tally reads `prev_distr` (the previous boundary's row), and the ledger likewise ratifies with the post-enactment pulser only at the *next* boundary.

## Tests

- `ratification_tests::enacted_withdrawal_credits_the_boundary_drep_distr` — harness: real EWRAP shard + finalize; the credit lands in the accumulator, the rotated copy, and `voting_power`.
- `tests::resolved_proposal_deposit_leaves_the_snapshot` — deposits of proposals resolved at the previous boundary stay out; resolved-at-this-boundary stay in.
- `tests::retiring_pool_refund_credits_the_boundary_drep_distr` — the refund credits the DRep leg only; the pool leg is unchanged.
- `distr_boundary_credit_roundtrip` / `_serde_roundtrip` — delta apply/undo and serde property tests.

`cargo test --all-features` (all 16 suites green, 258 in `dolos-cardano`), `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo +nightly fmt --all -- --check` clean. `cargo deny` is red with RUSTSEC-2026-0258 (`h2`, transitive) — pre-existing, red on `main` too.

## Verification — testnets (plan criterion 3)

Fresh instances from shared mithril snapshots, then in-place `doctor rebuild-state --rewrite-logs --force`, then full-width `dolos data check`, on this PR's build:

| network | rebuild-state | data check | DRep distr vs db-sync (direct SQL) |
|---|---|---|---|
| preprod (epoch 306) | 3,556 s | 101 s, **0 issues** (all five checks) | **exact, whole population** — 0 differing amounts incl. `Abstain`/`NoConfidence`; db-sync's 7 extra rows are all zero-amount |
| preview (epoch 1184) | 3,916 s | 73 s, **0 issues** | **exact, whole population** (2,854 entries) — the network that carried the old 2953/2954 divergence |

Both pinned boundaries carried real mechanism events (preprod: 4 resolved proposals + 2 retiring pools; preview: 1 retiring pool), so the parity exercised the changed paths.

## Verification — mainnet confirmation (plan criteria 4–5)

`dolos doctor rebuild-state --target … --stop-epoch 646` against the retained `mainnet-gov` instance's archive (instance stores untouched), 29,760 s wall-clock (shared machine; dedicated datum 26,206 s), cursor at slot 193,535,999. Dumps diffed against the pot-fix (#1227) baseline store — which is byte-identical to pre-pot-fix on `gov`/`dreps`, so this is also the pre-fix baseline:

**Row 9 — the 14 credentials.** Exactly 2 `dreps` rows move, the two mechanism credentials, both landing **exactly on Koios `drep_history@645`**:

| credential | before | after | vs oracle |
|---|---|---|---|
| `b3c2a80e…` (mechanism 3 — resolved-proposal deposit) | 48,664,267,209,133 | **48,564,267,209,133** | exact |
| `27757135…` (mechanism 2 — pool-deposit refund) | 50,437,376,424,221 | **50,437,876,424,221** | exact |

The other 12 differ from `drep_distr` by the amounts in the table above and are recorded as db-sync's, per-credential, from db-sync's own raw tables.

**Row 7 — `Abstain`.** 9,412,108,368,313,004 → **9,418,105,418,313,004**: exactly the predicted +5,997,050,000,000 (mechanism 1's six withdrawals +6,197,050,000,000, minus the two Abstain-side deposit double-counts −200,000,000,000). Residual vs Koios-implied: +1,045,106,987 — the same db-sync composition family, evidenced per-account.

**Regression guard (criterion 5).** `epochs` and `proposals` dumps **byte-identical** to baseline (every pot, pparam, nonce, proposal outcome, ratified/canceled epoch unchanged); `NoConfidence` and the 895-entry population untouched; committee/constitution unchanged.

**One movement beyond the DRep leg, verified correct.** Three `pool_distr` rows drop exactly 100,000,000,000 each (`pool_total` −300,000,000,000): the snapshot deposit-set feeds both legs, and the three pools are exactly the boundary pool delegations of the three refunded return accounts (db-sync `delegation` @ boundary tx). Koios `pool_voting_power_history@645` confirms **2 of the 3 land exact** (both were +100e9 high before this fix). The third (`894ff15d…`/`pool1398l…`) improves +600e9 → +500,000,000,000: exactly the five deposits refunded at the 644→645 enactment, which dolos's pool leg still counts via the deposit-set while the ledger's SPO power excludes (post-ENACT deposit read over pre-ENACT mark rewards). Pre-existing, strictly improved here, outside this plan's scope (rows 7/9 are DRep-side) — flagged as a follow-up: pool-leg deposit-set/boundary-refund timing.

## Consumer-visible surface change (for the v1.7 release notes)

Conway-era boundary governance stake distributions change value on a rebuilt/resynced store at every boundary that enacted a withdrawal, retired a pool, or resolved a proposal the epoch before:

- **DRep voting powers** — `DRepState.voting_power`, the gov distr row, minibf's DRep surfaces, Stelae snapshots. On mainnet at epoch 645 the net move is +5,997,050,000,000 across `Abstain` and two credential DReps.
- **SPO governance voting powers** — the gov distr's pool leg (`pool_distr`/`pool_total`) moves at boundaries where a resolved proposal's deposit was double-counted; on mainnet at epoch 645, three pools −100,000,000,000 each.

Instances synced before the fix are corrected by `dolos doctor rebuild-state` (no migration path, per the plan). Goes in the v1.7 release notes and breaking-change sweep alongside #1227's treasury/rewards change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved governance accounting for enacted treasury withdrawals and retiring pool refunds.
  * DRep voting power now reflects eligible boundary-period credits.
  * Proposal deposits are excluded when proposals resolve before the closing boundary.

* **Bug Fixes**
  * Corrected snapshot resolution and boundary distribution handling.
  * Added support for safely applying and undoing governance credit updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->