### PR TITLE
fix(archive): stop losing a block when two share a slot

### DIFF
--- a/crates/core/src/archive.rs
+++ b/crates/core/src/archive.rs
@@ -270,6 +270,18 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
     }
 
     fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError>;
+
+    /// Every block the archive holds at `slot`, in chain order.
+    ///
+    /// A slot is not always a unique chain position — a Byron epoch-boundary
+    /// block shares its slot with the first main block of the epoch it opens —
+    /// and [`Self::get_block_by_slot`] answers with only the block the slot
+    /// resolves to. A caller that reached the slot from a block hash needs the
+    /// candidates instead. A store that cannot hold two blocks at one slot
+    /// inherits the single-block answer.
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        Ok(self.get_block_by_slot(slot)?.into_iter().collect())
+    }
     fn get_range<'a>(
         &self,
         from: Option<BlockSlot>,

--- a/crates/core/src/async_query.rs
+++ b/crates/core/src/async_query.rs
@@ -34,6 +34,31 @@ impl Default for AsyncQueryOptions {
     }
 }
 
+/// Pick the block a hash names out of the blocks recorded at one slot.
+///
+/// The index answers with a slot, and a slot usually holds one block, which is
+/// then the answer without a decode. Where the chain put two blocks on one
+/// slot — a Byron epoch-boundary block and the first main block of the epoch
+/// it opens — the hash is what tells them apart.
+fn pick_by_hash(
+    candidates: Vec<BlockBody>,
+    hash: &[u8],
+) -> Result<Option<BlockBody>, ArchiveError> {
+    if candidates.len() <= 1 {
+        return Ok(candidates.into_iter().next());
+    }
+
+    for body in candidates {
+        let decoded = MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
+
+        if decoded.hash().as_ref() == hash {
+            return Ok(Some(body));
+        }
+    }
+
+    Ok(None)
+}
+
 #[derive(Clone)]
 pub struct AsyncQueryFacade<D: Domain> {
     inner: D,
@@ -92,7 +117,10 @@ where
         self.run_blocking(move |domain| {
             let slot = domain.indexes().slot_by_block_hash(&hash)?;
             match slot {
-                Some(slot) => Ok(domain.archive().get_block_by_slot(&slot)?),
+                Some(slot) => {
+                    let candidates = domain.archive().get_blocks_by_slot(&slot)?;
+                    Ok(pick_by_hash(candidates, &hash)?)
+                }
                 None => Ok(None),
             }
         })
@@ -233,5 +261,51 @@ where
     ) -> Result<Option<ChainPoint>, DomainError> {
         self.run_blocking(move |domain| Ok(domain.archive().find_intersect(&intersect)?))
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
+
+    use super::*;
+
+    /// The case the plural read exists for: a Byron epoch-boundary block and
+    /// the first main block of the epoch it opens share a slot, so resolving a
+    /// hash through the index lands on both and only the hash tells them
+    /// apart.
+    #[test]
+    fn a_shared_slot_is_resolved_by_hash() {
+        let (ebb_point, ebb) = make_byron_ebb(1, pallas::crypto::hash::Hash::new([7u8; 32]));
+        let (main_point, main) =
+            make_conway_block_with_prev(byron_ebb_slot(1), ebb_point.hash(), 1);
+
+        let candidates = vec![ebb.as_ref().clone(), main.as_ref().clone()];
+
+        let ebb_hash = ebb_point.hash().unwrap();
+        let main_hash = main_point.hash().unwrap();
+
+        assert_eq!(
+            pick_by_hash(candidates.clone(), ebb_hash.as_ref()).unwrap(),
+            Some(ebb.as_ref().clone())
+        );
+
+        assert_eq!(
+            pick_by_hash(candidates, main_hash.as_ref()).unwrap(),
+            Some(main.as_ref().clone())
+        );
+    }
+
+    /// The ordinary slot holds one block and the index already named it, so
+    /// the answer costs no decode — which an undecodable body is enough to
+    /// show.
+    #[test]
+    fn a_lone_candidate_is_returned_undecoded() {
+        let body = b"not a block".to_vec();
+
+        assert_eq!(
+            pick_by_hash(vec![body.clone()], &[0u8; 32]).unwrap(),
+            Some(body)
+        );
     }
 }

