### PR TITLE
refactor(snapshot): split the state layer into per-namespace kinds

### DIFF
--- a/adrs/004_stelae_snapshots.md
+++ b/adrs/004_stelae_snapshots.md
@@ -27,7 +27,7 @@ None of those four goals is Cardano-specific, and neither are the mechanisms tha
 - Namespace by vendor so profiles coexist: payload media types are `application/vnd.{vendor}.stele.{kind}.v{n}+{codec}` with a vendor slot the publisher controls (`dolos` for ours); `application/vnd.stelae.*` is reserved for the protocol's own envelope types and never used for payloads. Clients fail closed on an unknown profile or an unimplemented profile major version.
 - Use an OCI repository as the storage backend, one repository per (profile, network), targeting any OCI Distribution v1.1 registry (GHCR initially). Tags: an immutable tag per sequence, rendered by the profile (`epoch-E` for Dolos), plus a moving `latest`.
 - Split chain history into epochs; each epoch produces immutable, content-addressed layers. Per epoch there are three content types: raw block data (`blocks`), computed archive index records (`indexes`) and epoch-boundary ledger logs. The first two are one layer each; the logs are **one layer per log namespace** (`log-{ns}`, six of them), so a change to one namespace's log shape costs a backfill of that namespace's blobs rather than of every log layer ever published.
