### PR TITLE
feat(minibf): add txs required signers endpoint

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -530,6 +530,10 @@ where
             get(routes::txs::by_hash_redeemers::<D>),
         )
         .route(
+            "/txs/{tx_hash}/required_signers",
+            get(routes::txs::by_hash_required_signers::<D>),
+        )
+        .route(
             "/txs/{tx_hash}/withdrawals",
             get(routes::txs::by_hash_withdrawals::<D>),
         )

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -48,6 +48,7 @@ use blockfrost_openapi::models::{
     tx_content_pool_certs_inner_relays_inner::TxContentPoolCertsInnerRelaysInner,
     tx_content_pool_retires_inner::TxContentPoolRetiresInner,
     tx_content_redeemers_inner::{Purpose, TxContentRedeemersInner},
+    tx_content_required_signers_inner::TxContentRequiredSignersInner,
     tx_content_stake_addr_inner::TxContentStakeAddrInner,
     tx_content_utxo::TxContentUtxo,
     tx_content_utxo_inputs_inner::TxContentUtxoInputsInner,
@@ -1448,6 +1449,25 @@ impl IntoModel<Vec<TxContentWithdrawalsInner>> for TxModelBuilder<'_> {
             })
             .try_collect()
             .map_err(|_: StatusCode| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        Ok(items)
+    }
+}
+
+impl IntoModel<Vec<TxContentRequiredSignersInner>> for TxModelBuilder<'_> {
+    type SortKey = ();
+
+    fn into_model(self) -> Result<Vec<TxContentRequiredSignersInner>, StatusCode> {
+        let tx = self.tx()?;
+        let signers = tx.required_signers();
+
+        let items = signers
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|hash| TxContentRequiredSignersInner {
+                witness_hash: hash.to_string(),
+            })
+            .collect();
 
         Ok(items)
     }

--- a/crates/minibf/src/routes/txs.rs
+++ b/crates/minibf/src/routes/txs.rs
@@ -11,6 +11,7 @@ use blockfrost_openapi::models::{
     tx_content_pool_certs_inner::TxContentPoolCertsInner,
     tx_content_pool_retires_inner::TxContentPoolRetiresInner,
     tx_content_redeemers_inner::TxContentRedeemersInner,
+    tx_content_required_signers_inner::TxContentRequiredSignersInner,
     tx_content_stake_addr_inner::TxContentStakeAddrInner, tx_content_utxo::TxContentUtxo,
     tx_content_withdrawals_inner::TxContentWithdrawalsInner,
 };
@@ -179,6 +180,22 @@ where
     builder.into_response()
 }
 
+pub async fn by_hash_required_signers<D>(
+    Path(tx_hash): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<TxContentRequiredSignersInner>>, StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let hash = hex::decode(tx_hash).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let (raw, order) = domain.get_block_by_tx_hash(&hash).await?;
+
+    let tx = TxModelBuilder::new(&raw, order)?;
+
+    tx.into_response()
+}
+
 pub async fn by_hash_withdrawals<D>(
     Path(tx_hash): Path<String>,
     State(domain): State<Facade<D>>,
@@ -306,6 +323,7 @@ mod tests {
         tx_content_pool_certs_inner::TxContentPoolCertsInner,
         tx_content_pool_retires_inner::TxContentPoolRetiresInner,
         tx_content_redeemers_inner::TxContentRedeemersInner,
+        tx_content_required_signers_inner::TxContentRequiredSignersInner,
         tx_content_stake_addr_inner::TxContentStakeAddrInner, tx_content_utxo::TxContentUtxo,
         tx_content_withdrawals_inner::TxContentWithdrawalsInner,
     };
@@ -756,6 +774,49 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/stakes");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn txs_by_hash_required_signers_happy_path() {
+        let app = TestApp::new();
+        let tx_hash = app.vectors().tx_hash.as_str();
+        let path = format!("/txs/{tx_hash}/required_signers");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let parsed: Vec<TxContentRequiredSignersInner> =
+            serde_json::from_slice(&bytes).expect("failed to parse tx required signers");
+
+        // the synthetic sample transaction carries a single required signer
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].witness_hash, hex::encode([4u8; 28]));
+    }
+
+    #[tokio::test]
+    async fn txs_by_hash_required_signers_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/txs/{}/required_signers", invalid_hash());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn txs_by_hash_required_signers_not_found() {
+        let app = TestApp::new();
+        let path = format!("/txs/{}/required_signers", missing_hash());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn txs_by_hash_required_signers_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let tx_hash = app.vectors().tx_hash.as_str();
+        let path = format!("/txs/{tx_hash}/required_signers");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -695,7 +695,10 @@ fn sample_transaction(
         mint: Some(mint),
         script_data_hash: None,
         collateral: None,
-        required_signers: None,
+        required_signers: Some(
+            NonEmptySet::try_from(vec![AddrKeyhash::from([4u8; 28])])
+                .expect("non-empty required signers"),
+        ),
         network_id: None,
         collateral_return: None,
         total_collateral: None,

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -161,6 +161,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/txs/{tx_hash}/pool_retires`              | Get pool retirements for a specific transaction          |
 | `/txs/{tx_hash}/pool_updates`              | Get pool updates for a specific transaction              |
 | `/txs/{tx_hash}/redeemers`                 | Get redeemers for a specific transaction                 |
+| `/txs/{tx_hash}/required_signers`          | Get required signers for a specific transaction          |
 | `/txs/{tx_hash}/stakes`                    | Get stakes for a specific transaction                    |
 | `/txs/{tx_hash}/utxos`                     | Get UTXOs for a specific transaction                     |
 | `/txs/{tx_hash}/withdrawals`               | Get withdrawals for a specific transaction               |


### PR DESCRIPTION
Closes #1094.

## What

Implements the Blockfrost `/txs/{tx_hash}/required_signers` endpoint in the `minibf` crate.

## Design

The response is a pure mapping off the decoded tx body. The handler follows the same shape as the sibling tx sub-resources (`/withdrawals`, `/stakes`): decode the hash (400 on malformed hex), locate the block through `get_block_by_tx_hash` (404 on unknown tx), and map through `TxModelBuilder`.

The mapping reads `MultiEraTx::required_signers()` (pallas) and emits one `TxContentRequiredSignersInner { witness_hash }` per key hash, in tx body order. Eras without the field (pre-Alonzo) and txs without the optional field both serialize as `[]`, which matches Blockfrost.

## Testing

- Standard 4-test matrix (happy path, 400, 404, 500). The synthetic sample transaction now carries one required signer, so the happy path asserts real content instead of an empty list.
- Official blockfrost-tests fixtures for `txs/:tx/required_signers` pass against full-archive nodes on **preview** (2/2) and **mainnet** (2/2), both the empty and the one-witness cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve the required signers for a transaction by its hash.
  * Required signer hashes are returned with their corresponding witness hash.

* **Documentation**
  * Documented the new transaction required-signers endpoint.

* **Tests**
  * Added coverage for successful responses, invalid hashes, missing transactions, and internal errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->