--- a/crates/core/src/async_query.rs
+++ b/crates/core/src/async_query.rs
@@ -40,23 +40,18 @@ impl Default for AsyncQueryOptions {
 /// then the answer without a decode. Where the chain put two blocks on one
 /// slot — a Byron epoch-boundary block and the first main block of the epoch
 /// it opens — the hash is what tells them apart.
-fn pick_by_hash(
-    candidates: Vec<BlockBody>,
-    hash: &[u8],
-) -> Result<Option<BlockBody>, ArchiveError> {
+///
+/// A body that will not decode is not the block the hash names, so it is
+/// passed over rather than failing the lookup: the caller asked for one block,
+/// and the one it asked for may be the sibling.
+fn pick_by_hash(candidates: Vec<BlockBody>, hash: &[u8]) -> Option<BlockBody> {
     if candidates.len() <= 1 {
-        return Ok(candidates.into_iter().next());
+        return candidates.into_iter().next();
     }
 
-    for body in candidates {
-        let decoded = MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
-
-        if decoded.hash().as_ref() == hash {
-            return Ok(Some(body));
-        }
-    }
-
-    Ok(None)
+    candidates.into_iter().find(|body| {
+        MultiEraBlock::decode(body).is_ok_and(|decoded| decoded.hash().as_ref() == hash)
+    })
 }
 
 #[derive(Clone)]
@@ -119,7 +114,7 @@ where
             match slot {
                 Some(slot) => {
                     let candidates = domain.archive().get_blocks_by_slot(&slot)?;
-                    Ok(pick_by_hash(candidates, &hash)?)
+                    Ok(pick_by_hash(candidates, &hash))
                 }
                 None => Ok(None),
             }
@@ -286,13 +281,28 @@ mod tests {
         let main_hash = main_point.hash().unwrap();
 
         assert_eq!(
-            pick_by_hash(candidates.clone(), ebb_hash.as_ref()).unwrap(),
+            pick_by_hash(candidates.clone(), ebb_hash.as_ref()),
             Some(ebb.as_ref().clone())
         );
 
         assert_eq!(
-            pick_by_hash(candidates, main_hash.as_ref()).unwrap(),
+            pick_by_hash(candidates, main_hash.as_ref()),
             Some(main.as_ref().clone())
+        );
+    }
+
+    /// A body that will not decode must not take its sibling down with it: the
+    /// hash asked for here belongs to the block that is fine.
+    #[test]
+    fn an_undecodable_candidate_does_not_hide_its_sibling() {
+        let (ebb_point, ebb) = make_byron_ebb(1, pallas::crypto::hash::Hash::new([7u8; 32]));
+        let ebb_hash = ebb_point.hash().unwrap();
+
+        let candidates = vec![b"not a block".to_vec(), ebb.as_ref().clone()];
+
+        assert_eq!(
+            pick_by_hash(candidates, ebb_hash.as_ref()),
+            Some(ebb.as_ref().clone())
         );
     }
 
@@ -303,9 +313,6 @@ mod tests {
     fn a_lone_candidate_is_returned_undecoded() {
         let body = b"not a block".to_vec();
 
-        assert_eq!(
-            pick_by_hash(vec![body.clone()], &[0u8; 32]).unwrap(),
-            Some(body)
-        );
+        assert_eq!(pick_by_hash(vec![body.clone()], &[0u8; 32]), Some(body));
     }
 }

--- a/crates/redb3/Cargo.toml
+++ b/crates/redb3/Cargo.toml
@@ -30,10 +30,14 @@ dolos-testing = { path = "../testing" }
 
 # The Byron EBB recovery scan is a dev-only target — it is deliberately not
 # reachable from the `dolos` binary — but it writes to a real archive, so its
-# guard is covered by tests that `cargo test` runs like any other.
+# guard is covered by tests, which the all-features CI run executes like any
+# other. `maintenance` is what opens the archive internals it reads, and
+# nothing else enables it.
 [[example]]
 name = "heal-byron-ebbs"
 path = "examples/heal-byron-ebbs.rs"
 test = true
+required-features = ["maintenance"]
 
 [features]
+maintenance = []

--- a/crates/redb3/Cargo.toml
+++ b/crates/redb3/Cargo.toml
@@ -28,4 +28,12 @@ redb-extras = "0.6.1"
 [dev-dependencies]
 dolos-testing = { path = "../testing" }
 
+# The Byron EBB recovery scan is a dev-only target — it is deliberately not
+# reachable from the `dolos` binary — but it writes to a real archive, so its
+# guard is covered by tests that `cargo test` runs like any other.
+[[example]]
+name = "heal-byron-ebbs"
+path = "examples/heal-byron-ebbs.rs"
+test = true
+
 [features]

--- a/crates/redb3/examples/heal-byron-ebbs.rs
+++ b/crates/redb3/examples/heal-byron-ebbs.rs
@@ -216,6 +216,14 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
                     .map(|bytes| decode_locations(bytes).collect())
                     .unwrap_or_default();
 
+                // The gaps were found before this transaction opened, so the
+                // list is re-read here rather than trusted: a run racing this
+                // one would otherwise have its location appended twice, and the
+                // walk would yield the block twice.
+                if locations.contains(&block.location) {
+                    continue;
+                }
+
                 locations.push(block.location);
 
                 table.insert(block.slot, encode_locations(&locations).as_slice())?;

--- a/crates/redb3/examples/heal-byron-ebbs.rs
+++ b/crates/redb3/examples/heal-byron-ebbs.rs
@@ -1,14 +1,14 @@
 //! One-time recovery scan for Byron epoch-boundary blocks lost to slot-key
 //! overwrite.
 //!
-//! Every archive written before the `ebbs` sidecar landed keyed its block
-//! index by slot alone. A Byron EBB shares its absolute slot with the first
+//! Every archive written before a slot could index more than one block kept
+//! one location per slot. A Byron EBB shares its absolute slot with the first
 //! main block of the epoch it opens, so the main block overwrote the EBB's
 //! index row on every Byron epoch — 208 of them on mainnet, 4 on preprod, none
 //! on preview. The EBB's *bytes* were never lost: segment files are
 //! append-only and the EBB was appended first, so each orphaned block sits in
 //! the offset gap between two indexed blocks. This scan finds those gaps and
-//! inserts the missing `ebbs` rows.
+//! puts the missing locations back into their slots.
 //!
 //! **This is not a product surface.** The shipped `dolos` binary offers no
 //! repair command, no startup hook and no lazy heal: an operator on a pre-fix
@@ -49,8 +49,10 @@ use std::path::{Path, PathBuf};
 use pallas::ledger::traverse::{probe, MultiEraBlock};
 use redb::{Database, ReadableDatabase as _, ReadableTable as _};
 
-use dolos_redb3::archive::flatfiles::{BlockLocation, FlatFileStore};
-use dolos_redb3::archive::tables::{BlocksTable, EbbsTable};
+use dolos_redb3::archive::flatfiles::{
+    decode_locations, encode_locations, BlockLocation, FlatFileStore,
+};
+use dolos_redb3::archive::tables::BlocksTable;
 
 type BoxError = Box<dyn std::error::Error>;
 
@@ -61,7 +63,7 @@ struct Indexed {
     slot: u64,
     hash: pallas::crypto::hash::Hash<32>,
     prev: Option<pallas::crypto::hash::Hash<32>>,
-    is_ebb: bool,
+    shares_slot: bool,
 }
 
 /// A stretch of segment bytes no index row points at.
@@ -83,7 +85,7 @@ struct Report {
     recovered: Vec<Recovered>,
     refused: Vec<(Gap, String)>,
     indexed: usize,
-    already_ebbs: usize,
+    already_shared: usize,
     gaps: usize,
     committed: bool,
 }
@@ -118,8 +120,8 @@ fn main() -> Result<(), BoxError> {
     let report = heal(&archive_dir, &blocks_dir, commit)?;
 
     println!(
-        "indexed blocks: {} ({} epoch-boundary)",
-        report.indexed, report.already_ebbs
+        "indexed blocks: {} ({} sharing a slot)",
+        report.indexed, report.already_shared
     );
     println!("segment gaps: {}", report.gaps);
 
@@ -174,7 +176,7 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
     let flatfiles = FlatFileStore::new(blocks_dir)?;
 
     let indexed = read_index(&db, &flatfiles)?;
-    let already_ebbs = indexed.values().filter(|block| block.is_ebb).count();
+    let already_shared = indexed.values().filter(|block| block.shares_slot).count();
     let gaps = find_gaps(blocks_dir, &indexed)?;
 
     let mut recovered = Vec::new();
@@ -189,7 +191,7 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
 
     let mut report = Report {
         indexed: indexed.len(),
-        already_ebbs,
+        already_shared,
         gaps: recovered.len() + refused.len(),
         recovered,
         refused,
@@ -202,9 +204,21 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
     if commit && report.refused.is_empty() && !report.recovered.is_empty() {
         let wx = db.begin_write()?;
         {
-            let mut table = wx.open_table(EbbsTable::DEF)?;
+            let mut table = wx.open_table(BlocksTable::DEF)?;
+
             for block in &report.recovered {
-                table.insert(block.slot, block.location.to_bytes().as_slice())?;
+                // The list a slot holds is newest first, and a recovered EBB
+                // is the oldest block at its slot — it is what the epoch's
+                // first main block was written over — so it goes last.
+                let stored = table.get(block.slot)?.map(|value| value.value().to_vec());
+                let mut locations: Vec<BlockLocation> = stored
+                    .as_deref()
+                    .map(|bytes| decode_locations(bytes).collect())
+                    .unwrap_or_default();
+
+                locations.push(block.location);
+
+                table.insert(block.slot, encode_locations(&locations).as_slice())?;
             }
         }
         wx.commit()?;
@@ -215,11 +229,12 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
     Ok(report)
 }
 
-/// Read every index row from both tables and decode the block it points at.
+/// Read every indexed block and decode what it says about its neighbours.
 ///
 /// Keyed by segment position rather than by slot, because what the scan needs
 /// is the order the bytes were written in — which is the order the chain was
 /// applied in, and the only thing that makes a gap's neighbours meaningful.
+/// A slot that already holds more than one block contributes each of them.
 fn read_index(
     db: &Database,
     flatfiles: &FlatFileStore,
@@ -227,17 +242,14 @@ fn read_index(
     let rx = db.begin_read()?;
     let mut out = BTreeMap::new();
 
-    for (def, is_ebb_table) in [(BlocksTable::DEF, false), (EbbsTable::DEF, true)] {
-        let table = match rx.open_table(def) {
-            Ok(table) => table,
-            // A pre-fix archive has no `ebbs` table at all.
-            Err(redb::TableError::TableDoesNotExist(_)) => continue,
-            Err(err) => return Err(err.into()),
-        };
+    let table = rx.open_table(BlocksTable::DEF)?;
 
-        for entry in table.iter()? {
-            let (slot, loc_bytes) = entry?;
-            let location = BlockLocation::from_bytes(loc_bytes.value());
+    for entry in table.iter()? {
+        let (slot, value) = entry?;
+        let locations: Vec<BlockLocation> = decode_locations(value.value()).collect();
+        let shares_slot = locations.len() > 1;
+
+        for location in locations {
             let body = flatfiles.read(&location)?;
             let decoded = MultiEraBlock::decode(&body)?;
 
@@ -248,7 +260,7 @@ fn read_index(
                     slot: slot.value(),
                     hash: decoded.hash(),
                     prev: decoded.header().previous_hash(),
-                    is_ebb: is_ebb_table,
+                    shares_slot,
                 },
             );
         }

--- a/crates/redb3/examples/heal-byron-ebbs.rs
+++ b/crates/redb3/examples/heal-byron-ebbs.rs
@@ -1,0 +1,628 @@
+//! One-time recovery scan for Byron epoch-boundary blocks lost to slot-key
+//! overwrite.
+//!
+//! Every archive written before the `ebbs` sidecar landed keyed its block
+//! index by slot alone. A Byron EBB shares its absolute slot with the first
+//! main block of the epoch it opens, so the main block overwrote the EBB's
+//! index row on every Byron epoch — 208 of them on mainnet, 4 on preprod, none
+//! on preview. The EBB's *bytes* were never lost: segment files are
+//! append-only and the EBB was appended first, so each orphaned block sits in
+//! the offset gap between two indexed blocks. This scan finds those gaps and
+//! inserts the missing `ebbs` rows.
+//!
+//! **This is not a product surface.** The shipped `dolos` binary offers no
+//! repair command, no startup hook and no lazy heal: an operator on a pre-fix
+//! archive re-syncs from genesis or restores from a stele cut on a healed
+//! archive. This program exists for exactly one archive — the publisher's own
+//! local snapshot, which the published steles are generated from and which
+//! therefore has to be healed before the next stele is cut. It is an example
+//! target, built by `cargo build --examples` and reachable no other way.
+//!
+//! # Guard
+//!
+//! Restore's redo path deliberately leaves superseded bodies behind in segment
+//! files, so a gap is not automatically an orphaned EBB. A gap is accepted
+//! only when it holds exactly one CBOR item, the era probe calls that item an
+//! epoch-boundary block, and it chains: its `prev_block` is the hash of the
+//! indexed block before the gap, and the indexed block after the gap names the
+//! recovered block as its parent. A gap that fails any of these is **refused**
+//! — reported, and the whole run leaves the archive untouched. Nothing here
+//! skips a gap quietly: a wrong insert would be baked into every stele cut
+//! from this archive and would reach every operator who bootstraps from one.
+//!
+//! # Usage
+//!
+//!     cargo run -p dolos-redb3 --example heal-byron-ebbs -- \
+//!         <archive-dir> [options]
+//!
+//!     --blocks-dir <dir>   segment files live here (config `blocks_path`);
+//!                          defaults to <archive-dir>
+//!     --commit             write the recovered rows; without it the scan is
+//!                          read-only and only reports what it found
+//!
+//! Run it twice: the second run finds nothing left to recover, because the
+//! gaps it healed are no longer gaps.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use pallas::ledger::traverse::{probe, MultiEraBlock};
+use redb::{Database, ReadableDatabase as _, ReadableTable as _};
+
+use dolos_redb3::archive::flatfiles::{BlockLocation, FlatFileStore};
+use dolos_redb3::archive::tables::{BlocksTable, EbbsTable};
+
+type BoxError = Box<dyn std::error::Error>;
+
+/// An indexed block, as the scan needs to see it: where its bytes are, and
+/// what it says about the chain around it.
+struct Indexed {
+    location: BlockLocation,
+    slot: u64,
+    hash: pallas::crypto::hash::Hash<32>,
+    prev: Option<pallas::crypto::hash::Hash<32>>,
+    is_ebb: bool,
+}
+
+/// A stretch of segment bytes no index row points at.
+struct Gap {
+    segment_id: u32,
+    start: u64,
+    end: u64,
+}
+
+/// A gap the guard accepted: an orphaned epoch-boundary block, ready to index.
+struct Recovered {
+    slot: u64,
+    location: BlockLocation,
+    hash: pallas::crypto::hash::Hash<32>,
+}
+
+/// What one run of the scan found.
+struct Report {
+    recovered: Vec<Recovered>,
+    refused: Vec<(Gap, String)>,
+    indexed: usize,
+    already_ebbs: usize,
+    gaps: usize,
+    committed: bool,
+}
+
+fn main() -> Result<(), BoxError> {
+    let mut args = std::env::args().skip(1);
+
+    let mut archive_dir: Option<PathBuf> = None;
+    let mut blocks_dir: Option<PathBuf> = None;
+    let mut commit = false;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--commit" => commit = true,
+            "--blocks-dir" => {
+                blocks_dir = Some(PathBuf::from(
+                    args.next().ok_or("--blocks-dir needs a directory")?,
+                ))
+            }
+            "-h" | "--help" => {
+                eprintln!("usage: heal-byron-ebbs <archive-dir> [--blocks-dir <dir>] [--commit]");
+                return Ok(());
+            }
+            other if archive_dir.is_none() => archive_dir = Some(PathBuf::from(other)),
+            other => return Err(format!("unexpected argument: {other}").into()),
+        }
+    }
+
+    let archive_dir = archive_dir.ok_or("usage: heal-byron-ebbs <archive-dir> [--commit]")?;
+    let blocks_dir = blocks_dir.unwrap_or_else(|| archive_dir.clone());
+
+    let report = heal(&archive_dir, &blocks_dir, commit)?;
+
+    println!(
+        "indexed blocks: {} ({} epoch-boundary)",
+        report.indexed, report.already_ebbs
+    );
+    println!("segment gaps: {}", report.gaps);
+
+    for (gap, reason) in &report.refused {
+        eprintln!(
+            "REFUSED segment {} bytes {}..{} ({} bytes): {reason}",
+            gap.segment_id,
+            gap.start,
+            gap.end,
+            gap.end - gap.start
+        );
+    }
+
+    for block in &report.recovered {
+        println!(
+            "recovered epoch-boundary block {} at slot {} (segment {}, offset {}, {} bytes)",
+            block.hash,
+            block.slot,
+            block.location.segment_id,
+            block.location.offset,
+            block.location.length
+        );
+    }
+
+    if !report.refused.is_empty() {
+        return Err(format!(
+            "{} gap(s) could not be classified as orphaned epoch-boundary blocks; \
+             the archive was left untouched",
+            report.refused.len()
+        )
+        .into());
+    }
+
+    if report.recovered.is_empty() {
+        println!("nothing to recover; the archive already holds every epoch-boundary block");
+    } else if report.committed {
+        println!("indexed {} epoch-boundary block(s)", report.recovered.len());
+    } else {
+        println!(
+            "{} block(s) would be indexed; re-run with --commit to write them",
+            report.recovered.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Scan `archive_dir` for orphaned epoch-boundary blocks, and index them when
+/// `commit` is set and every gap was classified.
+fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, BoxError> {
+    let db = Database::builder().open(archive_dir.join("index"))?;
+    let flatfiles = FlatFileStore::new(blocks_dir)?;
+
+    let indexed = read_index(&db, &flatfiles)?;
+    let already_ebbs = indexed.values().filter(|block| block.is_ebb).count();
+    let gaps = find_gaps(blocks_dir, &indexed)?;
+
+    let mut recovered = Vec::new();
+    let mut refused = Vec::new();
+
+    for gap in gaps {
+        match classify(&flatfiles, &indexed, &gap) {
+            Ok(block) => recovered.push(block),
+            Err(reason) => refused.push((gap, reason)),
+        }
+    }
+
+    let mut report = Report {
+        indexed: indexed.len(),
+        already_ebbs,
+        gaps: recovered.len() + refused.len(),
+        recovered,
+        refused,
+        committed: false,
+    };
+
+    // One bad gap stops the whole run: the point of the guard is that this
+    // archive feeds every published stele, so a partial heal under an
+    // unexplained gap is worse than no heal at all.
+    if commit && report.refused.is_empty() && !report.recovered.is_empty() {
+        let wx = db.begin_write()?;
+        {
+            let mut table = wx.open_table(EbbsTable::DEF)?;
+            for block in &report.recovered {
+                table.insert(block.slot, block.location.to_bytes().as_slice())?;
+            }
+        }
+        wx.commit()?;
+
+        report.committed = true;
+    }
+
+    Ok(report)
+}
+
+/// Read every index row from both tables and decode the block it points at.
+///
+/// Keyed by segment position rather than by slot, because what the scan needs
+/// is the order the bytes were written in — which is the order the chain was
+/// applied in, and the only thing that makes a gap's neighbours meaningful.
+fn read_index(
+    db: &Database,
+    flatfiles: &FlatFileStore,
+) -> Result<BTreeMap<(u32, u64), Indexed>, BoxError> {
+    let rx = db.begin_read()?;
+    let mut out = BTreeMap::new();
+
+    for (def, is_ebb_table) in [(BlocksTable::DEF, false), (EbbsTable::DEF, true)] {
+        let table = match rx.open_table(def) {
+            Ok(table) => table,
+            // A pre-fix archive has no `ebbs` table at all.
+            Err(redb::TableError::TableDoesNotExist(_)) => continue,
+            Err(err) => return Err(err.into()),
+        };
+
+        for entry in table.iter()? {
+            let (slot, loc_bytes) = entry?;
+            let location = BlockLocation::from_bytes(loc_bytes.value());
+            let body = flatfiles.read(&location)?;
+            let decoded = MultiEraBlock::decode(&body)?;
+
+            out.insert(
+                (location.segment_id, location.offset),
+                Indexed {
+                    location,
+                    slot: slot.value(),
+                    hash: decoded.hash(),
+                    prev: decoded.header().previous_hash(),
+                    is_ebb: is_ebb_table,
+                },
+            );
+        }
+    }
+
+    Ok(out)
+}
+
+/// Walk every segment file and report the byte ranges no index row covers.
+fn find_gaps(
+    blocks_dir: &Path,
+    indexed: &BTreeMap<(u32, u64), Indexed>,
+) -> Result<Vec<Gap>, BoxError> {
+    let mut segments: BTreeMap<u32, u64> = BTreeMap::new();
+
+    for entry in std::fs::read_dir(blocks_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(id) = name.strip_suffix(".segment") else {
+            continue;
+        };
+        let Ok(id) = id.parse::<u32>() else { continue };
+
+        segments.insert(id, entry.metadata()?.len());
+    }
+
+    let mut gaps = Vec::new();
+
+    for (&segment_id, &file_len) in &segments {
+        let mut cursor = 0u64;
+
+        for (_, block) in indexed.range((segment_id, 0)..(segment_id + 1, 0)) {
+            if block.location.offset > cursor {
+                gaps.push(Gap {
+                    segment_id,
+                    start: cursor,
+                    end: block.location.offset,
+                });
+            }
+
+            cursor = block.location.offset + block.location.length as u64;
+        }
+
+        if file_len > cursor {
+            gaps.push(Gap {
+                segment_id,
+                start: cursor,
+                end: file_len,
+            });
+        }
+    }
+
+    Ok(gaps)
+}
+
+/// Decide whether a gap holds one orphaned epoch-boundary block, or refuse it.
+fn classify(
+    flatfiles: &FlatFileStore,
+    indexed: &BTreeMap<(u32, u64), Indexed>,
+    gap: &Gap,
+) -> Result<Recovered, String> {
+    let length = gap.end - gap.start;
+
+    let length: u32 = length
+        .try_into()
+        .map_err(|_| format!("{length} bytes is larger than any block"))?;
+
+    let location = BlockLocation {
+        segment_id: gap.segment_id,
+        offset: gap.start,
+        length,
+    };
+
+    let body = flatfiles
+        .read(&location)
+        .map_err(|err| format!("unreadable: {err}"))?;
+
+    // The gap must be exactly one CBOR item. More than one, or a trailing
+    // fragment, means these bytes are not a single orphaned block.
+    let mut decoder = pallas::codec::minicbor::Decoder::new(&body);
+    decoder
+        .skip()
+        .map_err(|err| format!("does not decode as CBOR: {err}"))?;
+
+    if decoder.position() != body.len() {
+        return Err(format!(
+            "holds {} bytes beyond the first CBOR item",
+            body.len() - decoder.position()
+        ));
+    }
+
+    if !matches!(probe::block_era(&body), probe::Outcome::EpochBoundary) {
+        return Err("is not an epoch-boundary block".to_string());
+    }
+
+    let decoded =
+        MultiEraBlock::decode(&body).map_err(|err| format!("does not decode as a block: {err}"))?;
+
+    // The gap's neighbours in write order. The predecessor is absent only for
+    // the very first bytes of the archive, which is where the genesis EBB
+    // sits; the successor is what the chain check needs above all, since it is
+    // the block whose parent the recovered block claims to be.
+    let predecessor = indexed
+        .range(..(gap.segment_id, gap.start))
+        .next_back()
+        .map(|(_, block)| block);
+
+    let successor = indexed
+        .range((gap.segment_id, gap.end)..)
+        .next()
+        .map(|(_, block)| block);
+
+    let Some(successor) = successor else {
+        return Err("has no indexed block after it to chain onto".to_string());
+    };
+
+    if let Some(predecessor) = predecessor {
+        if decoded.header().previous_hash() != Some(predecessor.hash) {
+            return Err(format!(
+                "names {:?} as its parent, but the block before it is {}",
+                decoded.header().previous_hash(),
+                predecessor.hash
+            ));
+        }
+    }
+
+    if successor.prev != Some(decoded.hash()) {
+        return Err(format!(
+            "is not the parent of the block after it: slot {} names {:?}",
+            successor.slot, successor.prev
+        ));
+    }
+
+    if successor.slot != decoded.slot() {
+        return Err(format!(
+            "sits at slot {} but the block after it is at slot {}; an \
+             epoch-boundary block shares its slot with the block that follows it",
+            decoded.slot(),
+            successor.slot
+        ));
+    }
+
+    Ok(Recovered {
+        slot: decoded.slot(),
+        location,
+        hash: decoded.hash(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use dolos_core::{ArchiveWriter as _, ChainPoint, RawBlock, StateSchema};
+    use dolos_redb3::archive::ArchiveStore;
+    use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
+
+    use super::*;
+
+    fn config() -> dolos_core::config::RedbArchiveConfig {
+        dolos_core::config::RedbArchiveConfig::default()
+    }
+
+    /// Build an archive the way the pre-fix writer did: both blocks appended
+    /// to the segment file, but only one index row per slot — so the epoch's
+    /// first main block overwrites the EBB that shares its slot, and the EBB's
+    /// bytes are left orphaned in the segment.
+    fn broken_archive(dir: &Path, epoch: u64) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+        let head = make_conway_block_with_prev(byron_ebb_slot(epoch) - 10, None, 0);
+        let ebb = make_byron_ebb(epoch, head.0.hash().unwrap());
+        let main = make_conway_block_with_prev(byron_ebb_slot(epoch), ebb.0.hash(), 1);
+
+        let flatfiles = FlatFileStore::new(dir).unwrap();
+        let locations = flatfiles
+            .append_batch(&[
+                (
+                    BlockLocation::segment_for_slot(head.0.slot()),
+                    head.1.as_slice(),
+                ),
+                (
+                    BlockLocation::segment_for_slot(ebb.0.slot()),
+                    ebb.1.as_slice(),
+                ),
+                (
+                    BlockLocation::segment_for_slot(main.0.slot()),
+                    main.1.as_slice(),
+                ),
+            ])
+            .unwrap();
+
+        let db = Database::builder().create(dir.join("index")).unwrap();
+        let wx = db.begin_write().unwrap();
+        {
+            let mut table = wx.open_table(BlocksTable::DEF).unwrap();
+            table
+                .insert(head.0.slot(), locations[0].to_bytes().as_slice())
+                .unwrap();
+            // Both of these carry the boundary slot; the second wins, which is
+            // the whole defect.
+            table
+                .insert(ebb.0.slot(), locations[1].to_bytes().as_slice())
+                .unwrap();
+            table
+                .insert(main.0.slot(), locations[2].to_bytes().as_slice())
+                .unwrap();
+        }
+        wx.commit().unwrap();
+        drop(db);
+
+        (ebb, main)
+    }
+
+    fn archived_bodies(dir: &Path) -> Vec<Vec<u8>> {
+        let store = ArchiveStore::open(StateSchema::default(), dir, &config()).unwrap();
+        let bodies = store
+            .get_range(None, None)
+            .unwrap()
+            .map(|(_, body)| body)
+            .collect();
+
+        store.shutdown().unwrap();
+        bodies
+    }
+
+    #[test]
+    fn an_orphaned_ebb_is_recovered_and_a_second_run_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let (ebb, main) = broken_archive(dir.path(), 1);
+
+        // Before the scan, the archive skips straight past the EBB.
+        let before = archived_bodies(dir.path());
+        assert_eq!(before.len(), 2);
+        assert!(!before.contains(&ebb.1.as_ref().clone()));
+
+        let report = heal(dir.path(), dir.path(), true).unwrap();
+        assert!(report.refused.is_empty(), "{:?}", report.refused.len());
+        assert_eq!(report.recovered.len(), 1);
+        assert_eq!(report.recovered[0].slot, ebb.0.slot());
+        assert!(report.committed);
+
+        // The archive now yields both blocks of the boundary, in chain order,
+        // with no re-import.
+        let after = archived_bodies(dir.path());
+        assert_eq!(
+            after[1..],
+            [ebb.1.as_ref().clone(), main.1.as_ref().clone()]
+        );
+
+        // Running it again finds nothing: the gap it healed is no longer one.
+        let report = heal(dir.path(), dir.path(), true).unwrap();
+        assert_eq!(report.gaps, 0);
+        assert!(report.recovered.is_empty());
+        assert!(!report.committed);
+
+        assert_eq!(archived_bodies(dir.path()), after);
+    }
+
+    #[test]
+    fn a_dry_run_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (ebb, _) = broken_archive(dir.path(), 1);
+
+        let report = heal(dir.path(), dir.path(), false).unwrap();
+        assert_eq!(report.recovered.len(), 1);
+        assert!(!report.committed);
+
+        assert!(!archived_bodies(dir.path()).contains(&ebb.1.as_ref().clone()));
+    }
+
+    /// Restore's redo path leaves superseded bodies in segment files, so a gap
+    /// is not proof of an orphaned EBB. A gap holding an ordinary block is
+    /// refused rather than indexed, and the run writes nothing at all.
+    #[test]
+    fn a_gap_that_is_not_an_ebb_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let head = make_conway_block_with_prev(100, None, 0);
+        let garbage = make_conway_block_with_prev(101, head.0.hash(), 1);
+        let tail = make_conway_block_with_prev(102, garbage.0.hash(), 2);
+
+        let flatfiles = FlatFileStore::new(dir.path()).unwrap();
+        let locations = flatfiles
+            .append_batch(&[
+                (0, head.1.as_slice()),
+                (0, garbage.1.as_slice()),
+                (0, tail.1.as_slice()),
+            ])
+            .unwrap();
+
+        let db = Database::builder()
+            .create(dir.path().join("index"))
+            .unwrap();
+        let wx = db.begin_write().unwrap();
+        {
+            let mut table = wx.open_table(BlocksTable::DEF).unwrap();
+            for i in [0usize, 2] {
+                let point = if i == 0 { &head.0 } else { &tail.0 };
+                table
+                    .insert(point.slot(), locations[i].to_bytes().as_slice())
+                    .unwrap();
+            }
+        }
+        wx.commit().unwrap();
+        drop(db);
+
+        let report = heal(dir.path(), dir.path(), true).unwrap();
+        assert_eq!(report.refused.len(), 1);
+        assert!(report.recovered.is_empty());
+        assert!(!report.committed);
+        assert!(report.refused[0].1.contains("not an epoch-boundary block"));
+    }
+
+    /// The chain guard, not just the era probe: an epoch-boundary block that
+    /// no indexed block claims as its parent is refused.
+    #[test]
+    fn an_ebb_that_does_not_chain_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let head = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+        let stray = make_byron_ebb(1, head.0.hash().unwrap());
+        // The block after the gap points at the head, not at the EBB — so the
+        // EBB is a leftover body, not a lost link.
+        let tail = make_conway_block_with_prev(byron_ebb_slot(1), head.0.hash(), 1);
+
+        let flatfiles = FlatFileStore::new(dir.path()).unwrap();
+        let locations = flatfiles
+            .append_batch(&[
+                (0, head.1.as_slice()),
+                (0, stray.1.as_slice()),
+                (0, tail.1.as_slice()),
+            ])
+            .unwrap();
+
+        let db = Database::builder()
+            .create(dir.path().join("index"))
+            .unwrap();
+        let wx = db.begin_write().unwrap();
+        {
+            let mut table = wx.open_table(BlocksTable::DEF).unwrap();
+            table
+                .insert(head.0.slot(), locations[0].to_bytes().as_slice())
+                .unwrap();
+            table
+                .insert(tail.0.slot(), locations[2].to_bytes().as_slice())
+                .unwrap();
+        }
+        wx.commit().unwrap();
+        drop(db);
+
+        let report = heal(dir.path(), dir.path(), true).unwrap();
+        assert_eq!(report.refused.len(), 1);
+        assert!(report.recovered.is_empty());
+        assert!(!report.committed);
+        assert!(report.refused[0].1.contains("is not the parent"));
+    }
+
+    /// A writer that already routes epoch-boundary blocks leaves no gaps, so
+    /// the scan has nothing to say about an archive written by the fixed code.
+    #[test]
+    fn a_healthy_archive_has_no_gaps() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let ebb = make_byron_ebb(1, pallas::crypto::hash::Hash::new([9u8; 32]));
+        let main = make_conway_block_with_prev(byron_ebb_slot(1), ebb.0.hash(), 1);
+
+        let store = ArchiveStore::open(StateSchema::default(), dir.path(), &config()).unwrap();
+        let writer = store.start_writer().unwrap();
+        writer.apply(&ebb.0, &ebb.1).unwrap();
+        writer.apply(&main.0, &main.1).unwrap();
+        writer.commit().unwrap();
+        store.shutdown().unwrap();
+        drop(store);
+
+        let report = heal(dir.path(), dir.path(), true).unwrap();
+        assert_eq!(report.gaps, 0);
+        assert!(report.recovered.is_empty());
+    }
+}

--- a/crates/redb3/examples/heal-byron-ebbs.rs
+++ b/crates/redb3/examples/heal-byron-ebbs.rs
@@ -88,6 +88,9 @@ struct Report {
     already_shared: usize,
     gaps: usize,
     committed: bool,
+    /// How many of `recovered` this run actually wrote. Lower than
+    /// `recovered.len()` only when another run indexed one first.
+    inserted: usize,
 }
 
 fn main() -> Result<(), BoxError> {
@@ -158,7 +161,16 @@ fn main() -> Result<(), BoxError> {
     if report.recovered.is_empty() {
         println!("nothing to recover; the archive already holds every epoch-boundary block");
     } else if report.committed {
-        println!("indexed {} epoch-boundary block(s)", report.recovered.len());
+        // What this run wrote, not what it classified: a run racing this one
+        // may have indexed some of these already, and saying otherwise would
+        // credit this run with writes it skipped.
+        match report.inserted {
+            0 => println!(
+                "nothing written: all {} recovered block(s) were already indexed by another run",
+                report.recovered.len()
+            ),
+            n => println!("indexed {n} epoch-boundary block(s)"),
+        }
     } else {
         println!(
             "{} block(s) would be indexed; re-run with --commit to write them",
@@ -196,12 +208,14 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
         recovered,
         refused,
         committed: false,
+        inserted: 0,
     };
 
     // One bad gap stops the whole run: the point of the guard is that this
     // archive feeds every published stele, so a partial heal under an
     // unexplained gap is worse than no heal at all.
     if commit && report.refused.is_empty() && !report.recovered.is_empty() {
+        let mut inserted = 0;
         let wx = db.begin_write()?;
         {
             let mut table = wx.open_table(BlocksTable::DEF)?;
@@ -227,11 +241,13 @@ fn heal(archive_dir: &Path, blocks_dir: &Path, commit: bool) -> Result<Report, B
                 locations.push(block.location);
 
                 table.insert(block.slot, encode_locations(&locations).as_slice())?;
+                inserted += 1;
             }
         }
         wx.commit()?;
 
         report.committed = true;
+        report.inserted = inserted;
     }
 
     Ok(report)
@@ -507,6 +523,7 @@ mod tests {
         assert_eq!(report.recovered.len(), 1);
         assert_eq!(report.recovered[0].slot, ebb.0.slot());
         assert!(report.committed);
+        assert_eq!(report.inserted, 1);
 
         // The archive now yields both blocks of the boundary, in chain order,
         // with no re-import.
@@ -533,6 +550,7 @@ mod tests {
         let report = heal(dir.path(), dir.path(), false).unwrap();
         assert_eq!(report.recovered.len(), 1);
         assert!(!report.committed);
+        assert_eq!(report.inserted, 0);
 
         assert!(!archived_bodies(dir.path()).contains(&ebb.1.as_ref().clone()));
     }

--- a/crates/redb3/src/archive/flatfiles.rs
+++ b/crates/redb3/src/archive/flatfiles.rs
@@ -27,6 +27,11 @@ impl BlockLocation {
         buf
     }
 
+    /// Unpack the first location in `bytes`.
+    ///
+    /// An index value holds one location per block recorded at its slot, and
+    /// the first is the canonical one, so this stays the point read it always
+    /// was — including for a binary that predates multi-block slots.
     pub fn from_bytes(bytes: &[u8]) -> Self {
         assert!(bytes.len() >= BLOCK_LOCATION_SIZE);
         let segment_id = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
@@ -43,6 +48,29 @@ impl BlockLocation {
     pub fn segment_for_slot(slot: u64) -> u32 {
         (slot / SLOTS_PER_SEGMENT) as u32
     }
+}
+
+/// Read the blocks recorded at one slot out of a packed index value.
+///
+/// The list is newest first: position 0 is the slot's canonical block and the
+/// entries after it are the ones it displaced, so reversing this yields chain
+/// order. A value written before the archive could hold more than one block
+/// per slot is one entry long and reads the same either way.
+pub fn decode_locations(bytes: &[u8]) -> impl DoubleEndedIterator<Item = BlockLocation> + '_ {
+    bytes
+        .chunks_exact(BLOCK_LOCATION_SIZE)
+        .map(BlockLocation::from_bytes)
+}
+
+/// Pack a slot's blocks back into an index value, newest first.
+pub fn encode_locations(locations: &[BlockLocation]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(locations.len() * BLOCK_LOCATION_SIZE);
+
+    for loc in locations {
+        buf.extend_from_slice(&loc.to_bytes());
+    }
+
+    buf
 }
 
 /// Segment file name for a given segment ID.

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -25,9 +25,13 @@ use redb_extras::buckets::BucketError;
 
 use crate::{build_tables, Error, Table};
 
-pub(crate) mod flatfiles;
+// `flatfiles` and `tables` are public so the one-time Byron EBB recovery scan
+// (`examples/heal-byron-ebbs.rs`) can reuse the exact index definitions and
+// location packing rather than restating them. Nothing in the `dolos` binary
+// reaches for them.
+pub mod flatfiles;
 pub(crate) mod indexes;
-pub(crate) mod tables;
+pub mod tables;
 
 #[cfg(test)]
 mod tests;
@@ -221,9 +225,10 @@ impl ArchiveStore {
         to: Option<BlockSlot>,
     ) -> Result<ArchiveRangeIter, RedbArchiveError> {
         let rx = self.db().begin_read()?;
-        let range = tables::BlocksTable::get_range(&rx, from, to)?;
+        let (blocks, ebbs) = tables::BlocksTable::get_range(&rx, from, to)?;
         Ok(ArchiveRangeIter {
-            range,
+            blocks: PeekRange::new(blocks),
+            ebbs: PeekRange::new(ebbs),
             flatfiles: self.flatfiles.clone(),
         })
     }
@@ -252,7 +257,17 @@ impl ArchiveStore {
                 return Ok(Some(ChainPoint::Origin));
             };
 
-            if let Some(body) = tables::BlocksTable::get_by_slot(&rx, &self.flatfiles, *slot)? {
+            let main = tables::BlocksTable::get_by_slot(&rx, &self.flatfiles, *slot)?;
+
+            // A Byron boundary slot holds two blocks. The main block is the
+            // one an intersect normally names, so it is tried first; the EBB
+            // is only consulted when its hash is not the one asked for.
+            let candidates = [
+                main,
+                tables::EbbsTable::get_by_slot(&rx, &self.flatfiles, *slot)?,
+            ];
+
+            for body in candidates.into_iter().flatten() {
                 let decoded =
                     MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
 
@@ -957,10 +972,125 @@ impl dolos_core::ArchiveStore for ArchiveStore {
     }
 }
 
+/// One index range with a peeked entry at each end.
+///
+/// The merge below needs to compare the next entry of both indexes before
+/// committing to one, and it has to do so from either end. `redb::Range` is a
+/// `DoubleEndedIterator` with no peek, so the peeked entries are buffered
+/// here. When the underlying range runs dry, the buffer at the *other* end
+/// holds the last remaining entry, and the empty end takes it — which is what
+/// keeps a front and a back peek from ever yielding the same entry twice.
+struct PeekRange {
+    inner: tables::IndexRange,
+    front: Option<IndexEntry>,
+    back: Option<IndexEntry>,
+}
+
+type IndexEntry = (BlockSlot, flatfiles::BlockLocation);
+
+/// What `redb::Range` hands back before the location is unpacked.
+type RawIndexEntry = Result<
+    (
+        redb::AccessGuard<'static, BlockSlot>,
+        redb::AccessGuard<'static, &'static [u8]>,
+    ),
+    redb::StorageError,
+>;
+
+impl PeekRange {
+    fn new(inner: tables::IndexRange) -> Self {
+        Self {
+            inner,
+            front: None,
+            back: None,
+        }
+    }
+
+    fn peek_front(&mut self) -> Option<IndexEntry> {
+        if self.front.is_none() {
+            self.front = Self::pull(self.inner.next());
+        }
+
+        if self.front.is_none() {
+            self.front = self.back.take();
+        }
+
+        self.front
+    }
+
+    fn peek_back(&mut self) -> Option<IndexEntry> {
+        if self.back.is_none() {
+            self.back = Self::pull(self.inner.next_back());
+        }
+
+        if self.back.is_none() {
+            self.back = self.front.take();
+        }
+
+        self.back
+    }
+
+    fn take_front(&mut self) -> Option<IndexEntry> {
+        self.peek_front();
+        self.front.take()
+    }
+
+    fn take_back(&mut self) -> Option<IndexEntry> {
+        self.peek_back();
+        self.back.take()
+    }
+
+    fn pull(entry: Option<RawIndexEntry>) -> Option<IndexEntry> {
+        let (slot, loc) = entry?.ok()?;
+        Some((
+            slot.value(),
+            flatfiles::BlockLocation::from_bytes(loc.value()),
+        ))
+    }
+}
+
 /// Iterator over a range of blocks, reading lazily from flat files.
+///
+/// The archive keeps Byron epoch-boundary blocks in a sidecar index, so this
+/// merges two slot-ordered ranges back into one chain-ordered sequence. At a
+/// shared slot the EBB comes first, because it is the block the epoch's first
+/// main block points back at.
 pub struct ArchiveRangeIter {
-    range: redb::Range<'static, BlockSlot, &'static [u8]>,
+    blocks: PeekRange,
+    ebbs: PeekRange,
     flatfiles: Arc<flatfiles::FlatFileStore>,
+}
+
+impl ArchiveRangeIter {
+    fn next_entry(&mut self) -> Option<IndexEntry> {
+        match (self.ebbs.peek_front(), self.blocks.peek_front()) {
+            (Some(ebb), Some(block)) => {
+                if ebb.0 <= block.0 {
+                    self.ebbs.take_front()
+                } else {
+                    self.blocks.take_front()
+                }
+            }
+            (Some(_), None) => self.ebbs.take_front(),
+            (None, Some(_)) => self.blocks.take_front(),
+            (None, None) => None,
+        }
+    }
+
+    fn next_entry_back(&mut self) -> Option<IndexEntry> {
+        match (self.ebbs.peek_back(), self.blocks.peek_back()) {
+            (Some(ebb), Some(block)) => {
+                if block.0 >= ebb.0 {
+                    self.blocks.take_back()
+                } else {
+                    self.ebbs.take_back()
+                }
+            }
+            (Some(_), None) => self.ebbs.take_back(),
+            (None, Some(_)) => self.blocks.take_back(),
+            (None, None) => None,
+        }
+    }
 }
 
 impl Iterator for ArchiveRangeIter {
@@ -968,10 +1098,9 @@ impl Iterator for ArchiveRangeIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let (slot, loc_bytes) = self.range.next()?.ok()?;
-            let loc = flatfiles::BlockLocation::from_bytes(loc_bytes.value());
+            let (slot, loc) = self.next_entry()?;
             match self.flatfiles.read(&loc) {
-                Ok(data) => return Some((slot.value(), data)),
+                Ok(data) => return Some((slot, data)),
                 Err(_) => continue, // skip unreadable blocks
             }
         }
@@ -981,10 +1110,9 @@ impl Iterator for ArchiveRangeIter {
 impl DoubleEndedIterator for ArchiveRangeIter {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
-            let (slot, loc_bytes) = self.range.next_back()?.ok()?;
-            let loc = flatfiles::BlockLocation::from_bytes(loc_bytes.value());
+            let (slot, loc) = self.next_entry_back()?;
             match self.flatfiles.read(&loc) {
-                Ok(data) => return Some((slot.value(), data)),
+                Ok(data) => return Some((slot, data)),
                 Err(_) => continue,
             }
         }
@@ -994,7 +1122,7 @@ impl DoubleEndedIterator for ArchiveRangeIter {
 impl dolos_core::archive::Skippable for ArchiveRangeIter {
     fn skip_forward(&mut self, n: usize) {
         for _ in 0..n {
-            if self.range.next().is_none() {
+            if self.next_entry().is_none() {
                 break;
             }
         }
@@ -1002,7 +1130,7 @@ impl dolos_core::archive::Skippable for ArchiveRangeIter {
 
     fn skip_backward(&mut self, n: usize) {
         for _ in 0..n {
-            if self.range.next_back().is_none() {
+            if self.next_entry_back().is_none() {
                 break;
             }
         }

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -1,7 +1,7 @@
 use ::redb::{Database, ReadableDatabase};
 use redb::ReadTransaction;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -25,12 +25,20 @@ use redb_extras::buckets::BucketError;
 
 use crate::{build_tables, Error, Table};
 
-// `flatfiles` and `tables` are public so the one-time Byron EBB recovery scan
-// (`examples/heal-byron-ebbs.rs`) can reuse the exact index definitions and
-// location packing rather than restating them. Nothing in the `dolos` binary
-// reaches for them.
+// The one-time Byron EBB recovery scan (`examples/heal-byron-ebbs.rs`) reuses
+// these index definitions and the location packing rather than restating them.
+// It is the only thing that ever enables `maintenance`; the `dolos` binary
+// does not, so the crate's ordinary surface keeps them private.
+#[cfg(not(feature = "maintenance"))]
+pub(crate) mod flatfiles;
+#[cfg(feature = "maintenance")]
 pub mod flatfiles;
+
 pub(crate) mod indexes;
+
+#[cfg(not(feature = "maintenance"))]
+pub(crate) mod tables;
+#[cfg(feature = "maintenance")]
 pub mod tables;
 
 #[cfg(test)]
@@ -225,10 +233,11 @@ impl ArchiveStore {
         to: Option<BlockSlot>,
     ) -> Result<ArchiveRangeIter, RedbArchiveError> {
         let rx = self.db().begin_read()?;
-        let (blocks, ebbs) = tables::BlocksTable::get_range(&rx, from, to)?;
+        let range = tables::BlocksTable::get_range(&rx, from, to)?;
         Ok(ArchiveRangeIter {
-            blocks: PeekRange::new(blocks),
-            ebbs: PeekRange::new(ebbs),
+            range,
+            front: VecDeque::new(),
+            back: VecDeque::new(),
             flatfiles: self.flatfiles.clone(),
         })
     }
@@ -257,17 +266,9 @@ impl ArchiveStore {
                 return Ok(Some(ChainPoint::Origin));
             };
 
-            let main = tables::BlocksTable::get_by_slot(&rx, &self.flatfiles, *slot)?;
-
-            // A Byron boundary slot holds two blocks. The main block is the
-            // one an intersect normally names, so it is tried first; the EBB
-            // is only consulted when its hash is not the one asked for.
-            let candidates = [
-                main,
-                tables::EbbsTable::get_by_slot(&rx, &self.flatfiles, *slot)?,
-            ];
-
-            for body in candidates.into_iter().flatten() {
+            // A slot can hold more than one block, and an intersect names one
+            // of them by hash, so every block recorded there is a candidate.
+            for body in tables::BlocksTable::get_all_by_slot(&rx, &self.flatfiles, *slot)? {
                 let decoded =
                     MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
 
@@ -599,6 +600,16 @@ impl ArchiveStore {
         tables::BlocksTable::get_by_slot(&rx, &self.flatfiles, *slot)
     }
 
+    /// Every block recorded at `slot`, in chain order.
+    ///
+    /// [`Self::get_block_by_slot`] answers with the block the slot resolves
+    /// to; this answers with all of them, which is what a caller holding a
+    /// hash needs when the chain put two blocks on one slot.
+    pub fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, RedbArchiveError> {
+        let rx = self.db().begin_read()?;
+        tables::BlocksTable::get_all_by_slot(&rx, &self.flatfiles, *slot)
+    }
+
     pub fn get_block_by_hash(
         &self,
         block_hash: &[u8],
@@ -899,6 +910,11 @@ impl dolos_core::ArchiveStore for ArchiveStore {
     fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
         Ok(Self::get_block_by_slot(self, slot)?)
     }
+
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        Ok(Self::get_blocks_by_slot(self, slot)?)
+    }
+
     fn get_range<'a>(
         &self,
         from: Option<BlockSlot>,
@@ -972,123 +988,62 @@ impl dolos_core::ArchiveStore for ArchiveStore {
     }
 }
 
-/// One index range with a peeked entry at each end.
-///
-/// The merge below needs to compare the next entry of both indexes before
-/// committing to one, and it has to do so from either end. `redb::Range` is a
-/// `DoubleEndedIterator` with no peek, so the peeked entries are buffered
-/// here. When the underlying range runs dry, the buffer at the *other* end
-/// holds the last remaining entry, and the empty end takes it — which is what
-/// keeps a front and a back peek from ever yielding the same entry twice.
-struct PeekRange {
-    inner: tables::IndexRange,
-    front: Option<IndexEntry>,
-    back: Option<IndexEntry>,
-}
-
 type IndexEntry = (BlockSlot, flatfiles::BlockLocation);
-
-/// What `redb::Range` hands back before the location is unpacked.
-type RawIndexEntry = Result<
-    (
-        redb::AccessGuard<'static, BlockSlot>,
-        redb::AccessGuard<'static, &'static [u8]>,
-    ),
-    redb::StorageError,
->;
-
-impl PeekRange {
-    fn new(inner: tables::IndexRange) -> Self {
-        Self {
-            inner,
-            front: None,
-            back: None,
-        }
-    }
-
-    fn peek_front(&mut self) -> Option<IndexEntry> {
-        if self.front.is_none() {
-            self.front = Self::pull(self.inner.next());
-        }
-
-        if self.front.is_none() {
-            self.front = self.back.take();
-        }
-
-        self.front
-    }
-
-    fn peek_back(&mut self) -> Option<IndexEntry> {
-        if self.back.is_none() {
-            self.back = Self::pull(self.inner.next_back());
-        }
-
-        if self.back.is_none() {
-            self.back = self.front.take();
-        }
-
-        self.back
-    }
-
-    fn take_front(&mut self) -> Option<IndexEntry> {
-        self.peek_front();
-        self.front.take()
-    }
-
-    fn take_back(&mut self) -> Option<IndexEntry> {
-        self.peek_back();
-        self.back.take()
-    }
-
-    fn pull(entry: Option<RawIndexEntry>) -> Option<IndexEntry> {
-        let (slot, loc) = entry?.ok()?;
-        Some((
-            slot.value(),
-            flatfiles::BlockLocation::from_bytes(loc.value()),
-        ))
-    }
-}
 
 /// Iterator over a range of blocks, reading lazily from flat files.
 ///
-/// The archive keeps Byron epoch-boundary blocks in a sidecar index, so this
-/// merges two slot-ordered ranges back into one chain-ordered sequence. At a
-/// shared slot the EBB comes first, because it is the block the epoch's first
-/// main block points back at.
+/// A slot can hold more than one block, so an index entry expands to a run of
+/// locations and whatever is left of the entry each end is working through is
+/// buffered here. When one end's range runs dry it drains the other end's
+/// buffer, which is what keeps a forward and a backward walk from yielding a
+/// block twice or dropping one where they meet.
 pub struct ArchiveRangeIter {
-    blocks: PeekRange,
-    ebbs: PeekRange,
+    range: redb::Range<'static, BlockSlot, &'static [u8]>,
+    front: VecDeque<IndexEntry>,
+    back: VecDeque<IndexEntry>,
     flatfiles: Arc<flatfiles::FlatFileStore>,
 }
 
 impl ArchiveRangeIter {
     fn next_entry(&mut self) -> Option<IndexEntry> {
-        match (self.ebbs.peek_front(), self.blocks.peek_front()) {
-            (Some(ebb), Some(block)) => {
-                if ebb.0 <= block.0 {
-                    self.ebbs.take_front()
-                } else {
-                    self.blocks.take_front()
-                }
+        loop {
+            if let Some(entry) = self.front.pop_front() {
+                return Some(entry);
             }
-            (Some(_), None) => self.ebbs.take_front(),
-            (None, Some(_)) => self.blocks.take_front(),
-            (None, None) => None,
+
+            let Some(next) = self.range.next() else {
+                return self.back.pop_front();
+            };
+
+            let (slot, value) = next.ok()?;
+            let slot = slot.value();
+
+            self.front.extend(
+                flatfiles::decode_locations(value.value())
+                    .rev()
+                    .map(|loc| (slot, loc)),
+            );
         }
     }
 
     fn next_entry_back(&mut self) -> Option<IndexEntry> {
-        match (self.ebbs.peek_back(), self.blocks.peek_back()) {
-            (Some(ebb), Some(block)) => {
-                if block.0 >= ebb.0 {
-                    self.blocks.take_back()
-                } else {
-                    self.ebbs.take_back()
-                }
+        loop {
+            if let Some(entry) = self.back.pop_back() {
+                return Some(entry);
             }
-            (Some(_), None) => self.ebbs.take_back(),
-            (None, Some(_)) => self.blocks.take_back(),
-            (None, None) => None,
+
+            let Some(next) = self.range.next_back() else {
+                return self.front.pop_back();
+            };
+
+            let (slot, value) = next.ok()?;
+            let slot = slot.value();
+
+            self.back.extend(
+                flatfiles::decode_locations(value.value())
+                    .rev()
+                    .map(|loc| (slot, loc)),
+            );
         }
     }
 }

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -791,6 +791,19 @@ impl ArchiveStore {
         Ok(done)
     }
 
+    /// Drop everything the archive holds after `after`.
+    ///
+    /// The cut is by slot, so at a slot holding more than one block every one
+    /// of them survives, including any that follow `after` in the chain. That
+    /// is only expressible where two blocks share a slot — a Byron
+    /// epoch-boundary block and the first main block of the epoch it opens —
+    /// and a rollback cannot reach one: `Domain::rollback` walks the WAL back
+    /// to `after`, and the WAL holds `max_rollback` slots behind the tip,
+    /// while epoch-boundary blocks stop at the end of Byron. The behaviour
+    /// also predates the archive keeping both blocks, which is why it is
+    /// recorded here rather than changed: resolving `after` to one block of a
+    /// slot means matching its hash, which is `find_intersect`'s job, not this
+    /// one's.
     fn truncate_front(&self, after: &ChainPoint) -> Result<(), RedbArchiveError> {
         let mut wx = self.db().begin_write()?;
         wx.set_quick_repair(true);

--- a/crates/redb3/src/archive/tables.rs
+++ b/crates/redb3/src/archive/tables.rs
@@ -1,167 +1,65 @@
-use pallas::ledger::traverse::probe;
 use redb::{ReadTransaction, ReadableTable as _, TableDefinition, WriteTransaction};
 use tracing::trace;
 
 use dolos_core::{BlockBody, BlockSlot, ChainPoint, RawBlock};
 
-use super::flatfiles::{BlockLocation, FlatFileStore};
+use super::flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
 
 type Error = super::RedbArchiveError;
-
-/// Shape shared by the block index and its epoch-boundary sidecar:
-/// `slot -> BlockLocation`, the location packed into 16 bytes.
-type IndexDef = TableDefinition<'static, BlockSlot, &'static [u8]>;
-
-/// A slot-ordered walk over one of those tables.
-pub type IndexRange = redb::Range<'static, BlockSlot, &'static [u8]>;
-
-/// True when `block` is a Byron epoch-boundary block.
-///
-/// The probe reads the first two CBOR tokens of the block wrapper, so this
-/// costs nothing next to the segment append it gates. Anything that is not a
-/// recognizable era wrapper — the opaque payloads the tests write, say — is
-/// not an EBB and belongs in the main index.
-pub fn is_ebb(block: &[u8]) -> bool {
-    matches!(probe::block_era(block), probe::Outcome::EpochBoundary)
-}
-
-/// Read a `BlockLocation` for `slot` out of one index table.
-fn get_location(
-    rx: &ReadTransaction,
-    def: IndexDef,
-    slot: BlockSlot,
-) -> Result<Option<BlockLocation>, Error> {
-    let table = rx.open_table(def)?;
-    match table.get(slot)? {
-        Some(value) => Ok(Some(BlockLocation::from_bytes(value.value()))),
-        None => Ok(None),
-    }
-}
-
-/// Same as [`get_location`], against a write transaction.
-fn get_location_mut(
-    wx: &WriteTransaction,
-    def: IndexDef,
-    slot: BlockSlot,
-) -> Result<Option<BlockLocation>, Error> {
-    let table = wx.open_table(def)?;
-    let found = table
-        .get(slot)?
-        .map(|value| BlockLocation::from_bytes(value.value()));
-
-    Ok(found)
-}
-
-fn first_of(
-    rx: &ReadTransaction,
-    def: IndexDef,
-) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-    let table = rx.open_table(def)?;
-    let entry = table.first()?;
-    Ok(entry.map(|(slot, loc)| (slot.value(), BlockLocation::from_bytes(loc.value()))))
-}
-
-fn last_of(
-    rx: &ReadTransaction,
-    def: IndexDef,
-) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-    let table = rx.open_table(def)?;
-    let entry = table.last()?;
-    Ok(entry.map(|(slot, loc)| (slot.value(), BlockLocation::from_bytes(loc.value()))))
-}
-
-fn range_of(
-    rx: &ReadTransaction,
-    def: IndexDef,
-    from: Option<BlockSlot>,
-    to: Option<BlockSlot>,
-) -> Result<IndexRange, Error> {
-    let table = rx.open_table(def)?;
-    match (from, to) {
-        (Some(from), Some(to)) => Ok(table.range(from..to)?),
-        (Some(from), None) => Ok(table.range(from..)?),
-        (None, Some(to)) => Ok(table.range(..to)?),
-        (None, None) => Ok(table.range(0..)?),
-    }
-}
-
-/// Order two segment positions. Within one segment the file is append-only, so
-/// the larger offset was written later; segments themselves are written in
-/// ascending order.
-fn written_later(a: &BlockLocation, b: &BlockLocation) -> bool {
-    (a.segment_id, a.offset) > (b.segment_id, b.offset)
-}
-
-/// The Byron epoch-boundary sidecar.
-///
-/// A Byron EBB carries the same absolute slot as the first main block of the
-/// epoch it opens, so a single `slot -> BlockLocation` index cannot hold both:
-/// whichever arrives second overwrites the first, and the archive silently
-/// loses one block per Byron epoch. This table has the same shape as
-/// [`BlocksTable`] and holds exactly the epoch-boundary blocks, which keeps
-/// `blocks` — and every point read that goes through it — untouched.
-///
-/// Ouroboros forbids two blocks at one slot in every post-Byron era, so the
-/// EBB is definitionally the only collision and this table stays small: 208
-/// rows on mainnet, 4 on preprod, none on preview.
-pub struct EbbsTable;
-
-impl EbbsTable {
-    pub const DEF: IndexDef = TableDefinition::new("ebbs");
-
-    pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
-        wx.open_table(Self::DEF)?;
-        Ok(())
-    }
-
-    /// Read the epoch-boundary block at `slot`, if the archive holds one.
-    pub fn get_by_slot(
-        rx: &ReadTransaction,
-        flatfiles: &FlatFileStore,
-        slot: BlockSlot,
-    ) -> Result<Option<BlockBody>, Error> {
-        match get_location(rx, Self::DEF, slot)? {
-            Some(loc) => {
-                let data = flatfiles
-                    .read(&loc)
-                    .map_err(super::RedbArchiveError::from_io)?;
-                Ok(Some(data))
-            }
-            None => Ok(None),
-        }
-    }
-}
 
 pub struct BlocksTable;
 
 impl BlocksTable {
-    pub const DEF: IndexDef = TableDefinition::new("blocks");
+    /// Index table: slot -> the blocks recorded at that slot, one packed
+    /// 16-byte BlockLocation each.
+    ///
+    /// A slot is not a unique chain position. Byron's epoch-boundary blocks
+    /// carry the same absolute slot as the first main block of the epoch they
+    /// open, and a value holding a single location loses whichever of the two
+    /// is written second — silently, since the body is already in the segment
+    /// file. The value is therefore a list, newest first: position 0 is the
+    /// block the slot resolves to and the entries behind it are the ones it
+    /// displaced. A value written before the list existed is one entry long
+    /// and reads identically, which is what keeps existing archives readable
+    /// and readers of position 0 unchanged.
+    ///
+    /// Nothing here knows why a slot would hold two blocks. It only refuses to
+    /// drop one.
+    pub const DEF: TableDefinition<'static, BlockSlot, &'static [u8]> =
+        TableDefinition::new("blocks");
 
     pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
         wx.open_table(Self::DEF)?;
-        EbbsTable::initialize(wx)?;
         Ok(())
     }
 
-    /// The tip of the archive.
-    ///
-    /// Both indexes are consulted so an archive whose last written block is an
-    /// epoch-boundary block reports that block rather than the previous
-    /// epoch's last main block. Where the two share a slot the main block
-    /// wins, which is the boundary-slot semantics every point read already
-    /// has.
+    /// Read the canonical BlockLocation from the index for a given slot.
+    fn get_location(rx: &ReadTransaction, slot: BlockSlot) -> Result<Option<BlockLocation>, Error> {
+        let table = rx.open_table(Self::DEF)?;
+        match table.get(slot)? {
+            Some(value) => Ok(Some(BlockLocation::from_bytes(value.value()))),
+            None => Ok(None),
+        }
+    }
+
+    /// Read every BlockLocation recorded at a slot, in chain order.
+    fn get_locations(rx: &ReadTransaction, slot: BlockSlot) -> Result<Vec<BlockLocation>, Error> {
+        let table = rx.open_table(Self::DEF)?;
+        match table.get(slot)? {
+            Some(value) => Ok(decode_locations(value.value()).rev().collect()),
+            None => Ok(vec![]),
+        }
+    }
+
     pub fn get_tip(
         rx: &ReadTransaction,
         flatfiles: &FlatFileStore,
     ) -> Result<Option<(BlockSlot, BlockBody)>, Error> {
-        let main = last_of(rx, Self::DEF)?;
-        let ebb = last_of(rx, EbbsTable::DEF)?;
-
-        let result = match (main, ebb) {
-            (Some(main), Some(ebb)) if ebb.0 > main.0 => Some(ebb),
-            (Some(main), _) => Some(main),
-            (None, ebb) => ebb,
-        };
+        let table = rx.open_table(Self::DEF)?;
+        let entry = table.last()?;
+        let result = entry
+            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value())));
+        drop(table);
 
         match result {
             Some((slot, loc)) => {
@@ -174,17 +72,12 @@ impl BlocksTable {
         }
     }
 
-    /// Read the main block at `slot`.
-    ///
-    /// At a Byron boundary slot this is the epoch's first main block, never
-    /// the EBB that shares the slot — the semantics callers already had.
-    /// [`EbbsTable::get_by_slot`] reaches the other one.
     pub fn get_by_slot(
         rx: &ReadTransaction,
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<Option<BlockBody>, Error> {
-        match get_location(rx, Self::DEF, slot)? {
+        match Self::get_location(rx, slot)? {
             Some(loc) => {
                 let data = flatfiles
                     .read(&loc)
@@ -195,15 +88,33 @@ impl BlocksTable {
         }
     }
 
+    /// Every block recorded at `slot`, in chain order.
+    ///
+    /// All but the last are what [`Self::get_by_slot`] cannot return: at a
+    /// Byron boundary that is the epoch-boundary block, which the epoch's
+    /// first main block shares a slot with and displaces.
+    pub fn get_all_by_slot(
+        rx: &ReadTransaction,
+        flatfiles: &FlatFileStore,
+        slot: BlockSlot,
+    ) -> Result<Vec<BlockBody>, Error> {
+        Self::get_locations(rx, slot)?
+            .into_iter()
+            .map(|loc| {
+                flatfiles
+                    .read(&loc)
+                    .map_err(super::RedbArchiveError::from_io)
+            })
+            .collect()
+    }
+
     /// Apply a batch of blocks: append to flat files (with fsync), then insert
     /// all index entries into redb.
     ///
-    /// Every block lands in the segment file; only the index row is routed,
-    /// epoch-boundary blocks to `ebbs` and everything else to `blocks`. The
-    /// caller hands blocks over in chain order and the batch sort upstream is
-    /// stable, so an EBB's bytes precede those of the main block it shares a
-    /// slot with — which is what lets the merged range iterator put them back
-    /// in that order.
+    /// The bodies are already durable when the index loop runs, so a slot that
+    /// turns out to be occupied can be resolved by reading what was stored
+    /// there: the same block again is a rewrite, a different one is a second
+    /// block at that slot and both are kept. See [`Self::merge_location`].
     pub fn apply_batch(
         wx: &WriteTransaction,
         flatfiles: &FlatFileStore,
@@ -228,28 +139,74 @@ impl BlocksTable {
             .map_err(super::RedbArchiveError::from_io)?;
 
         // Insert all index entries.
-        let mut main = wx.open_table(Self::DEF)?;
-        let mut ebbs = wx.open_table(EbbsTable::DEF)?;
-
+        let mut table = wx.open_table(Self::DEF)?;
         for (i, (point, body)) in blocks.iter().enumerate() {
-            let bytes = locations[i].to_bytes();
+            let slot = point.slot();
+            let bytes = encode_locations(&[locations[i]]);
 
-            if is_ebb(body) {
-                ebbs.insert(point.slot(), bytes.as_slice())?;
-            } else {
-                main.insert(point.slot(), bytes.as_slice())?;
+            // The insert answers whether the slot was already taken, so a slot
+            // no other block claims — every slot on a post-Byron chain — costs
+            // one index write and no lookup. Only a collision pays for the
+            // merge below.
+            let occupied = table
+                .insert(slot, bytes.as_slice())?
+                .map(|previous| previous.value().to_vec());
+
+            if let Some(occupied) = occupied {
+                let merged = Self::merge_location(&occupied, locations[i], body, flatfiles)?;
+                table.insert(slot, merged.as_slice())?;
             }
         }
 
         Ok(())
     }
 
+    /// Fold a newly written block into the value already held at its slot.
+    ///
+    /// The incoming block is compared against what is stored — length first,
+    /// so a body is read only where a match is possible at all. An identical
+    /// body means this block is being written again, as a resumed restore
+    /// rewrites the layer it was in the middle of, and its entry is repointed
+    /// at the new copy. Anything else is a second block at the same slot, and
+    /// it takes position 0: blocks arrive in chain order, so the newcomer is
+    /// the one the slot should resolve to.
+    fn merge_location(
+        existing: &[u8],
+        incoming: BlockLocation,
+        body: &[u8],
+        flatfiles: &FlatFileStore,
+    ) -> Result<Vec<u8>, Error> {
+        let mut locations: Vec<BlockLocation> = decode_locations(existing).collect();
+        let mut rewrites = None;
+
+        for (i, loc) in locations.iter().enumerate() {
+            if loc.length as usize != body.len() {
+                continue;
+            }
+
+            let stored = flatfiles
+                .read(loc)
+                .map_err(super::RedbArchiveError::from_io)?;
+
+            if stored == body {
+                rewrites = Some(i);
+                break;
+            }
+        }
+
+        match rewrites {
+            Some(i) => locations[i] = incoming,
+            None => locations.insert(0, incoming),
+        }
+
+        Ok(encode_locations(&locations))
+    }
+
     /// Undo the block at `point`.
     ///
-    /// At a Byron boundary slot the two indexes both hold a row, and the one
-    /// written later — the larger segment offset — is removed first. Rollback
-    /// walks the chain backwards, so that is the entry it means, and reading
-    /// the offset answers it without decoding either block.
+    /// A rollback walks the chain backwards, so at a slot holding more than
+    /// one block the one to remove is the newest — position 0 — and the slot
+    /// survives until its last block is gone.
     pub fn undo(
         wx: &WriteTransaction,
         flatfiles: &FlatFileStore,
@@ -257,25 +214,28 @@ impl BlocksTable {
     ) -> Result<(), Error> {
         let slot = point.slot();
 
-        let main = get_location_mut(wx, Self::DEF, slot)?;
-        let ebb = get_location_mut(wx, EbbsTable::DEF, slot)?;
+        // Read locations before removing.
+        let mut table = wx.open_table(Self::DEF)?;
+        let stored = table.get(slot)?.map(|value| value.value().to_vec());
 
-        let (def, loc) = match (main, ebb) {
-            (Some(main), Some(ebb)) => {
-                if written_later(&ebb, &main) {
-                    (EbbsTable::DEF, ebb)
-                } else {
-                    (Self::DEF, main)
-                }
-            }
-            (Some(main), None) => (Self::DEF, main),
-            (None, Some(ebb)) => (EbbsTable::DEF, ebb),
-            (None, None) => return Ok(()),
+        let Some(stored) = stored else {
+            return Ok(());
         };
 
-        // Remove from index.
-        let mut table = wx.open_table(def)?;
-        table.remove(slot)?;
+        let mut locations: Vec<BlockLocation> = decode_locations(&stored).collect();
+
+        if locations.is_empty() {
+            return Ok(());
+        }
+
+        let loc = locations.remove(0);
+
+        if locations.is_empty() {
+            table.remove(slot)?;
+        } else {
+            table.insert(slot, encode_locations(&locations).as_slice())?;
+        }
+
         drop(table);
 
         // Truncate the segment file at this block's offset.
@@ -286,30 +246,18 @@ impl BlocksTable {
         Ok(())
     }
 
-    /// The earliest block in the archive. At a shared slot the epoch-boundary
-    /// block is the earlier of the two.
     pub fn first(rx: &ReadTransaction) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-        let main = first_of(rx, Self::DEF)?;
-        let ebb = first_of(rx, EbbsTable::DEF)?;
-
-        Ok(match (main, ebb) {
-            (Some(main), Some(ebb)) if ebb.0 <= main.0 => Some(ebb),
-            (Some(main), _) => Some(main),
-            (None, ebb) => ebb,
-        })
+        let table = rx.open_table(Self::DEF)?;
+        let entry = table.first()?;
+        Ok(entry
+            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value()))))
     }
 
-    /// The latest block in the archive. At a shared slot the main block is the
-    /// later of the two.
     pub fn last(rx: &ReadTransaction) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-        let main = last_of(rx, Self::DEF)?;
-        let ebb = last_of(rx, EbbsTable::DEF)?;
-
-        Ok(match (main, ebb) {
-            (Some(main), Some(ebb)) if ebb.0 > main.0 => Some(ebb),
-            (Some(main), _) => Some(main),
-            (None, ebb) => ebb,
-        })
+        let table = rx.open_table(Self::DEF)?;
+        let entry = table.last()?;
+        Ok(entry
+            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value()))))
     }
 
     pub fn remove_before(
@@ -317,16 +265,14 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<(), Error> {
-        for def in [Self::DEF, EbbsTable::DEF] {
-            let mut table = wx.open_table(def)?;
-            let mut to_remove = table.extract_from_if(..slot, |_, _| true)?;
+        let mut table = wx.open_table(Self::DEF)?;
+        let mut to_remove = table.extract_from_if(..slot, |_, _| true)?;
 
-            while let Some(Ok((slot, _))) = to_remove.next() {
-                trace!(slot = slot.value(), "removing block index entry");
-            }
-            drop(to_remove);
-            drop(table);
+        while let Some(Ok((slot, _))) = to_remove.next() {
+            trace!(slot = slot.value(), "removing block index entry");
         }
+        drop(to_remove);
+        drop(table);
 
         // Delete segment files that are fully before this slot.
         let threshold_segment = BlockLocation::segment_for_slot(slot);
@@ -342,42 +288,42 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<(), Error> {
-        // An EBB opening the first epoch after the cut sits before that
-        // epoch's first main block in the segment, so taking the minimum
-        // across both indexes is what keeps its bytes from surviving the
-        // truncation.
+        // Find the last entry after `slot` to know where to truncate.
+        let table = wx.open_table(Self::DEF)?;
+
+        // Find the earliest entry after `slot` to determine truncation offset.
+        // A slot holding more than one block contributes all of them, so the
+        // cut lands before the earliest body it has to drop and none survives.
         let mut earliest_after: Option<BlockLocation> = None;
-
-        for def in [Self::DEF, EbbsTable::DEF] {
-            let table = wx.open_table(def)?;
+        {
             let range = table.range((slot + 1)..)?;
-
             for entry in range {
                 let (_, loc_bytes) = entry?;
-                let loc = BlockLocation::from_bytes(loc_bytes.value());
 
-                match &earliest_after {
-                    None => earliest_after = Some(loc),
-                    Some(prev) => {
-                        if written_later(prev, &loc) {
-                            earliest_after = Some(loc);
+                for loc in decode_locations(loc_bytes.value()) {
+                    match &earliest_after {
+                        None => earliest_after = Some(loc),
+                        Some(prev) => {
+                            if loc.segment_id < prev.segment_id
+                                || (loc.segment_id == prev.segment_id && loc.offset < prev.offset)
+                            {
+                                earliest_after = Some(loc);
+                            }
                         }
                     }
                 }
             }
         }
+        drop(table);
 
         // Remove index entries.
-        for def in [Self::DEF, EbbsTable::DEF] {
-            let mut table = wx.open_table(def)?;
-            let mut to_remove = table.extract_from_if(slot.., |x, _| x > slot)?;
-
-            while let Some(Ok((slot, _))) = to_remove.next() {
-                trace!(slot = slot.value(), "removing block index entry");
-            }
-            drop(to_remove);
-            drop(table);
+        let mut table = wx.open_table(Self::DEF)?;
+        let mut to_remove = table.extract_from_if(slot.., |x, _| x > slot)?;
+        while let Some(Ok((slot, _))) = to_remove.next() {
+            trace!(slot = slot.value(), "removing block index entry");
         }
+        drop(to_remove);
+        drop(table);
 
         // Truncate the segment file if we found entries to remove.
         if let Some(loc) = earliest_after {
@@ -389,19 +335,20 @@ impl BlocksTable {
         Ok(())
     }
 
-    /// Get a range of (slot, BlockLocation) from each index.
-    ///
-    /// The two are returned separately and merged by the iterator that reads
-    /// them; block data is NOT fetched here, so callers page through index
-    /// keys and only pay for the bodies they keep.
+    /// Get a range of (slot, index value) from the index.
+    /// Block data is NOT fetched here; callers use FlatFileStore to read
+    /// lazily.
     pub fn get_range(
         rx: &ReadTransaction,
         from: Option<BlockSlot>,
         to: Option<BlockSlot>,
-    ) -> Result<(IndexRange, IndexRange), Error> {
-        let main = range_of(rx, Self::DEF, from, to)?;
-        let ebbs = range_of(rx, EbbsTable::DEF, from, to)?;
-
-        Ok((main, ebbs))
+    ) -> Result<redb::Range<'static, u64, &'static [u8]>, Error> {
+        let table = rx.open_table(Self::DEF)?;
+        match (from, to) {
+            (Some(from), Some(to)) => Ok(table.range(from..to)?),
+            (Some(from), None) => Ok(table.range(from..)?),
+            (None, Some(to)) => Ok(table.range(..to)?),
+            (None, None) => Ok(table.range(0..)?),
+        }
     }
 }

--- a/crates/redb3/src/archive/tables.rs
+++ b/crates/redb3/src/archive/tables.rs
@@ -1,3 +1,4 @@
+use pallas::ledger::traverse::probe;
 use redb::{ReadTransaction, ReadableTable as _, TableDefinition, WriteTransaction};
 use tracing::trace;
 
@@ -7,36 +8,161 @@ use super::flatfiles::{BlockLocation, FlatFileStore};
 
 type Error = super::RedbArchiveError;
 
-pub struct BlocksTable;
+/// Shape shared by the block index and its epoch-boundary sidecar:
+/// `slot -> BlockLocation`, the location packed into 16 bytes.
+type IndexDef = TableDefinition<'static, BlockSlot, &'static [u8]>;
 
-impl BlocksTable {
-    /// Index table: slot -> BlockLocation (16 bytes packed).
-    pub const DEF: TableDefinition<'static, BlockSlot, &'static [u8]> =
-        TableDefinition::new("blocks");
+/// A slot-ordered walk over one of those tables.
+pub type IndexRange = redb::Range<'static, BlockSlot, &'static [u8]>;
+
+/// True when `block` is a Byron epoch-boundary block.
+///
+/// The probe reads the first two CBOR tokens of the block wrapper, so this
+/// costs nothing next to the segment append it gates. Anything that is not a
+/// recognizable era wrapper — the opaque payloads the tests write, say — is
+/// not an EBB and belongs in the main index.
+pub fn is_ebb(block: &[u8]) -> bool {
+    matches!(probe::block_era(block), probe::Outcome::EpochBoundary)
+}
+
+/// Read a `BlockLocation` for `slot` out of one index table.
+fn get_location(
+    rx: &ReadTransaction,
+    def: IndexDef,
+    slot: BlockSlot,
+) -> Result<Option<BlockLocation>, Error> {
+    let table = rx.open_table(def)?;
+    match table.get(slot)? {
+        Some(value) => Ok(Some(BlockLocation::from_bytes(value.value()))),
+        None => Ok(None),
+    }
+}
+
+/// Same as [`get_location`], against a write transaction.
+fn get_location_mut(
+    wx: &WriteTransaction,
+    def: IndexDef,
+    slot: BlockSlot,
+) -> Result<Option<BlockLocation>, Error> {
+    let table = wx.open_table(def)?;
+    let found = table
+        .get(slot)?
+        .map(|value| BlockLocation::from_bytes(value.value()));
+
+    Ok(found)
+}
+
+fn first_of(
+    rx: &ReadTransaction,
+    def: IndexDef,
+) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
+    let table = rx.open_table(def)?;
+    let entry = table.first()?;
+    Ok(entry.map(|(slot, loc)| (slot.value(), BlockLocation::from_bytes(loc.value()))))
+}
+
+fn last_of(
+    rx: &ReadTransaction,
+    def: IndexDef,
+) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
+    let table = rx.open_table(def)?;
+    let entry = table.last()?;
+    Ok(entry.map(|(slot, loc)| (slot.value(), BlockLocation::from_bytes(loc.value()))))
+}
+
+fn range_of(
+    rx: &ReadTransaction,
+    def: IndexDef,
+    from: Option<BlockSlot>,
+    to: Option<BlockSlot>,
+) -> Result<IndexRange, Error> {
+    let table = rx.open_table(def)?;
+    match (from, to) {
+        (Some(from), Some(to)) => Ok(table.range(from..to)?),
+        (Some(from), None) => Ok(table.range(from..)?),
+        (None, Some(to)) => Ok(table.range(..to)?),
+        (None, None) => Ok(table.range(0..)?),
+    }
+}
+
+/// Order two segment positions. Within one segment the file is append-only, so
+/// the larger offset was written later; segments themselves are written in
+/// ascending order.
+fn written_later(a: &BlockLocation, b: &BlockLocation) -> bool {
+    (a.segment_id, a.offset) > (b.segment_id, b.offset)
+}
+
+/// The Byron epoch-boundary sidecar.
+///
+/// A Byron EBB carries the same absolute slot as the first main block of the
+/// epoch it opens, so a single `slot -> BlockLocation` index cannot hold both:
+/// whichever arrives second overwrites the first, and the archive silently
+/// loses one block per Byron epoch. This table has the same shape as
+/// [`BlocksTable`] and holds exactly the epoch-boundary blocks, which keeps
+/// `blocks` — and every point read that goes through it — untouched.
+///
+/// Ouroboros forbids two blocks at one slot in every post-Byron era, so the
+/// EBB is definitionally the only collision and this table stays small: 208
+/// rows on mainnet, 4 on preprod, none on preview.
+pub struct EbbsTable;
+
+impl EbbsTable {
+    pub const DEF: IndexDef = TableDefinition::new("ebbs");
 
     pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
         wx.open_table(Self::DEF)?;
         Ok(())
     }
 
-    /// Read a BlockLocation from the index for a given slot.
-    fn get_location(rx: &ReadTransaction, slot: BlockSlot) -> Result<Option<BlockLocation>, Error> {
-        let table = rx.open_table(Self::DEF)?;
-        match table.get(slot)? {
-            Some(value) => Ok(Some(BlockLocation::from_bytes(value.value()))),
+    /// Read the epoch-boundary block at `slot`, if the archive holds one.
+    pub fn get_by_slot(
+        rx: &ReadTransaction,
+        flatfiles: &FlatFileStore,
+        slot: BlockSlot,
+    ) -> Result<Option<BlockBody>, Error> {
+        match get_location(rx, Self::DEF, slot)? {
+            Some(loc) => {
+                let data = flatfiles
+                    .read(&loc)
+                    .map_err(super::RedbArchiveError::from_io)?;
+                Ok(Some(data))
+            }
             None => Ok(None),
         }
     }
+}
 
+pub struct BlocksTable;
+
+impl BlocksTable {
+    /// Index table: slot -> BlockLocation (16 bytes packed).
+    pub const DEF: IndexDef = TableDefinition::new("blocks");
+
+    pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
+        wx.open_table(Self::DEF)?;
+        EbbsTable::initialize(wx)?;
+        Ok(())
+    }
+
+    /// The tip of the archive.
+    ///
+    /// Both indexes are consulted so an archive whose last written block is an
+    /// epoch-boundary block reports that block rather than the previous
+    /// epoch's last main block. Where the two share a slot the main block
+    /// wins, which is the boundary-slot semantics every point read already
+    /// has.
     pub fn get_tip(
         rx: &ReadTransaction,
         flatfiles: &FlatFileStore,
     ) -> Result<Option<(BlockSlot, BlockBody)>, Error> {
-        let table = rx.open_table(Self::DEF)?;
-        let entry = table.last()?;
-        let result = entry
-            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value())));
-        drop(table);
+        let main = last_of(rx, Self::DEF)?;
+        let ebb = last_of(rx, EbbsTable::DEF)?;
+
+        let result = match (main, ebb) {
+            (Some(main), Some(ebb)) if ebb.0 > main.0 => Some(ebb),
+            (Some(main), _) => Some(main),
+            (None, ebb) => ebb,
+        };
 
         match result {
             Some((slot, loc)) => {
@@ -49,12 +175,17 @@ impl BlocksTable {
         }
     }
 
+    /// Read the main block at `slot`.
+    ///
+    /// At a Byron boundary slot this is the epoch's first main block, never
+    /// the EBB that shares the slot — the semantics callers already had.
+    /// [`EbbsTable::get_by_slot`] reaches the other one.
     pub fn get_by_slot(
         rx: &ReadTransaction,
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<Option<BlockBody>, Error> {
-        match Self::get_location(rx, slot)? {
+        match get_location(rx, Self::DEF, slot)? {
             Some(loc) => {
                 let data = flatfiles
                     .read(&loc)
@@ -67,6 +198,13 @@ impl BlocksTable {
 
     /// Apply a batch of blocks: append to flat files (with fsync), then insert
     /// all index entries into redb.
+    ///
+    /// Every block lands in the segment file; only the index row is routed,
+    /// epoch-boundary blocks to `ebbs` and everything else to `blocks`. The
+    /// caller hands blocks over in chain order and the batch sort upstream is
+    /// stable, so an EBB's bytes precede those of the main block it shares a
+    /// slot with — which is what lets the merged range iterator put them back
+    /// in that order.
     pub fn apply_batch(
         wx: &WriteTransaction,
         flatfiles: &FlatFileStore,
@@ -91,15 +229,28 @@ impl BlocksTable {
             .map_err(super::RedbArchiveError::from_io)?;
 
         // Insert all index entries.
-        let mut table = wx.open_table(Self::DEF)?;
-        for (i, (point, _)) in blocks.iter().enumerate() {
+        let mut main = wx.open_table(Self::DEF)?;
+        let mut ebbs = wx.open_table(EbbsTable::DEF)?;
+
+        for (i, (point, body)) in blocks.iter().enumerate() {
             let bytes = locations[i].to_bytes();
-            table.insert(point.slot(), bytes.as_slice())?;
+
+            if is_ebb(body) {
+                ebbs.insert(point.slot(), bytes.as_slice())?;
+            } else {
+                main.insert(point.slot(), bytes.as_slice())?;
+            }
         }
 
         Ok(())
     }
 
+    /// Undo the block at `point`.
+    ///
+    /// At a Byron boundary slot the two indexes both hold a row, and the one
+    /// written later — the larger segment offset — is removed first. Rollback
+    /// walks the chain backwards, so that is the entry it means, and reading
+    /// the offset answers it without decoding either block.
     pub fn undo(
         wx: &WriteTransaction,
         flatfiles: &FlatFileStore,
@@ -107,16 +258,24 @@ impl BlocksTable {
     ) -> Result<(), Error> {
         let slot = point.slot();
 
-        // Read location before removing.
-        let table = wx.open_table(Self::DEF)?;
-        let loc = match table.get(slot)? {
-            Some(value) => BlockLocation::from_bytes(value.value()),
-            None => return Ok(()),
+        let main = get_location_mut(wx, Self::DEF, slot)?;
+        let ebb = get_location_mut(wx, EbbsTable::DEF, slot)?;
+
+        let (def, loc) = match (main, ebb) {
+            (Some(main), Some(ebb)) => {
+                if written_later(&ebb, &main) {
+                    (EbbsTable::DEF, ebb)
+                } else {
+                    (Self::DEF, main)
+                }
+            }
+            (Some(main), None) => (Self::DEF, main),
+            (None, Some(ebb)) => (EbbsTable::DEF, ebb),
+            (None, None) => return Ok(()),
         };
-        drop(table);
 
         // Remove from index.
-        let mut table = wx.open_table(Self::DEF)?;
+        let mut table = wx.open_table(def)?;
         table.remove(slot)?;
         drop(table);
 
@@ -128,18 +287,30 @@ impl BlocksTable {
         Ok(())
     }
 
+    /// The earliest block in the archive. At a shared slot the epoch-boundary
+    /// block is the earlier of the two.
     pub fn first(rx: &ReadTransaction) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-        let table = rx.open_table(Self::DEF)?;
-        let entry = table.first()?;
-        Ok(entry
-            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value()))))
+        let main = first_of(rx, Self::DEF)?;
+        let ebb = first_of(rx, EbbsTable::DEF)?;
+
+        Ok(match (main, ebb) {
+            (Some(main), Some(ebb)) if ebb.0 <= main.0 => Some(ebb),
+            (Some(main), _) => Some(main),
+            (None, ebb) => ebb,
+        })
     }
 
+    /// The latest block in the archive. At a shared slot the main block is the
+    /// later of the two.
     pub fn last(rx: &ReadTransaction) -> Result<Option<(BlockSlot, BlockLocation)>, Error> {
-        let table = rx.open_table(Self::DEF)?;
-        let entry = table.last()?;
-        Ok(entry
-            .map(|(slot, loc_bytes)| (slot.value(), BlockLocation::from_bytes(loc_bytes.value()))))
+        let main = last_of(rx, Self::DEF)?;
+        let ebb = last_of(rx, EbbsTable::DEF)?;
+
+        Ok(match (main, ebb) {
+            (Some(main), Some(ebb)) if ebb.0 > main.0 => Some(ebb),
+            (Some(main), _) => Some(main),
+            (None, ebb) => ebb,
+        })
     }
 
     pub fn remove_before(
@@ -147,14 +318,16 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<(), Error> {
-        let mut table = wx.open_table(Self::DEF)?;
-        let mut to_remove = table.extract_from_if(..slot, |_, _| true)?;
+        for def in [Self::DEF, EbbsTable::DEF] {
+            let mut table = wx.open_table(def)?;
+            let mut to_remove = table.extract_from_if(..slot, |_, _| true)?;
 
-        while let Some(Ok((slot, _))) = to_remove.next() {
-            trace!(slot = slot.value(), "removing block index entry");
+            while let Some(Ok((slot, _))) = to_remove.next() {
+                trace!(slot = slot.value(), "removing block index entry");
+            }
+            drop(to_remove);
+            drop(table);
         }
-        drop(to_remove);
-        drop(table);
 
         // Delete segment files that are fully before this slot.
         let threshold_segment = BlockLocation::segment_for_slot(slot);
@@ -170,38 +343,43 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<(), Error> {
-        // Find the last entry after `slot` to know where to truncate.
-        let table = wx.open_table(Self::DEF)?;
-
-        // Find the earliest entry after `slot` to determine truncation offset.
+        // Find the earliest entry after `slot` across both indexes to
+        // determine the truncation offset. An EBB opening the first epoch
+        // after the cut sits before that epoch's first main block in the
+        // segment, so taking the minimum is what keeps its bytes from
+        // surviving the truncation.
         let mut earliest_after: Option<BlockLocation> = None;
-        {
+
+        for def in [Self::DEF, EbbsTable::DEF] {
+            let table = wx.open_table(def)?;
             let range = table.range((slot + 1)..)?;
+
             for entry in range {
                 let (_, loc_bytes) = entry?;
                 let loc = BlockLocation::from_bytes(loc_bytes.value());
+
                 match &earliest_after {
                     None => earliest_after = Some(loc),
                     Some(prev) => {
-                        if loc.segment_id < prev.segment_id
-                            || (loc.segment_id == prev.segment_id && loc.offset < prev.offset)
-                        {
+                        if written_later(prev, &loc) {
                             earliest_after = Some(loc);
                         }
                     }
                 }
             }
         }
-        drop(table);
 
         // Remove index entries.
-        let mut table = wx.open_table(Self::DEF)?;
-        let mut to_remove = table.extract_from_if(slot.., |x, _| x > slot)?;
-        while let Some(Ok((slot, _))) = to_remove.next() {
-            trace!(slot = slot.value(), "removing block index entry");
+        for def in [Self::DEF, EbbsTable::DEF] {
+            let mut table = wx.open_table(def)?;
+            let mut to_remove = table.extract_from_if(slot.., |x, _| x > slot)?;
+
+            while let Some(Ok((slot, _))) = to_remove.next() {
+                trace!(slot = slot.value(), "removing block index entry");
+            }
+            drop(to_remove);
+            drop(table);
         }
-        drop(to_remove);
-        drop(table);
 
         // Truncate the segment file if we found entries to remove.
         if let Some(loc) = earliest_after {
@@ -213,20 +391,19 @@ impl BlocksTable {
         Ok(())
     }
 
-    /// Get a range of (slot, BlockLocation) from the index.
-    /// Block data is NOT fetched here; callers use FlatFileStore to read
-    /// lazily.
+    /// Get a range of (slot, BlockLocation) from each index.
+    ///
+    /// The two are returned separately and merged by the iterator that reads
+    /// them; block data is NOT fetched here, so callers page through index
+    /// keys and only pay for the bodies they keep.
     pub fn get_range(
         rx: &ReadTransaction,
         from: Option<BlockSlot>,
         to: Option<BlockSlot>,
-    ) -> Result<redb::Range<'static, u64, &'static [u8]>, Error> {
-        let table = rx.open_table(Self::DEF)?;
-        match (from, to) {
-            (Some(from), Some(to)) => Ok(table.range(from..to)?),
-            (Some(from), None) => Ok(table.range(from..)?),
-            (None, Some(to)) => Ok(table.range(..to)?),
-            (None, None) => Ok(table.range(0..)?),
-        }
+    ) -> Result<(IndexRange, IndexRange), Error> {
+        let main = range_of(rx, Self::DEF, from, to)?;
+        let ebbs = range_of(rx, EbbsTable::DEF, from, to)?;
+
+        Ok((main, ebbs))
     }
 }

--- a/crates/redb3/src/archive/tables.rs
+++ b/crates/redb3/src/archive/tables.rs
@@ -164,12 +164,20 @@ impl BlocksTable {
     /// Fold a newly written block into the value already held at its slot.
     ///
     /// The incoming block is compared against what is stored — length first,
-    /// so a body is read only where a match is possible at all. An identical
-    /// body means this block is being written again, as a resumed restore
-    /// rewrites the layer it was in the middle of, and its entry is repointed
-    /// at the new copy. Anything else is a second block at the same slot, and
-    /// it takes position 0: blocks arrive in chain order, so the newcomer is
-    /// the one the slot should resolve to.
+    /// so a body is read only where a match is possible at all.
+    ///
+    /// An identical body means this block is being written again, as a resumed
+    /// restore rewrites the layer it was in the middle of. The entry that
+    /// points at it is then left exactly where it is, and the copy just
+    /// appended is the one nothing points at — which is the dead space restore
+    /// already documents. Repointing at the new copy would move an index entry
+    /// forward in the segment past a block it precedes in the chain, and
+    /// [`Self::undo`] truncates at the offset it removes, so that block's bytes
+    /// would go with the cut.
+    ///
+    /// Anything else is a second block at the same slot, and it takes position
+    /// 0: blocks arrive in chain order, so the newcomer is the one the slot
+    /// should resolve to.
     fn merge_location(
         existing: &[u8],
         incoming: BlockLocation,
@@ -177,9 +185,8 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
     ) -> Result<Vec<u8>, Error> {
         let mut locations: Vec<BlockLocation> = decode_locations(existing).collect();
-        let mut rewrites = None;
 
-        for (i, loc) in locations.iter().enumerate() {
+        for loc in locations.iter() {
             if loc.length as usize != body.len() {
                 continue;
             }
@@ -189,15 +196,11 @@ impl BlocksTable {
                 .map_err(super::RedbArchiveError::from_io)?;
 
             if stored == body {
-                rewrites = Some(i);
-                break;
+                return Ok(existing.to_vec());
             }
         }
 
-        match rewrites {
-            Some(i) => locations[i] = incoming,
-            None => locations.insert(0, incoming),
-        }
+        locations.insert(0, incoming);
 
         Ok(encode_locations(&locations))
     }

--- a/crates/redb3/src/archive/tables.rs
+++ b/crates/redb3/src/archive/tables.rs
@@ -135,7 +135,6 @@ impl EbbsTable {
 pub struct BlocksTable;
 
 impl BlocksTable {
-    /// Index table: slot -> BlockLocation (16 bytes packed).
     pub const DEF: IndexDef = TableDefinition::new("blocks");
 
     pub fn initialize(wx: &WriteTransaction) -> Result<(), Error> {
@@ -343,11 +342,10 @@ impl BlocksTable {
         flatfiles: &FlatFileStore,
         slot: BlockSlot,
     ) -> Result<(), Error> {
-        // Find the earliest entry after `slot` across both indexes to
-        // determine the truncation offset. An EBB opening the first epoch
-        // after the cut sits before that epoch's first main block in the
-        // segment, so taking the minimum is what keeps its bytes from
-        // surviving the truncation.
+        // An EBB opening the first epoch after the cut sits before that
+        // epoch's first main block in the segment, so taking the minimum
+        // across both indexes is what keeps its bytes from surviving the
+        // truncation.
         let mut earliest_after: Option<BlockLocation> = None;
 
         for def in [Self::DEF, EbbsTable::DEF] {

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use dolos_core::{ArchiveWriter, BlockSlot, ChainPoint, StateSchema};
+use dolos_core::{ArchiveWriter, BlockSlot, ChainPoint, RawBlock, StateSchema};
 
 use super::ArchiveStore;
 
@@ -399,4 +399,306 @@ fn test_write_after_undo() {
     writer.commit().unwrap();
 
     assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(new_block));
+}
+
+// ============================================================================
+// Byron epoch-boundary blocks
+// ============================================================================
+//
+// An EBB carries the same absolute slot as the first main block of the epoch
+// it opens. These tests pin the two apart: the sidecar index holds the EBB,
+// the main index holds the block that follows it, and every read that walks
+// the archive puts them back in chain order — EBB first.
+
+use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
+
+/// A Byron epoch boundary: the EBB opening `epoch`, then the epoch's first
+/// main block, chained onto it and sharing its slot.
+fn boundary(epoch: u64) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let ebb = make_byron_ebb(epoch, pallas::crypto::hash::Hash::new([7u8; 32]));
+    let slot = byron_ebb_slot(epoch);
+    let main = make_conway_block_with_prev(slot, ebb.0.hash(), epoch);
+
+    (ebb, main)
+}
+
+/// Write a whole boundary through one writer, in chain order.
+fn write_boundary(
+    store: &ArchiveStore,
+    epoch: u64,
+) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let (ebb, main) = boundary(epoch);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    (ebb, main)
+}
+
+fn bodies(items: Vec<(BlockSlot, Vec<u8>)>) -> Vec<Vec<u8>> {
+    items.into_iter().map(|(_, body)| body).collect()
+}
+
+#[test]
+fn an_ebb_survives_the_block_that_shares_its_slot() {
+    let store = test_store();
+    let (ebb, main) = write_boundary(&store, 3);
+    let slot = ebb.0.slot();
+
+    // The point read keeps its old meaning: the main block wins the slot.
+    assert_eq!(
+        store.get_block_by_slot(&slot).unwrap().as_ref(),
+        Some(main.1.as_ref())
+    );
+
+    // The EBB is still there, and the walk yields both, EBB first.
+    let items = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(items, vec![ebb.1.as_ref().clone(), main.1.as_ref().clone()]);
+}
+
+#[test]
+fn a_boundary_slot_reverses_into_chain_order() {
+    let store = test_store();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let items = bodies(store.get_range(None, None).unwrap().rev().collect());
+    assert_eq!(items, vec![main.1.as_ref().clone(), ebb.1.as_ref().clone()]);
+}
+
+#[test]
+fn several_boundaries_interleave_with_ordinary_blocks() {
+    let store = test_store();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    // One ordinary block between the two epochs, and one after the second.
+    let mid = make_conway_block_with_prev(byron_ebb_slot(1) + 5, main1.0.hash(), 100);
+    let tail = make_conway_block_with_prev(byron_ebb_slot(2) + 5, main2.0.hash(), 200);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &mid, &ebb2, &main2, &tail] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let expected: Vec<Vec<u8>> = [&ebb1, &main1, &mid, &ebb2, &main2, &tail]
+        .iter()
+        .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+        .collect();
+
+    let forward = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(forward, expected);
+
+    let mut backward = bodies(store.get_range(None, None).unwrap().rev().collect());
+    backward.reverse();
+    assert_eq!(backward, expected);
+}
+
+/// The two ends of the merged iterator meet without yielding a block twice or
+/// dropping one, whichever end consumes the boundary slot.
+#[test]
+fn walking_from_both_ends_covers_every_block_once() {
+    let store = test_store();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    for front_first in [0usize, 1, 2, 3, 4] {
+        let mut iter = store.get_range(None, None).unwrap();
+        let mut seen = Vec::new();
+
+        for _ in 0..front_first {
+            if let Some((_, body)) = iter.next() {
+                seen.push(body);
+            }
+        }
+
+        let mut back = Vec::new();
+        while let Some((_, body)) = iter.next_back() {
+            back.push(body);
+        }
+        back.reverse();
+        seen.extend(back);
+
+        let expected: Vec<Vec<u8>> = [&ebb1, &main1, &ebb2, &main2]
+            .iter()
+            .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+            .collect();
+
+        assert_eq!(seen, expected, "split after {front_first} from the front");
+    }
+}
+
+#[test]
+fn skipping_counts_the_ebb() {
+    use dolos_core::archive::Skippable as _;
+
+    let store = test_store();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_forward(1);
+    assert_eq!(iter.next().map(|(_, b)| b), Some(main.1.as_ref().clone()));
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_backward(1);
+    assert_eq!(
+        iter.next_back().map(|(_, b)| b),
+        Some(ebb.1.as_ref().clone())
+    );
+}
+
+#[test]
+fn the_tip_is_the_ebb_until_its_epochs_first_block_arrives() {
+    let store = test_store();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let writer = store.start_writer().unwrap();
+    writer.apply(&earlier.0, &earlier.1).unwrap();
+    writer.commit().unwrap();
+
+    let (ebb, main) = boundary(1);
+
+    // Commit the EBB on its own: for that moment it is the archive's tip.
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, ebb.0.slot());
+    assert_eq!(&tip_body, ebb.1.as_ref());
+
+    // Once the epoch's first main block lands, the slot reads as it always did.
+    let writer = store.start_writer().unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, main.0.slot());
+    assert_eq!(&tip_body, main.1.as_ref());
+}
+
+#[test]
+fn undo_unwinds_a_boundary_slot_in_reverse_arrival_order() {
+    let store = test_store();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    // First undo at the shared slot takes the main block — the one written
+    // last — and leaves the EBB.
+    let writer = store.start_writer().unwrap();
+    writer.undo(&main.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&main.0.slot()).unwrap(), None);
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone(), ebb.1.as_ref().clone()]
+    );
+
+    // The second undo at the same slot takes the EBB.
+    let writer = store.start_writer().unwrap();
+    writer.undo(&ebb.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+}
+
+#[test]
+fn truncate_front_drops_an_ebb_past_the_cut() {
+    let store = test_store();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&earlier.0).unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+
+    // The segment was truncated at the EBB's offset, so the archive can be
+    // written forward again from there.
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![
+            earlier.1.as_ref().clone(),
+            ebb.1.as_ref().clone(),
+            main.1.as_ref().clone()
+        ]
+    );
+}
+
+#[test]
+fn remove_before_prunes_both_indexes() {
+    let store = test_store();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    // Prune everything more than one Byron epoch behind the tip.
+    store.prune_history(1, None).unwrap();
+
+    let slots: Vec<BlockSlot> = store
+        .get_range(None, None)
+        .unwrap()
+        .map(|(slot, _)| slot)
+        .collect();
+
+    assert_eq!(slots, vec![byron_ebb_slot(2), byron_ebb_slot(2)]);
+}
+
+#[test]
+fn find_intersect_resolves_an_ebb_by_its_own_hash() {
+    let store = test_store();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    // The main block still resolves at the shared slot.
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&main.0)).unwrap(),
+        Some(main.0.clone())
+    );
+
+    // And so does the EBB, which the slot alone can no longer distinguish.
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&ebb.0)).unwrap(),
+        Some(ebb.0.clone())
+    );
 }

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -401,10 +401,6 @@ fn test_write_after_undo() {
     assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(new_block));
 }
 
-// ============================================================================
-// Byron epoch-boundary blocks
-// ============================================================================
-//
 // An EBB carries the same absolute slot as the first main block of the epoch
 // it opens. These tests pin the two apart: the sidecar index holds the EBB,
 // the main index holds the block that follows it, and every read that walks

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -500,6 +500,40 @@ fn rewriting_a_shared_slot_keeps_both_blocks_in_order() {
 }
 
 #[test]
+fn rewriting_the_older_block_at_a_shared_slot_leaves_undo_sound() {
+    let store = test_store();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    // The older block on its own, written again — what a restore that stops
+    // between the two blocks of a shared slot redoes when it resumes. Its
+    // index entry must not move ahead of the block it precedes.
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer.commit().unwrap();
+
+    // Undo takes the newest block and truncates the segment at its offset, so
+    // an entry that had moved past that offset would lose its bytes to the cut.
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(100)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(first.clone()));
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first]
+    );
+}
+
+#[test]
 fn a_shared_slot_resolves_the_way_a_single_location_did() {
     use ::redb::ReadableDatabase as _;
 

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -401,10 +401,135 @@ fn test_write_after_undo() {
     assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(new_block));
 }
 
-// An EBB carries the same absolute slot as the first main block of the epoch
-// it opens. These tests pin the two apart: the sidecar index holds the EBB,
-// the main index holds the block that follows it, and every read that walks
-// the archive puts them back in chain order — EBB first.
+// A slot is not a unique chain position, so these tests pin what the archive
+// does when two blocks are written to one: it keeps both, resolves the slot to
+// the one written last, and walks them in the order they arrived. The first
+// group says that with opaque payloads, because nothing in the store needs to
+// know what kind of block causes the collision.
+
+#[test]
+fn a_slot_keeps_every_block_written_to_it() {
+    let store = test_store();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    // The slot resolves to the block written last, which is what the
+    // overwrite this fixes already yielded.
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second.clone()));
+
+    assert_eq!(
+        store.get_blocks_by_slot(&100).unwrap(),
+        vec![first.clone(), second.clone()]
+    );
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+#[test]
+fn a_slot_keeps_blocks_written_in_separate_batches() {
+    let store = test_store();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for body in [&first, &second] {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second.clone()]
+    );
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second));
+}
+
+#[test]
+fn writing_the_same_block_again_leaves_one_copy() {
+    let store = test_store();
+    let body = fake_block(100);
+
+    // What a resumed restore does to the layer it was in the middle of: the
+    // same records again, over rows that are already committed.
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(store.get_blocks_by_slot(&100).unwrap(), vec![body.clone()]);
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![body]
+    );
+}
+
+#[test]
+fn rewriting_a_shared_slot_keeps_both_blocks_in_order() {
+    let store = test_store();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+        writer
+            .apply(&point(100), &Arc::new(second.clone()))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+#[test]
+fn a_shared_slot_resolves_the_way_a_single_location_did() {
+    use ::redb::ReadableDatabase as _;
+
+    let store = test_store();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first)).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    // What a binary that predates multi-block slots reads out of the index
+    // value: the first packed location. It has to be the block the slot
+    // resolves to, or such a binary would start answering with a different
+    // block than it did before.
+    let rx = store.db().begin_read().unwrap();
+    let table = rx.open_table(super::tables::BlocksTable::DEF).unwrap();
+    let value = table.get(100u64).unwrap().unwrap();
+    let loc = super::flatfiles::BlockLocation::from_bytes(value.value());
+
+    assert_eq!(store.flatfiles.read(&loc).unwrap(), second);
+}
+
+// The Byron case the invariant above exists for: an EBB carries the same
+// absolute slot as the first main block of the epoch it opens, and every read
+// that walks the archive puts them back in chain order — EBB first.
 
 use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
 
@@ -596,12 +721,15 @@ fn undo_unwinds_a_boundary_slot_in_reverse_arrival_order() {
     writer.commit().unwrap();
 
     // First undo at the shared slot takes the main block — the one written
-    // last — and leaves the EBB.
+    // last — and leaves the EBB, which the slot then resolves to.
     let writer = store.start_writer().unwrap();
     writer.undo(&main.0).unwrap();
     writer.commit().unwrap();
 
-    assert_eq!(store.get_block_by_slot(&main.0.slot()).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&main.0.slot()).unwrap().as_ref(),
+        Some(ebb.1.as_ref())
+    );
     assert_eq!(
         bodies(store.get_range(None, None).unwrap().collect()),
         vec![earlier.1.as_ref().clone(), ebb.1.as_ref().clone()]
@@ -616,6 +744,8 @@ fn undo_unwinds_a_boundary_slot_in_reverse_arrival_order() {
         bodies(store.get_range(None, None).unwrap().collect()),
         vec![earlier.1.as_ref().clone()]
     );
+
+    assert_eq!(store.get_block_by_slot(&main.0.slot()).unwrap(), None);
 }
 
 #[test]
@@ -657,7 +787,7 @@ fn truncate_front_drops_an_ebb_past_the_cut() {
 }
 
 #[test]
-fn remove_before_prunes_both_indexes() {
+fn remove_before_prunes_every_block_at_a_slot() {
     let store = test_store();
 
     let (ebb1, main1) = boundary(1);

--- a/crates/testing/src/blocks.rs
+++ b/crates/testing/src/blocks.rs
@@ -136,6 +136,58 @@ pub fn make_conway_block_with_tx(
     (chain_point, Arc::new(raw_bytes))
 }
 
+/// Number of slots in a Byron epoch on the default genesis values pallas uses
+/// to resolve an epoch-boundary block's absolute slot.
+pub const BYRON_EPOCH_LENGTH: u64 = 21_600;
+
+/// The absolute slot a Byron epoch-boundary block for `epoch` lands on — the
+/// same slot the epoch's first main block carries, which is the collision the
+/// archive has to keep both sides of.
+pub fn byron_ebb_slot(epoch: u64) -> BlockSlot {
+    epoch * BYRON_EPOCH_LENGTH
+}
+
+/// Build a Byron epoch-boundary block opening `epoch`, chained onto
+/// `prev_hash`.
+///
+/// The body is empty: nothing downstream of the archive reads an EBB's
+/// stakeholder list, and what the tests need from it is the shape the era
+/// probe and the header hash see.
+pub fn make_byron_ebb(epoch: u64, prev_hash: Hash<32>) -> (ChainPoint, RawBlock) {
+    use pallas::codec::utils::{EmptyMap, MaybeIndefArray};
+    use pallas::ledger::primitives::byron::{EbBlock, EbbCons, EbbHead};
+
+    let header = KeepRaw::from(EbbHead {
+        protocol_magic: 764_824_073,
+        prev_block: prev_hash,
+        body_proof: Hash::new([0u8; 32]),
+        consensus_data: EbbCons {
+            epoch_id: epoch,
+            difficulty: MaybeIndefArray::Def(vec![epoch]),
+        },
+        extra_data: (EmptyMap,),
+    });
+
+    let block = EbBlock {
+        header,
+        body: MaybeIndefArray::Def(vec![]),
+        extra: MaybeIndefArray::Def(vec![]),
+    };
+
+    let wrapper = (0u16, block);
+    let raw_bytes = pallas::codec::minicbor::to_vec(&wrapper).unwrap();
+
+    // The header hash is taken off the encoded bytes rather than computed from
+    // the value, so it is the hash every reader of the archived block will
+    // arrive at.
+    let decoded = pallas::ledger::traverse::MultiEraBlock::decode(&raw_bytes).unwrap();
+    let point = ChainPoint::Specific(decoded.slot(), decoded.hash());
+
+    debug_assert_eq!(decoded.slot(), byron_ebb_slot(epoch));
+
+    (point, Arc::new(raw_bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use pallas::ledger::traverse::MultiEraBlock;

--- a/crates/testing/src/faults.rs
+++ b/crates/testing/src/faults.rs
@@ -211,6 +211,15 @@ impl ArchiveStore for FaultyArchiveStore {
             .map_err(ArchiveError::from)
     }
 
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner
+            .get_blocks_by_slot(slot)
+            .map_err(ArchiveError::from)
+    }
+
     fn get_range<'a>(
         &self,
         from: Option<BlockSlot>,

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -877,6 +877,13 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         }
     }
 
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        match self {
+            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
+            Self::NoOp(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
+        }
+    }
+
     fn get_range<'a>(
         &self,
         from: Option<BlockSlot>,

--- a/src/bin/dolos/data/check/archive.rs
+++ b/src/bin/dolos/data/check/archive.rs
@@ -114,6 +114,48 @@ mod tests {
         assert!(issues.is_empty(), "{issues:?}");
     }
 
+    /// A Byron epoch boundary as the archive now yields it: the EBB, then the
+    /// epoch's first main block on the same slot, pointing back at it. The
+    /// walk has to accept both — the slot does not advance and the parent is
+    /// the EBB, not the block before it.
+    #[test]
+    fn a_byron_boundary_passes_when_the_ebb_is_there() {
+        use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb};
+
+        let mut blocks = chain(byron_ebb_slot(1) - 2, 2);
+        let last_hash = MultiEraBlock::decode(&blocks[1].1).unwrap().hash();
+
+        let (ebb_point, ebb_body) = make_byron_ebb(1, last_hash);
+        let slot = ebb_point.slot();
+        blocks.push((slot, ebb_body.as_ref().clone()));
+
+        let (_, first_of_epoch) = make_conway_block_with_prev(slot, ebb_point.hash(), 2);
+        blocks.push((slot, first_of_epoch.as_ref().clone()));
+
+        let issues = check_continuity(blocks.into_iter(), |_| {});
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    /// The defect this check exists to catch: the same boundary with the EBB
+    /// missing, which is what every pre-fix archive holds. The epoch's first
+    /// block then claims a parent the archive never yields.
+    #[test]
+    fn a_byron_boundary_is_reported_when_the_ebb_is_missing() {
+        use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb};
+
+        let mut blocks = chain(byron_ebb_slot(1) - 2, 2);
+        let last_hash = MultiEraBlock::decode(&blocks[1].1).unwrap().hash();
+
+        let (ebb_point, _) = make_byron_ebb(1, last_hash);
+        let slot = ebb_point.slot();
+
+        let (_, first_of_epoch) = make_conway_block_with_prev(slot, ebb_point.hash(), 2);
+        blocks.push((slot, first_of_epoch.as_ref().clone()));
+
+        let issues = check_continuity(blocks.into_iter(), |_| {});
+        assert_eq!(issues.len(), 1, "{issues:?}");
+    }
+
     #[test]
     fn an_empty_archive_passes() {
         let issues = check_continuity(std::iter::empty(), |_| {});


### PR DESCRIPTION
Plan: `plans/dolos-archive-byron-ebb-overwrite.md`

## The defect

The redb archive's `blocks` table mapped a slot to exactly one block
(`crates/redb3/src/archive/tables.rs`), and a Byron epoch-boundary block
carries the same absolute slot as the first main block of the epoch it opens.
`apply_batch` appended both blocks to the segment file but could only keep one
index row, so the main block **overwrote the EBB** on every Byron epoch. The
EBB's bytes stayed orphaned in the segment; no iteration or point read ever
yielded them. `data dump-blocks`, minibf, `data check`, and every stele cut
from such an archive inherited the omission.

## What changed

**A slot maps to a list of blocks, not to one.** The `blocks` table keeps its
key and its shape; its value widens from one packed 16-byte `BlockLocation` to
a sequence of them, newest first.

The archive is not told what a Byron epoch-boundary block is, and does not ask.
The invariant it holds is **the slot index never loses a block to a key
collision**, which needs no chain knowledge at all:

- **Position 0 is the block the slot resolves to** — the one written there
  last, which at a Byron boundary is the main block, which is exactly what the
  overwrite already yielded. `BlockLocation::from_bytes` reads the first 16
  bytes, so a v1.6 binary opening a healed archive returns the same block it
  returns today. Compatibility is not merely additive; at every slot it is
  identical.
- **Chain order is the list order.** The writer hands blocks over in chain
  order, so a block arriving at an occupied slot is the chain-later one and
  takes position 0. Nothing compares offsets to work out which block is "the
  boundary one".
- **No migration and no re-key.** An existing 16-byte value is a one-element
  list, so ~13M mainnet rows are read as they stand. The composite
  `(slot, ordinal)` key would have re-keyed all of them to disambiguate 208.

**Write path.** The index insert already answers whether the slot was taken —
`redb::Table::insert` returns the previous value — so an uncontested slot costs
one index write and no lookup, exactly as before. On a collision the incoming
block is compared against what was stored, length first and then the bytes, so
a body is read only where a match is possible. Identical means this block is
being written again — a resumed restore rewrites the layer it was in the middle
of — and the entry that points at it is **left where it is**, the freshly
appended copy becoming the dead space restore already documents; repointing it
would move an index entry forward in the segment past a block it precedes in
the chain, and `undo` truncates at the offset it removes, so that block's bytes
would go with the cut (found in review, regression test included). Anything
else is a second block at that slot and both are kept. There is no era probe on
the write path.

**Read path.** `get_block_by_slot`, `get_tip`, `first` and `last` read position
0 and keep their meaning. `ArchiveRangeIter` keeps its single `redb::Range`;
an entry expands to its locations and whatever is left of the entry each end is
working through is buffered, so a forward and a backward walk meet without
yielding a block twice or dropping one. `find_intersect` walks the slot's
blocks and compares hashes, with no fallback branch. `undo` takes position 0 —
LIFO matches rollback order — and the slot survives until its last block is
gone. `remove_after` takes the truncation minimum across every location in each
value; `remove_before` is untouched.

**Retrieval by hash, which the first revision of this PR left open.**
`dolos_core::ArchiveStore` gains `get_blocks_by_slot`, defaulted to
`get_block_by_slot` so `NoOpArchiveStore` inherits it, and overridden by redb3
and by the two wrappers on the live path. `AsyncQuery::block_by_hash` resolves
the slot through `IndexStore::slot_by_block_hash` as before and picks the
candidate whose hash matches — one candidate, the ordinary case, still costs no
decode. **An EBB is now retrievable by its own hash**, which is what makes the
plan's objective true rather than nearly true. The store hands back candidates;
hash matching stays in Cardano-land.

## Why not the `ebbs` sidecar this PR first proposed

It worked and it was verified against mainnet, and it put a Cardano era concept
inside the storage crate: a table named for a Byron block kind, an era probe on
the write path of every block, cross-table special cases in `undo`, `first`,
`last` and `remove_after`, a ~140-line double-ended merge of two ranges, and a
permanently widened public module surface so a Byron-specific example could
reach the index definitions. The keying above costs less code, keeps the store
generic, and makes the guarantee structural rather than conditional on every
writer classifying its blocks correctly.

## Migration: restore or re-sync, no in-place repair

Unchanged by the redesign. Per the sequencing ruling recorded on the plan
(`org/founder`, 2026-08-20):

- **The change rides v1.7.** It changes what the on-disk archive holds, and
  v1.7 is the release that carries those.
- **The operator-facing upgrade path is a full restore or re-sync.** The
  shipped binary gains **no** repair capability — no `dolos data` maintenance
  subcommand, no startup hook, no lazy heal.
- **No stele-format change.** Steles carry `(slot, hash, body)` records and the
  codec's `OrderCheck` already tolerates same-slot runs; restore ingests through
  `ArchiveWriter::apply`, so the fixed writer fixes restore for free.

**One out-of-band exception**: `crates/redb3/examples/heal-byron-ebbs.rs`, a
dev-only example target outside the `dolos` CLI, for the single archive that
cannot wait — the publisher's own local snapshot, since every stele cut from it
inherits the omission. Its guards are unchanged: a gap is indexed **only** if it
holds exactly one CBOR item, the era probe calls that item an epoch-boundary
block, and it chains onto both neighbours; an unclassifiable gap **refuses the
whole run** and writes nothing. It now folds the recovered location into its
slot's list rather than into a sidecar table, and it reaches the archive
internals through a new non-default `maintenance` feature, so the crate's
ordinary public surface stays where it was.

## Verification

`cargo +nightly fmt --all --check`, `cargo clippy --all-targets --all-features
-- -D warnings` (CI's invocation, exit 0), `cargo test --workspace
--all-targets` (38 targets, 0 failures) and `cargo test --workspace
--all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo
--exclude dolos-trp` (36 targets, 0 failures) all pass. The recovery example is
now gated on `maintenance`, so its 5 guard tests run in the all-features job
rather than in both.

Tests: 6 new ones in `crates/redb3/src/archive/tests.rs` state the invariant
with **opaque payloads** — two blocks at one slot survive, in one batch and
across batches; writing the same block again leaves one copy; rewriting a
shared slot keeps both in order; rewriting the *older* block of a shared slot on
its own leaves `undo`'s truncation sound (the review finding above — it fails on
the prior commit with a dangling index entry); and the slot still resolves
through the first packed location. That the store's contract is now testable without a single
Cardano fixture is the point of the redesign. The 11 Byron-block tests from the
first revision are kept unchanged (boundary slot forward, reversed, interleaved,
met from both ends, skipped, tipped on, undone, truncated, pruned, intersected
by hash), as are the 2 continuity tests in `data/check/archive.rs` and the 5 in
the example. 2 new tests in `crates/core/src/async_query.rs` pin hash picking.

**Against real chain data**, using release builds of this branch and of a
pre-fix commit, both synced from mainnet genesis:

| | pre-fix | this branch |
|---|---|---|
| slot 0 | `f0f7892b…` only | `89d9b5a5…` (EBB) then `f0f7892b…` |
| `/blocks/89d9b5a5…` — the EBB's own hash | `f0f7892b…`, the wrong block, silently | the EBB, 648085 bytes |
| `data check --check archive-continuity` | 0 issues | 0 issues |

- **Mainnet, synced from genesis on this branch**: slot 0 yields both blocks in
  chain order — the genesis EBB `89d9b5a5…` (number 0) then the first main block
  `f0f7892b…` (number 1). Continuity clean. *(Criteria 1 and 2.)*
- **The live by-hash path**: on a pre-fix archive, asking for the EBB's hash
  returns the epoch's first main block — the index resolves the hash to slot 0
  and the archive answers with the block the slot resolved to. On this branch it
  returns the EBB. *(Criterion 5, the escalation the first revision left open.)*
- **Mainnet, synced from genesis with a pre-fix binary**: 599 indexed blocks, 0
  sharing a slot, 1 segment gap of 648087 bytes at offset 0 — the orphaned
  genesis EBB. The scan recovered it, a second run reported 0 gaps and nothing
  to recover, and the healed archive then yields both blocks at slot 0 **without
  a re-import**, passes continuity, and answers the EBB's hash with the EBB.
  *(Criterion 3.)*
- **Backward compatibility, measured on both archives**: the pre-fix release
  binary reads the archive this branch wrote, and the archive the scan healed,
  and returns `f0f7892b…` at slot 0 — exactly what it returned before. Not
  "it doesn't see the new table": the same answer, byte for byte.
- `dolos data --help` on the release build offers no repair command.

## Findings

1. **`archive-continuity` cannot catch a missing *genesis* EBB.** Established in
   the first revision and unchanged: with the tip at `ChainPoint::Origin` there
   is no hash to compare against, so a pre-fix mainnet archive passes the check
   despite the hole. Interior boundaries are caught, and a unit test pins that.
   Outside this plan's scope.
2. **The plan's done criteria named preprod; preprod cannot show the defect.**
   Its Byron era holds exactly one EBB (at slot 0) and its first main block is
   at slot 2, so nothing shares a slot. Mainnet is the case, and the plan record
   now says so.
3. **`ArchiveStore::get_block_by_hash` and `get_block_by_number` are dead code**
   — they read archive-database tables that are never initialized or populated,
   and have no caller. Unchanged and not revived here: the live path is
   `IndexStore::slot_by_block_hash` → `get_blocks_by_slot` → pick by hash.
4. **Three pre-existing clippy findings in `crates/cardano`**
   (`model/proposals.rs`, `ewrap/loading.rs` ×2) surface under AGENTS.md's
   `--workspace --all-targets --all-features` invocation. Confirmed still
   present on this branch, outside CI's clippy invocation, which passes. Not
   touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archive queries now return all blocks stored at the same slot, improving handling of Byron boundaries and shared-slot blocks.
  * Added a maintenance tool to safely detect and recover missing Byron epoch-boundary blocks, with dry-run and commit modes.
  * Block lookup by hash now continues past unreadable candidates to find valid matches.

* **Bug Fixes**
  * Improved archive iteration, undo, truncation, pruning, and continuity checks for shared-slot blocks.
  * Added safeguards against unsafe or incomplete boundary-block recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->