-- Keep the ledger state as a set of "tip" layers that are swapped as a whole on every publish: 16 uniform key-value shard layers, where the UTxO set is just another key-value namespace alongside the 16 entity namespaces.
+- Keep the ledger state as a set of "tip" layers that are swapped as a whole on every publish: one `state-{ns}` kind per state namespace, sharded 16 ways for the four chain-scale namespaces and a single blob for the rest, where the UTxO set is just another key-value namespace alongside the 16 entity namespaces.
 - No layer kind is mandatory for consumers: the inscription declares what the stele contains, and the client selects which layers to fetch and which data to source elsewhere — block data especially, which may come from `blocks` layers, from a Mithril aggregator, or from relay replay. `sync.max_history`-driven partial fetches are one instance of this general rule, not a special mode. The same holds for a kind the client has never heard of: a restore skips it and reports the skip, so adding a kind is an additive change rather than one that bricks every deployed reader. A publisher gets no such latitude — it attests every layer it lists.
 - Ship an optional per-stele `digests` layer that pins the sha256 of every Cardano immutable-DB file (`.chunk`/`.primary`/`.secondary` — Mithril Cardano DB v2's certification granularity) covered by the snapshot. It carries no restorable data; it makes externally sourced block data verifiable against the signed inscription, and is the enabler for a future Mithril-sourced restore mode.
 - Serialize all layer content as deterministic CBOR sequences (RFC 8742 framing, RFC 8949 §4.2.1 deterministic encoding) of canonical logical records — never database files.
@@ -52,7 +52,7 @@ None of those four goals is Cardano-specific, and neither are the mechanisms tha
 ## Limitations
 
 - **Snapshots exist only at epoch boundaries.** A restored node must chain-sync the partial current epoch from a relay — up to ~5 days of blocks on mainnet (minutes to a few hours of sync). Mid-epoch state-only tip refreshes are a possible follow-up using the same format.
-- **The state tip does not delta.** Every publish re-uploads the full state shards (~several GB on mainnet); every restore downloads them. Content-identical shards dedupe by digest, but reward distribution at each boundary touches most account entities, so in practice the tip is re-transferred. This matches the status quo (full snapshot per bootstrap) and only affects the tip, not history. Content-defined chunking of the state stream is a possible v2 optimization.
+- **The state tip does not delta.** Every publish re-uploads the full state layers (~several GB on mainnet); every restore downloads them. Content-identical layers dedupe by digest, but reward distribution at each boundary touches most account entities, so in practice the tip is re-transferred. This matches the status quo (full snapshot per bootstrap) and only affects the tip, not history. Content-defined chunking of the state stream is a possible v2 optimization.
 - **The index hash scheme becomes a compatibility surface.** Changing the xxh3-64 scheme, bucket semantics or dimension set requires a new media-type version. Old epochs can be backfilled by recomputing index layers from the (permanently available) blocks layers, so the migration path exists, but it is a real cost.
 - **Profile evolution is a second compatibility surface.** The profile major version and the payload media-type version move together, independently of the protocol version, and clients reject profile majors they do not implement. That is the price of the extension point: three version axes (protocol schema, profile, media type) must be kept coherent, and the conformance suite is what keeps them honest.
 - **Determinism depends on deterministic entity encoding.** Entity minicbor values are copied verbatim, so any map-ordering or shard-merge nondeterminism in ledger code would break cross-party digests. This requires a one-time audit and is permanently enforced by an independent-builds digest comparison in CI.
@@ -61,7 +61,7 @@ None of those four goals is Cardano-specific, and neither are the mechanisms tha
 
 ## Performance Impact
 
-- **Publish**: export is a sequential scan of local stores plus zstd compression — no input resolution, no replay. Steady-state publishes upload one epoch of layers (tens to hundreds of MB compressed) plus the state shards.
+- **Publish**: export is a sequential scan of local stores plus zstd compression — no input resolution, no replay. Steady-state publishes upload one epoch of layers (tens to hundreds of MB compressed) plus the state tip's layers.
 - **Restore**: dominated by download and sequential ingestion. Sorted state records make fjall ingestion near-optimal; per-epoch layers allow parallel fetch and per-epoch resume, so interrupted restores lose at most one epoch of work. Light nodes (`max_history`-limited) skip historical layers entirely and download only recent epochs plus the state tip.
 - **Verification** adds a streaming sha256 over each blob (compressed and uncompressed), which is negligible against network I/O.
 - Rebuilding live-UTxO index dimensions at restore adds one linear pass over the UTxO set (CPU-bound CBOR parsing), overlapping with I/O.
@@ -94,7 +94,7 @@ None of those four goals is Cardano-specific, and neither are the mechanisms tha
 
 7. **State as one monolithic layer / separate special-cased UTxO layers** (earlier draft)
    - Pros: slightly simpler inscription.
-   - Cons: single layers hit registry size limits as state grows and serialize downloads; special-casing UTxOs couples the format to a Dolos internal that is already slated to change (#1042). Rejected in favor of 16 uniform key-value shards.
+   - Cons: single layers hit registry size limits as state grows and serialize downloads; special-casing UTxOs couples the format to a Dolos internal that is already slated to change (#1042). Rejected in favor of one key-value kind per state namespace, sharded 16 ways where the population is chain-scale.
 
 8. **Adopt Mithril's immutable-file format as the `blocks` layer** (chunk files stored verbatim as blobs, reusing Mithril's stake-based signatures directly)
    - Pros: per-file diffIds would literally equal the stake-certified digests — signature reuse with zero re-derivation, and blob-level dedupe with any other chunk-file mirror.
@@ -120,7 +120,7 @@ Envelope types are protocol-owned and shared by every profile; payload types are
 | Config blob (the inscription) | `application/vnd.stelae.inscription.v1+json` | protocol |
 | Signature (referrer artifact) | `application/vnd.stelae.signature.v1` | protocol |
 | Layer payloads | `application/vnd.{vendor}.stele.{kind}.v{n}+{codec}` | vendor |
-| — Dolos profile | `application/vnd.dolos.stele.{blocks\|indexes\|log-{ns}\|state\|digests}.v1+zstd` | Dolos |
+| — Dolos profile | `application/vnd.dolos.stele.{blocks\|indexes\|log-{ns}\|state-{ns}\|digests}.v1+zstd` | Dolos |
 
 Normative rules for coexistence:
 
@@ -140,7 +140,7 @@ All layers are zstd-compressed CBOR sequences (RFC 8742). Deterministic encoding
 [format_version = 1, profile: tstr, kind: tstr, scope: any]
 ```
 
-`scope` is opaque to the protocol. The Dolos profile encodes `[network_magic, epoch, start_slot, end_slot]` for epoch layers, `[network_magic, epoch, shard]` for state layers and `[network_magic, epoch, last_immutable]` for the digests layer.
+`scope` is opaque to the protocol. The Dolos profile encodes `[network_magic, epoch, start_slot, end_slot]` for epoch layers, `[network_magic, epoch, shard]` for every state layer — one shape across all seventeen kinds, single-blob namespaces included, whose one layer is shard 0 — and `[network_magic, epoch, last_immutable]` for the digests layer.
 
 Content records per kind (Dolos profile):
 
@@ -149,16 +149,18 @@ Content records per kind (Dolos profile):
 | `blocks` (per epoch) | `[slot, hash: bytes(32), body: bytes]`, body = raw wire CBOR verbatim | ascending slot, stream order for same-slot (Byron EBB) | `ArchiveWriter::apply` |
 | `indexes` (per epoch) | tags: `[0, dimension: tstr, key_hash: bytes(8), slot]` with `key_hash = xxh3_64(key)` BE — except dimension `metadata`, see below; exact: `[1, kind: tstr, key: bytes, slot]` for block-hash/block-number/tx | sorted, deduped | new `IndexWriter::append_prehashed` |
 | `log-{ns}` (per epoch, per log namespace, omitted when empty) | `[log_key: bytes(40), value: bytes]`, value = stored EntityValue verbatim | `log_key` | `ArchiveWriter::write_log` into the namespace the kind names |
-| `state` (tip, 16 shards, `scope.shard` = 0..15) | `[ns: tstr, key: bytes, value: bytes]` | `(ns, key)`; shard = first nibble of `key[0]` | dispatch on ns: `utxos` → chunked `StateWriter::apply_utxoset`, else `write_entity` |
+| `state-{ns}` (tip, per state namespace, `scope.shard` = 0..`parameters.shards[ns]`-1) | `[key: bytes, value: bytes]` | `key`; shard = first nibble of `key[0]` for a 16-way namespace, 0 for a single blob | dispatch on the kind: `state-utxos` → chunked `StateWriter::apply_utxoset`, else `write_entity` into the namespace the kind names |
 | `digests` (tip, optional) | `[immutable_number, chunk: bytes(32), primary: bytes(32), secondary: bytes(32)]`, each sha256 over the raw file bytes | ascending `immutable_number` | none — verification metadata, not written to stores |
 
 One exception to the tag hashing rule is normative for `indexes` v1: records in dimension `metadata` carry the logical u64 metadata label **verbatim** (big-endian) in `key_hash`, never hashed. The index stores keep metadata labels as raw labels rather than hashes, and the layer ships the stored form — that is the whole point of the pre-hashed design. `parameters.indexKeyHash` therefore describes every dimension *except* `metadata`. A publisher that hashes metadata labels produces structurally valid records that restore cleanly but can never be matched by a metadata query; conformance tooling must check this dimension specifically (#1149 tracks whether a future media-type version unifies the rule).
 
 State namespaces: the 16 entity namespaces from `dolos_cardano::model::build_schema()` (key = 32-byte `EntityKey` verbatim, value = stored minicbor verbatim) plus `utxos` (key = `tx_hash(32) ‖ output_index(4, BE)`, value = CBOR `[era: uint, body: bytes]`). The chain point lives in the inscription's `position`, not in a layer. Live-UTxO index dimensions (`utxo::*`) are not shipped; they are rebuilt at restore via `index_delta_from_utxo_delta`.
 
+State kinds: one per state namespace, and the set is closed — 17 of them, spelled `state-` followed by the namespace with `_` rewritten to `-`, by the same rule and for the same reasons as the log kinds below. The namespace is therefore **not** in the record — it is the layer — which is what puts the fail-closed edge of a breaking change on exactly the namespace that broke, and lets a reader skip a namespace this profile does not define at the transport rather than choking on one shared layer. The shard count is **specification, never tuning**: `utxos`, `accounts`, `assets` and `datums` split 16 ways, every other namespace is a single blob, and `parameters.shards` reports the map so a reader never has to discover it from the data. Re-sharding a namespace is a media-type-version event for that namespace's kind. Every shard of every kind is published, empty ones included, so tip completeness is structural: a restore requires all 17 kinds and, per kind, exactly the shards its count promises.
+
 Log kinds: one per namespace the ledger writes epoch-boundary logs under, and the set is closed — `log-account-stakes`, `log-epochs`, `log-leader-rewards`, `log-member-rewards`, `log-pool-deposit-refunds`, `log-stakes`. The kind token is `log-` followed by the namespace with `_` rewritten to `-`, since a media type's kind token admits hyphens and not underscores; the mapping is injective, and a publisher spells the kinds out rather than composing them, so a namespace rename cannot silently rename a published kind. The namespace is therefore **not** in the record — it is the layer — and a restore writes a layer's records into the namespace its kind names. A publisher that finds logs under a namespace no kind covers **fails the publish** naming the namespace: the format has no layer to carry them, and shipping a snapshot that silently omits a slice of the ledger is the failure that costs most and shows least. Log layers wear the epoch scope unchanged, so per-(kind, scope) inheritance works across the split with no new scope shape.
 
-Empty log layers are omitted: **a `log-{ns}` layer exists if and only if it holds at least one record.** The rule is content-determined and not writer discretion — that is what keeps it deterministic across publishers, since two honest publishers agree about whether a layer exists exactly because they agree about whether a record does. Byron alone sheds ~1,200 empty blobs to it. Absence is normative and never a defect: a restore that finds no `log-stakes` for an epoch restores that epoch with no stake logs, exactly as the ledger had none. Every other kind keeps the arity it had — `blocks` and `indexes` are one layer per epoch whatever the window holds, and the 16 state shards are always all present.
+Empty log layers are omitted: **a `log-{ns}` layer exists if and only if it holds at least one record.** The rule is content-determined and not writer discretion — that is what keeps it deterministic across publishers, since two honest publishers agree about whether a layer exists exactly because they agree about whether a record does. Byron alone sheds ~1,200 empty blobs to it. Absence is normative and never a defect: a restore that finds no `log-stakes` for an epoch restores that epoch with no stake logs, exactly as the ledger had none. Every other kind keeps the arity it had — `blocks` and `indexes` are one layer per epoch whatever the window holds, and every state layer is always present, empty or not.
 
 The `digests` layer covers the immutable files fully contained in the stele's block range: `lastImmutable` is derived from the boundary slot and the chunk geometry observed in the chain — canonical, never dependent on aggregator state at publish time. Digest values equal Mithril Cardano DB v2's merkle leaves (hex-decoded), so any Mithril certificate whose beacon covers `lastImmutable` can verify them via the aggregator's digest route and a merkle proof. The certificate reference is deliberately *not* part of the inscription: certificates are produced on the aggregator's cadence, so two independent publishers at the same boundary would reference different certificates — including one would break cross-publisher determinism, while the digest values themselves are byte-stable properties of the chain.
 
@@ -185,7 +187,9 @@ It is load-bearing because of how boundary data is keyed. **All of epoch X's bou
   "position": { "network": {"magic": 764824073, "name": "mainnet"},
                 "point": {"slot": 152236812, "hash": "…"},
                 "epoch": 550 },
-  "parameters": { "stateShards": 16, "indexKeyHash": "xxh3-64" },
+  "parameters": { "indexKeyHash": "xxh3-64",
+                   "shards": {"accounts": 16, "assets": 16, "datums": 16, "utxos": 16, "…": 1},
+                   "schemas": {"accounts": 1, "utxos": 1, "…": 1} },
   "compression": {"algo": "zstd", "level": 9},
   "history": [
     {"sequence": 548, "inscriptionDigest": "sha256:…"},
@@ -194,13 +198,18 @@ It is load-bearing because of how boundary data is keyed. **All of epoch X's bou
     {"kind": "blocks", "mediaType": "application/vnd.dolos.stele.blocks.v1+zstd",
      "diffId": "sha256:…", "records": 21600, "uncompressedSize": 43210000,
      "scope": {"epoch": 0, "startSlot": 0, "endSlot": 21599}},
-    {"kind": "state", "mediaType": "application/vnd.dolos.stele.state.v1+zstd",
+    {"kind": "state-utxos", "mediaType": "application/vnd.dolos.stele.state-utxos.v1+zstd",
      "diffId": "sha256:…", "records": 812345, "uncompressedSize": 402653184,
+     "scope": {"shard": 0}},
+    {"kind": "state-pools", "mediaType": "application/vnd.dolos.stele.state-pools.v1+zstd",
+     "diffId": "sha256:…", "records": 3210, "uncompressedSize": 1048576,
      "scope": {"shard": 0}},
     {"kind": "digests", "mediaType": "application/vnd.dolos.stele.digests.v1+zstd",
      "diffId": "sha256:…", "records": 6188, "uncompressedSize": 618800,
      "scope": {"lastImmutable": 6187}} ] }
 ```
+
+`parameters` is the profile's compatibility declaration, and every value in it is a consequence of publisher code rather than a free choice: `indexKeyHash` names the hash behind the pre-hashed index keys; `shards` is the per-namespace shard map above; and `schemas` is a per-namespace revision of the *record content* — the stored minicbor a `state-{ns}` or `log-{ns}` layer carries verbatim — which moves when that namespace's stored shape changes. All 17 revisions are 1 today. The split between the two is deliberate: a change to how a layer is *framed* moves that kind's media type and fails closed at the transport, while a change to what a record *contains* moves its schema revision, which a reader consults to decide whether it can interpret what it can already parse.
 
 `sequence` is the protocol's ordering key; the Dolos profile sets it to the epoch. `diffId` = sha256 of the uncompressed CBOR sequence. `position`, `parameters` and `scope` are canonicalized by JCS like every other key, so determinism holds without the protocol interpreting them; verifiers reject unknown *generic* top-level keys, so extension happens only inside those three objects. Determinism and signing are defined only over this document's sha256. Signatures are Ed25519 over the inscription digest, pushed as OCI referrer artifacts (`application/vnd.stelae.signature.v1`, cosign-compatible envelope where convenient). Restore verifies registry blob digests (transport integrity) and diffIds (canonical identity).
 
@@ -251,7 +260,7 @@ A client refuses a manifest — before any blob is fetched — when:
 
 A manifest past **4 MiB** (`stelae::MANIFEST_SIZE_LIMIT`) is refused before the push. The figure is not a limit the OCI specification imposes; it is the ceiling registries converge on, and the refusal is measured on the exact canonical bytes that would have been pushed, so it names the document and its layer count instead of arriving later as a registry's `413`.
 
-The arithmetic is counted in layers, because layers are what the ceiling counts: a descriptor with its annotations costs ~350 bytes, so the ceiling falls near 12,000 layers. A mainnet stele is bounded above by ~600 epochs × 8 per-epoch kinds (`blocks`, `indexes` and the six `log-{ns}`), plus 16 state shards — at most ~4,816 layers, a manifest of roughly 1.7 MB, still comfortably inside the ceiling. The bound is loose in the direction that helps: the log kinds are omitted when empty, and Byron's ~200 epochs carry no reward or stake logs at all, so the realized count sits near ~3,600. (The Rationale's "~1,700 manifest descriptors" is decision-time sizing of the pre-split artifact; this paragraph is the authoritative count, and it counts layers rather than epochs.)
+The arithmetic is counted in layers, because layers are what the ceiling counts: a descriptor with its annotations costs ~350 bytes, so the ceiling falls near 12,000 layers. A mainnet stele is bounded above by ~600 epochs × 8 per-epoch kinds (`blocks`, `indexes` and the six `log-{ns}`), plus the state tip's 77 layers (4 namespaces × 16 shards + 13 single blobs) — at most ~4,877 layers, a manifest of roughly 1.7 MB, still comfortably inside the ceiling. The bound is loose in the direction that helps: the log kinds are omitted when empty, and Byron's ~200 epochs carry no reward or stake logs at all, so the realized count sits near ~3,700. (The Rationale's "~1,700 manifest descriptors" is decision-time sizing of the pre-split artifact; this paragraph is the authoritative count, and it counts layers rather than epochs.)
 
 #### What the transport requires of its host
 
@@ -331,7 +340,7 @@ The resolution is `dolos::common::stele_registry_auth`, a pure function of `[ste
 
 1. Restore the publisher node from the previous stele (self-hosting delta pull; first run via Mithril).
 2. Sync with `chain.stop_epoch = E` until `StopEpochReached` — the state crosses the boundary and lands on the **first block of epoch E**, the block that gives `position.point` a hash.
-3. `dolos snapshot publish` — only the newly closed epoch's layers and epoch E's boundary sliver upload; fresh state shards + inscription; tag `epoch-E`, move `latest`. On networks with a Mithril aggregator, fetch the immutable-file digest list from the aggregator's digest route, verify it against a certificate, and write the `digests` layer for the files within the boundary.
+3. `dolos snapshot publish` — only the newly closed epoch's layers and epoch E's boundary sliver upload; fresh state layers + inscription; tag `epoch-E`, move `latest`. On networks with a Mithril aggregator, fetch the immutable-file digest list from the aggregator's digest route, verify it against a certificate, and write the `digests` layer for the files within the boundary.
 4. Determinism job: an independent runner that synced by any means runs `dolos snapshot digest` and alerts on inscription mismatch.
 5. Matching verifiers sign and push referrer signatures; clients enforce k-of-n.
 
@@ -343,7 +352,7 @@ Registry hygiene: keep a trailing window of `epoch-E` tags (e.g. 12); untagged s
 2. Plan which layers to consume — no kind is mandatory: ledger-only nodes skip `blocks`/`indexes`/`log-{ns}`, and a layer of a kind this client does not implement is skipped too, reported alongside the epochs `sync.max_history` drops — unless its `scope` marks it `required`, which refuses the restore before a store is opened; a future Mithril-sourced mode fetches block data from an aggregator instead of `blocks` layers, verifying each immutable file against the `digests` layer before the usual decode→append import. Plan the epoch range from `sync.max_history`; diff against the progress file (`<storage.path>/.snapshot-restore.json`, records inscription digest + completed layer diffIds) for `--continue`. Preflight: sum the `uncompressedSize` of the planned layers and fail early if free space at `storage.path` is insufficient; derive download progress and time-remaining estimates from the compressed blob sizes of the layers that remain to be fetched — excluding layers already completed per the progress file or already present locally — so resumed and deduplicated restores report correct totals.
 3. Open stores; `IndexStore::initialize_schema()`.
 4. Per epoch (checkpointed): fetch + verify `blocks` and each `log-{ns}` the epoch carries → archive appends, commit; fetch `indexes` → pre-hashed appends, commit.
-5. State tip: fetch the 16 shards (parallelizable) → dispatch per namespace; `set_cursor(position.point)` last so `has_existing_data()` only ever sees complete restores; commit.
+5. State tip: fetch every shard of every `state-{ns}` kind (parallelizable) → dispatch on the kind; `set_cursor(position.point)` last so `has_existing_data()` only ever sees complete restores; commit.
 6. Rebuild live-UTxO indexes: `iter_utxos()` → `index_delta_from_utxo_delta` chunks; final chunk aligns the index cursor.
 7. Delete progress file; existing `seed_wal_from_state` reseeds the WAL; the daemon chain-syncs the partial current epoch.
 

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -27,8 +27,9 @@
 //! ## Memory
 //!
 //! Nothing here holds a layer. Records go into a [`RecordSink`] one at a time,
-//! and the state pass keeps all sixteen shard sinks open across a single walk
-//! of the store rather than sorting a mainnet-sized set into buckets first.
+//! and each state kind's pass keeps that kind's shard sinks open across a
+//! single walk of its namespace rather than sorting a mainnet-sized set into
+//! buckets first.
 //!
 //! ## Where the stele ends up is not this module's business
 //!
@@ -73,9 +74,9 @@ use crate::{
     layers::{blocks, digests, indexes, logs, state},
     namespaces::NAMESPACES,
     reporting::{Cursor, Records},
-    DigestsScope, DolosProfile, EpochScope, Error, Network, Scope, StateScope, BLOCKS,
-    COMPRESSION_LEVEL, DENSE_EPOCH_KINDS, DIGESTS, INDEXES, LOG_KINDS, LOG_NAMESPACES, STATE,
-    STATE_SHARDS, UTXOS,
+    state_layer_count, DigestsScope, DolosProfile, EpochScope, Error, Network, Scope, StateScope,
+    BLOCKS, COMPRESSION_LEVEL, DENSE_EPOCH_KINDS, DIGESTS, INDEXES, LOG_KINDS, LOG_NAMESPACES,
+    STATE_KINDS, UTXOS,
 };
 
 /// The slot window one epoch layer covers.
@@ -599,7 +600,7 @@ where
     // both sides, since an empty log kind produces no layer to multiply.
     let total = plan.epochs.len() * DENSE_EPOCH_KINDS.len()
         + log_layers(plan, archive, previous)?
-        + STATE_SHARDS as usize
+        + state_layer_count()
         + usize::from(digest_records.is_some());
 
     let mut cursor = Cursor::new(observer, total);
@@ -1253,18 +1254,22 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
     Ok(descriptor)
 }
 
-/// The state tip, as sixteen shards written in one pass.
+/// The state tip: seventeen kinds, walked one namespace at a time.
 ///
-/// All sixteen sinks stay open while the store is walked once and each record
-/// is routed by [`crate::shard_of`]. The alternative — sixteen passes, or one
+/// Kinds go in [`STATE_KINDS`] order — the inscription's order — and within a
+/// kind every shard is written ascending. Per kind, that kind's shard sinks
+/// stay open while its namespace is walked once and each record is routed by
+/// [`crate::shard_of`]; the alternative — sixteen passes over `utxos`, or one
 /// pass buffering into sixteen buckets — is either sixteen full scans of a
-/// mainnet-sized state or the whole tip in memory.
+/// mainnet-sized set or the whole of it in memory. The I/O adds up to what the
+/// pre-split single walk cost, because that walk was already seventeen
+/// sequential per-namespace iterations under one loop.
 ///
-/// Every shard is written, including an empty one, so the shard count a reader
-/// sees is [`STATE_SHARDS`] and never a function of what the data happened to
-/// contain.
+/// Every shard of every kind is written, including an empty one, so the layer
+/// set a reader sees is fixed by [`STATE_KINDS`] and never a function of what
+/// the data happened to contain — tip completeness stays structural.
 ///
-/// ## No shard is ever inherited from a predecessor
+/// ## No state layer is ever inherited from a predecessor
 ///
 /// Two reasons, and the second is the one that matters. The first is what a
 /// reader expects: the state is the *tip*, so it changes every publish and
@@ -1281,81 +1286,89 @@ fn write_state<W: SteleWriter, S: StateStore>(
     store: &S,
     cursor: &mut Cursor<'_>,
 ) -> Result<Vec<LayerDescriptor>, Error> {
-    let shards = 0..STATE_SHARDS as u8;
+    let mut layers = Vec::with_capacity(state_layer_count());
 
-    let mut sinks = Vec::with_capacity(shards.len());
-    let mut orders = Vec::with_capacity(shards.len());
-    let mut positions = Vec::with_capacity(shards.len());
+    for (kind, ns, shards) in STATE_KINDS {
+        let mut sinks = Vec::with_capacity(shards as usize);
+        let mut orders = Vec::with_capacity(shards as usize);
+        let mut positions = Vec::with_capacity(shards as usize);
 
-    for shard in shards {
-        let spec = plan.state_scope(shard).layer_spec(STATE)?;
+        for shard in 0..shards {
+            let spec = plan.state_scope(shard).layer_spec(kind)?;
 
-        positions.push(cursor.open(STATE, &spec.scope));
-        sinks.push(sink(stele, &spec)?);
-        orders.push(state::OrderCheck::for_shard(shard));
-    }
+            positions.push(cursor.open(kind, &spec.scope));
+            sinks.push(sink(stele, &spec)?);
+            orders.push(state::OrderCheck::for_shard(shard, shards));
+        }
 
-    let mut records = cursor.records();
+        let mut records = cursor.records();
 
-    // `NAMESPACES` is sorted and `utxos` is its last entry, so one walk in
-    // registry order yields `(ns, key)` ascending within every shard — the
-    // layer's ordering rule, for free.
-    for ns in NAMESPACES {
         if ns == UTXOS {
-            continue;
+            for entry in store.iter_utxos()? {
+                let (txo, value) = entry?;
+
+                route(
+                    &mut sinks,
+                    &mut orders,
+                    ns,
+                    shards,
+                    state::utxo(&txo, &value)?,
+                )?;
+                records.tick();
+            }
+        } else {
+            // `full_range` is the store's own name for everything, and it ends
+            // *exclusively* at `[0xff; 32]` — so an entity keyed with
+            // thirty-two `0xff` bytes is invisible to it. That is a limit of a
+            // fixed-width key type rather than something export could route
+            // around: there is no representable exclusive bound above the
+            // maximum key. It is stated rather than silently inherited, because
+            // a state entity that no publisher can export is worth someone
+            // knowing about.
+            for entry in store.iter_entities(ns, EntityKey::full_range())? {
+                let (key, value) = entry?;
+
+                route(
+                    &mut sinks,
+                    &mut orders,
+                    ns,
+                    shards,
+                    state::entity(&key, &value),
+                )?;
+                records.tick();
+            }
         }
 
-        // `full_range` is the store's own name for everything, and it ends
-        // *exclusively* at `[0xff; 32]` — so an entity keyed with thirty-two
-        // `0xff` bytes is invisible to it. That is a limit of a fixed-width key
-        // type rather than something export could route around: there is no
-        // representable exclusive bound above the maximum key. It is stated
-        // rather than silently inherited, because a state entity that no
-        // publisher can export is worth someone knowing about.
-        for entry in store.iter_entities(ns, EntityKey::full_range())? {
-            let (key, value) = entry?;
+        records.flush();
 
-            route(&mut sinks, &mut orders, state::entity(ns, &key, &value)?)?;
-            records.tick();
-        }
-    }
-
-    for entry in store.iter_utxos()? {
-        let (txo, value) = entry?;
-
-        route(&mut sinks, &mut orders, state::utxo(&txo, &value)?)?;
-        records.tick();
-    }
-
-    records.flush();
-
-    sinks
-        .into_iter()
-        .zip(positions)
-        .map(|(sink, at)| {
+        for (sink, at) in sinks.into_iter().zip(positions) {
             let descriptor = sink.finish()?.descriptor;
-            cursor.close(at, STATE, Outcome::Transferred);
+            cursor.close(at, kind, Outcome::Transferred);
 
-            Ok(descriptor)
-        })
-        .collect()
+            layers.push(descriptor);
+        }
+    }
+
+    Ok(layers)
 }
 
-/// Send one state record to the shard its key belongs to.
+/// Send one state record to the shard its key belongs to under `ns`'s count.
 ///
 /// The shard's own `OrderCheck` is what catches a routing mistake. Without it a
-/// misrouted record still restores — the write path dispatches on the
-/// namespace, not the shard — and only a client fetching shards selectively
-/// would ever notice it was missing.
+/// misrouted record still restores — the write path dispatches on the kind, not
+/// the shard — and only a client fetching shards selectively would ever notice
+/// it was missing.
 fn route<K: RecordSink>(
     sinks: &mut [K],
     orders: &mut [state::OrderCheck],
+    ns: Namespace,
+    shards: u8,
     record: state::StateRecord,
 ) -> Result<(), Error> {
-    let shard = record.shard() as usize;
+    let shard = state::shard_of(&record.key, shards) as usize;
 
     orders[shard].check(&record)?;
-    sinks[shard].write_record(&state::encode(&record)?)?;
+    sinks[shard].write_record(&state::encode(ns, &record)?)?;
 
     Ok(())
 }

--- a/crates/snapshot/src/layers/state.rs
+++ b/crates/snapshot/src/layers/state.rs
@@ -1,16 +1,31 @@
-//! The `state` layer: the ledger tip, as sixteen uniform key-value shards.
+//! The `state-{ns}` layers: the ledger tip, one namespace per kind.
 //!
-//! `[ns: tstr, key: bytes, value: bytes]`, ordered by `(ns, key)`, with the
-//! shard given by the first nibble of `key[0]`.
+//! `[key: bytes, value: bytes]`, ordered by `key`, with the shard given by the
+//! first nibble of `key[0]` for a sixteen-way namespace and fixed at 0 for a
+//! single-blob one.
+//!
+//! The namespace is not in the record: it is the layer's *kind*, one per state
+//! namespace (`crate::STATE_KINDS`), so a shape change to one namespace's
+//! records costs that namespace's kind a media-type move and leaves the other
+//! sixteen alone — and a namespace a reader does not know is skippable at the
+//! transport instead of poisoning one shared layer. Which is also why this
+//! module has one codec rather than seventeen — the kinds differ in what they
+//! carry, never in how a record is written — and why its refusals name the
+//! record shape, `state`, rather than a layer.
 //!
 //! ## One record shape, including for UTxOs
 //!
-//! ADR-004 treats the UTxO set as namespace [`crate::UTXOS`] beside the
-//! fifteen entity namespaces, rather than as a special layer kind. That is
-//! what keeps the format's state vocabulary to a single record, and it makes
-//! the planned refactor folding UTxOs into the entity system (#1042) invisible
-//! from outside: the day `utxos` becomes an ordinary namespace, nothing in this
+//! ADR-004 treats the UTxO set as namespace [`crate::UTXOS`] beside the sixteen
+//! entity namespaces, rather than as a special layer kind. That is what keeps
+//! the format's state vocabulary to a single record, and it makes the planned
+//! refactor folding UTxOs into the entity system (#1042) invisible from
+//! outside: the day `utxos` becomes an ordinary namespace, nothing in this
 //! file changes.
+//!
+//! The namespace still governs the *codec parameters* — the key width above
+//! all — so [`encode`] and [`decode`] take it as an argument, derived by the
+//! caller from the layer's kind. It is per-layer configuration now, not
+//! per-record content.
 //!
 //! ## The one place bytes are built rather than carried
 //!
@@ -23,19 +38,27 @@
 //!
 //! ## Sharding
 //!
-//! The first nibble of the first key byte, so sixteen shards. Keys are
+//! The four chain-scale namespaces (`utxos`, `accounts`, `assets`, `datums`)
+//! split sixteen ways by the first nibble of the first key byte. Keys are
 //! hash-derived (transaction hashes, credentials, script hashes), so the split
 //! is uniform without a hash of its own; shards can be fetched in parallel and
-//! stay far from registry size limits as state grows.
+//! stay far from registry size limits as state grows. Every other namespace is
+//! a single blob — shard 0 — because sixteen slivers of a kilobyte-scale
+//! population would be all overhead. The counts are fixed by the profile
+//! specification (`crate::STATE_KINDS`), never by data or configuration.
 
 use dolos_core::{state::KEY_SIZE, EntityKey, EntityValue, Era, EraCbor, Namespace, TxoRef};
 use stelae::frame::{self, CanonicalCbor};
 
-use super::{blob, close, open, text, uint};
-use crate::{namespaces, Error, STATE, UTXOS};
+use super::{blob, close, open, uint};
+use crate::{namespaces, Error, UTXOS};
 
-/// Number of state shards. Reported to readers as `parameters.stateShards`.
-pub const STATE_SHARDS: u64 = 16;
+/// The name this codec refuses under.
+///
+/// One record shape serves all seventeen `state-{ns}` kinds, so an error names
+/// the shape rather than a layer — the layer is already in the message the
+/// caller wraps it in.
+const STATE: &str = "state";
 
 /// Width of an entity key — every namespace but [`crate::UTXOS`].
 pub const ENTITY_KEY_LEN: usize = KEY_SIZE;
@@ -43,19 +66,27 @@ pub const ENTITY_KEY_LEN: usize = KEY_SIZE;
 /// Width of a UTxO key: `tx_hash(32) ‖ output_index(4, BE)`.
 pub const UTXO_KEY_LEN: usize = KEY_SIZE + 4;
 
-/// The shard a state key belongs to: the first nibble of its first byte.
+/// The shard a state key belongs to under a kind published in `shards` shards:
+/// the first nibble of its first byte for a sixteen-way namespace, 0 for a
+/// single blob.
 ///
 /// Total by construction — [`decode`] refuses a record whose key is not the
 /// width its namespace requires, and both widths are non-zero — so the fallback
 /// for an empty key is unreachable rather than a policy.
-pub fn shard_of(key: &[u8]) -> u8 {
+pub fn shard_of(key: &[u8], shards: u8) -> u8 {
+    if shards <= 1 {
+        return 0;
+    }
+
     key.first().copied().unwrap_or(0) >> 4
 }
 
 /// One state entry, as the layer carries it.
+///
+/// No namespace: the layer's kind is the namespace, and a record that repeated
+/// it could disagree with the layer it sits in.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StateRecord {
-    pub ns: Namespace,
     /// [`ENTITY_KEY_LEN`] bytes, or [`UTXO_KEY_LEN`] under [`crate::UTXOS`].
     pub key: Vec<u8>,
     /// The stored `EntityValue` verbatim, or CBOR `[era, body]` under
@@ -63,31 +94,12 @@ pub struct StateRecord {
     pub value: EntityValue,
 }
 
-impl StateRecord {
-    /// The shard this record belongs in.
-    pub fn shard(&self) -> u8 {
-        shard_of(&self.key)
-    }
-}
-
 /// A record for an entity, whose value is carried verbatim.
-///
-/// Refuses [`crate::UTXOS`]: that namespace's value has a shape this function
-/// would not build, and a raw byte string smuggled in under it would restore as
-/// an unreadable UTxO.
-pub fn entity(ns: Namespace, key: &EntityKey, value: &EntityValue) -> Result<StateRecord, Error> {
-    if ns == UTXOS {
-        return Err(Error::malformed(
-            STATE,
-            format!("namespace {UTXOS:?} is built by `utxo`, not by `entity`"),
-        ));
-    }
-
-    Ok(StateRecord {
-        ns: namespaces::resolve(ns)?,
+pub fn entity(key: &EntityKey, value: &EntityValue) -> StateRecord {
+    StateRecord {
         key: key.as_ref().to_vec(),
         value: value.clone(),
-    })
+    }
 }
 
 /// A record for one UTxO, composing the `[era, body]` value.
@@ -97,44 +109,30 @@ pub fn utxo(txo: &TxoRef, value: &EraCbor) -> Result<StateRecord, Error> {
     key.extend_from_slice(&txo.1.to_be_bytes());
 
     Ok(StateRecord {
-        ns: UTXOS,
         key,
         value: encode_utxo_value(value)?.into_bytes(),
     })
 }
 
-/// Read a record back as an entity. Refuses a [`crate::UTXOS`] record.
-pub fn as_entity(record: &StateRecord) -> Result<(Namespace, EntityKey), Error> {
-    if record.ns == UTXOS {
-        return Err(Error::malformed(
-            STATE,
-            format!("namespace {UTXOS:?} is read by `as_utxo`, not by `as_entity`"),
-        ));
-    }
-
+/// Read a record back as an entity. Refuses a key that is not entity-width —
+/// a UTxO record, above all.
+pub fn as_entity(record: &StateRecord) -> Result<EntityKey, Error> {
     let key: [u8; ENTITY_KEY_LEN] = record.key.as_slice().try_into().map_err(|_| {
         Error::malformed(
             STATE,
             format!(
-                "{}: expected a {ENTITY_KEY_LEN}-byte key, found {}",
-                record.ns,
+                "expected a {ENTITY_KEY_LEN}-byte entity key, found {}",
                 record.key.len()
             ),
         )
     })?;
 
-    Ok((record.ns, EntityKey::from(&key)))
+    Ok(EntityKey::from(&key))
 }
 
-/// Read a record back as a UTxO. Refuses any namespace but [`crate::UTXOS`].
+/// Read a record back as a UTxO. Refuses a key that is not UTxO-width — an
+/// entity record, above all.
 pub fn as_utxo(record: &StateRecord) -> Result<(TxoRef, EraCbor), Error> {
-    if record.ns != UTXOS {
-        return Err(Error::malformed(
-            STATE,
-            format!("namespace {:?} is not the utxo set", record.ns),
-        ));
-    }
-
     let key: [u8; UTXO_KEY_LEN] = record.key.as_slice().try_into().map_err(|_| {
         Error::malformed(
             STATE,
@@ -178,26 +176,30 @@ pub fn decode_utxo_value(bytes: &[u8]) -> Result<EraCbor, Error> {
     Ok(EraCbor(era, body))
 }
 
-pub fn encode(record: &StateRecord) -> Result<CanonicalCbor, Error> {
-    let ns = namespaces::resolve(record.ns)?;
+/// Encode one record of `ns`'s state layer.
+///
+/// The namespace is a parameter rather than a field: it comes from the layer's
+/// kind, and it decides the key width this refuses under.
+pub fn encode(ns: Namespace, record: &StateRecord) -> Result<CanonicalCbor, Error> {
+    let ns = namespaces::resolve(ns)?;
 
     check_key_width(ns, record.key.len())?;
 
     Ok(frame::encode(|e| {
-        e.array(3)?
-            .str(ns)?
-            .bytes(&record.key)?
-            .bytes(&record.value)?;
+        e.array(2)?.bytes(&record.key)?.bytes(&record.value)?;
         Ok(())
     })?)
 }
 
-pub fn decode(bytes: &[u8]) -> Result<StateRecord, Error> {
+/// Decode one record of `ns`'s state layer, holding the key to the width the
+/// namespace requires.
+pub fn decode(ns: Namespace, bytes: &[u8]) -> Result<StateRecord, Error> {
+    let ns = namespaces::resolve(ns)?;
+
     let mut decoder = minicbor::Decoder::new(bytes);
 
-    open(STATE, &mut decoder, 3)?;
+    open(STATE, &mut decoder, 2)?;
 
-    let ns = namespaces::resolve(text(STATE, "ns", &mut decoder)?)?;
     let key = blob(STATE, "key", &mut decoder)?.to_vec();
     let value = blob(STATE, "value", &mut decoder)?.to_vec();
 
@@ -205,7 +207,7 @@ pub fn decode(bytes: &[u8]) -> Result<StateRecord, Error> {
 
     check_key_width(ns, key.len())?;
 
-    Ok(StateRecord { ns, key, value })
+    Ok(StateRecord { key, value })
 }
 
 /// Both key widths are fixed by their namespace, and both `EntityKey` and a
@@ -228,60 +230,60 @@ fn check_key_width(ns: Namespace, len: usize) -> Result<(), Error> {
     Ok(())
 }
 
-/// Strictly ascending `(ns, key)`, optionally within one shard.
+/// Strictly ascending `key`, optionally within one shard.
+///
+/// One namespace per layer, so the key alone orders it — the ordering rule the
+/// store's own iterator already yields.
 #[derive(Debug, Default, Clone)]
 pub struct OrderCheck {
-    shard: Option<u8>,
-    last: Option<(Namespace, Vec<u8>)>,
+    /// `(shard, shards)`: which shard every record must belong to, under the
+    /// kind's shard count.
+    shard: Option<(u8, u8)>,
+    last: Option<Vec<u8>>,
 }
 
 impl OrderCheck {
-    /// A check that also insists every record belongs to `shard`.
+    /// A check that also insists every record belongs to `shard` of `shards`.
     ///
     /// Worth having beside the ordering rule: a record in the wrong shard layer
-    /// still restores — the write path dispatches on the namespace, not on the
+    /// still restores — the write path dispatches on the kind, not on the
     /// shard — so nothing downstream would ever notice, and a client fetching
     /// shards selectively would silently miss it.
-    pub fn for_shard(shard: u8) -> Self {
+    pub fn for_shard(shard: u8, shards: u8) -> Self {
         Self {
-            shard: Some(shard),
+            shard: Some((shard, shards)),
             last: None,
         }
     }
 
     pub fn check(&mut self, record: &StateRecord) -> Result<(), Error> {
-        if let Some(shard) = self.shard {
-            if record.shard() != shard {
+        if let Some((shard, shards)) = self.shard {
+            if shard_of(&record.key, shards) != shard {
                 return Err(Error::malformed(
                     STATE,
                     format!(
-                        "{}/{} belongs to shard {}, not shard {shard}",
-                        record.ns,
+                        "{} belongs to shard {}, not shard {shard}",
                         hex::encode(&record.key),
-                        record.shard(),
+                        shard_of(&record.key, shards),
                     ),
                 ));
             }
         }
 
-        let current = (record.ns, record.key.clone());
-
         if let Some(previous) = &self.last {
-            if current <= *previous {
+            if record.key <= *previous {
                 return Err(Error::out_of_order(
                     STATE,
                     format!(
-                        "{}/{} follows {}/{}",
-                        current.0,
-                        hex::encode(&current.1),
-                        previous.0,
-                        hex::encode(&previous.1),
+                        "{} follows {}",
+                        hex::encode(&record.key),
+                        hex::encode(previous),
                     ),
                 ));
             }
         }
 
-        self.last = Some(current);
+        self.last = Some(record.key.clone());
 
         Ok(())
     }
@@ -289,7 +291,7 @@ impl OrderCheck {
 
 #[cfg(test)]
 mod tests {
-    use dolos_cardano::model::{AccountState, FixedNamespace, PoolState};
+    use dolos_cardano::model::{AccountState, FixedNamespace};
 
     use super::*;
 
@@ -303,17 +305,13 @@ mod tests {
 
     #[test]
     fn an_entity_record_round_trips() {
-        let original =
-            entity(AccountState::NS, &entity_key(0x5a), &vec![0x82, 0x01, 0x02]).unwrap();
+        let original = entity(&entity_key(0x5a), &vec![0x82, 0x01, 0x02]);
 
-        let encoded = encode(&original).unwrap();
-        let decoded = decode(encoded.as_bytes()).unwrap();
+        let encoded = encode(AccountState::NS, &original).unwrap();
+        let decoded = decode(AccountState::NS, encoded.as_bytes()).unwrap();
 
         assert_eq!(decoded, original);
-        assert_eq!(
-            as_entity(&decoded).unwrap(),
-            (AccountState::NS, entity_key(0x5a))
-        );
+        assert_eq!(as_entity(&decoded).unwrap(), entity_key(0x5a));
     }
 
     #[test]
@@ -323,11 +321,10 @@ mod tests {
 
         let original = utxo(&ref_, &value).unwrap();
 
-        assert_eq!(original.ns, UTXOS);
         assert_eq!(original.key.len(), UTXO_KEY_LEN);
 
-        let encoded = encode(&original).unwrap();
-        let decoded = decode(encoded.as_bytes()).unwrap();
+        let encoded = encode(UTXOS, &original).unwrap();
+        let decoded = decode(UTXOS, encoded.as_bytes()).unwrap();
 
         assert_eq!(decoded, original);
         assert_eq!(as_utxo(&decoded).unwrap(), (ref_, value));
@@ -370,14 +367,15 @@ mod tests {
         }
     }
 
+    /// The key widths tell the two record shapes apart, now that no namespace
+    /// field does: each reader refuses the other's record on the width.
     #[test]
     fn the_two_readers_refuse_each_others_records() {
-        let entity_record = entity(PoolState::NS, &entity_key(1), &Vec::new()).unwrap();
+        let entity_record = entity(&entity_key(1), &Vec::new());
         let utxo_record = utxo(&txo(1, 0), &EraCbor(1, Vec::new())).unwrap();
 
         assert!(as_utxo(&entity_record).is_err());
         assert!(as_entity(&utxo_record).is_err());
-        assert!(entity(UTXOS, &entity_key(1), &Vec::new()).is_err());
     }
 
     #[test]
@@ -389,12 +387,12 @@ mod tests {
             (UTXOS, UTXO_KEY_LEN + 1),
         ] {
             let wire = frame::encode(|e| {
-                e.array(3)?.str(ns)?.bytes(&vec![0u8; width])?.bytes(&[])?;
+                e.array(2)?.bytes(&vec![0u8; width])?.bytes(&[])?;
                 Ok(())
             })
             .unwrap();
 
-            let err = decode(wire.as_bytes()).unwrap_err();
+            let err = decode(ns, wire.as_bytes()).unwrap_err();
             assert!(
                 matches!(err, Error::MalformedRecord { .. }),
                 "{ns}/{width}: {err:?}"
@@ -402,64 +400,111 @@ mod tests {
         }
     }
 
-    /// Hash-derived keys spread evenly over the sixteen shards, which is the
-    /// premise the shard split rests on.
+    /// The shape the `state` kind carried before the split, offered to the
+    /// decoder of the kinds that replaced it.
+    ///
+    /// It has to be refused, and refused on the arity: a decoder that read the
+    /// first two elements and stopped would take the namespace string for a
+    /// key, and a decoder that tolerated the extra element would restore v1
+    /// records into a namespace decided by the layer rather than by the record
+    /// — silently, and only for the namespaces that happen to agree.
     #[test]
-    fn sharding_is_the_first_nibble_and_covers_every_shard() {
-        assert_eq!(shard_of(&[0x00]), 0);
-        assert_eq!(shard_of(&[0x0f]), 0);
-        assert_eq!(shard_of(&[0x10]), 1);
-        assert_eq!(shard_of(&[0xff]), 15);
+    fn the_pre_split_three_element_record_is_refused() {
+        let wire = frame::encode(|e| {
+            e.array(3)?
+                .str("accounts")?
+                .bytes(&[0u8; ENTITY_KEY_LEN])?
+                .bytes(&[])?;
+            Ok(())
+        })
+        .unwrap();
 
-        let mut counts = [0usize; STATE_SHARDS as usize];
+        let err = decode(AccountState::NS, wire.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+    }
+
+    /// A namespace this profile does not define is refused by the codec itself,
+    /// not left to a later stage.
+    #[test]
+    fn an_unknown_namespace_is_refused_by_both_directions() {
+        let record = entity(&entity_key(1), &Vec::new());
+
+        assert!(encode("receipts", &record).is_err());
+
+        let wire = encode(AccountState::NS, &record).unwrap();
+        assert!(decode("receipts", wire.as_bytes()).is_err());
+    }
+
+    /// Hash-derived keys spread evenly over the sixteen shards, which is the
+    /// premise the shard split rests on — and a single-blob namespace is
+    /// always shard 0, whatever its keys.
+    #[test]
+    fn sharding_is_the_first_nibble_or_the_single_blob() {
+        assert_eq!(shard_of(&[0x00], 16), 0);
+        assert_eq!(shard_of(&[0x0f], 16), 0);
+        assert_eq!(shard_of(&[0x10], 16), 1);
+        assert_eq!(shard_of(&[0xff], 16), 15);
+
+        let mut counts = [0usize; 16];
         for byte in 0u8..=255 {
-            counts[shard_of(&[byte]) as usize] += 1;
+            counts[shard_of(&[byte], 16) as usize] += 1;
         }
 
         assert!(counts.iter().all(|c| *c == 16), "{counts:?}");
+
+        for byte in [0x00, 0x0f, 0x10, 0xff] {
+            assert_eq!(shard_of(&[byte], 1), 0, "{byte:#x}");
+        }
     }
 
-    /// The two key widths shard the same way, so one rule covers the whole
-    /// layer kind.
+    /// The two key widths shard the same way, so one rule covers every kind.
     #[test]
     fn both_key_widths_shard_identically() {
-        let entity_record = entity(PoolState::NS, &entity_key(0xc3), &Vec::new()).unwrap();
+        let entity_record = entity(&entity_key(0xc3), &Vec::new());
         let utxo_record = utxo(&txo(0xc3, 0), &EraCbor(1, Vec::new())).unwrap();
 
-        assert_eq!(entity_record.shard(), 12);
-        assert_eq!(utxo_record.shard(), 12);
+        assert_eq!(shard_of(&entity_record.key, 16), 12);
+        assert_eq!(shard_of(&utxo_record.key, 16), 12);
     }
 
     #[test]
-    fn ordering_is_namespace_then_key() {
+    fn ordering_is_by_key() {
         let mut order = OrderCheck::default();
 
         for record in [
-            entity(AccountState::NS, &entity_key(0x00), &Vec::new()).unwrap(),
-            entity(AccountState::NS, &entity_key(0x01), &Vec::new()).unwrap(),
-            entity(PoolState::NS, &entity_key(0x00), &Vec::new()).unwrap(),
-            utxo(&txo(0x00, 0), &EraCbor(1, Vec::new())).unwrap(),
+            entity(&entity_key(0x00), &Vec::new()),
+            entity(&entity_key(0x01), &Vec::new()),
+            utxo(&txo(0x01, 0), &EraCbor(1, Vec::new())).unwrap(),
         ] {
             order.check(&record).unwrap();
         }
 
         let err = order
-            .check(&entity(AccountState::NS, &entity_key(0x09), &Vec::new()).unwrap())
+            .check(&entity(&entity_key(0x01), &Vec::new()))
             .unwrap_err();
         assert!(matches!(err, Error::OutOfOrder { .. }), "{err:?}");
     }
 
     #[test]
     fn a_record_from_another_shard_is_refused() {
-        let mut order = OrderCheck::for_shard(0);
+        let mut order = OrderCheck::for_shard(0, 16);
 
         order
-            .check(&entity(AccountState::NS, &entity_key(0x0a), &Vec::new()).unwrap())
+            .check(&entity(&entity_key(0x0a), &Vec::new()))
             .unwrap();
 
         let err = order
-            .check(&entity(AccountState::NS, &entity_key(0xa0), &Vec::new()).unwrap())
+            .check(&entity(&entity_key(0xa0), &Vec::new()))
             .unwrap_err();
         assert!(matches!(err, Error::MalformedRecord { .. }), "{err:?}");
+
+        // Under a single-blob count the same keys are all shard 0.
+        let mut single = OrderCheck::for_shard(0, 1);
+        single
+            .check(&entity(&entity_key(0x0a), &Vec::new()))
+            .unwrap();
+        single
+            .check(&entity(&entity_key(0xa0), &Vec::new()))
+            .unwrap();
     }
 }

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -3,7 +3,8 @@
 //! [`stelae`] is the protocol: framing, canonicalization, digests and the
 //! naming rules that let vendors coexist in one registry. It knows nothing
 //! about Cardano. This crate is the other half — the *profile* — and it says
-//! what a Dolos stele actually contains: ten layer kinds, their media types,
+//! what a Dolos stele actually contains: twenty-six layer kinds, their media
+//! types,
 //! the tag a sequence renders as, what goes in `position`, `parameters` and
 //! each layer's `scope`, and the byte-exact codec for every record shape.
 //!
@@ -67,8 +68,9 @@ pub mod restore;
 pub use stelae::progress;
 
 use dolos_cardano::model::{
-    AccountStakeLog, EpochState, FixedNamespace, LeaderRewardLog, MemberRewardLog,
-    PoolDepositRefundLog, StakeLog,
+    AccountStakeLog, AccountState, AssetState, DRepState, DatumState, EpochState, EraSummary,
+    FixedNamespace, GovState, LeaderRewardLog, MemberRewardLog, PendingMirState,
+    PendingRewardState, PoolDepositRefundLog, PoolState, ProposalState, StakeLog,
 };
 use dolos_core::{ChainPoint, Namespace};
 use serde_json::json;
@@ -78,8 +80,8 @@ use stelae::{
     Compression, Profile,
 };
 
-pub use layers::state::{shard_of, STATE_SHARDS};
-pub use namespaces::{NAMESPACES, UTXOS};
+pub use layers::state::shard_of;
+pub use namespaces::{NAMESPACES, SCHEMA_REVS, UTXOS};
 
 /// Reverse-DNS name of this profile. Vendor-owned; the protocol validates the
 /// shape and never composes it.
@@ -90,7 +92,6 @@ pub const PROFILE_VERSION: u64 = 1;
 
 pub const BLOCKS: &str = "blocks";
 pub const INDEXES: &str = "indexes";
-pub const STATE: &str = "state";
 pub const DIGESTS: &str = "digests";
 
 /// The namespaces the ledger writes epoch-boundary logs under, byte-sorted.
@@ -128,6 +129,120 @@ pub const LOG_KINDS: [(&str, Namespace); 6] = [
     ("log-stakes", StakeLog::NS),
 ];
 
+/// The state layer kinds: the namespace each carries and the shard count its
+/// tip is published in, in inscription order.
+///
+/// One kind per namespace, for the same reason [`LOG_KINDS`] is one per log
+/// namespace (decision 0026): a breaking change to one namespace's record shape
+/// moves that kind's media type and fails closed on exactly the namespace that
+/// broke, and a namespace this profile does not know is skippable at the
+/// transport rather than poisoning one shared layer. The kind is `state-`
+/// followed by the namespace with `_` rewritten to `-` — a media type's kind
+/// token admits hyphens and not underscores — but it is *spelled out* here
+/// rather than composed, so the wire vocabulary is greppable and a namespace
+/// rename cannot silently rename a published kind. The derivation is a test,
+/// not a constructor (`state_kinds_derive_from_their_namespaces`).
+///
+/// The shard count is **specification, never tuning**: the four namespaces
+/// whose populations are chain-scale — the UTxO set, accounts, assets and
+/// datums — shard sixteen ways by the first key nibble, and every other
+/// namespace is a single blob. Re-sharding a namespace is a media-type-version
+/// event for that namespace's kind, decided by the format's owner; it is not a
+/// constant to nudge.
+pub const STATE_KINDS: [(&str, Namespace, u8); 17] = [
+    ("state-account-stakes", AccountStakeLog::NS, 1),
+    ("state-accounts", AccountState::NS, 16),
+    ("state-assets", AssetState::NS, 16),
+    ("state-datums", DatumState::NS, 16),
+    ("state-dreps", DRepState::NS, 1),
+    ("state-epochs", EpochState::NS, 1),
+    ("state-eras", EraSummary::NS, 1),
+    ("state-gov", GovState::NS, 1),
+    ("state-leader-rewards", LeaderRewardLog::NS, 1),
+    ("state-member-rewards", MemberRewardLog::NS, 1),
+    ("state-pending-mirs", PendingMirState::NS, 1),
+    ("state-pending-rewards", PendingRewardState::NS, 1),
+    ("state-pool-deposit-refunds", PoolDepositRefundLog::NS, 1),
+    ("state-pools", PoolState::NS, 1),
+    ("state-proposals", ProposalState::NS, 1),
+    ("state-stakes", StakeLog::NS, 1),
+    ("state-utxos", namespaces::UTXOS, 16),
+];
+
+/// The seventeen state kind names alone: what [`StateScope`] answers for
+/// [`Scope::kinds`].
+pub const STATE_KIND_NAMES: [&str; 17] = [
+    STATE_KINDS[0].0,
+    STATE_KINDS[1].0,
+    STATE_KINDS[2].0,
+    STATE_KINDS[3].0,
+    STATE_KINDS[4].0,
+    STATE_KINDS[5].0,
+    STATE_KINDS[6].0,
+    STATE_KINDS[7].0,
+    STATE_KINDS[8].0,
+    STATE_KINDS[9].0,
+    STATE_KINDS[10].0,
+    STATE_KINDS[11].0,
+    STATE_KINDS[12].0,
+    STATE_KINDS[13].0,
+    STATE_KINDS[14].0,
+    STATE_KINDS[15].0,
+    STATE_KINDS[16].0,
+];
+
+/// The kind carrying `ns`'s state tip, or `None` where the namespace is not one
+/// this profile defines.
+pub fn state_kind_for(ns: Namespace) -> Option<&'static str> {
+    STATE_KINDS
+        .into_iter()
+        .find(|(_, known, _)| *known == ns)
+        .map(|(kind, _, _)| kind)
+}
+
+/// The namespace `kind` carries state for, or `None` where the kind is not a
+/// state layer.
+///
+/// The reader's half of the split, exactly as [`log_ns_for`] is for the logs:
+/// a restore learns which namespace a layer's records belong to from its kind,
+/// since the records no longer say.
+pub fn state_ns_for(kind: &str) -> Option<Namespace> {
+    STATE_KINDS
+        .into_iter()
+        .find(|(known, _, _)| *known == kind)
+        .map(|(_, ns, _)| ns)
+}
+
+/// Whether `kind` is one of the seventeen state kinds — the tip predicate the
+/// staging arithmetic in [`registry`] sums under.
+pub fn is_state_kind(kind: &str) -> bool {
+    state_ns_for(kind).is_some()
+}
+
+/// How many shards `ns`'s state kind publishes, or `None` where the namespace
+/// is not one this profile defines.
+pub fn shards_for(ns: Namespace) -> Option<u8> {
+    STATE_KINDS
+        .into_iter()
+        .find(|(_, known, _)| *known == ns)
+        .map(|(_, _, shards)| shards)
+}
+
+/// How many state layers every publish writes: the shard counts summed — 77
+/// today. Every shard of every namespace kind is written even when empty, so
+/// tip completeness stays structural rather than data-dependent.
+pub const fn state_layer_count() -> usize {
+    let mut total = 0;
+    let mut i = 0;
+
+    while i < STATE_KINDS.len() {
+        total += STATE_KINDS[i].2 as usize;
+        i += 1;
+    }
+
+    total
+}
+
 /// The epoch kinds a window always produces a layer for.
 ///
 /// The log kinds are the exception, and the only one: a log layer exists if and
@@ -137,8 +252,8 @@ pub const LOG_KINDS: [(&str, Namespace); 6] = [
 /// [`registry::preview`] is made of.
 pub const DENSE_EPOCH_KINDS: [&str; 2] = [BLOCKS, INDEXES];
 
-/// The ten layer kinds, in the order the inscription lists them.
-pub const KINDS: [&str; 10] = [
+/// The twenty-six layer kinds, in the order the inscription lists them.
+pub const KINDS: [&str; 26] = [
     BLOCKS,
     INDEXES,
     LOG_KINDS[0].0,
@@ -147,7 +262,23 @@ pub const KINDS: [&str; 10] = [
     LOG_KINDS[3].0,
     LOG_KINDS[4].0,
     LOG_KINDS[5].0,
-    STATE,
+    STATE_KIND_NAMES[0],
+    STATE_KIND_NAMES[1],
+    STATE_KIND_NAMES[2],
+    STATE_KIND_NAMES[3],
+    STATE_KIND_NAMES[4],
+    STATE_KIND_NAMES[5],
+    STATE_KIND_NAMES[6],
+    STATE_KIND_NAMES[7],
+    STATE_KIND_NAMES[8],
+    STATE_KIND_NAMES[9],
+    STATE_KIND_NAMES[10],
+    STATE_KIND_NAMES[11],
+    STATE_KIND_NAMES[12],
+    STATE_KIND_NAMES[13],
+    STATE_KIND_NAMES[14],
+    STATE_KIND_NAMES[15],
+    STATE_KIND_NAMES[16],
     DIGESTS,
 ];
 
@@ -638,12 +769,26 @@ pub fn read_position(value: &serde_json::Value) -> Result<Position, Error> {
 /// Build the profile's `parameters`: what a reader needs in order to interpret
 /// the layers.
 ///
-/// Both values are consequences of code in this workspace rather than free
-/// choices, so both are sourced rather than spelled: the shard count is
-/// [`STATE_SHARDS`], which [`shard_of`] divides by, and the hash scheme is
-/// [`INDEX_KEY_HASH`], which describes [`dolos_core::key_hash`].
+/// Every value is a consequence of code in this workspace rather than a free
+/// choice, so every one is sourced rather than spelled: the hash scheme is
+/// [`INDEX_KEY_HASH`], which describes [`dolos_core::key_hash`]; `shards` is
+/// the shard column of [`STATE_KINDS`], which the export routes by; and
+/// `schemas` is [`SCHEMA_REVS`], the per-namespace record-content revision the
+/// compatibility machinery of decision 0026 keys on. Both maps are keyed by
+/// namespace — JCS sorts the keys, so the maps render in the byte order the
+/// tables are kept in.
 pub fn parameters() -> serde_json::Value {
-    json!({"stateShards": STATE_SHARDS, "indexKeyHash": INDEX_KEY_HASH})
+    let shards: serde_json::Map<String, serde_json::Value> = STATE_KINDS
+        .into_iter()
+        .map(|(_, ns, shards)| (ns.to_owned(), json!(shards)))
+        .collect();
+
+    let schemas: serde_json::Map<String, serde_json::Value> = SCHEMA_REVS
+        .into_iter()
+        .map(|(ns, rev)| (ns.to_owned(), json!(rev)))
+        .collect();
+
+    json!({"indexKeyHash": INDEX_KEY_HASH, "shards": shards, "schemas": schemas})
 }
 
 /// The compression this profile publishes under.
@@ -666,7 +811,11 @@ pub struct EpochScope {
     pub end_slot: u64,
 }
 
-/// Scope of one shard of the state tip.
+/// Scope of one shard of one state kind's tip.
+///
+/// Uniform across all seventeen kinds, single-blob namespaces included — their
+/// one layer is shard 0 — so the header and descriptor shapes stay one shape
+/// and a reader never dispatches on the kind to parse a scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateScope {
     pub network_magic: u64,
@@ -761,7 +910,7 @@ impl Scope for StateScope {
     }
 
     fn kinds(&self) -> &'static [&'static str] {
-        &[STATE]
+        &STATE_KIND_NAMES
     }
 
     fn shape(&self) -> &'static str {
@@ -827,7 +976,7 @@ mod tests {
 
     #[test]
     fn an_undefined_kind_is_refused() {
-        for kind in ["utxos", "receipts", "", "Blocks"] {
+        for kind in ["utxos", "state", "logs", "receipts", "", "Blocks"] {
             assert!(DolosProfile.layer_media_type(kind).is_err(), "{kind:?}");
             assert!(
                 checked_layer_media_type(&DolosProfile, kind).is_err(),
@@ -962,18 +1111,44 @@ mod tests {
         assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
     }
 
-    /// The two parameters are claims about code elsewhere in this workspace, so
+    /// The parameters are claims about code elsewhere in this workspace, so
     /// they are compared against that code rather than against themselves.
     #[test]
     fn parameters_report_what_the_code_does() {
         let parameters = parameters();
 
-        assert_eq!(parameters["stateShards"], STATE_SHARDS);
         assert_eq!(parameters["indexKeyHash"], INDEX_KEY_HASH);
+        assert!(
+            parameters.get("stateShards").is_none(),
+            "the flat shard count was replaced by the per-namespace map"
+        );
 
-        let shards: Vec<u8> = (0u8..=255).map(|b| shard_of(&[b])).collect();
-        let distinct: std::collections::BTreeSet<u8> = shards.iter().copied().collect();
-        assert_eq!(distinct.len() as u64, STATE_SHARDS);
+        // The two maps are the two tables, entry for entry — and nothing more:
+        // a namespace in the JSON that no table has would be a claim about code
+        // that does not exist.
+        for (_, ns, shards) in STATE_KINDS {
+            assert_eq!(parameters["shards"][ns], shards, "{ns}");
+        }
+        assert_eq!(
+            parameters["shards"].as_object().unwrap().len(),
+            STATE_KINDS.len()
+        );
+
+        for (ns, rev) in SCHEMA_REVS {
+            assert_eq!(parameters["schemas"][ns], rev, "{ns}");
+        }
+        assert_eq!(
+            parameters["schemas"].as_object().unwrap().len(),
+            SCHEMA_REVS.len()
+        );
+
+        // The routing rule behind the map: a sixteen-way namespace covers every
+        // shard its count promises, and a single blob is always shard 0.
+        let nibbles: std::collections::BTreeSet<u8> =
+            (0u8..=255).map(|b| shard_of(&[b], 16)).collect();
+        assert_eq!(nibbles.len(), 16);
+
+        assert!((0u8..=255).all(|b| shard_of(&[b], 1) == 0));
     }
 
     /// A scope belongs to the kinds whose shape it is, and to no others.
@@ -999,13 +1174,16 @@ mod tests {
         for kind in EPOCH_KINDS {
             epoch.layer_spec(kind).unwrap();
         }
-        state.layer_spec(STATE).unwrap();
+        for kind in STATE_KIND_NAMES {
+            state.layer_spec(kind).unwrap();
+        }
         digests.layer_spec(DIGESTS).unwrap();
 
         for (spec, kind) in [
-            (epoch.layer_spec(STATE), STATE),
+            (epoch.layer_spec(STATE_KIND_NAMES[0]), STATE_KIND_NAMES[0]),
             (epoch.layer_spec(DIGESTS), DIGESTS),
             (state.layer_spec(BLOCKS), BLOCKS),
+            (state.layer_spec("state"), "state"),
             (digests.layer_spec(LOG_KINDS[0].0), LOG_KINDS[0].0),
         ] {
             let err = spec.unwrap_err();

--- a/crates/snapshot/src/namespaces.rs
+++ b/crates/snapshot/src/namespaces.rs
@@ -54,6 +54,34 @@ pub const NAMESPACES: [Namespace; 17] = [
     UTXOS,
 ];
 
+/// The schema revision of each namespace's record content, as
+/// `parameters.schemas` reports it.
+///
+/// All 1 today: the revision moves when a namespace's stored record shape
+/// changes in a way its `state-{ns}` / `log-{ns}` layers carry — the signal the
+/// compatibility machinery of decision 0026 keys adoption on. Kept beside
+/// [`NAMESPACES`], in the same order, and held to it by
+/// `every_namespace_has_a_schema_rev` below.
+pub const SCHEMA_REVS: [(Namespace, u64); 17] = [
+    (AccountStakeLog::NS, 1),
+    (AccountState::NS, 1),
+    (AssetState::NS, 1),
+    (DatumState::NS, 1),
+    (DRepState::NS, 1),
+    (EpochState::NS, 1),
+    (EraSummary::NS, 1),
+    (GovState::NS, 1),
+    (LeaderRewardLog::NS, 1),
+    (MemberRewardLog::NS, 1),
+    (PendingMirState::NS, 1),
+    (PendingRewardState::NS, 1),
+    (PoolDepositRefundLog::NS, 1),
+    (PoolState::NS, 1),
+    (ProposalState::NS, 1),
+    (StakeLog::NS, 1),
+    (UTXOS, 1),
+];
+
 /// Resolve a namespace read off the wire to the `&'static str` the stores use.
 ///
 /// Fails closed. A namespace this profile does not define cannot be restored —
@@ -81,6 +109,15 @@ mod tests {
         let mut deduped = sorted.to_vec();
         deduped.dedup();
         assert_eq!(deduped.len(), NAMESPACES.len(), "duplicate namespace");
+    }
+
+    #[test]
+    fn every_namespace_has_a_schema_rev() {
+        assert_eq!(
+            SCHEMA_REVS.map(|(ns, _)| ns),
+            NAMESPACES,
+            "SCHEMA_REVS and NAMESPACES disagree about the namespaces"
+        );
     }
 
     #[test]

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -91,8 +91,8 @@
 //! file: a host-local note beside the stores, naming each **epoch layer** whose
 //! upload succeeded. A restart reads it and adopts those layers through
 //! [`Registry::adopt_carried`] — the same move an inherited layer makes, one
-//! `HEAD` and no store read. The sixteen state shards are never in it, for the
-//! reason they are never inherited.
+//! `HEAD` and no store read. The state layers are never in it, for the reason
+//! they are never inherited.
 //!
 //! The record is **a stand-in for the predecessor manifest an unfinished
 //! publish never got to write, and nothing more.** Four properties keep it from
@@ -169,7 +169,7 @@ use crate::{
     export::{self, history_for, same_network, Plan, Predecessor, Standing},
     layers::digests,
     restore::{Outlook, Restoring, Summary, Target},
-    DolosProfile, Error, Scope as _, DENSE_EPOCH_KINDS, EPOCH_KINDS, STATE, STATE_SHARDS,
+    DolosProfile, Error, Scope as _, DENSE_EPOCH_KINDS, EPOCH_KINDS,
 };
 
 /// Which stele in a repository a restore wants.
@@ -808,13 +808,15 @@ pub fn inspect(registry: &Registry, point: Point) -> Result<Inspected, Error> {
 /// What a publish holds staged on disk at its peak.
 ///
 /// Not the size of the stele: a publish never has the whole document on disk at
-/// once. What it does have at once is the state pass, which keeps all sixteen
-/// shard sinks open across a single walk of the store — see
-/// [`crate::export`] for why sixteen passes is the alternative — plus whatever
-/// epoch layer is in flight beside it.
+/// once. What it does have at once is a state kind's pass, which keeps that
+/// kind's shard sinks open across a single walk of its namespace — see
+/// [`crate::export`] for why sixteen passes over `utxos` is the alternative —
+/// plus whatever epoch layer is in flight beside it. Summing *every* state
+/// layer rather than the widest kind's is deliberately conservative: the peak
+/// it prices is the pre-split one, an upper bound on any per-kind pass.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StagingPeak {
-    /// The sixteen state shards, which are staged concurrently.
+    /// Every state layer, summed — the conservative reading above.
     pub state_bytes: u64,
     /// The largest single non-state layer, which is staged alongside them.
     pub largest_other_bytes: u64,
@@ -859,14 +861,15 @@ pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
     for descriptor in &inscription.layers {
         match previous.compressed_size(&blobs, descriptor)? {
             None => peak.unsized_layers += 1,
-            // Every shard is open at once, so they add. Everything else is one
-            // layer at a time beside them, so only the biggest counts.
+            // Every state layer adds — the conservative sum-all-state rule the
+            // type documents. Everything else is one layer at a time beside
+            // them, so only the biggest counts.
             //
             // Saturating because these are a manifest's numbers and a manifest
             // is not this node's document: a wrapped sum would be a *small*
             // need, which is the one direction a refusal must never be wrong
             // in.
-            Some(bytes) if descriptor.kind == STATE => {
+            Some(bytes) if crate::is_state_kind(&descriptor.kind) => {
                 peak.state_bytes = peak.state_bytes.saturating_add(bytes)
             }
             Some(bytes) => peak.largest_other_bytes = peak.largest_other_bytes.max(bytes),
@@ -1061,11 +1064,11 @@ pub fn preview<A: ArchiveStore>(
 
     // Every epoch selected contributes one `blocks` and one `indexes` layer and
     // as many log layers as it has namespaces with logs, the state tip
-    // contributes its sixteen shards however the epochs were restricted, and
-    // the digests layer is there exactly when its records are.
+    // contributes every shard of every kind however the epochs were restricted,
+    // and the digests layer is there exactly when its records are.
     let total = plan.epochs.len() * DENSE_EPOCH_KINDS.len()
         + export::log_layers(plan, archive, &previous)?
-        + STATE_SHARDS as usize
+        + crate::state_layer_count()
         + usize::from(digest_records.is_some());
 
     // The same lookup `export` will make, through the same `layer_spec`, so a
@@ -1428,7 +1431,7 @@ mod tests {
                 json!({"epoch": 2, "startSlot": 200, "endSlot": 299}),
                 1,
             ),
-            layer(crate::STATE, json!({"shard": 0}), 2),
+            layer(crate::STATE_KINDS[16].0, json!({"shard": 0}), 2),
             layer(crate::DIGESTS, json!({"lastImmutable": 7}), 3),
         ];
 
@@ -1587,7 +1590,7 @@ mod tests {
                     json!({"epoch": 2, "startSlot": 200, "endSlot": 299}),
                     1,
                 ),
-                written(crate::STATE, json!({"shard": 0}), 2),
+                written(crate::STATE_KINDS[16].0, json!({"shard": 0}), 2),
             ],
         }
     }

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -20,7 +20,8 @@
 //! 3. [`dolos_core::IndexStore::initialize_schema`].
 //! 4. Per epoch: `blocks`, then the `log-{ns}` layers the epoch carries, then
 //!    `indexes`.
-//! 5. The state tip, sixteen shards, `set_cursor` **last**.
+//! 5. The state tip — every shard of every `state-{ns}` kind — with
+//!    `set_cursor` **last**.
 //! 6. Rebuild the live-UTxO index dimensions from the restored UTxO set. They
 //!    are never shipped — ADR-004's Amendment 2 — so this is where they come
 //!    back.
@@ -58,12 +59,12 @@
 //! Epoch layers may. They describe a closed window of a chain that cannot
 //! change again, so the same `diffId` in a newer inscription is the same layer.
 //!
-//! **State shards never may.** They are the tip. They are rewritten by every
-//! publish, and — independently of that — a shard's descriptor scope is
+//! **State layers never may.** They are the tip. They are rewritten by every
+//! publish, and — independently of that — a state layer's descriptor scope is
 //! `{"shard": n}` and names no epoch, so nothing in a shard's identity could
 //! distinguish one publish's tip from another's even if a caller wanted it to.
-//! So they are never asked about and never recorded, and the sixteen of them
-//! plus the live-UTxO rebuild are what every resumed restore pays.
+//! So they are never asked about and never recorded, and the tip's layers plus
+//! the live-UTxO rebuild are what every resumed restore pays.
 //!
 //! The checkpoint lands after each epoch layer's own commit, which is possible
 //! only because the driver commits per layer. That is the ownership split
@@ -129,8 +130,8 @@ use crate::{
     layers::{blocks, indexes, logs, state},
     log_ns_for, preflight, read_position,
     reporting::Cursor,
-    DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, SCOPE_REQUIRED, STATE, STATE_SHARDS,
-    UTXOS,
+    state_ns_for, DolosProfile, Error, Position, BLOCKS, DIGESTS, INDEXES, SCOPE_REQUIRED,
+    STATE_KINDS, UTXOS,
 };
 
 /// What a restore holds at once.
@@ -211,8 +212,10 @@ pub struct Plan {
     pub sequence: u64,
     /// The epochs whose layers this restore consumes, ascending.
     pub epochs: Vec<EpochLayers>,
-    /// The sixteen state shards, ascending.
-    pub state: Vec<LayerDescriptor>,
+    /// The state tip, by the namespace each kind names — every kind, with its
+    /// shards ascending inside. Namespace byte order is kind byte order, so
+    /// iterating the map is iterating the inscription's own layer order.
+    pub state: BTreeMap<Namespace, Vec<LayerDescriptor>>,
     /// Epochs the stele carries and `sync.max_history` excludes.
     pub skipped_epochs: usize,
     /// Layers of a kind this build does not implement, which it skips rather
@@ -239,13 +242,13 @@ impl Plan {
         self.epochs.iter().flat_map(EpochLayers::descriptors)
     }
 
-    /// The layers a resume never skips: the sixteen state shards.
+    /// The layers a resume never skips: the state tip's, every kind and shard.
     ///
     /// A separate method rather than a comment on a `filter`, because "state
-    /// shards are always redone" is a rule and not a detail — see the module
+    /// layers are always redone" is a rule and not a detail — see the module
     /// documentation for the two independent reasons it holds.
     pub fn tip_layers(&self) -> impl Iterator<Item = &LayerDescriptor> {
-        self.state.iter()
+        self.state.values().flatten()
     }
 
     /// Compressed bytes this restore still has to move, given what is done.
@@ -492,36 +495,59 @@ fn select_epochs(inscription: &Inscription) -> Result<Vec<EpochLayers>, Error> {
     Ok(by_epoch.into_values().collect())
 }
 
-/// The sixteen state shards, ascending.
+/// The state tip: every kind, every shard, grouped by the namespace the kind
+/// names.
 ///
-/// Every shard must be there, including an empty one. A missing shard is a
+/// Completeness is structural, in both dimensions. Every one of the seventeen
+/// kinds must be there — a publish writes all of them, so an absent kind means
+/// a slice of the ledger this stele does not carry — and per kind, exactly the
+/// shards its spec'd count promises, empty ones included. A missing piece is a
 /// missing slice of the ledger that no later step would notice — the write path
-/// dispatches on the namespace, not the shard — so it is refused rather than
-/// restored into a node whose queries quietly miss a sixteenth of the state.
-fn select_state(inscription: &Inscription) -> Result<Vec<LayerDescriptor>, Error> {
-    let mut by_shard: BTreeMap<u64, LayerDescriptor> = BTreeMap::new();
+/// dispatches on the kind, not the shard — so it is refused rather than
+/// restored into a node whose queries quietly miss part of the state.
+fn select_state(
+    inscription: &Inscription,
+) -> Result<BTreeMap<Namespace, Vec<LayerDescriptor>>, Error> {
+    let mut by_ns: BTreeMap<Namespace, BTreeMap<u64, LayerDescriptor>> = BTreeMap::new();
 
-    for descriptor in inscription.layers_of_kind(STATE) {
+    for descriptor in &inscription.layers {
+        let Some(ns) = state_ns_for(&descriptor.kind) else {
+            continue;
+        };
+
         let shard = scope_uint(descriptor, "shard")?;
 
-        if by_shard.insert(shard, descriptor.clone()).is_some() {
+        if by_ns
+            .entry(ns)
+            .or_default()
+            .insert(shard, descriptor.clone())
+            .is_some()
+        {
             return Err(Error::malformed_inscription(
-                "layers[state].scope",
+                format!("layers[{}].scope", descriptor.kind),
                 format!("shard {shard} is described twice"),
             ));
         }
     }
 
-    let expected: Vec<u64> = (0..STATE_SHARDS).collect();
-    let found: Vec<u64> = by_shard.keys().copied().collect();
+    for (kind, ns, shards) in STATE_KINDS {
+        let expected: Vec<u64> = (0..u64::from(shards)).collect();
+        let found: Vec<u64> = by_ns
+            .get(ns)
+            .map(|layers| layers.keys().copied().collect())
+            .unwrap_or_default();
 
-    if found != expected {
-        return Err(Error::IncompleteStele(format!(
-            "the state tip needs all {STATE_SHARDS} shards, and this stele carries {found:?}",
-        )));
+        if found != expected {
+            return Err(Error::IncompleteStele(format!(
+                "the state tip needs {kind} shards {expected:?}, and this stele carries {found:?}",
+            )));
+        }
     }
 
-    Ok(by_shard.into_values().collect())
+    Ok(by_ns
+        .into_iter()
+        .map(|(ns, layers)| (ns, layers.into_values().collect()))
+        .collect())
 }
 
 /// Drop the epochs `sync.max_history` puts out of reach.
@@ -872,18 +898,24 @@ where
         }
     }
 
-    info!(shards = plan.state.len(), "restoring the state tip");
+    info!(
+        layers = plan.tip_layers().count(),
+        "restoring the state tip"
+    );
 
-    for descriptor in &plan.state {
-        let at = cursor.open(STATE, &descriptor.scope);
+    for (ns, layers) in &plan.state {
+        for descriptor in layers {
+            let kind = descriptor.kind.as_str();
+            let at = cursor.open(kind, &descriptor.scope);
 
-        let (entities, utxos) = restore_state(&reader, descriptor, state)?;
+            let (entities, utxos) = restore_state(&reader, descriptor, state, ns)?;
 
-        cursor.close(at, STATE, Outcome::Transferred);
+            cursor.close(at, kind, Outcome::Transferred);
 
-        summary.entities += entities;
-        summary.utxos += utxos;
-        summary.layers_fetched += 1;
+            summary.entities += entities;
+            summary.utxos += utxos;
+            summary.layers_fetched += 1;
+        }
     }
 
     // Last, so that until this commit lands `has_existing_data()` reports an
@@ -1034,7 +1066,7 @@ impl<R: SteleReader> Reader<'_, R> {
     fn drain<T>(
         &self,
         descriptor: &LayerDescriptor,
-        decode: fn(&[u8]) -> Result<T, Error>,
+        decode: impl Fn(&[u8]) -> Result<T, Error>,
         size: impl Fn(&T) -> usize,
         mut flush: impl FnMut(Vec<T>) -> Result<(), Error>,
     ) -> Result<u64, Error> {
@@ -1201,55 +1233,62 @@ fn restore_indexes<R: SteleReader, I: IndexStore>(
     )
 }
 
-/// One state shard, dispatched per namespace.
+/// One state layer, written through the path its kind names.
+///
+/// `ns` comes from the layer's kind, not from its records — the split moved it
+/// there — so the dispatch is per layer rather than per record: the
+/// `state-utxos` kind goes through `apply_utxoset` in chunks (the UTxO set has
+/// its own writer method rather than a per-record one), and every other kind
+/// through `write_entity`.
 ///
 /// Returns the entities and the UTxOs it wrote, separately, because they are
-/// the two halves the cross-check compares and a shard that restored one and
+/// the two halves the cross-check compares and a layer that restored one and
 /// silently dropped the other would still add up.
 fn restore_state<R: SteleReader, S: StateStore>(
     reader: &Reader<'_, R>,
     descriptor: &LayerDescriptor,
     state: &S,
+    ns: Namespace,
 ) -> Result<(u64, u64), Error> {
-    let mut entities = 0u64;
-    let mut utxos = 0u64;
+    let decode = |bytes: &[u8]| state::decode(ns, bytes);
+    let size = |record: &state::StateRecord| record.key.len() + record.value.len();
 
-    reader.drain(
-        descriptor,
-        state::decode,
-        |record| record.key.len() + record.value.len(),
-        |chunk| {
+    if ns == UTXOS {
+        let utxos = reader.drain(descriptor, decode, size, |chunk| {
             let writer = state.start_writer()?;
 
-            // The UTxO set has its own writer method rather than a per-record
-            // one, so it is collected into a delta and applied once per chunk.
             let mut produced = UtxoSetDelta::default();
 
             for record in chunk {
-                if record.ns == UTXOS {
-                    let (txo, value) = state::as_utxo(&record)?;
+                let (txo, value) = state::as_utxo(&record)?;
 
-                    produced.produced_utxo.insert(txo, Arc::new(value));
-                    utxos += 1;
-                } else {
-                    let (ns, key) = state::as_entity(&record)?;
-
-                    writer.write_entity(ns, &key, &record.value)?;
-                    entities += 1;
-                }
+                produced.produced_utxo.insert(txo, Arc::new(value));
             }
 
-            if !produced.produced_utxo.is_empty() {
-                writer.apply_utxoset(&produced)?;
-            }
-
+            writer.apply_utxoset(&produced)?;
             writer.commit()?;
 
             Ok(())
-        },
-    )?;
+        })?;
 
-    Ok((entities, utxos))
+        return Ok((0, utxos));
+    }
+
+    let entities = reader.drain(descriptor, decode, size, |chunk| {
+        let writer = state.start_writer()?;
+
+        for record in chunk {
+            let key = state::as_entity(&record)?;
+
+            writer.write_entity(ns, &key, &record.value)?;
+        }
+
+        writer.commit()?;
+
+        Ok(())
+    })?;
+
+    Ok((entities, 0))
 }
 
 /// Rebuild the live-UTxO index dimensions from the restored UTxO set.
@@ -1355,24 +1394,70 @@ mod tests {
         inscription
     }
 
-    fn state_shards() -> Vec<LayerDescriptor> {
-        (0..STATE_SHARDS)
-            .map(|shard| descriptor(STATE, json!({ "shard": shard }), shard as u8))
+    /// Every state layer a complete tip carries: each kind, shards ascending.
+    fn state_layers() -> Vec<LayerDescriptor> {
+        let mut byte = 0u8;
+
+        STATE_KINDS
+            .into_iter()
+            .flat_map(|(kind, _, shards)| (0..shards).map(move |shard| (kind, shard)))
+            .map(|(kind, shard)| {
+                byte = byte.wrapping_add(1);
+                descriptor(kind, json!({ "shard": shard }), byte)
+            })
             .collect()
     }
 
+    /// Done criterion 2: completeness per kind and per shard, and the grouping
+    /// a complete tip selects into.
     #[test]
-    fn every_shard_of_the_state_tip_is_required() {
-        select_state(&inscription(state_shards())).unwrap();
+    fn the_state_tip_requires_every_kind_and_every_shard() {
+        let selected = select_state(&inscription(state_layers())).unwrap();
 
-        let mut short = state_shards();
-        short.pop();
+        assert_eq!(selected.len(), STATE_KINDS.len(), "one entry per kind");
+
+        for (kind, ns, shards) in STATE_KINDS {
+            let layers = &selected[ns];
+
+            assert_eq!(layers.len(), shards as usize, "{kind}");
+
+            for (shard, layer) in layers.iter().enumerate() {
+                assert_eq!(layer.kind, kind);
+                assert_eq!(layer.scope["shard"], shard as u64, "{kind}");
+            }
+        }
+
+        // A missing shard of a sixteen-way kind.
+        let mut short = state_layers();
+        let dropped = short
+            .iter()
+            .rposition(|layer| layer.kind == "state-utxos")
+            .unwrap();
+        short.remove(dropped);
 
         let err = select_state(&inscription(short)).unwrap_err();
         assert!(matches!(err, Error::IncompleteStele(_)), "{err:?}");
 
-        let mut doubled = state_shards();
-        doubled.push(descriptor(STATE, json!({"shard": 0}), 0xff));
+        // An absent kind: tip completeness is all seventeen, not "what's there".
+        let absent: Vec<LayerDescriptor> = state_layers()
+            .into_iter()
+            .filter(|layer| layer.kind != "state-epochs")
+            .collect();
+
+        let err = select_state(&inscription(absent)).unwrap_err();
+        assert!(matches!(err, Error::IncompleteStele(_)), "{err:?}");
+        assert!(err.to_string().contains("state-epochs"), "{err}");
+
+        // A shard past a single-blob kind's count.
+        let mut oversharded = state_layers();
+        oversharded.push(descriptor("state-pools", json!({"shard": 1}), 0xfe));
+
+        let err = select_state(&inscription(oversharded)).unwrap_err();
+        assert!(matches!(err, Error::IncompleteStele(_)), "{err:?}");
+
+        // One shard described twice.
+        let mut doubled = state_layers();
+        doubled.push(descriptor("state-utxos", json!({"shard": 0}), 0xff));
 
         let err = select_state(&inscription(doubled)).unwrap_err();
         assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
@@ -1481,7 +1566,7 @@ mod tests {
 
     #[test]
     fn the_selected_size_is_the_selected_layers_and_not_the_document() {
-        let mut layers = state_shards();
+        let mut layers = state_layers();
         layers.push(epoch_descriptor(BLOCKS, 0, 0xa0));
         layers.push(epoch_descriptor(BLOCKS, 2, 0xa2));
 
@@ -1498,9 +1583,11 @@ mod tests {
             skipped_unknown: Vec::new(),
         };
 
+        let tip = crate::state_layer_count() as u64;
+
         assert_eq!(plan.skipped_epochs, 1);
-        assert_eq!(plan.layers().count(), STATE_SHARDS as usize + 1);
-        assert_eq!(plan.uncompressed_size(), (STATE_SHARDS + 1) * 100);
+        assert_eq!(plan.layers().count() as u64, tip + 1);
+        assert_eq!(plan.uncompressed_size(), (tip + 1) * 100);
         assert!(plan.uncompressed_size() < stele.uncompressed_size());
     }
 
@@ -1508,7 +1595,7 @@ mod tests {
     /// store, not after it has written half a ledger.
     #[test]
     fn a_foreign_network_is_refused_by_the_plan() {
-        let stele = inscription(state_shards());
+        let stele = inscription(state_layers());
         let position = read_position(&stele.position).unwrap();
 
         assert_eq!(position.network.magic(), MAINNET_MAGIC);
@@ -1565,7 +1652,7 @@ mod tests {
                 .unwrap(),
             ),
             (
-                STATE,
+                STATE_KINDS[16].0,
                 StateScope {
                     network_magic: MAINNET_MAGIC,
                     epoch: 1,
@@ -1602,12 +1689,13 @@ mod tests {
     /// refused — the client half of decision 0026's additive-change rule.
     #[test]
     fn a_kind_this_build_does_not_implement_is_skipped_and_reported() {
-        let mut layers = state_shards();
+        let mut layers = state_layers();
         layers.push(epoch_descriptor(BLOCKS, 0, 0xa0));
         layers.push(descriptor("log-votes", json!({"epoch": 0}), 0xb0));
         layers.push(descriptor("state-treasury", json!({"epoch": 0}), 0xb1));
 
-        let skipped = unknown_layers(&inscription(layers)).unwrap();
+        let stele = inscription(layers);
+        let skipped = unknown_layers(&stele).unwrap();
 
         assert_eq!(
             skipped
@@ -1617,9 +1705,15 @@ mod tests {
             vec!["log-votes", "state-treasury"],
         );
 
+        // The two halves of the rule compose: a `state-{ns}` this build has no
+        // namespace for is skipped like any other unknown kind, and the tip is
+        // still complete, because completeness is counted over the seventeen
+        // kinds this profile defines rather than over the state layers present.
+        assert_eq!(select_state(&stele).unwrap().len(), STATE_KINDS.len());
+
         // And a stele written by a publisher this build keeps up with skips
         // nothing at all.
-        let mut known = state_shards();
+        let mut known = state_layers();
         known.push(epoch_descriptor(BLOCKS, 0, 0xa0));
         known.push(descriptor(DIGESTS, json!({"lastImmutable": 4}), 0xa1));
 
@@ -1629,7 +1723,7 @@ mod tests {
     /// The one unknown kind a restore refuses.
     #[test]
     fn a_required_unknown_kind_refuses_the_restore() {
-        let mut layers = state_shards();
+        let mut layers = state_layers();
         layers.push(descriptor(
             "log-votes",
             json!({"epoch": 7, "required": true}),
@@ -1648,7 +1742,7 @@ mod tests {
         // `required` is a flag, not a truthy field: only `true` refuses, so a
         // publisher cannot brick a reader by writing the key at all.
         for benign in [json!(false), json!("true"), json!(1), json!(null)] {
-            let mut layers = state_shards();
+            let mut layers = state_layers();
             layers.push(descriptor("log-votes", json!({"required": benign}), 0xb0));
 
             assert_eq!(unknown_layers(&inscription(layers)).unwrap().len(), 1);
@@ -1666,7 +1760,7 @@ mod tests {
             position: read_position(&inscription(vec![]).position).unwrap(),
             sequence: 3,
             epochs: Vec::new(),
-            state: state_shards(),
+            state: select_state(&inscription(state_layers())).unwrap(),
             skipped_epochs: 0,
             skipped_unknown: Vec::new(),
         };
@@ -1678,8 +1772,10 @@ mod tests {
         plan.preflight(&temp.path().join("not").join("created").join("yet"), None)
             .unwrap();
 
-        for descriptor in &mut plan.state {
-            descriptor.uncompressed_size = u64::MAX / STATE_SHARDS;
+        let tip = crate::state_layer_count() as u64;
+
+        for descriptor in plan.state.values_mut().flatten() {
+            descriptor.uncompressed_size = u64::MAX / tip;
         }
 
         let err = plan.preflight(temp.path(), None).unwrap_err();
@@ -1702,7 +1798,7 @@ mod tests {
             position: read_position(&inscription(vec![]).position).unwrap(),
             sequence: 3,
             epochs: Vec::new(),
-            state: Vec::new(),
+            state: BTreeMap::new(),
             skipped_epochs: 0,
             skipped_unknown: Vec::new(),
         };

--- a/crates/snapshot/tests/common/mod.rs
+++ b/crates/snapshot/tests/common/mod.rs
@@ -12,8 +12,8 @@
 //! stored key. What the fixture does have to be is *complete*, because the
 //! golden digests are what freeze the vocabulary: every archive dimension,
 //! every exact-record kind, every state namespace and every log *kind* appears
-//! at least once. Log namespaces are frozen through their kinds now — the
-//! record no longer carries one.
+//! at least once. Namespaces are frozen through their kinds now, for the state
+//! layers as for the logs — neither record carries one any more.
 
 // Each integration test binary compiles this module in full, so the parts one
 // binary does not reach look dead to it. They are not.
@@ -32,7 +32,7 @@ use dolos_snapshot::{
         state::{self, StateRecord, ENTITY_KEY_LEN},
     },
     DigestsScope, DolosProfile, EpochScope, Error, Network, Scope, StateScope, BLOCKS, DIGESTS,
-    INDEXES, LOG_KINDS, LOG_NAMESPACES, NAMESPACES, STATE, UTXOS,
+    INDEXES, LOG_KINDS, LOG_NAMESPACES, NAMESPACES, STATE_KINDS, UTXOS,
 };
 use stelae::{
     dir::{BlobIndex, SteleDir, WrittenLayer},
@@ -55,8 +55,10 @@ pub const POINT_HASH: [u8; 32] = [0x0b; 32];
 /// A transaction-metadata label, carried verbatim rather than hashed.
 pub const METADATA_LABEL: u64 = 674;
 
-/// The two state shards the fixture populates. Sixteen exist; a fixture that
-/// wrote all of them would say nothing more than two do about the split.
+/// The shards the fixture populates for a sixteen-way state kind. Sixteen
+/// exist; a fixture that wrote all of them would say nothing more than two do
+/// about the split. A single-blob kind has only shard 0, so it takes the first
+/// of these and stops — see [`state_layers`].
 pub const SHARDS: [u8; 2] = [0, 1];
 
 pub fn network() -> Network {
@@ -161,34 +163,56 @@ pub fn logs(ns: Namespace) -> Vec<LogRecord> {
     vec![LogRecord::new(log_key(START_SLOT, 0x30 + i), vec![0x81, i])]
 }
 
-/// One record per state namespace, in the requested shard.
+/// Every state layer the fixture writes: `(kind, namespace, shard)`, in
+/// inscription order.
 ///
-/// Every namespace appears in every shard, which no real stele would do — real
-/// keys are hash-derived and land where they land. It is what makes the golden
-/// freeze all seventeen namespace strings twice over.
-pub fn state(shard: u8) -> Vec<StateRecord> {
-    NAMESPACES
+/// One layer per namespace now, rather than sixteen layers carrying all
+/// seventeen namespaces between them, so a kind's shards are the shards its
+/// spec'd count allows: both of [`SHARDS`] for the four sixteen-way kinds, and
+/// shard 0 alone for the thirteen single blobs. Twenty-one layers, and every
+/// namespace among them — which is what
+/// `the_golden_state_layers_cover_every_namespace` holds this to.
+pub fn state_layers() -> Vec<(&'static str, Namespace, u8)> {
+    STATE_KINDS
         .into_iter()
-        .enumerate()
-        .map(|(i, ns)| {
-            let byte = (shard << 4) | (i as u8 & 0x0f);
-
-            if ns == UTXOS {
-                state::utxo(
-                    &TxoRef([byte; ENTITY_KEY_LEN].into(), 3),
-                    &EraCbor(6, vec![0xa0, byte]),
-                )
-                .unwrap()
-            } else {
-                state::entity(
-                    ns,
-                    &EntityKey::from(&[byte; ENTITY_KEY_LEN]),
-                    &vec![byte, 0xff],
-                )
-                .unwrap()
-            }
+        .flat_map(|(kind, ns, shards)| {
+            SHARDS
+                .into_iter()
+                .filter(move |shard| *shard < shards)
+                .map(move |shard| (kind, ns, shard))
         })
         .collect()
+}
+
+/// One record for `ns`, which is one layer's worth.
+///
+/// The namespace is no longer in the record — it is the layer's kind — so what
+/// distinguishes one state layer's content from another's is the record's key
+/// and value, both derived from the namespace's position in [`NAMESPACES`].
+/// The seventeen namespace strings are frozen by the kinds in the layer
+/// headers instead, which is where they now live on the wire.
+///
+/// The key's first byte carries the shard in its high nibble, so the record
+/// lands in the layer that claims it under [`state_layers`] — the routing rule
+/// [`dolos_snapshot::shard_of`] applies, spelled out here because the fixture
+/// writes layers directly rather than through the export's router.
+pub fn state(ns: Namespace, shard: u8) -> Vec<StateRecord> {
+    let i = NAMESPACES
+        .iter()
+        .position(|known| *known == ns)
+        .expect("a state namespace") as u8;
+
+    let byte = (shard << 4) | (i & 0x0f);
+
+    vec![if ns == UTXOS {
+        state::utxo(
+            &TxoRef([byte; ENTITY_KEY_LEN].into(), 3),
+            &EraCbor(6, vec![0xa0, byte]),
+        )
+        .unwrap()
+    } else {
+        state::entity(&EntityKey::from(&[byte; ENTITY_KEY_LEN]), &vec![byte, 0xff])
+    }]
 }
 
 pub fn digests() -> Vec<ImmutableDigests> {
@@ -255,10 +279,11 @@ pub fn write_layer(
 
 /// The fixture's kinds, encoded, in inscription order.
 ///
-/// `state` appears twice — one layer per populated shard — which is the normal
-/// case for this profile rather than an edge one. Every log kind appears, which
-/// is what makes the goldens freeze all six kind strings: the namespace lives
-/// in the layer header now, and nowhere else on the wire.
+/// Every log kind and every state kind appears, which is what makes the goldens
+/// freeze all twenty-three namespace-bearing kind strings: the namespace lives
+/// in the layer header now, and nowhere else on the wire. A sixteen-way state
+/// kind appears twice — one layer per populated shard — which is the normal
+/// case for this profile rather than an edge one.
 pub fn all_layers() -> Vec<(&'static str, Box<dyn Scope>, Vec<CanonicalCbor>)> {
     use dolos_snapshot::layers::{
         blocks, digests as digests_layer, indexes as indexes_layer, logs,
@@ -285,11 +310,11 @@ pub fn all_layers() -> Vec<(&'static str, Box<dyn Scope>, Vec<CanonicalCbor>)> {
         ));
     }
 
-    for shard in SHARDS {
+    for (kind, ns, shard) in state_layers() {
         layers.push((
-            STATE,
+            kind,
             Box::new(state_scope(shard)),
-            encode_all(&state(shard), state::encode),
+            encode_all(&state(ns, shard), |record| state::encode(ns, record)),
         ));
     }
 

--- a/crates/snapshot/tests/coverage.rs
+++ b/crates/snapshot/tests/coverage.rs
@@ -18,12 +18,11 @@ mod common;
 
 use std::collections::BTreeSet;
 
-use common::*;
 use dolos_cardano::{indexes::archive_dimensions, model::build_schema};
 use dolos_core::{ExactKind, IndexRecord, Namespace};
 use dolos_snapshot::{
-    layers::indexes, log_kind_for, log_ns_for, namespaces, LOG_KINDS, LOG_NAMESPACES, NAMESPACES,
-    UTXOS,
+    layers::indexes, log_kind_for, log_ns_for, namespaces, shards_for, state_kind_for,
+    state_ns_for, LOG_KINDS, LOG_NAMESPACES, NAMESPACES, STATE_KINDS, UTXOS,
 };
 
 /// The state namespaces this profile carries are exactly `build_schema`'s, plus
@@ -140,22 +139,53 @@ fn the_golden_indexes_layer_covers_every_dimension_and_kind() {
     );
 }
 
-/// Every state namespace appears in the golden `state` layers.
+/// Every state namespace appears in the golden state layers.
+///
+/// The record no longer names its namespace, so this counts *layers* rather
+/// than records: a namespace is covered when the fixture writes the kind that
+/// carries it. That is the only thing keeping the split honest here — a
+/// namespace whose kind the fixture skipped would have no golden digest
+/// freezing its media type.
 #[test]
 fn the_golden_state_layers_cover_every_namespace() {
     let expected: BTreeSet<Namespace> = NAMESPACES.into_iter().collect();
 
-    for shard in SHARDS {
-        let present: BTreeSet<Namespace> = common::state(shard)
-            .iter()
-            .map(|record| record.ns)
-            .collect();
+    let present: BTreeSet<Namespace> = common::state_layers()
+        .into_iter()
+        .map(|(_, ns, _)| ns)
+        .collect();
 
-        assert_eq!(
-            present, expected,
-            "shard {shard}: the golden state layer no longer freezes every namespace"
+    assert_eq!(
+        present, expected,
+        "the golden state layers no longer freeze every namespace"
+    );
+
+    // And each of those layers actually carries a record: an empty layer would
+    // freeze the kind string and nothing about the codec under it.
+    for (kind, ns, shard) in common::state_layers() {
+        assert!(
+            !common::state(ns, shard).is_empty(),
+            "{kind}/{shard}: no golden record"
         );
     }
+}
+
+/// Every state kind appears in the golden stele, so all seventeen kind strings
+/// are frozen by a published digest — the state half of
+/// `the_golden_stele_covers_every_log_kind`.
+#[test]
+fn the_golden_stele_covers_every_state_kind() {
+    let present: BTreeSet<&str> = common::all_layers()
+        .iter()
+        .filter_map(|(kind, _, _)| state_ns_for(kind).map(|_| *kind))
+        .collect();
+
+    let expected: BTreeSet<&str> = STATE_KINDS.into_iter().map(|(kind, _, _)| kind).collect();
+
+    assert_eq!(
+        present, expected,
+        "the golden stele no longer freezes every state kind"
+    );
 }
 
 /// The log namespaces draw from the same registry, so a log kind can never name
@@ -252,4 +282,83 @@ fn the_golden_stele_covers_every_log_kind() {
     for (_, ns) in LOG_KINDS {
         assert!(!common::logs(ns).is_empty(), "{ns}: no golden record");
     }
+}
+
+/// Done criterion 3's table half: the STATE_KINDS table, held to its own rule.
+///
+/// The same discipline `log_kinds_derive_from_their_namespaces` applies, plus
+/// the column the log table does not have — the shard count, which is
+/// specification rather than tuning and so is pinned here namespace by
+/// namespace.
+#[test]
+fn state_kinds_derive_from_their_namespaces() {
+    assert_eq!(STATE_KINDS.len(), NAMESPACES.len());
+
+    let mut kinds = Vec::new();
+
+    for (kind, ns, shards) in STATE_KINDS {
+        assert_eq!(kind, format!("state-{}", ns.replace('_', "-")), "{ns}");
+
+        // Both directions of the lookup, against the spelling and not against
+        // the derivation: a table entry nothing can find is a layer nothing can
+        // restore.
+        assert_eq!(state_kind_for(ns), Some(kind), "{ns}");
+        assert_eq!(state_ns_for(kind), Some(ns), "{kind}");
+        assert_eq!(shards_for(ns), Some(shards), "{ns}");
+
+        kinds.push(kind);
+    }
+
+    // The underscore rewrite is not hypothetical here, as it is for the logs:
+    // two state namespaces carry one.
+    assert_eq!(
+        state_kind_for("pending_rewards"),
+        Some("state-pending-rewards")
+    );
+    assert_eq!(state_kind_for("pending_mirs"), Some("state-pending-mirs"));
+
+    // Injective in both columns. Two namespaces sharing a kind would publish one
+    // namespace's tip under another's name; two kinds sharing a namespace would
+    // restore the same records twice.
+    let distinct_kinds: BTreeSet<&str> = kinds.iter().copied().collect();
+    let distinct_namespaces: BTreeSet<Namespace> =
+        STATE_KINDS.into_iter().map(|(_, ns, _)| ns).collect();
+
+    assert_eq!(distinct_kinds.len(), STATE_KINDS.len());
+    assert_eq!(distinct_namespaces.len(), STATE_KINDS.len());
+
+    // Ascending, in both columns: the inscription lists layers in `KINDS` order,
+    // so the table's order is published order.
+    let mut sorted = kinds.clone();
+    sorted.sort_unstable();
+    assert_eq!(kinds, sorted, "STATE_KINDS must be in byte order");
+
+    assert_eq!(
+        STATE_KINDS.map(|(_, ns, _)| ns),
+        NAMESPACES,
+        "STATE_KINDS and NAMESPACES disagree about the namespaces"
+    );
+
+    // The shard map is the spec's, not the data's: four chain-scale namespaces
+    // split sixteen ways, and every other namespace is a single blob. Changing
+    // one of these is a media-type-version event for that kind, so it is spelled
+    // out here rather than derived from the table it is checking.
+    for (_, ns, shards) in STATE_KINDS {
+        let expected = match ns {
+            "utxos" | "accounts" | "assets" | "datums" => 16,
+            _ => 1,
+        };
+
+        assert_eq!(shards, expected, "{ns}");
+    }
+
+    // Nothing else is a state kind — `state`, above all, which is what these
+    // seventeen replaced.
+    for absent in ["state", "state-", "state-logs", "blocks", "", "state_utxos"] {
+        assert!(state_ns_for(absent).is_none(), "{absent:?}");
+    }
+
+    // And a namespace this profile does not define has neither kind nor count.
+    assert_eq!(state_kind_for("receipts"), None);
+    assert_eq!(shards_for("receipts"), None);
 }

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -29,6 +29,8 @@ mod common;
 mod node;
 mod watcher;
 
+use std::collections::BTreeMap;
+
 use common::read_both_ways;
 use dolos_cardano::{
     eras::ChainSummary, indexes::archive_dimensions, model::EraSummary,
@@ -37,13 +39,14 @@ use dolos_cardano::{
 use dolos_core::{
     builtin::{MemoryIndexStore, MemoryStateStore},
     ArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, Domain, EntityKey, ExactRecord,
-    IndexRecord, IndexStore, LogKey, StateStore, StateWriter as _, TagRecord, TemporalKey,
+    IndexRecord, IndexStore, LogKey, Namespace, StateStore, StateWriter as _, TagRecord,
+    TemporalKey,
 };
 use dolos_snapshot::{
     export::{self, EpochWindow, Plan},
     layers::{blocks, indexes, logs, state},
-    DolosProfile, Network, BLOCKS, INDEXES, LOG_KINDS, LOG_NAMESPACES, NAMESPACES, STATE,
-    STATE_SHARDS, UTXOS,
+    state_layer_count, DolosProfile, Network, BLOCKS, INDEXES, LOG_KINDS, LOG_NAMESPACES,
+    NAMESPACES, STATE_KINDS, UTXOS,
 };
 use dolos_testing::toy_domain::{FjallStores, MemoryStores, ToyDomain, ToyStores};
 use node::{export_to, harness, plan_for};
@@ -57,7 +60,7 @@ use watcher::Watcher;
 
 /// The identity of an export over an empty store set at [`SKELETON_POINT`].
 const GOLDEN_SKELETON: &str =
-    "sha256:6eecdf3b910983cc559f35df6246a2920b11fe442a6297d1e673224e25e24dba";
+    "sha256:f834f8bc649d1a55d35d29ada7f2112393ba7c193bffcc405d2579b29338e603";
 
 /// The chain point the skeleton fixture stands at: mid-epoch-2 under
 /// [`skeleton_summary`], so the export covers three epochs and the last window
@@ -146,11 +149,11 @@ fn an_empty_store_set_exports_the_pinned_skeleton() {
     )
     .unwrap();
 
-    // Three epochs of blocks and indexes, then sixteen state shards. No
+    // Three epochs of blocks and indexes, then every state layer. No
     // `digests` layer: nothing supplies one — and **no log layers at all**,
     // which is the omit-if-empty rule seen from the other side: a store with no
     // logs in it publishes no layer claiming there are none.
-    assert_eq!(inscription.layers.len(), 3 * 2 + STATE_SHARDS as usize);
+    assert_eq!(inscription.layers.len(), 3 * 2 + state_layer_count());
 
     for (kind, _) in LOG_KINDS {
         assert_eq!(
@@ -265,8 +268,13 @@ fn a_harness_domain_exports_a_complete_stele() {
     inscription.validate().unwrap();
     inscription.check_profile(&DolosProfile).unwrap();
 
-    // Every kind but `digests`, which has no source in this slice.
-    for kind in [BLOCKS, INDEXES, STATE] {
+    // Every kind but the log kinds and `digests`, which have no source in this
+    // slice. The state kinds are all here, seeded or not: a namespace the
+    // harness never wrote still publishes its shards, empty.
+    for kind in [BLOCKS, INDEXES]
+        .into_iter()
+        .chain(STATE_KINDS.into_iter().map(|(kind, _, _)| kind))
+    {
         assert!(
             inscription.layers_of_kind(kind).next().is_some(),
             "no {kind} layer"
@@ -428,34 +436,43 @@ fn every_layer_reads_back_as_the_store_yields_it() {
     assert!(exact > 0, "the fixture produced no exact records");
 
     // --- state ------------------------------------------------------------
-    let written: Vec<_> = inscription.layers_of_kind(STATE).collect();
-
-    // Sixteen, always: an empty shard is still a shard, so a client planning a
-    // selective fetch never has to discover the count from the data.
-    assert_eq!(written.len(), STATE_SHARDS as usize);
-
     let expected = expected_state(&domain);
 
-    for (shard, descriptor) in written.iter().enumerate() {
-        assert_eq!(descriptor.scope["shard"], shard);
+    let mut records = 0usize;
 
-        let found: Vec<state::StateRecord> = read_both_ways(&stele, &index, descriptor)
-            .iter()
-            .map(|raw| state::decode(raw).unwrap())
-            .collect();
+    for (kind, ns, shards) in STATE_KINDS {
+        let written: Vec<_> = inscription.layers_of_kind(kind).collect();
 
-        let expected: Vec<state::StateRecord> = expected
-            .iter()
-            .filter(|record| record.shard() as usize == shard)
-            .cloned()
-            .collect();
+        // Exactly the shards the kind's spec'd count promises, always: an empty
+        // shard is still a shard, so a client planning a selective fetch never
+        // has to discover the count from the data.
+        assert_eq!(written.len(), shards as usize, "{kind}");
 
-        assert_eq!(found, expected, "shard {shard}");
+        let carried = expected.get(ns).cloned().unwrap_or_default();
+
+        for (shard, descriptor) in written.iter().enumerate() {
+            assert_eq!(descriptor.scope["shard"], shard, "{kind}");
+
+            let found: Vec<state::StateRecord> = read_both_ways(&stele, &index, descriptor)
+                .iter()
+                .map(|raw| state::decode(ns, raw).unwrap())
+                .collect();
+
+            let expected: Vec<state::StateRecord> = carried
+                .iter()
+                .filter(|record| state::shard_of(&record.key, shards) as usize == shard)
+                .cloned()
+                .collect();
+
+            assert_eq!(found, expected, "{kind} shard {shard}");
+
+            records += found.len();
+        }
     }
 
     assert!(
-        !expected.is_empty(),
-        "the fixture produced no state, so the shards prove nothing"
+        records > 0,
+        "the fixture produced no state, so the layers prove nothing"
     );
 }
 
@@ -533,8 +550,12 @@ fn expected_indexes<B: ToyStores>(domain: &ToyDomain<B>, window: &EpochWindow) -
         .collect()
 }
 
-fn expected_state<B: ToyStores>(domain: &ToyDomain<B>) -> Vec<state::StateRecord> {
-    let mut found = Vec::new();
+/// The state the store holds, by namespace — the grouping the layers are in
+/// now, so the comparison above is per kind rather than across one mixed run.
+fn expected_state<B: ToyStores>(
+    domain: &ToyDomain<B>,
+) -> BTreeMap<Namespace, Vec<state::StateRecord>> {
+    let mut found: BTreeMap<Namespace, Vec<state::StateRecord>> = BTreeMap::new();
 
     for ns in NAMESPACES {
         if ns == UTXOS {
@@ -547,16 +568,24 @@ fn expected_state<B: ToyStores>(domain: &ToyDomain<B>) -> Vec<state::StateRecord
             .unwrap()
         {
             let (key, value) = entry.unwrap();
-            found.push(state::entity(ns, &key, &value).unwrap());
+            found
+                .entry(ns)
+                .or_default()
+                .push(state::entity(&key, &value));
         }
     }
 
     for entry in domain.state().iter_utxos().unwrap() {
         let (txo, value) = entry.unwrap();
-        found.push(state::utxo(&txo, &value).unwrap());
+        found
+            .entry(UTXOS)
+            .or_default()
+            .push(state::utxo(&txo, &value).unwrap());
     }
 
-    found.sort_by(|a, b| (a.ns, &a.key).cmp(&(b.ns, &b.key)));
+    for records in found.values_mut() {
+        records.sort_by(|a, b| a.key.cmp(&b.key));
+    }
 
     found
 }
@@ -653,23 +682,88 @@ const CANONICAL_SKELETON: &str = concat!(
     r#"{"diffId":"sha256:0517f93e76f9fe6059bcde6218af5c90f51020af09890c5e3a05cc8f3a32e447","kind":"indexes","mediaType":"application/vnd.dolos.stele.indexes.v1+zstd","records":1,"scope":{"endSlot":99,"epoch":0,"startSlot":0},"uncompressedSize":44},"#,
     r#"{"diffId":"sha256:b64ae324280c4335089cdf9918ac0596fe7f429dbf5a54c2fd2d44f25280b935","kind":"indexes","mediaType":"application/vnd.dolos.stele.indexes.v1+zstd","records":1,"scope":{"endSlot":199,"epoch":1,"startSlot":100},"uncompressedSize":45},"#,
     r#"{"diffId":"sha256:a76e2bb47934f8473a232a31da4930db8d50ce90a4cab2c232fc032644fff62e","kind":"indexes","mediaType":"application/vnd.dolos.stele.indexes.v1+zstd","records":1,"scope":{"endSlot":250,"epoch":2,"startSlot":200},"uncompressedSize":45},"#,
-    r#"{"diffId":"sha256:c1d65578a9da3b2453c50a8958bcdf426a59b22873012e51409e8acb732822cc","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:21cb592e80427ce7a6c8a24c0f5d5cf3c51da28a61325f47ffcb900ca629ad8d","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":1},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:bf5d5484e7def2851a425f266836c1fc0bfdd67db35acad39a5b488742e32855","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":2},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:f6b34bef2565e75cef039500c892c07b0e73aa258afe8885c9abdd9537e5e83b","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":3},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:69a78d4b3460bbdd65910ad985086afc82fb22c4158ce62b19b65dbc74eb0e73","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":4},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:1dd622715f2275dd3a1bc20b34a825ed4fe1c790ea268e0812918e72c4b48856","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":5},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:367f3f93a2f78522a1d29bd8a70632c2983c9a47fd107b55948c88cf62bb89f4","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":6},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:0a54558b493112b15ee2e5061021cc8d0e2d5211a550e7bfcae66a597f2771ca","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":7},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:292f3cd8d6f7ea605d33c16f60ca16b0a3bf8322df4c79a561b2b2d96a1df066","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":8},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:0cf3c2340b708a503a5e4301c19f6568599a8b15238d18805b0e26df58293f66","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":9},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:e4c0d0e60343333a0e78fddd8cb1885cc05f386065c36f8a58e3ec2ff52ce6cf","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":10},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:242048cec84854de49abdb62dd42d1b186b243a7095f05ba95b1862a5cf5e907","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":11},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:3825bee5e3bcf04483294f9cb40732f6a66169e222bb2da9cd294a3befd4fbcb","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":12},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:e6efd8da5e50463a9380ec4600741407ea84ac2baac44917707bb137d1b119d2","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:1953096685ae64ae6f5d1bbc04d8d3678fbb567138809f581bdcdacfa1e1b90b","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":40},"#,
-    r#"{"diffId":"sha256:0eb6fed603f60e527eb9622e04d72a74c21dcd7ee88e98b95ae6f8895736d5fd","kind":"state","mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":40}"#,
-    r#"],"parameters":{"indexKeyHash":"xxh3-64","stateShards":16},"position":{"epoch":2,"network":{"magic":764824073,"name":"mainnet"},"point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":250}},"profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":2}"#,
+    r#"{"diffId":"sha256:318ad5ac29478218eaf3d04f8dfe93fc86834f2f7eca108817e811a603f09a8f","kind":"state-account-stakes","mediaType":"application/vnd.dolos.stele.state-account-stakes.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":55},"#,
+    r#"{"diffId":"sha256:02522facba4552263d4dfaded9dbb82ec8a90937284a15539f6f1f7a7a9ef4fd","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:9c3e2a317428abc07cd8a29934c10d6ed406eef31b0ffebbaa95679ed11a4e89","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":1},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:bad9e2528c56aab15c5c593550f17bd850d52804dd17172fefb4b11940641d8d","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":2},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:9d296077954a6e1a79ec9139edc2b73c4f292999e697f99e688887045a1ab1e2","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":3},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:36a70b77ff0e7ff67d3e42a4dbf9aafc7c3e9e093d2fa0a746253f5d693b5362","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":4},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:48ddd612a9127f81231cd901135c791bc9b812bb54ee95d9e3544962e1b3a46c","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":5},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:4cb5ff0a33d2e88172898f0565fb91d0c3c0e3f636daff1ec0ab50c2da7a8dd1","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":6},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:0eb957c6d2d2b2ae787539fafacfccdd9a2aaad410d5af096fed5b60e5d30967","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":7},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:b3f376aa124ed9110f4d6ee6a30848bc8cbec2eaec65020f39439849d75e304e","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":8},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:96b86a20d7ba613efa3e1925148b2a9ccaa969c75ca4dc466434a46e0fe6a82f","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":9},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:462a4295f3c6ee4d43b2c201d166a225eb59d55e4880e66fe3b947d005a48132","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":10},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:87a29f9edd16dc7521df050f8645b99082df697fa42e772e262a61a5b756497a","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":11},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:b478aa2b0c1385dfeba5f26da0edc223260f0cac947d91da6d1dc629d48a7541","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":12},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:a2c9fa81aec9cac32b36fd325bdf3afe6ac72a95c7412cfaff6f05288354b085","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:5cf477db9c26c4f251c836844db2405f37fa789d03aea868540eb07cdf43bdfe","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:964771e3ed841725948305ad74029c7be92b0aad4e6c43a7569fb09b8e67253f","kind":"state-accounts","mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":49},"#,
+    r#"{"diffId":"sha256:6b217ee2a4173c3446c8ea31bc84d8c59f1c0b2eb583439f443322ada7dfb5a1","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:833ffb5dbd39bb5eaacf1c2439de47fdd31ad3a100c2ec50f6f1100eeee0801a","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":1},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:321c3b09a833a633a61fc7af4e6df23e3f3adfd3f08a11505efcf9069d9da8e2","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":2},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:f68da008f436dbac4425da5b7c582a35ea077559312e128755b0eef2899c1f12","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":3},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:9f6c54e7404ddd5d37db028eef00fe943dc5a29746f5af17fb9ed022f1c4489f","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":4},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:6e87f3f58d31f08051f7c7bdb404767203d56f699f6f05129921017328390946","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":5},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:adf44192f4f91e651b43a841fbc81ee74c0bf42bac15c059bcd4e9277ef9a08f","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":6},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:542b315989aa1e5f5c8a3fcf2bee5750b9de87ecf63e19aebb1544c5c303edbc","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":7},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:ec60a65290505b4351128d7e5676376f691656b9080fb4a9ade9dce8e3a760e7","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":8},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:68ef06144365168b8a36c352a3e1d26dcde9029a2857be937c01cda5906172ae","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":9},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:ddb6a5961aade95fb820a669d97dcf116021a1b54d8a0d59d4820849b922f286","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":10},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:9049a9631a589437e0dc2005552e44cbf414915ae25970d37dd78452162de6ac","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":11},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:403ac5c18e878ce6193b5697d754100267961e9a13d7dd5920a741c6a861de00","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":12},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:21660b8e2e4fadede65e89589ca10fd9aa467dd0845a7487ada048545d889cdc","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:7bf0d679da18a075420267ce16f38cfefb68efec28b5a74e8c1b7be9fed86654","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:8899bed13545893de75851c8537b383608ea92b29e9beeca19c6ff8f6e64109a","kind":"state-assets","mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:5c79490ba5bd0febb78a297aa3273fff7119c9af37fa48a8fba01b3c4e93ba1a","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:128bba0aeae290cbe00284557a591198676a94dd8c948c5c5b8bf78deb892978","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":1},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:a1f52ea5164adaecaa2cdb1e306772afe5209fbe81d8ab1bcd66badfeb5238d5","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":2},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:468198f05873a9c1c748e6ed213fa0307b7bd6f1baf3784ec3ec765ca3b03383","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":3},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:f553bf184e843725c49e9645560876519f9e6994f2bf468efd90150a58ad45fb","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":4},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:0cd44b79cc2336ba42d9df42979c9145e391f98b028407e9895e24ceae188e72","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":5},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:99855d833d23137d927485ebe6a610b0640bafa7b89e8eceaf5b57754e75927b","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":6},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:3325d1e65ccc52abede1ba2bd35f4289af41afbd8f1ff3007c659fe12fb85e00","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":7},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:f8b305e7a74ddd9b49f36dc0af339fd1fd0bb600e7a1c86c99c3ad46e1b61fac","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":8},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:151817f8cc62d02d9bb9c7980df48240776c1b66f759ee6665057d3ee0056fbb","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":9},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:4775430b2bdf697c94bb53d77b304e6ddb7a16b4a51d533bf21915d1ac96c5df","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":10},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:df563c54b5d255acc3358a33271f0816673cb8e9ce2e3c29960f55e60d25baf5","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":11},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:b4945645a766617aaf3bcfbc09363b107c507455dcc4482e31c42b2a51fcb7a0","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":12},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:8140e32dd30b763b9e30d4ec9e3f4c4839674271068028c0eb280acf95fb6803","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:2ac9b61903e09ba2a01e2192cd9e6a1c0ecb30886d3752374cf0d45dfdc3fbda","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:d1f06100a97cbf233453ee235ae2af84fed2ebc9afba1ef44f1a560fa9092517","kind":"state-datums","mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:0c02e395163b8721766f4e70ade836dcbeabcb5b660e6538caee76757315305e","kind":"state-dreps","mediaType":"application/vnd.dolos.stele.state-dreps.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:d2956a7d3251484d5ef8f45cd923e34ecbc890552eac579c500ba99b0a98cb9a","kind":"state-epochs","mediaType":"application/vnd.dolos.stele.state-epochs.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:a53fdfbe13f40703e1e8cd661ddc5ba5bb54541b22bf7cdcb3b7aa9697fd9cb6","kind":"state-eras","mediaType":"application/vnd.dolos.stele.state-eras.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":45},"#,
+    r#"{"diffId":"sha256:0a74ea019634f7c0135b1030e692d4e3680ff534c89462819fa04c15ada63114","kind":"state-gov","mediaType":"application/vnd.dolos.stele.state-gov.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":44},"#,
+    r#"{"diffId":"sha256:87ed310e3fefe592d1f45dde73677bf2de5642b4f9d64363b64debe6999d07a5","kind":"state-leader-rewards","mediaType":"application/vnd.dolos.stele.state-leader-rewards.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":55},"#,
+    r#"{"diffId":"sha256:22a28d8b6fdb0add20994fda1401bfe694e50c79886d5c4517eac96ddb94bc0b","kind":"state-member-rewards","mediaType":"application/vnd.dolos.stele.state-member-rewards.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":55},"#,
+    r#"{"diffId":"sha256:2e07a341e23cf37667da069d3e75ba7a7bf2665572f2183353ff0266369cf17f","kind":"state-pending-mirs","mediaType":"application/vnd.dolos.stele.state-pending-mirs.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":53},"#,
+    r#"{"diffId":"sha256:ad5994d901c69e757457b2ad6bac6a2679e45ae25769cc616375c10c8c6dc582","kind":"state-pending-rewards","mediaType":"application/vnd.dolos.stele.state-pending-rewards.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":56},"#,
+    r#"{"diffId":"sha256:1d1a0547655e532c3c52d29fab6fcd82e7a3ef3fed1d0c2a9e670f269384ba2b","kind":"state-pool-deposit-refunds","mediaType":"application/vnd.dolos.stele.state-pool-deposit-refunds.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":62},"#,
+    r#"{"diffId":"sha256:da799488bcc20ea1d8c8e236169d7204e328b34f806075a951f266819bd35e34","kind":"state-pools","mediaType":"application/vnd.dolos.stele.state-pools.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:640c0f9db84510212ae0d71860df7c518244db6eed6728e9fcc6540d99bdcbe7","kind":"state-proposals","mediaType":"application/vnd.dolos.stele.state-proposals.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":50},"#,
+    r#"{"diffId":"sha256:c8517773130f10b7dfb51ca3415ccbe9005f1b84abada0418f46bee7dc7d095f","kind":"state-stakes","mediaType":"application/vnd.dolos.stele.state-stakes.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":47},"#,
+    r#"{"diffId":"sha256:6978ebcdd1accb802d0711afbe6c25747eea28f533de050c184ea24bade637a5","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":0},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:aa056a5c4a03811c52492eec692ba0612f7f32f9c447ddd63f64a4c7b1c5ed4a","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":1},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:c0055cfef082a8ebe5ada0637de774cc2613d00714d05f74b19690ced71e89c2","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":2},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:5b298cc5852e2c25e9bccfcfcc7c379e68b55439b34ecdbbd26fb93d5306dbfd","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":3},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:09081604a9f2fc740fdeabb3a331ff3d35cdde0179a7a95271a2b43079d5962b","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":4},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:86e95890bde0bf9230b48d9ff30d0e37b3e4441f041046d9674d3aecc2381284","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":5},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:e6fe3b69728c8f4587689733e537d593ba4901e175d1b81f583ad6fe3f30b48a","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":6},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:9fc971b8fe01687d280947d27b4b495b8a13b11696b61379c81701db821e1d12","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":7},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:a3ddecb338e823bff9f3269571ae9f8858451ca8f98700501d57273ac141ec01","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":8},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:20c25aaf590428fd30f7ff2e17cdf8b12e2d4819dbdbd27cd36b2e3a59c79bf1","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":9},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:cd57e7f5986a2e811577422b7a174d02a786ea75c79b855a547292aaa3cb9801","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":10},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:ac1e3bdff176deca129ff6ea85f8e32d98c56eb55845fbbb535e145817c2f27c","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":11},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:1b257f003b61fd4389b580e368725779e84d0931916f4e5f21336e3b5775462f","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":12},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:4145245584090ba5ec600cc41743036cd02580999490cd38e94ccb47e713f529","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":13},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:fa3101937f3491ae614180384787cfeb1d2ffb7e522c4c731b60208472573917","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":14},"uncompressedSize":46},"#,
+    r#"{"diffId":"sha256:e59d8b7ec7144216a9caab188b2de8d09d98c7c419e228a41131722796b81711","kind":"state-utxos","mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":1,"scope":{"shard":15},"uncompressedSize":46}"#,
+    r#"],"parameters":{"#,
+    r#""indexKeyHash":"xxh3-64","#,
+    r#""schemas":{"account-stakes":1,"accounts":1,"assets":1,"datums":1,"dreps":1,"epochs":1,"eras":1,"gov":1,"leader-rewards":1,"member-rewards":1,"pending_mirs":1,"pending_rewards":1,"pool-deposit-refunds":1,"pools":1,"proposals":1,"stakes":1,"utxos":1},"#,
+    r#""shards":{"account-stakes":1,"accounts":16,"assets":16,"datums":16,"dreps":1,"epochs":1,"eras":1,"gov":1,"leader-rewards":1,"member-rewards":1,"pending_mirs":1,"pending_rewards":1,"pool-deposit-refunds":1,"pools":1,"proposals":1,"stakes":1,"utxos":16}"#,
+    r#"},"position":{"epoch":2,"network":{"magic":764824073,"name":"mainnet"},"point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":250}},"profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":2}"#,
 );
 
 // --------------------------------------------------------------------------
@@ -778,7 +872,7 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
 
     // The state tip alone, which is a legitimate publish and the narrowest one
     // there is.
-    assert_eq!(stored.layers.len(), STATE_SHARDS as usize);
+    assert_eq!(stored.layers.len(), state_layer_count());
 
     assert_eq!(
         stored.canonicalize().unwrap(),

--- a/crates/snapshot/tests/goldens.rs
+++ b/crates/snapshot/tests/goldens.rs
@@ -15,11 +15,12 @@
 //! a re-run on unchanged code is encoding nondeterminism, which is a finding,
 //! never a re-pin.
 //!
-//! Between them these freeze: the ten media types, the tag string, the twelve
-//! archive dimension names, the three exact-record kind literals, the seventeen
-//! state namespace strings, the six `log-{ns}` kind strings — carried in the
-//! layer headers now that the records no longer name a namespace — the layer
-//! header and scope shapes, and the `position`/`parameters` key spellings.
+//! Between them these freeze: the twenty-six media types, the tag string, the
+//! twelve archive dimension names, the three exact-record kind literals, the
+//! six `log-{ns}` and seventeen `state-{ns}` kind strings — which is where the
+//! twenty-three namespace strings live now that neither record names one — the
+//! layer header and scope shapes, and the `position`/`parameters` key
+//! spellings, the shard and schema maps included.
 
 mod common;
 
@@ -27,7 +28,7 @@ use common::*;
 use dolos_core::{BlockHash, ChainPoint};
 use dolos_snapshot::{
     layers::{blocks, digests, indexes, logs, state},
-    log_ns_for, DolosProfile, BLOCKS, DIGESTS, INDEXES, STATE,
+    log_ns_for, state_ns_for, DolosProfile, BLOCKS, DIGESTS, INDEXES,
 };
 use stelae::{
     dir::SteleDir,
@@ -39,7 +40,7 @@ use stelae::{
 /// `(kind, diffId, records, uncompressedSize)`, in inscription order.
 ///
 /// `records` counts the protocol's header record, as a descriptor does.
-const GOLDEN_LAYERS: [(&str, &str, u64, u64); 11] = [
+const GOLDEN_LAYERS: [(&str, &str, u64, u64); 30] = [
     (
         BLOCKS,
         "sha256:14a05418723da3c0b4117b5f30ef07d96887b3e12eae114988ff299a654ff106",
@@ -89,16 +90,130 @@ const GOLDEN_LAYERS: [(&str, &str, u64, u64); 11] = [
         94,
     ),
     (
-        STATE,
-        "sha256:2dadb9a35b6e89adf01e3c915325b398037b388bafa63da99a6a2f3ce77e6b97",
-        18,
-        862,
+        "state-account-stakes",
+        "sha256:1b30a5fef9ec458336cbde5a7aa80aaec76d0c5a8bf68b577152d0bd506be80b",
+        2,
+        93,
     ),
     (
-        STATE,
-        "sha256:d2230021ccaa604e93f189653ca23b5e22376bb93c6c1bbf724d45dd037671e2",
-        18,
-        862,
+        "state-accounts",
+        "sha256:db47596747e81165ce2948f333cc6e6ab3c240f6973fb627df1d9b65dc50c8f2",
+        2,
+        87,
+    ),
+    (
+        "state-accounts",
+        "sha256:0c7bc44f2f59b16a803369072e19011789cf4221dc94f409626e52d00f10eb1f",
+        2,
+        87,
+    ),
+    (
+        "state-assets",
+        "sha256:8077fd64690d954acc788df3b8046d151729ccd2b7d1dae42ed177f3931747aa",
+        2,
+        85,
+    ),
+    (
+        "state-assets",
+        "sha256:c7c1ff92712bfa3bff88b9ce2445bb3f4e55139ac5bc89c989f41188f894eeff",
+        2,
+        85,
+    ),
+    (
+        "state-datums",
+        "sha256:41c9a9cba05c8bfc0d7e345b820f62d4fc3e16fa5deef8ac224f9422ae1c3bb0",
+        2,
+        85,
+    ),
+    (
+        "state-datums",
+        "sha256:444ae56c151ffb66b8dd716e16b578d9ec4e339251ba24406d935b5214db27da",
+        2,
+        85,
+    ),
+    (
+        "state-dreps",
+        "sha256:96f0a867e25607b374f34830c4499ae735a860486b866e740998c781ef0f29ca",
+        2,
+        84,
+    ),
+    (
+        "state-epochs",
+        "sha256:93b0aab4fd80315a8bf106397e7575f58b031a8fe9680dac5d21bf84c880a23a",
+        2,
+        85,
+    ),
+    (
+        "state-eras",
+        "sha256:ad1c687b6b519d6d922764504a333d91733a98a251c606524532c6b066167648",
+        2,
+        83,
+    ),
+    (
+        "state-gov",
+        "sha256:f569b56280287b58f66dc13c1f4c0b2f6895befb01399ec6d2c73e13a8679a97",
+        2,
+        82,
+    ),
+    (
+        "state-leader-rewards",
+        "sha256:35d6299d7c44b696f5ff9bc4ba1ad9bf565ef7ef8044bb7a729a0b8acaf7cef4",
+        2,
+        93,
+    ),
+    (
+        "state-member-rewards",
+        "sha256:900e8cbd5e6e0e24342acda6ea98547a402eb7f7a06909d96cc8a3cbefbcb962",
+        2,
+        93,
+    ),
+    (
+        "state-pending-mirs",
+        "sha256:b0902d68fbcfeb299e56b72bf9de34299928d6a0d25501ceaa5161d209c5bdf6",
+        2,
+        91,
+    ),
+    (
+        "state-pending-rewards",
+        "sha256:14f3ba06ea6efef528513e8a515d7642a58de6745726358c43c7674585228b9c",
+        2,
+        94,
+    ),
+    (
+        "state-pool-deposit-refunds",
+        "sha256:d7d44918e486050d16ccd0453336949a94e04ac0f16d3e1be526bf83e51635c4",
+        2,
+        100,
+    ),
+    (
+        "state-pools",
+        "sha256:ed53688d4d705b0403a38874f710aa44aecb5b2746beba513db5773d28b500c7",
+        2,
+        84,
+    ),
+    (
+        "state-proposals",
+        "sha256:45f5f9c494e2ed8971b944e45d0cce187d9b08227589ef636a6974a054d1f4b6",
+        2,
+        88,
+    ),
+    (
+        "state-stakes",
+        "sha256:30d99b0aa88a7e8b35f1a6c1601535c157f2b5d42f50853391ee596fa5a7ef44",
+        2,
+        85,
+    ),
+    (
+        "state-utxos",
+        "sha256:2f55f54d9ad1e7bd1b4419c6508741347865d732aeb817f0785f4bf329f18d19",
+        2,
+        91,
+    ),
+    (
+        "state-utxos",
+        "sha256:ce4874d77aeb1e3c553f88c59f010315038b0577302e1c2b8d518a3877b48371",
+        2,
+        91,
     ),
     (
         DIGESTS,
@@ -110,7 +225,7 @@ const GOLDEN_LAYERS: [(&str, &str, u64, u64); 11] = [
 
 /// The stele's identity: sha256 of the canonical inscription.
 const GOLDEN_INSCRIPTION: &str =
-    "sha256:f784cbd63002e8e853a8a4aced5da81c976da65c1538fba662d9d7254447a4d1";
+    "sha256:703085bd06ecf68128023352253c95e66b5bb3079ad2e5155c1498ff4722931f";
 
 fn history() -> Vec<HistoryEntry> {
     vec![
@@ -125,7 +240,7 @@ fn history() -> Vec<HistoryEntry> {
     ]
 }
 
-/// Write the whole fixture stele into `root`: eleven layers and an inscription.
+/// Write the whole fixture stele into `root`: thirty layers and an inscription.
 fn write_stele(root: &std::path::Path) -> (Inscription, Digest) {
     let stele = SteleDir::create(root).unwrap();
 
@@ -308,10 +423,8 @@ fn the_canonical_inscription_is_pinned() {
 /// crate's — but every *string* in it is this profile's, and that is what the
 /// literal is for.
 const CANONICAL_INSCRIPTION: &str = concat!(
-    r#"{"compression":{"algo":"zstd","level":9},"#,
-    r#""history":[{"inscriptionDigest":"sha256:5555555555555555555555555555555555555555555555555555555555555555","sequence":5},"#,
-    r#"{"inscriptionDigest":"sha256:6666666666666666666666666666666666666666666666666666666666666666","sequence":6}],"#,
-    r#""layers":[{"diffId":"sha256:14a05418723da3c0b4117b5f30ef07d96887b3e12eae114988ff299a654ff106","kind":"blocks","#,
+    r#"{"compression":{"algo":"zstd","level":9},"history":[{"inscriptionDigest":"sha256:5555555555555555555555555555555555555555555555555555555555555555","sequence":5},{"inscriptionDigest":"sha256:6666666666666666666666666666666666666666666666666666666666666666","sequence":6}],"layers":["#,
+    r#"{"diffId":"sha256:14a05418723da3c0b4117b5f30ef07d96887b3e12eae114988ff299a654ff106","kind":"blocks","#,
     r#""mediaType":"application/vnd.dolos.stele.blocks.v1+zstd","records":4,"#,
     r#""scope":{"endSlot":101,"epoch":7,"startSlot":100},"uncompressedSize":167},"#,
     r#"{"diffId":"sha256:557948cad9dec8605fbde96912db9b6421b47f2ded4c00886ed59f1638b4678c","kind":"indexes","#,
@@ -335,19 +448,79 @@ const CANONICAL_INSCRIPTION: &str = concat!(
     r#"{"diffId":"sha256:4a38c30b91b4bb4142721f10c74c2c2fbd9cbf5e1efb5a08eb2c330fd204d0bd","kind":"log-stakes","#,
     r#""mediaType":"application/vnd.dolos.stele.log-stakes.v1+zstd","records":2,"#,
     r#""scope":{"endSlot":101,"epoch":7,"startSlot":100},"uncompressedSize":94},"#,
-    r#"{"diffId":"sha256:2dadb9a35b6e89adf01e3c915325b398037b388bafa63da99a6a2f3ce77e6b97","kind":"state","#,
-    r#""mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":18,"#,
-    r#""scope":{"shard":0},"uncompressedSize":862},"#,
-    r#"{"diffId":"sha256:d2230021ccaa604e93f189653ca23b5e22376bb93c6c1bbf724d45dd037671e2","kind":"state","#,
-    r#""mediaType":"application/vnd.dolos.stele.state.v1+zstd","records":18,"#,
-    r#""scope":{"shard":1},"uncompressedSize":862},"#,
+    r#"{"diffId":"sha256:1b30a5fef9ec458336cbde5a7aa80aaec76d0c5a8bf68b577152d0bd506be80b","kind":"state-account-stakes","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-account-stakes.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":93},"#,
+    r#"{"diffId":"sha256:db47596747e81165ce2948f333cc6e6ab3c240f6973fb627df1d9b65dc50c8f2","kind":"state-accounts","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":87},"#,
+    r#"{"diffId":"sha256:0c7bc44f2f59b16a803369072e19011789cf4221dc94f409626e52d00f10eb1f","kind":"state-accounts","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-accounts.v1+zstd","records":2,"#,
+    r#""scope":{"shard":1},"uncompressedSize":87},"#,
+    r#"{"diffId":"sha256:8077fd64690d954acc788df3b8046d151729ccd2b7d1dae42ed177f3931747aa","kind":"state-assets","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:c7c1ff92712bfa3bff88b9ce2445bb3f4e55139ac5bc89c989f41188f894eeff","kind":"state-assets","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-assets.v1+zstd","records":2,"#,
+    r#""scope":{"shard":1},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:41c9a9cba05c8bfc0d7e345b820f62d4fc3e16fa5deef8ac224f9422ae1c3bb0","kind":"state-datums","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:444ae56c151ffb66b8dd716e16b578d9ec4e339251ba24406d935b5214db27da","kind":"state-datums","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-datums.v1+zstd","records":2,"#,
+    r#""scope":{"shard":1},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:96f0a867e25607b374f34830c4499ae735a860486b866e740998c781ef0f29ca","kind":"state-dreps","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-dreps.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":84},"#,
+    r#"{"diffId":"sha256:93b0aab4fd80315a8bf106397e7575f58b031a8fe9680dac5d21bf84c880a23a","kind":"state-epochs","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-epochs.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:ad1c687b6b519d6d922764504a333d91733a98a251c606524532c6b066167648","kind":"state-eras","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-eras.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":83},"#,
+    r#"{"diffId":"sha256:f569b56280287b58f66dc13c1f4c0b2f6895befb01399ec6d2c73e13a8679a97","kind":"state-gov","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-gov.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":82},"#,
+    r#"{"diffId":"sha256:35d6299d7c44b696f5ff9bc4ba1ad9bf565ef7ef8044bb7a729a0b8acaf7cef4","kind":"state-leader-rewards","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-leader-rewards.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":93},"#,
+    r#"{"diffId":"sha256:900e8cbd5e6e0e24342acda6ea98547a402eb7f7a06909d96cc8a3cbefbcb962","kind":"state-member-rewards","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-member-rewards.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":93},"#,
+    r#"{"diffId":"sha256:b0902d68fbcfeb299e56b72bf9de34299928d6a0d25501ceaa5161d209c5bdf6","kind":"state-pending-mirs","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-pending-mirs.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":91},"#,
+    r#"{"diffId":"sha256:14f3ba06ea6efef528513e8a515d7642a58de6745726358c43c7674585228b9c","kind":"state-pending-rewards","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-pending-rewards.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":94},"#,
+    r#"{"diffId":"sha256:d7d44918e486050d16ccd0453336949a94e04ac0f16d3e1be526bf83e51635c4","kind":"state-pool-deposit-refunds","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-pool-deposit-refunds.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":100},"#,
+    r#"{"diffId":"sha256:ed53688d4d705b0403a38874f710aa44aecb5b2746beba513db5773d28b500c7","kind":"state-pools","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-pools.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":84},"#,
+    r#"{"diffId":"sha256:45f5f9c494e2ed8971b944e45d0cce187d9b08227589ef636a6974a054d1f4b6","kind":"state-proposals","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-proposals.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":88},"#,
+    r#"{"diffId":"sha256:30d99b0aa88a7e8b35f1a6c1601535c157f2b5d42f50853391ee596fa5a7ef44","kind":"state-stakes","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-stakes.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":85},"#,
+    r#"{"diffId":"sha256:2f55f54d9ad1e7bd1b4419c6508741347865d732aeb817f0785f4bf329f18d19","kind":"state-utxos","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":2,"#,
+    r#""scope":{"shard":0},"uncompressedSize":91},"#,
+    r#"{"diffId":"sha256:ce4874d77aeb1e3c553f88c59f010315038b0577302e1c2b8d518a3877b48371","kind":"state-utxos","#,
+    r#""mediaType":"application/vnd.dolos.stele.state-utxos.v1+zstd","records":2,"#,
+    r#""scope":{"shard":1},"uncompressedSize":91},"#,
     r#"{"diffId":"sha256:13f9bbdf676ac47ad7238a52fa525f4413a88335c23d2d567c888abd8dedec80","kind":"digests","#,
     r#""mediaType":"application/vnd.dolos.stele.digests.v1+zstd","records":3,"#,
-    r#""scope":{"lastImmutable":3},"uncompressedSize":250}],"#,
-    r#""parameters":{"indexKeyHash":"xxh3-64","stateShards":16},"#,
-    r#""position":{"epoch":7,"network":{"magic":764824073,"name":"mainnet"},"#,
-    r#""point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":101}},"#,
-    r#""profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":7}"#,
+    r#""scope":{"lastImmutable":3},"uncompressedSize":250}"#,
+    r#"],"parameters":{"#,
+    r#""indexKeyHash":"xxh3-64","#,
+    r#""schemas":{"account-stakes":1,"accounts":1,"assets":1,"datums":1,"dreps":1,"epochs":1,"eras":1,"gov":1,"leader-rewards":1,"member-rewards":1,"pending_mirs":1,"pending_rewards":1,"pool-deposit-refunds":1,"pools":1,"proposals":1,"stakes":1,"utxos":1},"#,
+    r#""shards":{"account-stakes":1,"accounts":16,"assets":16,"datums":16,"dreps":1,"epochs":1,"eras":1,"gov":1,"leader-rewards":1,"member-rewards":1,"pending_mirs":1,"pending_rewards":1,"pool-deposit-refunds":1,"pools":1,"proposals":1,"stakes":1,"utxos":16}"#,
+    r#"},"position":{"#,
+    r#""epoch":7,"network":{"magic":764824073,"name":"mainnet"},"#,
+    r#""point":{"hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b","slot":101}},"profile":{"name":"io.txpipe.dolos.cardano","version":1},"schema":1,"sequence":7}"#,
 );
 /// Decode one record with the codec its layer kind names, so the streaming pass
 /// exercises every codec rather than only the framing underneath them.
@@ -360,15 +533,20 @@ fn decode_one(kind: &str, record: &[u8]) {
         return;
     }
 
+    // And one codec for all seventeen state kinds, for the same reason — the
+    // namespace it needs is the one the kind names.
+    if let Some(ns) = state_ns_for(kind) {
+        state::decode(ns, record).unwrap();
+
+        return;
+    }
+
     match kind {
         BLOCKS => {
             blocks::decode(record).unwrap();
         }
         INDEXES => {
             indexes::decode(record).unwrap();
-        }
-        STATE => {
-            state::decode(record).unwrap();
         }
         DIGESTS => {
             digests::decode(record).unwrap();

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -64,8 +64,9 @@ mod watcher;
 use dolos_core::Domain as _;
 use dolos_snapshot::{
     export::{self, Following, Predecessor as _, Standing},
+    is_state_kind,
     registry::{self, Publishing},
-    DolosProfile, Error, BLOCKS, INDEXES, STATE_SHARDS,
+    state_layer_count, DolosProfile, Error, BLOCKS, INDEXES,
 };
 use stelae::{progress::Outcome, SteleReader as _};
 
@@ -89,10 +90,10 @@ const EPOCH_0: usize = 2 + EPOCH_0_LOGS.len();
 const EPOCH_1: usize = 2;
 
 /// Layers a publish of sequence 0 writes: epoch 0 plus the state tip.
-const PER_PUBLISH: usize = EPOCH_0 + STATE_SHARDS as usize;
+const PER_PUBLISH: usize = EPOCH_0 + state_layer_count();
 
 /// Layers a publish of sequence 1 carries: both epochs plus the state tip.
-const WHOLE_SECOND: usize = EPOCH_0 + EPOCH_1 + STATE_SHARDS as usize;
+const WHOLE_SECOND: usize = EPOCH_0 + EPOCH_1 + state_layer_count();
 
 // ---------------------------------------------------------------------------
 // Done criteria 1 and 2
@@ -127,7 +128,7 @@ fn a_second_publish_builds_and_uploads_only_what_is_new() {
     );
     assert_eq!(
         second.layers_built,
-        EPOCH_1 + STATE_SHARDS as usize,
+        EPOCH_1 + state_layer_count(),
         "epoch 1's blocks and indexes, and the sixteen state shards"
     );
     assert_eq!(second.inscription.layers.len(), WHOLE_SECOND);
@@ -137,7 +138,7 @@ fn a_second_publish_builds_and_uploads_only_what_is_new() {
     // state shard's header record names its epoch.
     assert_eq!(
         second.transfer.layers_uploaded,
-        (EPOCH_1 + STATE_SHARDS as usize) as u64
+        (EPOCH_1 + state_layer_count()) as u64
     );
     assert_eq!(second.transfer.layers_reused, EPOCH_0 as u64);
     assert_eq!(second.transfer.layers_skipped, 0);
@@ -605,13 +606,14 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
     {
         let size = size.expect("the manifest sizes every layer");
 
-        match descriptor.kind.as_str() {
-            dolos_snapshot::STATE => state_bytes += size,
-            _ => largest_other_bytes = std::cmp::max(largest_other_bytes, size),
+        if is_state_kind(&descriptor.kind) {
+            state_bytes += size;
+        } else {
+            largest_other_bytes = std::cmp::max(largest_other_bytes, size);
         }
     }
 
-    assert_eq!(peak.state_bytes, state_bytes, "all sixteen shards at once");
+    assert_eq!(peak.state_bytes, state_bytes, "every state layer summed");
     assert_eq!(
         peak.largest_other_bytes, largest_other_bytes,
         "and the largest single layer beside them"
@@ -708,8 +710,8 @@ fn a_restarted_publish_carries_forward_the_layers_it_finished() {
         record
             .layers
             .iter()
-            .all(|layer| layer.descriptor.kind != dolos_snapshot::STATE),
-        "a state shard is the tip, and is never recorded",
+            .all(|layer| !is_state_kind(&layer.descriptor.kind)),
+        "a state layer is the tip, and is never recorded",
     );
 
     // The restart, against the same repository and the same storage.
@@ -727,14 +729,17 @@ fn a_restarted_publish_carries_forward_the_layers_it_finished() {
 
     assert_eq!(
         resumed.layers_built,
-        1 + STATE_SHARDS as usize,
-        "epoch 1's indexes and the sixteen state shards, and nothing else",
+        1 + state_layer_count(),
+        "epoch 1's indexes and every state layer, and nothing else",
     );
 
     // The claim in the counters the transport keeps: the layers the record
-    // carried moved no bytes at all, and the shards it never carried did.
+    // carried moved no bytes at all, and the state layers it never carried did.
     assert_eq!(resumed.transfer.layers_reused, (EPOCH_0 + 1) as u64);
-    assert_eq!(resumed.transfer.layers_uploaded, 1 + STATE_SHARDS);
+    assert_eq!(
+        resumed.transfer.layers_uploaded,
+        1 + state_layer_count() as u64
+    );
     assert_eq!(
         resumed.transfer.layers_skipped, 0,
         "a layer skipped by the blob check is one that was built first, which is \
@@ -827,8 +832,8 @@ fn a_rebuild_and_another_repository_both_ignore_the_record() {
     );
     assert_eq!(
         published.layers_built,
-        EPOCH_1 + STATE_SHARDS as usize,
-        "epoch 1's two layers and the sixteen state shards, exactly as if no \
+        EPOCH_1 + state_layer_count(),
+        "epoch 1's two layers and every state layer, exactly as if no \
          record existed",
     );
 

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -46,8 +46,10 @@ use dolos_core::{
     StateStore, TagRecord, TxoRef, UtxoSet, UtxoSetDelta,
 };
 use dolos_snapshot::{
+    is_state_kind,
     restore::{self, Budget, Checkpoint},
-    DolosProfile, Error, COMPRESSION_LEVEL, KINDS, NAMESPACES, STATE, STATE_SHARDS, UTXOS,
+    state_layer_count, DolosProfile, Error, COMPRESSION_LEVEL, KINDS, NAMESPACES, STATE_KINDS,
+    UTXOS,
 };
 use dolos_testing::toy_domain::{FjallStores, MemoryStores, ToyDomain, ToyStores};
 use node::{export_to, harness, Blank};
@@ -348,8 +350,8 @@ fn a_required_unknown_layer_kind_is_refused_before_anything_is_written() {
 
 /// Done criterion 3, second half.
 ///
-/// One state shard's blob is removed, so the restore fails partway through the
-/// tip — after epochs and other shards have landed. `set_cursor` is the last
+/// One state layer's blob is removed, so the restore fails partway through the
+/// tip — after epochs and other layers have landed. `set_cursor` is the last
 /// thing a restore does, so what it leaves behind is a store set with data in
 /// it and no cursor, which is what `bootstrap`'s `has_existing_data()` reads.
 #[test]
@@ -359,11 +361,13 @@ fn a_restore_that_fails_partway_leaves_no_cursor() {
     let temp = tempfile::tempdir().unwrap();
     let inscription = export_to(temp.path(), &domain);
 
-    // The last shard, so the failure lands after fifteen others have committed.
+    // The last state layer, so the failure lands after every other one has
+    // committed.
     let last = inscription
-        .layers_of_kind(STATE)
-        .last()
-        .expect("a stele has state shards");
+        .layers
+        .iter()
+        .rfind(|layer| is_state_kind(&layer.kind))
+        .expect("a stele has state layers");
 
     let stele = SteleDir::open(temp.path()).unwrap();
     let blob = stele
@@ -961,12 +965,12 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
     assert_eq!(second.sequence, 1, "and one slot later, in epoch 1");
 
     // And the two sides of the rule, as bytes. Epoch 0's layers carry forward;
-    // every state shard is new.
+    // every state layer is new.
     let epoch_zero = |stele: &Inscription| -> Vec<Digest> {
         stele
             .layers
             .iter()
-            .filter(|l| l.kind != STATE && l.scope["epoch"] == 0)
+            .filter(|l| !is_state_kind(&l.kind) && l.scope["epoch"] == 0)
             .map(|l| l.diff_id)
             .collect()
     };
@@ -980,19 +984,19 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
     assert!(
         state_diff_ids(&first)
             .iter()
-            .all(|shard| !state_diff_ids(&second).contains(shard)),
-        "a state shard names the epoch it is the tip of, so none can be shared"
+            .all(|layer| !state_diff_ids(&second).contains(layer)),
+        "a state layer names the epoch it is the tip of, so none can be shared"
     );
 
     let storage = tempfile::tempdir().unwrap();
     let blank = Blank::<MemoryStores>::open();
 
     // The node is pre-seeded by an actual interrupted restore of the older
-    // stele, stopped at its first state shard, rather than by a hand-written
+    // stele, stopped at its first state layer, rather than by a hand-written
     // progress file. That matters: a hand-written one would claim layers whose
     // records were never committed, and the store comparison at the end would
     // then be checking that a resume skipped work nobody had done.
-    let (_, state_shards) = layers_in_driver_order(older.path(), magic);
+    let (_, tip_layers) = layers_in_driver_order(older.path(), magic);
 
     let err = restore_checkpointed(
         older.path(),
@@ -1000,7 +1004,7 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
         magic,
         &blank,
         false,
-        Some(state_shards[0]),
+        Some(tip_layers[0]),
     )
     .unwrap_err();
 
@@ -1017,7 +1021,7 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
 
     assert_eq!(
         seeded,
-        first.layers.len() - STATE_SHARDS as usize,
+        first.layers.len() - state_layer_count(),
         "every epoch layer committed before the tip was reached"
     );
 
@@ -1034,11 +1038,11 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
         resumed.layers_fetched,
         second.layers.len() - seeded,
         "and everything the newer stele adds was fetched: epoch 1's layers, \
-         and all sixteen shards because a shard is never inherited"
+         and every state layer because a state layer is never inherited"
     );
 
     assert!(
-        resumed.layers_fetched > STATE_SHARDS as usize,
+        resumed.layers_fetched > state_layer_count(),
         "the newer stele has to add an epoch, or the tip is all this proves"
     );
 
@@ -1214,16 +1218,16 @@ fn the_remaining_download_excludes_what_is_already_done() {
     assert!(resumed.compressed_bytes < fresh.compressed_bytes);
 
     // The tip is still in it, always.
-    assert_eq!(resumed.layers, STATE_SHARDS as usize);
+    assert_eq!(resumed.layers, state_layer_count());
 
-    // So the peak a resumed run stages is the widest shard, not the widest
+    // So the peak a resumed run stages is the widest state layer, not the widest
     // layer of the stele — the epoch layers it skips are not staged either.
     assert_eq!(resumed.largest_compressed, widest(&mut plan.tip_layers()));
     assert!(resumed.largest_compressed <= fresh.largest_compressed);
 }
 
-/// The epoch layers and the state shards, each in the order the driver reaches
-/// them.
+/// The epoch layers and the state tip's layers, each in the order the driver
+/// reaches them.
 ///
 /// Read off the [`restore::Plan`] and not the inscription. The document's order
 /// is whatever the export wrote; the driver's is epoch by epoch and, within an
@@ -1242,7 +1246,9 @@ fn layers_in_driver_order(root: &std::path::Path, magic: u64) -> (Vec<Digest>, V
 
 fn state_diff_ids(inscription: &Inscription) -> Vec<Digest> {
     inscription
-        .layers_of_kind(STATE)
+        .layers
+        .iter()
+        .filter(|layer| is_state_kind(&layer.kind))
         .map(|layer| layer.diff_id)
         .collect()
 }
@@ -1251,7 +1257,7 @@ fn epoch_diff_ids(inscription: &Inscription) -> Vec<Digest> {
     inscription
         .layers
         .iter()
-        .filter(|layer| layer.kind != STATE)
+        .filter(|layer| !is_state_kind(&layer.kind))
         .map(|layer| layer.diff_id)
         .collect()
 }
@@ -1261,7 +1267,7 @@ fn epoch_diff_ids(inscription: &Inscription) -> Vec<Digest> {
 // --------------------------------------------------------------------------
 
 /// A stele always carries the whole tip, whatever history travels with it, so
-/// `sync.max_history` never touches the state shards — only the epoch layers.
+/// `sync.max_history` never touches the state layers — only the epoch layers.
 #[test]
 fn max_history_selects_epochs_and_never_the_tip() {
     let domain: ToyDomain = harness();
@@ -1274,7 +1280,14 @@ fn max_history_selects_epochs_and_never_the_tip() {
     for max_history in [None, Some(0), Some(u64::MAX)] {
         let plan = restore::plan(&stele, magic_of(&domain), max_history).unwrap();
 
-        assert_eq!(plan.state.len(), STATE_SHARDS as usize, "{max_history:?}");
+        // Keyed by namespace now, so the tip is seventeen entries and every
+        // layer under them.
+        assert_eq!(plan.state.len(), STATE_KINDS.len(), "{max_history:?}");
+        assert_eq!(
+            plan.tip_layers().count(),
+            state_layer_count(),
+            "{max_history:?}"
+        );
 
         // The fixture stands inside epoch zero, so every window reaches the tip
         // and nothing is ever dropped — which is the assertion, not a shortcut:

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -56,7 +56,7 @@ use dolos_snapshot::{
     export::Plan,
     registry::{self, Point},
     restore::{self, Budget, Checkpoint},
-    Error, Network, NAMESPACES, STATE_SHARDS, UTXOS,
+    state_layer_count, Error, Network, NAMESPACES, UTXOS,
 };
 use dolos_testing::toy_domain::{MemoryStores, ToyDomain, ToyStores};
 use node::{harness, Blank};
@@ -83,7 +83,7 @@ const EPOCH_0: usize = 4;
 const EPOCH_1: usize = 2;
 
 /// Layers a publish of sequence 0 writes: epoch 0 plus the state tip.
-const PER_PUBLISH: usize = EPOCH_0 + STATE_SHARDS as usize;
+const PER_PUBLISH: usize = EPOCH_0 + state_layer_count();
 
 // ---------------------------------------------------------------------------
 // The node, and the two chain points it publishes from
@@ -500,8 +500,8 @@ fn a_pre_seeded_node_fetches_only_what_it_lacks() {
 
     assert_eq!(
         resumed.layers_fetched,
-        EPOCH_1 + STATE_SHARDS as usize,
-        "epoch 1's two layers and the sixteen shards, and nothing else"
+        EPOCH_1 + state_layer_count(),
+        "epoch 1's two layers and every state layer, and nothing else"
     );
 
     // The point resolved to what it claimed. `latest` is sequence 1 here, and

--- a/crates/snapshot/tests/roundtrip.rs
+++ b/crates/snapshot/tests/roundtrip.rs
@@ -14,7 +14,7 @@ use dolos_core::{
 };
 use dolos_snapshot::{
     layers::{blocks, digests, indexes, logs, state},
-    DolosProfile, Error, Scope, BLOCKS, DIGESTS, INDEXES, LOG_KINDS, STATE,
+    shards_for, DolosProfile, Error, Scope, BLOCKS, DIGESTS, INDEXES, LOG_KINDS,
 };
 use stelae::{
     dir::SteleDir,
@@ -151,33 +151,34 @@ fn logs_round_trip_through_a_layer_per_namespace() {
 }
 
 #[test]
-fn state_round_trips_through_a_layer_per_shard() {
-    for shard in SHARDS {
-        let records = common::state(shard);
+fn state_round_trips_through_a_layer_per_kind_and_shard() {
+    for (kind, ns, shard) in common::state_layers() {
+        let shards = shards_for(ns).expect("a state namespace");
+        let records = common::state(ns, shard);
+
         let decoded = roundtrip(
-            STATE,
+            kind,
             &state_scope(shard),
             &records,
-            state::encode,
-            state::decode,
+            |record| state::encode(ns, record),
+            |bytes| state::decode(ns, bytes),
         );
 
-        let mut order = state::OrderCheck::for_shard(shard);
+        let mut order = state::OrderCheck::for_shard(shard, shards);
         for record in &decoded {
             order.check(record).unwrap();
         }
 
         // The utxo value is the one field this profile composes rather than
         // carries, so it is the one that has to survive the trip as a value and
-        // not merely as bytes.
-        let utxo = decoded
-            .iter()
-            .find(|record| record.ns == dolos_snapshot::UTXOS)
-            .expect("the fixture carries a utxo record");
+        // not merely as bytes. It rides in its own kind now, so this is a check
+        // on that kind rather than a search through a mixed layer.
+        if ns == dolos_snapshot::UTXOS {
+            let (txo, value) = state::as_utxo(&decoded[0]).unwrap();
 
-        let (txo, value) = state::as_utxo(utxo).unwrap();
-        assert_eq!(txo.1, 3);
-        assert_eq!(value.0, 6);
+            assert_eq!(txo.1, 3);
+            assert_eq!(value.0, 6);
+        }
     }
 }
 

--- a/tests/snapshot_publish.rs
+++ b/tests/snapshot_publish.rs
@@ -117,13 +117,15 @@ fn an_epoch_range_selects_the_layers_it_names() {
         }
 
         // The state tip is not history, so restricting the epochs never touches
-        // it: a stele always carries all sixteen shards.
-        assert_eq!(
-            inscription.layers_of_kind(dolos_snapshot::STATE).count(),
-            dolos_snapshot::STATE_SHARDS as usize,
-            "{}",
-            out.display()
-        );
+        // it: a stele always carries every shard of every `state-{ns}` kind.
+        for (kind, _, shards) in dolos_snapshot::STATE_KINDS {
+            assert_eq!(
+                inscription.layers_of_kind(kind).count(),
+                shards as usize,
+                "{kind} in {}",
+                out.display()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Second link of the layer-compatibility chain ([decision 0026](https://github.com/txpipe/dolos/blob/main/adrs/004_stelae_snapshots.md)), after the log split in #1241. Plan: `plans/dolos-stelae-layer-compat-state-split.md`.

## What changed

The single `state` kind becomes seventeen `state-{ns}` kinds, one per state namespace, mirroring the log split. A record drops its namespace field to `[key, value]` — the namespace is the layer's *kind*.

Why, in one sentence: it puts the fail-closed edge of a breaking change on exactly the namespace that broke, and makes a namespace a reader does not define skippable at the transport instead of poisoning one shared layer. (It is *not* motivated by backfill economics — the tip re-uploads wholesale every publish regardless.)

Shard counts are **specification, never tuning**: `utxos`, `accounts`, `assets` and `datums` split sixteen ways, every other namespace is a single blob. 77 state layers per publish, all written even when empty, so tip completeness stays structural.

### `crates/snapshot`

- **`lib.rs`** — `STATE_KINDS: [(&str, Namespace, u8); 17]` (spelled out, `_`→`-`), with `state_kind_for` / `state_ns_for` / `shards_for` / `is_state_kind` and a `const fn state_layer_count()`. `KINDS` reaches its final shape at 26. `STATE` and `STATE_SHARDS` are gone.
- **`parameters()`** — now `{indexKeyHash, shards: {ns: n}, schemas: {ns: rev}}`. `stateShards` removed; `SCHEMA_REVS` lands beside `NAMESPACES` (all `1` today) as the per-namespace record-content revision decision 0026's compatibility machinery keys on.
- **`layers/state.rs`** — `StateRecord { key, value }`; `encode`/`decode` take the namespace as a parameter derived from the layer kind, so the 32-vs-36 key-width rule is per-layer configuration. `shard_of(key, shards)`; `OrderCheck` drops the ns component.
- **`export.rs`** — `write_state` walks namespaces sequentially, opening only that kind's sinks. Same I/O as before: the old "one walk" was already 17 sequential per-namespace iterations.
- **`restore.rs`** — `Plan.state` is a `BTreeMap<Namespace, Vec<LayerDescriptor>>`; `select_state` requires every kind and, per kind, exactly its spec'd shards; `restore_state` dispatches per layer rather than per record.
- **`registry.rs`** — the staging-peak predicate becomes `is_state_kind()`, keeping the conservative sum-all-state rule (an upper bound on any per-kind pass).

### ADR-004

Moves in the same commit: layer table row, media types, scope shapes, a new `parameters` paragraph documenting the media-type-vs-schema-revision split, manifest arithmetic (~4,877 layers, ~1.7 MB, still under the 4 MiB ceiling) and the Alternative-7 prose.

### Tests

Goldens (30 layers), `CANONICAL_INSCRIPTION`, the export skeleton (83 layers), the shared `tests/common` fixture, roundtrip, restore, coverage and the registry suites are all re-pinned. New: `state_kinds_derive_from_their_namespaces` pins spelling, injectivity, order and the shard map; `the_state_tip_requires_every_kind_and_every_shard` replaces `every_shard_of_the_state_tip_is_required`; `the_pre_split_three_element_record_is_refused` pins the v1 record's rejection on arity.

## Verification

- `cargo test --workspace` — 1309 passed, 0 failed
- `cargo test -p dolos-snapshot --features oci --test publish --test restore_registry --test snapshot_verify -- --ignored` against `registry:2` — 24 passed, 0 failed (`both_backends_publish_the_same_inscription` included)
- `cargo clippy -p dolos-snapshot -p stelae -p dolos --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo tree -p stelae` — no `dolos-*`

## Findings (not caused by this change)

`rust-toolchain.toml` pins **1.93** but `.github/workflows/ci.yml` pins clippy to `dtolnay/rust-toolchain@1.91`. Under 1.93 the base commit already fails workspace clippy with 4 pre-existing errors in `dolos-cardano` (`model/proposals.rs:1170`, `ewrap/loading.rs:2879,2987`) — confirmed pre-existing by stashing this branch's changes. Left alone; the two pins should probably agree.

## Follow-up filed by the plan

`--rebuild <kinds>` (kind-scoped rebuild instead of all-or-nothing) becomes cheap and natural now that kinds are per-namespace — worth a flag if a measured publish wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot state is now organized into namespace-specific layers.
  * Namespaces support configurable sharding, including single-layer and 16-shard layouts.
  * Snapshot parameters now include per-namespace shard counts and schema revisions.
  * Export and restore workflows support all configured state namespaces.
  * Optional unknown layers can be skipped during restore, while required unknown layers are reported.

* **Bug Fixes**
  * Empty state layers and shards are consistently published.
  * Restore validation detects incomplete or mismatched namespace shard coverage and supports reliable resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->