### PR TITLE
fix(snapshot): align the stele's sequence and tag with the epoch it names

### DIFF
--- a/adrs/004_stelae_snapshots.md
+++ b/adrs/004_stelae_snapshots.md
@@ -156,9 +156,19 @@ State namespaces: the 16 entity namespaces from `dolos_cardano::model::build_sch
 
 The `digests` layer covers the immutable files fully contained in the stele's block range: `lastImmutable` is derived from the boundary slot and the chunk geometry observed in the chain — canonical, never dependent on aggregator state at publish time. Digest values equal Mithril Cardano DB v2's merkle leaves (hex-decoded), so any Mithril certificate whose beacon covers `lastImmutable` can verify them via the aggregator's digest route and a merkle proof. The certificate reference is deliberately *not* part of the inscription: certificates are produced on the aggregator's cadence, so two independent publishers at the same boundary would reference different certificates — including one would break cross-publisher determinism, while the digest values themselves are byte-stable properties of the chain.
 
+### The cut point and the boundary sliver
+
+A stele is cut by syncing with `chain.stop_epoch = E`, and the halt is **one block past the epoch boundary**, not on it. The sync crosses the boundary — Ewrap closes epoch E-1, Estart opens epoch E — and then applies the first block of epoch E before stopping. That block is what makes the stele addressable: after Estart alone the cursor names a slot with no block at it, and `position.point` must carry a block hash for a stele to be verifiable against a chain.
+
+So the epoch windows a stele covers are `0..=E`: epochs `0..E-1` **complete**, plus epoch E's **boundary sliver** — the window that opens at `epoch_start(E)` and closes at the anchoring block. The sliver is normative, not an artifact of where a publisher happened to stop.
+
+It is load-bearing because of how boundary data is keyed. **All of epoch X's boundary logs key at `epoch_start(X)`**: Ewrap writes the *ending* epoch's closing logs and its completed `EpochState` at `epoch_start(X)` when X is the epoch it closes, and Estart writes the *starting* epoch's opening account logs at `epoch_start(X)` when X is the epoch it opens. One temporal key per epoch, and nothing straddles two windows. Epoch E's estart logs therefore live inside the sliver and nowhere else: a stele that dropped the sliver in the name of a clean boundary would ship a state tip whose opening logs are in no layer at all, and a restored node would never regenerate them.
+
+`sequence`, the immutable tag's E, and `position.epoch` are consequently **one number**: the epoch the cursor stands in, which is also the last epoch the layers cover. The operator-facing form of the same rule is *configure the epoch you want the node to start in* — `stop_epoch = E` produces the stele tagged `epoch-E`.
+
 ### OCI layout and the inscription
 
-- Repository per (profile, network) — e.g. `ghcr.io/txpipe/dolos-snapshots/mainnet`; tags `epoch-E` (E = newly started epoch; layers cover epochs `0..E-1`) and `latest`. The protocol requires an immutable tag per sequence plus a moving `latest`; the profile renders the strings.
+- Repository per (profile, network) — e.g. `ghcr.io/txpipe/dolos-snapshots/mainnet`; tags `epoch-E` (E = the newly started epoch, equal to `sequence` and to `position.epoch`; layers cover epochs `0..E-1` complete plus epoch E's boundary sliver — see "The cut point and the boundary sliver" above) and `latest`. The protocol requires an immutable tag per sequence plus a moving `latest`; the profile renders the strings.
 - `artifactType: application/vnd.stelae.stele.v1`; layer media types per the table above; three annotations per layer, named in "The manifest" below — one of them normative, the other two informational.
 - Config blob (`application/vnd.stelae.inscription.v1+json`), canonical JSON per RFC 8785. Generic keys plus three profile-owned opaque objects — `position`, `parameters` and each layer's `scope`:
 
@@ -167,7 +177,7 @@ The `digests` layer covers the immutable files fully contained in the stele's bl
   "profile": {"name": "io.txpipe.dolos.cardano", "version": 1},
   "sequence": 550,
   "position": { "network": {"magic": 764824073, "name": "mainnet"},
-                "point": {"slot": 133660800, "hash": "…"},
+                "point": {"slot": 152236812, "hash": "…"},
                 "epoch": 550 },
   "parameters": { "stateShards": 16, "indexKeyHash": "xxh3-64" },
   "compression": {"algo": "zstd", "level": 9},
@@ -314,8 +324,8 @@ The resolution is `dolos::common::stele_registry_auth`, a pure function of `[ste
 ### Publisher pipeline
 
 1. Restore the publisher node from the previous stele (self-hosting delta pull; first run via Mithril).
-2. Sync with `chain.stop_epoch = E` until `StopEpochReached` — state lands exactly on the boundary.
-3. `dolos snapshot publish` — only the newly closed epoch's layers upload; fresh state shards + inscription; tag `epoch-E`, move `latest`. On networks with a Mithril aggregator, fetch the immutable-file digest list from the aggregator's digest route, verify it against a certificate, and write the `digests` layer for the files within the boundary.
+2. Sync with `chain.stop_epoch = E` until `StopEpochReached` — the state crosses the boundary and lands on the **first block of epoch E**, the block that gives `position.point` a hash.
+3. `dolos snapshot publish` — only the newly closed epoch's layers and epoch E's boundary sliver upload; fresh state shards + inscription; tag `epoch-E`, move `latest`. On networks with a Mithril aggregator, fetch the immutable-file digest list from the aggregator's digest route, verify it against a certificate, and write the `digests` layer for the files within the boundary.
 4. Determinism job: an independent runner that synced by any means runs `dolos snapshot digest` and alerts on inscription mismatch.
 5. Matching verifiers sign and push referrer signatures; clients enforce k-of-n.
 

--- a/adrs/004_stelae_snapshots.md
+++ b/adrs/004_stelae_snapshots.md
@@ -158,7 +158,7 @@ The `digests` layer covers the immutable files fully contained in the stele's bl
 
 ### The cut point and the boundary sliver
 
-A stele is cut by syncing with `chain.stop_epoch = E`, and the halt is **one block past the epoch boundary**, not on it. The sync crosses the boundary — Ewrap closes epoch E-1, Estart opens epoch E — and then applies the first block of epoch E before stopping. That block is what makes the stele addressable: after Estart alone the cursor names a slot with no block at it, and `position.point` must carry a block hash for a stele to be verifiable against a chain.
+A stele is cut by syncing with `chain.stop_epoch = E`, and the halt is **one block past the epoch boundary**, not on it. The sync crosses the boundary — Ewrap closes epoch E-1, Estart opens epoch E — and then applies the first block of epoch E before stopping. That block is what makes the stele addressable: Estart alone leaves the cursor a bare `ChainPoint::Slot` carrying no block hash (`estart::commit_finalize`), and `position.point` must carry one for a stele to be verifiable against a chain. The anchoring block may itself sit exactly on `epoch_start(E)`, in which case the sliver is one slot wide.
 
 So the epoch windows a stele covers are `0..=E`: epochs `0..E-1` **complete**, plus epoch E's **boundary sliver** — the window that opens at `epoch_start(E)` and closes at the anchoring block. The sliver is normative, not an artifact of where a publisher happened to stop.
 

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -8,13 +8,16 @@
 //!
 //! ## The two facts only an exporter can know
 //!
-//! **Epoch geometry.** A stele's `sequence` is the epoch its cursor has just
-//! entered, and its layers cover every epoch below that. [`Plan`] derives both
-//! from a [`ChainSummary`] and a cursor, so two publishers standing at the same
-//! chain point compute the same windows — including for the final, possibly
-//! partial epoch, whose slot window is clamped to the cursor rather than to the
-//! epoch boundary. Landing on a true boundary is the publisher pipeline's job,
-//! not this module's.
+//! **Epoch geometry.** A stele's `sequence` is the epoch its cursor stands in,
+//! and its layers cover every epoch up to and including that one — decision
+//! 0025: `stop_epoch`, the tag, `sequence` and `position.epoch` all name the
+//! same epoch. [`Plan`] derives both from a [`ChainSummary`] and a cursor, so
+//! two publishers standing at the same chain point compute the same windows —
+//! including for the final epoch, whose slot window is clamped to the cursor
+//! rather than to the epoch boundary. That last window is a deliberate sliver,
+//! not an accident: a `stop_epoch = E` sync halts after applying the *first
+//! block of epoch E*, so the window carries that one block together with epoch
+//! E's opening (estart) logs, which key at `epoch_start(E)`.
 //!
 //! **The network name.** It rides inside the canonical JSON, so it is inside
 //! the stele's identity. [`crate::Network::for_magic`] is the only way to build
@@ -111,7 +114,8 @@ pub struct Plan {
     pub network: Network,
     /// The chain point the stele stands at — the state store's cursor.
     pub cursor: ChainPoint,
-    /// The protocol's `sequence`: the epoch the cursor has just entered.
+    /// The protocol's `sequence`: the epoch the cursor stands in, which is
+    /// also the last epoch the layers cover and this stele's `position.epoch`.
     pub sequence: u64,
     /// The epochs whose layers this export writes, ascending.
     pub epochs: Vec<EpochWindow>,
@@ -120,11 +124,12 @@ pub struct Plan {
 impl Plan {
     /// Derive the geometry of a publish standing at `cursor`.
     ///
-    /// The stele's `sequence` is `epoch_of(cursor) + 1` — ADR-004's E, the
-    /// newly started epoch — and its layers cover `0..=epoch_of(cursor)`.
-    /// The last window's `end_slot` is clamped to the cursor, so a stele
-    /// cut mid-epoch is still byte-identical between two publishers
-    /// standing at the same point.
+    /// The stele's `sequence` is `epoch_of(cursor)` — ADR-004's E, the newly
+    /// entered epoch — and its layers cover `0..=epoch_of(cursor)`: epochs
+    /// `0..E-1` complete, plus epoch E's boundary sliver. The last window's
+    /// `end_slot` is clamped to the cursor, so a stele cut on the first block
+    /// of E is still byte-identical between two publishers standing at the
+    /// same point.
     pub fn new(
         summary: &ChainSummary,
         network: Network,
@@ -152,7 +157,7 @@ impl Plan {
         Ok(Self {
             network,
             cursor,
-            sequence: tip_epoch + 1,
+            sequence: tip_epoch,
             epochs,
         })
     }
@@ -173,9 +178,9 @@ impl Plan {
 
     /// The profile's `position` for this plan.
     pub fn position(&self) -> Result<serde_json::Value, Error> {
-        // `sequence` names the epoch just entered; `position.epoch` names the
-        // one the cursor is standing in, which is the last one the layers cover.
-        crate::position(&self.network, &self.cursor, self.sequence - 1)
+        // One number: the epoch just entered is the one the cursor stands in
+        // and the last one the layers cover (decision 0025).
+        crate::position(&self.network, &self.cursor, self.sequence)
     }
 
     /// The immutable tag this stele would publish under.
@@ -189,7 +194,7 @@ impl Plan {
     fn state_scope(&self, shard: u8) -> StateScope {
         StateScope {
             network_magic: self.network.magic(),
-            epoch: self.sequence - 1,
+            epoch: self.sequence,
             shard,
         }
     }
@@ -1253,7 +1258,7 @@ fn write_digests<W: SteleWriter>(
 
     let scope = DigestsScope {
         network_magic: plan.network.magic(),
-        epoch: plan.sequence - 1,
+        epoch: plan.sequence,
         last_immutable,
     };
 
@@ -1311,13 +1316,68 @@ mod tests {
         ChainPoint::Specific(slot, BlockHash::new([0xab; 32]))
     }
 
+    /// Decision 0025's one number: `sequence`, the tag and `position.epoch`
+    /// all name the epoch the cursor stands in, and the layers cover
+    /// `0..=sequence`.
     #[test]
     fn the_sequence_is_the_epoch_the_cursor_has_just_entered() {
         let plan = Plan::new(&summary(), Network::for_magic(2), point(250)).unwrap();
 
-        assert_eq!(plan.sequence, 3);
-        assert_eq!(plan.epochs.len(), 3);
+        assert_eq!(plan.sequence, 2);
+        assert_eq!(plan.tag().unwrap(), "epoch-2");
         assert_eq!(plan.position().unwrap()["epoch"], 2u64);
+        assert_eq!(plan.epochs.len(), 3);
+        assert_eq!(plan.epochs.last().unwrap().epoch, plan.sequence);
+    }
+
+    /// The geometry a `stop_epoch = E` sync actually produces, pinned as
+    /// deliberate rather than tolerated (decision 0025).
+    ///
+    /// The sync halts after applying the *first block of epoch E* — the block
+    /// that gives `position.point` a hash — so the last window is epoch E's
+    /// boundary sliver: it opens at `epoch_start(E)`, where estart writes
+    /// epoch E's opening logs, and closes at that one block. Epochs `0..E-1`
+    /// are complete beneath it.
+    #[test]
+    fn the_last_window_is_the_boundary_sliver_of_the_sequence_epoch() {
+        // Epoch 3 opens at slot 300; the anchoring block lands just inside it.
+        let plan = Plan::new(&summary(), Network::for_magic(2), point(301)).unwrap();
+
+        assert_eq!(plan.sequence, 3);
+        assert_eq!(plan.tag().unwrap(), "epoch-3");
+        assert_eq!(plan.position().unwrap()["epoch"], 3u64);
+
+        assert_eq!(
+            plan.epochs.last().unwrap(),
+            &EpochWindow {
+                epoch: 3,
+                start_slot: 300,
+                end_slot: 301,
+            },
+            "the sliver carries the anchoring block and epoch 3's estart logs"
+        );
+
+        assert_eq!(
+            &plan.epochs[..3],
+            &[
+                EpochWindow {
+                    epoch: 0,
+                    start_slot: 0,
+                    end_slot: 99
+                },
+                EpochWindow {
+                    epoch: 1,
+                    start_slot: 100,
+                    end_slot: 199
+                },
+                EpochWindow {
+                    epoch: 2,
+                    start_slot: 200,
+                    end_slot: 299
+                },
+            ],
+            "every epoch below the sliver is complete"
+        );
     }
 
     /// A stele cut mid-epoch clamps its last window to the cursor, so two
@@ -1386,7 +1446,7 @@ mod tests {
             .restrict_epochs(Some(1), Some(1));
 
         assert_eq!(
-            plan.sequence, 3,
+            plan.sequence, 2,
             "the sequence is the cursor's, not the cut"
         );
         assert_eq!(plan.epochs.len(), 1);
@@ -1407,7 +1467,7 @@ mod chain_tests {
         let mut inscription = Inscription::new(
             &DolosProfile,
             sequence,
-            json!({"epoch": sequence.saturating_sub(1)}),
+            json!({"epoch": sequence}),
             crate::parameters(),
             crate::compression(),
         );

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -178,8 +178,6 @@ impl Plan {
 
     /// The profile's `position` for this plan.
     pub fn position(&self) -> Result<serde_json::Value, Error> {
-        // One number: the epoch just entered is the one the cursor stands in
-        // and the last one the layers cover (decision 0025).
         crate::position(&self.network, &self.cursor, self.sequence)
     }
 

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -1397,7 +1397,7 @@ mod tests {
         let mut inscription = Inscription::new(
             &DolosProfile,
             sequence,
-            json!({"epoch": sequence.saturating_sub(1)}),
+            json!({"epoch": sequence}),
             crate::parameters(),
             crate::compression(),
         );

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -56,7 +56,7 @@ use watcher::Watcher;
 
 /// The identity of an export over an empty store set at [`SKELETON_POINT`].
 const GOLDEN_SKELETON: &str =
-    "sha256:39760ea7fb39fb5f9bb87b279532087bba36ac120e61e0eba1a0c8056372fad7";
+    "sha256:269fcc843a25e97ffdfecee796ca1c4b2e7f3e85575abf5736a640baff8d4fe7";
 
 /// The chain point the skeleton fixture stands at: mid-epoch-2 under
 /// [`skeleton_summary`], so the export covers three epochs and the last window
@@ -581,7 +581,7 @@ const CANONICAL_SKELETON: &str = concat!(
     r#"{"diffId":"sha256:e6efd8da5e50463a9380ec4600741407ea84ac2baac44917707bb137d1b119d2","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":40},"#,
     r#"{"diffId":"sha256:1953096685ae64ae6f5d1bbc04d8d3678fbb567138809f581bdcdacfa1e1b90b","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":40},"#,
     r#"{"diffId":"sha256:0eb6fed603f60e527eb9622e04d72a74c21dcd7ee88e98b95ae6f8895736d5fd","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":40}"#,
-    r#"],"parameters":{"indexKeyHash":"xxh3-64","stateShards":16},"position":{"epoch":2,"network":{"magic":764824073,"name":"mainnet"},"point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":250}},"profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":3}"#,
+    r#"],"parameters":{"indexKeyHash":"xxh3-64","stateShards":16},"position":{"epoch":2,"network":{"magic":764824073,"name":"mainnet"},"point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":250}},"profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":2}"#,
 );
 
 // --------------------------------------------------------------------------

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -129,8 +129,10 @@ mod registry_node {
 
     use super::harness;
 
-    /// The harness ledger and the two plans it publishes: sequence 1 standing
-    /// on the epoch-0 boundary, and sequence 2 one slot past it.
+    /// The harness ledger and the two plans it publishes: sequence 0 standing
+    /// on the last slot of epoch 0, and sequence 1 one slot past it — the
+    /// first block of epoch 1 (decision 0025: `sequence` is the epoch the
+    /// cursor stands in).
     ///
     /// That the first cursor sits on the boundary is not a convenience: a
     /// stele cut mid-epoch clamps its last window to the cursor, so the same
@@ -161,8 +163,8 @@ mod registry_node {
             let first = Plan::new(&summary, network.clone(), point(boundary - 1)).unwrap();
             let second = Plan::new(&summary, network, point(boundary)).unwrap();
 
-            assert_eq!(first.sequence, 1);
-            assert_eq!(second.sequence, 2);
+            assert_eq!(first.sequence, 0);
+            assert_eq!(second.sequence, 1);
             assert_eq!(
                 first.epochs,
                 second.epochs[..1],

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -189,11 +189,11 @@ fn a_dry_run_agrees_with_the_publish_that_follows_it() {
     // And against the stele that is now there.
     let next = registry::preview(Publishing::new(&repository), &node.second, None).unwrap();
 
-    assert_eq!(next.predecessor, Some((1, first.identity)));
+    assert_eq!(next.predecessor, Some((0, first.identity)));
     assert_eq!(next.history, 1);
 
     // `--rebuild` is visible in the preview, not only in the publish. Asked
-    // here, while sequence 2 is still unpublished: a preview reads the chain
+    // here, while sequence 1 is still unpublished: a preview reads the chain
     // through the same rule a publish does, so asking after the fact would be
     // refused as a republish.
     let rebuilding = registry::preview(
@@ -310,15 +310,15 @@ fn a_publish_that_does_not_follow_latest_is_refused() {
     let second = node.publish(&repository, &node.second, false);
 
     // A republish of the sequence already there.
-    expect_break(node.refuse(&repository, &node.second), 2, 2);
+    expect_break(node.refuse(&repository, &node.second), 1, 1);
 
     // And one behind it.
-    expect_break(node.refuse(&repository, &node.first), 2, 1);
+    expect_break(node.refuse(&repository, &node.first), 1, 0);
 
-    // A gap: the repository is at 2 and this stele is sequence 4.
+    // A gap: the repository is at 1 and this stele is sequence 4.
     let mut skipped = node.second.clone();
     skipped.sequence = 4;
-    expect_break(node.refuse(&repository, &skipped), 2, 4);
+    expect_break(node.refuse(&repository, &skipped), 1, 4);
 
     // Every refusal happened before anything was written, so the repository is
     // exactly where it was.
@@ -474,22 +474,22 @@ fn a_publisher_can_ask_where_it_stands() {
     // epoch raises.
     assert_eq!(
         registry::standing(&repository, &node.first).unwrap(),
-        Standing::UpToDate { latest: 1 },
+        Standing::UpToDate { latest: 0 },
     );
 
     assert_eq!(
         registry::standing(&repository, &node.second).unwrap(),
-        Standing::Next { latest: 1 },
+        Standing::Next { latest: 0 },
     );
 
     // A node three epochs ahead of the repository.
     let mut skipped = node.second.clone();
-    skipped.sequence = 4;
+    skipped.sequence = 3;
 
     assert_eq!(
         registry::standing(&repository, &skipped).unwrap(),
         Standing::Ahead {
-            latest: 1,
+            latest: 0,
             distance: 3
         },
     );
@@ -498,8 +498,8 @@ fn a_publisher_can_ask_where_it_stands() {
     // distance.
     let message = node.refuse(&repository, &skipped).to_string();
 
-    assert!(message.contains('1'), "{message}");
-    assert!(message.contains('4'), "{message}");
+    assert!(message.contains('0'), "{message}");
+    assert!(message.contains('3'), "{message}");
     assert!(message.contains("3 sequences ahead"), "{message}");
 }
 

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -45,9 +45,9 @@
 //!
 //! The harness ledger lives inside epoch zero, so the two publishes are made by
 //! standing at two synthetic chain points and letting `Plan::new` derive
-//! everything: one at the last slot of epoch 0, which publishes sequence 1 with
+//! everything: one at the last slot of epoch 0, which publishes sequence 0 with
 //! epoch 0's window **unclamped**, and one at the first slot of epoch 1, which
-//! publishes sequence 2 with an identical epoch-0 window plus an empty epoch 1.
+//! publishes sequence 1 with an identical epoch-0 window plus an empty epoch 1.
 //!
 //! That the first cursor has to sit on the boundary is not a convenience. A
 //! stele cut mid-epoch clamps its last window to the cursor, so the same epoch
@@ -137,7 +137,7 @@ fn a_second_publish_builds_and_uploads_only_what_is_new() {
 
     // Done criterion 2: the chain, and that it validates.
     assert_eq!(second.inscription.history.len(), 1);
-    assert_eq!(second.inscription.history[0].sequence, 1);
+    assert_eq!(second.inscription.history[0].sequence, 0);
     assert_eq!(
         second.inscription.history[0].inscription_digest,
         first.identity

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -787,8 +787,8 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
     // the first staying true under the second, and that says nothing unless
     // the second is a different document.
     assert_ne!(first.digest().unwrap(), second.digest().unwrap());
-    assert_eq!(first.sequence, 1);
-    assert_eq!(second.sequence, 2);
+    assert_eq!(first.sequence, 0, "the cursor stands in epoch 0");
+    assert_eq!(second.sequence, 1, "and one slot later, in epoch 1");
 
     // And the two sides of the rule, as bytes. Epoch 0's layers carry forward;
     // every state shard is new.

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -109,8 +109,8 @@ impl Node {
         let first = Plan::new(&summary, network.clone(), point(boundary - 1)).unwrap();
         let second = Plan::new(&summary, network, point(boundary)).unwrap();
 
-        assert_eq!(first.sequence, 1);
-        assert_eq!(second.sequence, 2);
+        assert_eq!(first.sequence, 0);
+        assert_eq!(second.sequence, 1);
 
         Self {
             domain,
@@ -438,9 +438,9 @@ fn a_pre_seeded_node_fetches_only_what_it_lacks() {
     let storage = tempfile::tempdir().unwrap();
     let blank = Blank::<MemoryStores>::open();
 
-    // Sequence 1, interrupted at its first state shard: every epoch layer it
+    // Sequence 0, interrupted at its first state shard: every epoch layer it
     // carries commits, the tip does not.
-    let first = Point::Epoch(1).pull(&repository).unwrap();
+    let first = Point::Epoch(0).pull(&repository).unwrap();
     let identity = first.read_inscription().unwrap().digest().unwrap();
     let plan = restore::plan(&first, node.magic, None).unwrap();
     let index = first.blob_index().unwrap();
@@ -472,7 +472,7 @@ fn a_pre_seeded_node_fetches_only_what_it_lacks() {
 
     assert_eq!(seeded, epoch_layers, "epoch 0's layers all committed");
 
-    // Now catch up to sequence 2 — which describes epoch 0 with the same
+    // Now catch up to sequence 1 — which describes epoch 0 with the same
     // identities, epoch 1 besides, and a tip of its own.
     let resumed = restore_from(
         &fixture.repository("dolos/delta"),
@@ -494,12 +494,12 @@ fn a_pre_seeded_node_fetches_only_what_it_lacks() {
         "epoch 1's three layers and the sixteen shards, and nothing else"
     );
 
-    // The point resolved to what it claimed. `latest` is sequence 2 here, and
-    // `epoch-1` is still the stele the first half of this test read.
+    // The point resolved to what it claimed. `latest` is sequence 1 here, and
+    // `epoch-0` is still the stele the first half of this test read.
     let latest = Point::Latest.pull(&repository).unwrap();
-    assert_eq!(latest.read_inscription().unwrap().sequence, 2);
+    assert_eq!(latest.read_inscription().unwrap().sequence, 1);
     assert_eq!(
-        Point::Epoch(1)
+        Point::Epoch(0)
             .pull(&repository)
             .unwrap()
             .read_inscription()

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -530,7 +530,7 @@ fn a_point_that_names_no_stele_is_refused() {
     let storage = tempfile::tempdir().unwrap();
     let blank = Blank::<MemoryStores>::open();
 
-    // The repository holds sequence 1 and nothing else.
+    // The repository holds sequence 0 and nothing else.
     let err = restore_from(
         &repository,
         Point::Epoch(97),

--- a/crates/snapshot/tests/snapshot_verify.rs
+++ b/crates/snapshot/tests/snapshot_verify.rs
@@ -280,7 +280,7 @@ fn a_reproduction_passes_at_the_published_epoch_and_fails_at_another() {
 
     assert!(matches!(err, Error::ReproductionMismatch { .. }), "{err:?}");
     assert!(
-        message.contains("sequence 2") && message.contains("sequence 1"),
+        message.contains("sequence 1") && message.contains("sequence 0"),
         "{message}"
     );
 

--- a/crates/snapshot/tests/snapshot_verify.rs
+++ b/crates/snapshot/tests/snapshot_verify.rs
@@ -84,12 +84,12 @@ fn a_freshly_published_stele_verifies_clean() {
     assert!(verified.compressed_bytes > 0);
 
     // The immutable tag reads the predecessor back just as clean.
-    let predecessor = registry::verify(&repository, Point::Epoch(1)).unwrap();
+    let predecessor = registry::verify(&repository, Point::Epoch(0)).unwrap();
 
     assert_eq!(predecessor.identity, first.identity);
 
     eprintln!(
-        "verified latest = {} ({} layers, {} compressed bytes) and epoch-1 = {}",
+        "verified latest = {} ({} layers, {} compressed bytes) and epoch-0 = {}",
         verified.identity,
         verified.inscription.layers.len(),
         verified.compressed_bytes,
@@ -334,7 +334,7 @@ fn an_inspection_reports_the_manifest_and_its_json_chains_a_digest() {
     assert_eq!(total, inspected.total_compressed);
 
     // The `--json` output is the canonical document, verbatim.
-    let predecessor = registry::inspect(&repository, Point::Epoch(1)).unwrap();
+    let predecessor = registry::inspect(&repository, Point::Epoch(0)).unwrap();
 
     assert_eq!(predecessor.identity, first.identity);
 
@@ -360,7 +360,7 @@ fn an_inspection_reports_the_manifest_and_its_json_chains_a_digest() {
     );
 
     eprintln!(
-        "inspected {} layers, {} compressed bytes; epoch-1's document chained to {}",
+        "inspected {} layers, {} compressed bytes; epoch-0's document chained to {}",
         inspected.inscription.layers.len(),
         inspected.total_compressed,
         reproduced.digest().unwrap(),


### PR DESCRIPTION
Implements `plans/dolos-stelae-cut-geometry-naming.md`, the code half of
[decision 0025 — *Stele cut geometry: own the anchoring block, align the
naming*].

## The defect

ADR-004 and `crates/snapshot` disagreed by exactly one about what a published
stele is called.

`Plan::new` computed `sequence = epoch_of(cursor) + 1`, so a `stop_epoch = E`
publish was tagged `epoch-(E+1)` while carrying `position.epoch = sequence - 1
= E`. ADR-004's model — tag `epoch-E`, and a sample inscription pairing
`sequence: 550` with `position.epoch: 550` — is internally self-consistent and
equals `sequence = epoch_of(cursor)`.

The `+1` descends from a "the cursor stands at the end of its epoch" model that
the boundary-block halt invalidated: a `stop_epoch = E` sync does not stop on
the boundary, it crosses it (Ewrap closes E-1, Estart opens E) and then applies
the *first block of epoch E*, because `position.point` must carry a block hash.
The code's own doc comment ("the epoch the cursor has just entered") already
described `epoch_of(cursor)`. So this is an off-by-one against a coherent spec,
not a design fork.

## What changed

**`crates/snapshot/src/export.rs` — drop the `+1`.**

- `Plan::new`: `sequence: tip_epoch`.
- `Plan::position`, `Plan::state_scope`, `write_digests`' `DigestsScope`: pass
  `self.sequence` where they passed `self.sequence - 1`.

Every `sequence`-derived expression corrected for the `+1`, so removing it
removes the corrections with it. **The only observable change is `sequence` and
therefore the tag**: `position.epoch`, the state scopes and the digests scope
all resolve to the same integer they did before, which the goldens confirm —
the pinned skeleton document moves in exactly one place (`"sequence":3` →
`"sequence":2`) and not one `diffId` moves with it.

The `epochs` vector is untouched: `(0..=tip_epoch)` with the last window clamped
to the cursor is exactly the adopted geometry — epochs `0..E-1` complete, plus
epoch E's boundary sliver.

**`adrs/004_stelae_snapshots.md` — own the anchoring block.**

- New section **"The cut point and the boundary sliver"**: the halt is one block
  past the boundary and why; the windows are `0..=E`; and the normative note
  that **all of epoch X's boundary logs key at `epoch_start(X)`** — Ewrap writes
  the ending epoch's closing logs and completed `EpochState` there, Estart the
  opening epoch's account logs. That is what makes the sliver load-bearing
  rather than cosmetic: epoch E's estart logs live in it and nowhere else.
- The tag definition now says E equals `sequence` and `position.epoch`, and that
  the layers are `0..E-1` complete plus the sliver.
- The publisher-pipeline narrative no longer claims "state lands exactly on the
  boundary".
- The sample inscription's `position.point` moves to a slot that is actually
  inside epoch 550. As written it paired `position.epoch: 550` with slot
  `133660800`, which is `epoch_start(507)` on mainnet — the sample named two
  different epochs at once.

## What deliberately did not change

`crates/cardano/src/work.rs` and the `EstartBoundary → PreForcedStop` route; the
`StopEpochReached` halt; the `stop_epoch` config surface and its non-publisher
consumers (`tests/epoch_pots`' `stop_epoch = subject + 1`, `xtask bootstrap`,
`doctor rebuild-state`), which use the mechanism and never the tag; the layer
windows; the wire format.

One consequence worth naming: a repository's first stele can now carry
`sequence = 0` / tag `epoch-0`, where the minimum used to be 1. Nothing in the
contiguity rules or `Standing::read` assumes a positive sequence.

## Tests

- `the_sequence_is_the_epoch_the_cursor_has_just_entered` now pins all three
  faces of the one number: `sequence`, `tag()` and `position.epoch`.
- New `the_last_window_is_the_boundary_sliver_of_the_sequence_epoch` pins the
  sliver as **deliberate** — a cursor one slot into epoch 3 yields `sequence
  3` / `epoch-3`, a last window of `{epoch: 3, start_slot: 300, end_slot: 301}`,
  and three complete epochs beneath it.
- Golden churn is exactly the shape the plan's risk note demands: every diff is
  a sequence integer shifting by one. `GOLDEN_SKELETON` moves because the
  canonical document it hashes moved by that one field.

## Verification

```
cargo test --workspace --all-targets                                    # pass
cargo test --workspace --all-targets --all-features \
  --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp    # pass
cargo test -p dolos-snapshot --features oci                              # pass
cargo clippy -p dolos-snapshot --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                                  # clean
```

### Done criterion 4 — end to end on preview

Not read off the code: a preview node synced from genesis with
`chain.stop_epoch = 1` until `StopEpochReached` ("forced stop epoch reached"),
then published to a directory.

```
network:  preview (2)
cursor:   86400(4a9761ddc291b0c352d1712b624759132936a07b3e02d1d3bdaaf17b9abfe683)
sequence: 1 (tag epoch-1)
epochs:   0..=1 (2 of them, slots 0..=86400)
identity: sha256:352b3e42c1dbf4bbf2f42e5b5f3f79ebea8a42912ce8f66db7bf99f392c7abcd
```

and the inscription it wrote:

| field | value |
|---|---|
| `sequence` | `1` |
| `position.epoch` | `1` |
| `position.point.slot` | `86400` |
| epoch-0 layers | `0..=86399` — complete |
| epoch-1 layers | `86400..=86400` — the boundary sliver |

`stop_epoch`, the tag, `sequence` and `position.epoch` are one number, and the
last window is the sliver.

Two things the run settled that the plan had assumed otherwise:

- **The anchoring block can sit exactly on `epoch_start(E)`.** Preview's first
  block of epoch 1 is at slot 86400, which *is* `epoch_start(1)`, so the sliver
  is one slot wide. The plan's premise that "no block may occupy" the boundary
  slot is wrong; what Estart actually leaves behind is a bare
  `ChainPoint::Slot` with no *hash* on it (`estart::commit_finalize`), which is
  the real reason the block is rolled. The ADR says it that way.
- **The sliver's `logs` layer can be empty**, and is here — header record only.
  Epoch 0's closing logs and its completed `EpochState` key at
  `epoch_start(0)`, inside epoch 0's window, exactly as the new note says;
  epoch 1's opening account logs key at `epoch_start(1)` inside the sliver,
  and at this boundary preview simply has none to write. The keying rule holds;
  the sliver is not always non-empty.

Published to a throwaway directory, never into `cardano/preprod` or any other
live repository — the plan's first risk.

### Findings, not caused by this branch

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` fails
  on `origin/main` with three errors in `dolos-cardano`
  (`cloned_ref_to_slice_refs` ×2 in `ewrap/loading.rs`, `filter_next_back` ×1 in
  `model/proposals.rs`) — all in test code. They are lints newer than
  CI's pinned clippy, which is `1.91` while `rust-toolchain.toml` pins `1.93`.
  The pin gap is itself worth closing: `cargo +1.91 clippy` cannot build the
  current lockfile at all ("rustc 1.91.1 is not supported by the following
  packages"), so the CI clippy job is running against a toolchain the tree has
  outgrown.
- The registry suites (`--test publish`, `--test restore_registry`,
  `--test snapshot_verify`) are `#[ignore]`d and need a container runtime;
  Docker was not available on this machine, so their updated expectations are
  verified by the `Registry` workflow rather than locally. Their sequence
  assertions and `Point::Epoch(n)` selectors moved with the numbering.
- The plan's Approach says "nothing else in the crate reads `sequence`
  arithmetically". `write_digests`' `DigestsScope` did — a fourth site the plan
  does not enumerate. It is fixed on the same rule, and like the other two it
  resolves to the integer it already did.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Epoch snapshots now use zero-based sequencing, with the first snapshot identified as sequence 0.
  * Epoch boundaries are consistently anchored to the first block of the new epoch, including its boundary data.
  * Snapshot publishing, restoring, verification, and registry lookups now use the updated epoch and sequence identities.
* **Documentation**
  * Updated snapshot and publishing guidance to reflect boundary handling and refreshed state and digest layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->