### PR TITLE
fix(cardano): delete the unredeemed AVVM utxos the Allegra boundary reclaims

### DIFF
--- a/crates/cardano/src/estart/avvm.rs
+++ b/crates/cardano/src/estart/avvm.rs
@@ -1,0 +1,201 @@
+//! The Shelley→Allegra AVVM reclamation.
+//!
+//! Crossing into Allegra the Haskell ledger's `translateEra` deletes every
+//! unredeemed Byron genesis AVVM UTxO and returns its value to `reserves`.
+//! The two halves are one event, and [`AvvmReclamation`] is what keeps them
+//! one: the pot arithmetic in [`crate::pots::apply_delta`] takes its
+//! `avvm_reclamation` from [`AvvmReclamation::total`] and the deletion staged
+//! in `WorkContext::commit_finalize` takes its refs from
+//! [`AvvmReclamation::utxos`], both from the same read of the UTxO set, in the
+//! same commit. A store cannot end up with one applied and not the other.
+//!
+//! The refs are derived from the Byron genesis on every run — never from a
+//! recorded list, which is a census of one tip rather than an input. A network
+//! whose Byron genesis carries an empty `avvmDistr` (preprod and preview: their
+//! whole supply sits in `nonAvvmBalances`) derives nothing, so the reclamation
+//! is a no-op there and mainnet is the only network on which it has ever moved
+//! anything.
+//!
+//! # Rollback
+//!
+//! The deletion carries no `recovered_stxi` / `undone_utxo` counterpart, and
+//! deliberately not. [`dolos_core::sync::SyncExt::rollback`] unwinds *blocks*:
+//! it walks the WAL entries after the target point and undoes each one's entity
+//! and UTxO deltas. Epoch-boundary work units write no WAL entry — ESTART's pot
+//! recalculation, snapshot rotation, nonce transition and era transition are
+//! none of them undone by a rollback today — so a deletion staged in the
+//! boundary commit is exactly as recoverable as everything else the boundary
+//! does. Rolling back *across* an epoch boundary is not an operation this node
+//! supports, and giving this one boundary effect an undo path would not make it
+//! one. The boundary in question is mainnet epoch 236 (December 2020), several
+//! thousand epochs behind any rollback window a node keeps.
+
+use dolos_core::{
+    ChainError, ChainPoint, Domain, EntityKey, Genesis, IndexStore, IndexWriter, StateStore,
+    StateWriter, TxoRef, UtxoMap, UtxoSetDelta,
+};
+use pallas::ledger::traverse::MultiEraOutput;
+
+use crate::{model::EraSummary, EraProtocol, FixedNamespace as _};
+
+/// The protocol major Shelley runs at. The end of that era *is* the
+/// reclamation boundary.
+const SHELLEY: u16 = 2;
+
+/// The unredeemed Byron genesis AVVM UTxOs of one store, and the lovelace
+/// they hold.
+///
+/// Default (empty, zero) is the honest value everywhere the reclamation does
+/// not apply: every boundary that is not Shelley→Allegra, and every network
+/// whose Byron genesis has no `avvmDistr`.
+#[derive(Default, Clone)]
+pub struct AvvmReclamation {
+    /// The refs still in the UTxO set, with their bodies — what the boundary
+    /// deletes.
+    pub utxos: UtxoMap,
+
+    /// What those refs hold — what the boundary subtracts from the `utxos`
+    /// pot and adds to `reserves`.
+    pub total: u64,
+}
+
+impl AvvmReclamation {
+    /// Every AVVM UTxO ref the Byron genesis distributes, redeemed or not.
+    ///
+    /// The one derivation both the boundary and `dolos doctor reclaim-avvm`
+    /// go through, so the repair can never delete a ref the boundary would
+    /// have kept.
+    pub fn genesis_refs(genesis: &Genesis) -> Vec<TxoRef> {
+        pallas::interop::hardano::configs::byron::genesis_avvm_utxos(&genesis.byron)
+            .iter()
+            .map(|(tx, _, _)| TxoRef(*tx, 0))
+            .collect()
+    }
+
+    /// Read which of the genesis AVVM refs the store still holds, and sum
+    /// them.
+    ///
+    /// An output that fails to decode is an error rather than a zero: the
+    /// total funds a pot movement that has to match the deletion to the
+    /// lovelace, and a store holding a Byron genesis output it cannot decode
+    /// is broken in a way this boundary must not paper over.
+    pub fn unredeemed<D: Domain>(state: &D::State, genesis: &Genesis) -> Result<Self, ChainError> {
+        let refs = Self::genesis_refs(genesis);
+
+        if refs.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let derived = refs.len();
+        let utxos = state.get_utxos(refs)?;
+
+        let mut total = 0u64;
+
+        for utxo in utxos.values() {
+            let output = MultiEraOutput::try_from(utxo.as_ref())?;
+            total += output.value().coin();
+        }
+
+        tracing::debug!(
+            derived,
+            unredeemed = utxos.len(),
+            total,
+            "AVVM reclamation census"
+        );
+
+        Ok(Self { utxos, total })
+    }
+
+    /// The reclamation for the boundary closing the current epoch: the
+    /// census above at the Shelley→Allegra transition, and nothing anywhere
+    /// else.
+    pub fn at_boundary<D: Domain>(state: &D::State, genesis: &Genesis) -> Result<Self, ChainError> {
+        let ended_state = crate::load_epoch::<D>(state)?;
+
+        let entering_allegra = ended_state
+            .pparams
+            .era_transition()
+            .is_some_and(|x| x.entering_allegra());
+
+        if !entering_allegra {
+            return Ok(Self::default());
+        }
+
+        Self::unredeemed::<D>(state, genesis)
+    }
+
+    /// Whether the store has already been through the Shelley→Allegra
+    /// boundary.
+    ///
+    /// The Shelley era summary gains its `end` at that boundary and only
+    /// there, so its presence is the store's own record of having crossed.
+    /// A store that never had a Shelley era at all — a devnet forced straight
+    /// into a later protocol — never crossed it either, and reads `false`.
+    pub fn boundary_crossed<D: Domain>(state: &D::State) -> Result<bool, ChainError> {
+        let shelley = state.read_entity_typed::<EraSummary>(
+            EraSummary::NS,
+            &EntityKey::from(EraProtocol::from(SHELLEY)),
+        )?;
+
+        Ok(shelley.is_some_and(|x| x.end.is_some()))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.utxos.is_empty()
+    }
+
+    /// The UTxO-set delta that removes them.
+    ///
+    /// `consumed_utxo` is the existing write path for "this ref is no longer
+    /// unspent"; the boundary is not a transaction, but the effect on the set
+    /// is the same one, and reusing it keeps every backend's ordering rules
+    /// (`StateWriter::apply_utxoset`) in force.
+    pub fn deletion_delta(&self) -> UtxoSetDelta {
+        UtxoSetDelta {
+            consumed_utxo: self.utxos.clone(),
+            ..Default::default()
+        }
+    }
+
+    /// Delete this census from the state store and from the UTxO filter
+    /// indexes, leaving every pot untouched.
+    ///
+    /// This is the repair path — `dolos doctor reclaim-avvm` against a store
+    /// an earlier binary built, where the boundary already moved the value
+    /// and left the rows. The boundary itself does not come through here: it
+    /// stages the same deletion inside its own commit, alongside the pot
+    /// delta it must be atomic with.
+    ///
+    /// Indexes follow the state commit, the order the block path uses. A
+    /// crash between the two leaves an index entry pointing at a ref the
+    /// state no longer holds, which readers already tolerate — they resolve
+    /// refs against the state and drop what is not there. Re-running the
+    /// repair after such a crash finds nothing unspent and does nothing, so
+    /// the stale tags outlive it; the other order would hide a live UTxO
+    /// instead, which is worse.
+    pub fn apply_deletion<D: Domain>(
+        &self,
+        state: &D::State,
+        indexes: &D::Indexes,
+    ) -> Result<(), ChainError> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let delta = self.deletion_delta();
+
+        let writer = state.start_writer()?;
+        writer.apply_utxoset(&delta)?;
+        writer.commit()?;
+
+        // The delta carries the index's own cursor: this changes what the
+        // index holds, never how far it has been advanced.
+        let cursor = indexes.cursor()?.unwrap_or(ChainPoint::Origin);
+
+        let index_writer = indexes.start_writer()?;
+        index_writer.apply(&crate::indexes::index_delta_from_utxo_delta(cursor, &delta))?;
+        index_writer.commit()?;
+
+        Ok(())
+    }
+}

--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -237,11 +237,6 @@ impl super::WorkContext {
         // Conway-boundary `GovGenesisInit`) go through the singleton path.
         self.deltas.apply_singleton::<GovState, _>(state, &writer)?;
 
-        // The Shelley→Allegra AVVM reclamation: the unredeemed AVVM UTxOs
-        // leave the set here, in the very transaction whose `EpochTransition`
-        // moves their value from the `utxos` pot to `reserves`. Both halves
-        // read the same `AvvmReclamation`, so no crash can land one without
-        // the other. `None` — and therefore free — at every other boundary.
         let avvm_deletion =
             (!self.avvm_reclamation.is_empty()).then(|| self.avvm_reclamation.deletion_delta());
 
@@ -285,12 +280,8 @@ impl super::WorkContext {
 
         // The by-address (and every other UTxO filter) index has to lose the
         // reclaimed refs too, or the serving APIs keep answering with outputs
-        // the state store no longer holds. Same ordering as the block path:
-        // indexes follow the state commit, so a crash between the two leaves
-        // an index entry pointing at a ref the state no longer has — which
-        // every reader already tolerates, because it resolves refs against
-        // the state and drops what is not there. The other order would hide
-        // a live UTxO instead.
+        // the state store no longer holds. Indexes follow the state commit;
+        // `AvvmReclamation::apply_deletion` records why that order.
         if let Some(delta) = avvm_deletion.as_ref() {
             // Carry the index's own cursor through: this changes what the
             // index holds, not how far it has been advanced, and

--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -286,7 +286,10 @@ impl super::WorkContext {
             // Carry the index's own cursor through: this changes what the
             // index holds, not how far it has been advanced, and
             // `IndexWriter::apply` writes whatever cursor the delta names.
-            let cursor = indexes.cursor()?.unwrap_or(ChainPoint::Slot(slot));
+            // `None` is the never-indexed store, which bootstrap reads as
+            // "replay the whole WAL": `Origin` keeps saying that, where this
+            // boundary's slot would claim every block before it as indexed.
+            let cursor = indexes.cursor()?.unwrap_or(ChainPoint::Origin);
 
             let delta = crate::indexes::index_delta_from_utxo_delta(cursor, delta);
 

--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -11,7 +11,8 @@
 
 use dolos_core::{
     ArchiveStore, ArchiveWriter, BlockSlot, BrokenInvariant, ChainError, ChainPoint, Domain,
-    Entity, EntityDelta as _, EntityKey, LogKey, NsKey, StateStore, StateWriter, TemporalKey,
+    Entity, EntityDelta as _, EntityKey, IndexStore, IndexWriter, LogKey, NsKey, StateStore,
+    StateWriter, TemporalKey,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -176,11 +177,16 @@ impl super::WorkContext {
     /// runs. The cursor is set only here, so a crash mid-shard restarts
     /// from the boundary block and the pre-finalize state stays at the
     /// previous-epoch cursor.
+    ///
+    /// It is also where the Shelley→Allegra AVVM reclamation deletes its
+    /// UTxOs — see [`crate::estart::avvm`] for why that belongs in the same
+    /// transaction as the pot delta.
     #[instrument(skip_all)]
     pub fn commit_finalize<D: Domain>(
         &mut self,
         state: &D::State,
         archive: &D::Archive,
+        indexes: &D::Indexes,
         slot: BlockSlot,
     ) -> Result<(), ChainError> {
         debug!("committing estart finalize changes");
@@ -231,6 +237,24 @@ impl super::WorkContext {
         // Conway-boundary `GovGenesisInit`) go through the singleton path.
         self.deltas.apply_singleton::<GovState, _>(state, &writer)?;
 
+        // The Shelley→Allegra AVVM reclamation: the unredeemed AVVM UTxOs
+        // leave the set here, in the very transaction whose `EpochTransition`
+        // moves their value from the `utxos` pot to `reserves`. Both halves
+        // read the same `AvvmReclamation`, so no crash can land one without
+        // the other. `None` — and therefore free — at every other boundary.
+        let avvm_deletion =
+            (!self.avvm_reclamation.is_empty()).then(|| self.avvm_reclamation.deletion_delta());
+
+        if let Some(delta) = avvm_deletion.as_ref() {
+            debug!(
+                count = self.avvm_reclamation.utxos.len(),
+                total = self.avvm_reclamation.total,
+                "deleting unredeemed AVVM utxos"
+            );
+
+            writer.apply_utxoset(delta)?;
+        }
+
         // Write era transition if needed (only 2 entities)
         if let Some(transition) = era_transition {
             writer
@@ -259,6 +283,27 @@ impl super::WorkContext {
         writer.commit()?;
         archive_writer.commit()?;
 
+        // The by-address (and every other UTxO filter) index has to lose the
+        // reclaimed refs too, or the serving APIs keep answering with outputs
+        // the state store no longer holds. Same ordering as the block path:
+        // indexes follow the state commit, so a crash between the two leaves
+        // an index entry pointing at a ref the state no longer has — which
+        // every reader already tolerates, because it resolves refs against
+        // the state and drops what is not there. The other order would hide
+        // a live UTxO instead.
+        if let Some(delta) = avvm_deletion.as_ref() {
+            // Carry the index's own cursor through: this changes what the
+            // index holds, not how far it has been advanced, and
+            // `IndexWriter::apply` writes whatever cursor the delta names.
+            let cursor = indexes.cursor()?.unwrap_or(ChainPoint::Slot(slot));
+
+            let delta = crate::indexes::index_delta_from_utxo_delta(cursor, delta);
+
+            let index_writer = indexes.start_writer()?;
+            index_writer.apply(&delta)?;
+            index_writer.commit()?;
+        }
+
         debug!("estart finalize commit complete");
 
         Ok(())
@@ -282,7 +327,7 @@ mod tests {
             active_protocol: EraProtocol::from(9),
             chain_summary: ChainSummary::default(),
             genesis: domain.genesis(),
-            avvm_reclamation: 0,
+            avvm_reclamation: Default::default(),
             deltas: Default::default(),
             logs: Default::default(),
         }

--- a/crates/cardano/src/estart/loading.rs
+++ b/crates/cardano/src/estart/loading.rs
@@ -5,15 +5,16 @@
 //! `compute_shard_deltas`) and the finalize-time global pass
 //! (`compute_global_deltas` / `load_finalize`). The shared boundary state
 //! (ended_state + chain summary + AVVM reclamation) is built by
-//! `new_empty_with_avvm`; `compute_boundary_avvm` exposes the once-per-
-//! boundary AVVM lookup so the work unit can hoist it into `initialize`.
+//! `new_empty_with_avvm`; the once-per-boundary AVVM lookup itself is
+//! `AvvmReclamation::at_boundary`, which the work unit hoists into
+//! `initialize`.
 
 use std::{ops::Range, sync::Arc};
 
-use dolos_core::{ChainError, Domain, EntityKey, Genesis, StateStore, TxoRef};
+use dolos_core::{ChainError, Domain, EntityKey, Genesis, StateStore};
 
 use crate::{
-    estart::{BoundaryVisitor as _, WorkContext},
+    estart::{avvm::AvvmReclamation, BoundaryVisitor as _, WorkContext},
     gov_from_conway_genesis, load_era_summary,
     roll::WorkDeltas,
     AccountState, DRepState, EStartProgress, EraProtocol, FixedNamespace as _, GovGenesisInit,
@@ -87,58 +88,6 @@ impl WorkContext {
         Ok(())
     }
 
-    /// Compute the value of unredeemed AVVM UTxOs at the Shelley→Allegra
-    /// boundary. These UTxOs are removed from the UTxO set and their value
-    /// returned to reserves, matching the Haskell ledger's `translateEra`.
-    fn compute_avvm_reclamation<D: Domain>(
-        state: &D::State,
-        genesis: &Genesis,
-    ) -> Result<u64, ChainError> {
-        let avvm_utxos =
-            pallas::interop::hardano::configs::byron::genesis_avvm_utxos(&genesis.byron);
-
-        // Collect all Byron genesis AVVM UTxO refs (bootstrap redeemer addresses)
-        let refs: Vec<TxoRef> = avvm_utxos.iter().map(|(tx, _, _)| TxoRef(*tx, 0)).collect();
-
-        // Query the UTxO set to find which are still unspent
-        let remaining = state.get_utxos(refs)?;
-
-        // Sum the remaining values
-        let total: u64 = remaining
-            .values()
-            .map(|utxo| {
-                pallas::ledger::traverse::MultiEraOutput::try_from(utxo.as_ref())
-                    .map(|o| o.value().coin())
-                    .unwrap_or(0)
-            })
-            .sum();
-
-        tracing::debug!(
-            remaining_count = remaining.len(),
-            total_avvm = total,
-            "AVVM reclamation at Shelley→Allegra boundary"
-        );
-
-        Ok(total)
-    }
-
-    /// Compute the AVVM reclamation total for the boundary closing the
-    /// current epoch. Returns `0` outside the Shelley→Allegra transition.
-    /// Exposed so the work unit can hoist this once-per-boundary state read
-    /// out of the per-shard `load` calls.
-    pub(crate) fn compute_boundary_avvm<D: Domain>(
-        state: &D::State,
-        genesis: &Genesis,
-    ) -> Result<u64, ChainError> {
-        let ended_state = crate::load_epoch::<D>(state)?;
-        if let Some(transition) = ended_state.pparams.era_transition() {
-            if transition.entering_allegra() {
-                return Self::compute_avvm_reclamation::<D>(state, genesis);
-            }
-        }
-        Ok(0)
-    }
-
     /// Build a fresh `WorkContext` (ended_state + chain summary + AVVM
     /// reclamation) without any computed deltas. Used by the finalize-phase
     /// loader; for the per-shard loader prefer `new_empty_with_avvm` so the
@@ -147,17 +96,17 @@ impl WorkContext {
         state: &D::State,
         genesis: Arc<Genesis>,
     ) -> Result<Self, ChainError> {
-        let avvm_reclamation = Self::compute_boundary_avvm::<D>(state, &genesis)?;
+        let avvm_reclamation = AvvmReclamation::at_boundary::<D>(state, &genesis)?;
         Self::new_empty_with_avvm::<D>(state, genesis, avvm_reclamation)
     }
 
-    /// Variant of `new_empty` that takes a precomputed AVVM reclamation
-    /// total. Used by the per-shard loader so the AVVM state read happens
-    /// once per boundary (in `initialize`) rather than once per shard.
+    /// Variant of `new_empty` that takes a precomputed AVVM reclamation.
+    /// Used by the per-shard loader so the AVVM state read happens once per
+    /// boundary (in `initialize`) rather than once per shard.
     pub(crate) fn new_empty_with_avvm<D: Domain>(
         state: &D::State,
         genesis: Arc<Genesis>,
-        avvm_reclamation: u64,
+        avvm_reclamation: AvvmReclamation,
     ) -> Result<Self, ChainError> {
         let ended_state = crate::load_epoch::<D>(state)?;
         let chain_summary = load_era_summary::<D>(state)?;
@@ -222,7 +171,7 @@ impl WorkContext {
     pub fn load_shard<D: Domain>(
         state: &D::State,
         genesis: Arc<Genesis>,
-        avvm_reclamation: u64,
+        avvm_reclamation: AvvmReclamation,
         shard_index: u32,
         total_shards: u32,
         ranges: Vec<Range<EntityKey>>,

--- a/crates/cardano/src/estart/mod.rs
+++ b/crates/cardano/src/estart/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     EpochState, EraProtocol, PoolState, ProposalState,
 };
 
+pub mod avvm;
 pub mod commit;
 pub mod loading;
 pub mod work_unit;
@@ -29,6 +30,7 @@ pub mod work_unit;
 pub mod nonces;
 pub mod reset;
 
+pub use avvm::AvvmReclamation;
 pub use work_unit::EstartWorkUnit;
 
 pub trait BoundaryVisitor {
@@ -91,8 +93,10 @@ pub struct WorkContext {
     pub chain_summary: ChainSummary,
     pub genesis: Arc<Genesis>,
 
-    /// Unredeemed AVVM UTxOs reclaimed at the Shelley→Allegra boundary.
-    pub avvm_reclamation: u64,
+    /// Unredeemed AVVM UTxOs reclaimed at the Shelley→Allegra boundary:
+    /// the value credited to `reserves` and the refs deleted from the UTxO
+    /// set, which are one event and travel together. Empty everywhere else.
+    pub avvm_reclamation: AvvmReclamation,
 
     // computed via visitors
     pub deltas: WorkDeltas,

--- a/crates/cardano/src/estart/reset.rs
+++ b/crates/cardano/src/estart/reset.rs
@@ -47,7 +47,7 @@ pub fn define_new_pots(ctx: &super::WorkContext) -> Pots {
             .mark()
             .map(|p| p.protocol_major_or_default())
             .unwrap_or_else(|| epoch.pparams.unwrap_live().protocol_major_or_default()),
-        avvm_reclamation: ctx.avvm_reclamation,
+        avvm_reclamation: ctx.avvm_reclamation.total,
     };
 
     tracing::debug!(

--- a/crates/cardano/src/estart/work_unit.rs
+++ b/crates/cardano/src/estart/work_unit.rs
@@ -119,10 +119,9 @@ where
         self.total_shards = progress.map(|p| p.total).unwrap_or(ACCOUNT_SHARDS);
         self.start_shard = progress.map(|p| p.committed).unwrap_or(0);
 
-        // Compute the AVVM reclamation once per boundary instead of once
-        // per shard. Empty unless we're crossing the Shelley→Allegra
-        // hardfork — a one-time chain event, but the per-shard cost adds
-        // up at that boundary.
+        // Empty unless we're crossing the Shelley→Allegra hardfork — a
+        // one-time chain event, but the per-shard cost adds up at that
+        // boundary.
         self.avvm_reclamation = AvvmReclamation::at_boundary::<D>(domain.state(), &self.genesis)?;
 
         debug!(

--- a/crates/cardano/src/estart/work_unit.rs
+++ b/crates/cardano/src/estart/work_unit.rs
@@ -24,7 +24,7 @@ use dolos_core::{BlockSlot, Domain, DomainError, Genesis, WorkUnit};
 use tracing::{debug, info};
 
 use crate::{
-    estart::WorkContext,
+    estart::{AvvmReclamation, WorkContext},
     load_epoch,
     shard::{shard_key_ranges, ACCOUNT_SHARDS},
     CardanoLogic, EpochState,
@@ -50,10 +50,10 @@ pub struct EstartWorkUnit {
     /// rotate every account in the replayed shard).
     start_shard: u32,
 
-    /// AVVM reclamation total for this boundary, computed once in
-    /// `initialize()`. Reused across all shards so the per-shard `load`
-    /// doesn't re-query the UTxO set.
-    avvm_reclamation: u64,
+    /// AVVM reclamation for this boundary, computed once in `initialize()`.
+    /// Reused across all shards so the per-shard `load` doesn't re-query the
+    /// UTxO set.
+    avvm_reclamation: AvvmReclamation,
 
     /// During the per-shard loop, holds the in-flight shard's
     /// `WorkContext` (build-and-discard between shards). After
@@ -70,7 +70,7 @@ impl EstartWorkUnit {
             genesis,
             total_shards: 0,
             start_shard: 0,
-            avvm_reclamation: 0,
+            avvm_reclamation: AvvmReclamation::default(),
             context: None,
         }
     }
@@ -119,18 +119,18 @@ where
         self.total_shards = progress.map(|p| p.total).unwrap_or(ACCOUNT_SHARDS);
         self.start_shard = progress.map(|p| p.committed).unwrap_or(0);
 
-        // Compute AVVM reclamation once per boundary instead of once per
-        // shard. Returns 0 unless we're crossing the Shelley→Allegra
+        // Compute the AVVM reclamation once per boundary instead of once
+        // per shard. Empty unless we're crossing the Shelley→Allegra
         // hardfork — a one-time chain event, but the per-shard cost adds
         // up at that boundary.
-        self.avvm_reclamation =
-            WorkContext::compute_boundary_avvm::<D>(domain.state(), &self.genesis)?;
+        self.avvm_reclamation = AvvmReclamation::at_boundary::<D>(domain.state(), &self.genesis)?;
 
         debug!(
             slot = self.slot,
             total = self.total_shards,
             start = self.start_shard,
-            avvm = self.avvm_reclamation,
+            avvm = self.avvm_reclamation.total,
+            avvm_utxos = self.avvm_reclamation.utxos.len(),
             "estart initialize"
         );
         Ok(())
@@ -149,7 +149,7 @@ where
         let context = WorkContext::load_shard::<D>(
             domain.state(),
             self.genesis.clone(),
-            self.avvm_reclamation,
+            self.avvm_reclamation.clone(),
             shard_index,
             self.total_shards,
             ranges,
@@ -195,7 +195,12 @@ where
 
         info!(epoch = context.starting_epoch_no(), "starting epoch");
 
-        context.commit_finalize::<D>(domain.state(), domain.archive(), self.slot)?;
+        context.commit_finalize::<D>(
+            domain.state(),
+            domain.archive(),
+            domain.indexes(),
+            self.slot,
+        )?;
 
         // Replace the per-shard context with the finalize-phase
         // WorkContext so post-finalize introspection (e.g. `ended_state`

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -2674,7 +2674,7 @@ mod ratification_tests {
         let mut shard = crate::estart::WorkContext::load_shard::<ToyDomain>(
             domain.state(),
             domain.genesis(),
-            0,
+            Default::default(),
             0,
             1,
             ranges.clone(),
@@ -2691,7 +2691,7 @@ mod ratification_tests {
         .unwrap();
         let slot = estart.chain_summary.epoch_start(estart.starting_epoch_no());
         estart
-            .commit_finalize::<ToyDomain>(domain.state(), domain.archive(), slot)
+            .commit_finalize::<ToyDomain>(domain.state(), domain.archive(), domain.indexes(), slot)
             .unwrap();
 
         let after = crate::load_epoch::<ToyDomain>(domain.state()).unwrap();

--- a/crates/cardano/tests/avvm_reclamation.rs
+++ b/crates/cardano/tests/avvm_reclamation.rs
@@ -11,8 +11,8 @@
 use std::sync::Arc;
 
 use dolos_core::{
-    sync::execute_work_unit, ChainPoint, Domain as _, Genesis, IndexStore as _, IndexWriter as _,
-    StateStore as _, StateWriter as _, TxoRef, UtxoSetDelta,
+    builtin::MemoryIndexStore, sync::execute_work_unit, ChainPoint, Domain as _, Genesis,
+    IndexStore as _, IndexWriter as _, StateStore as _, StateWriter as _, TxoRef, UtxoSetDelta,
 };
 use dolos_testing::toy_domain::ToyDomain;
 
@@ -199,6 +199,65 @@ fn allegra_boundary_deletes_unredeemed_avvm_utxos() {
     assert_eq!(after.reserves, before.reserves + UNREDEEMED_AMOUNT);
     assert_eq!(after.utxos, before.utxos - UNREDEEMED_AMOUNT);
     assert_eq!(after.max_supply(), before.max_supply());
+}
+
+/// The fallback the deletion needs when the index store carries no cursor at
+/// all — what a restore that skipped cursor placement leaves behind. `None` is
+/// how bootstrap reads "never indexed, replay the whole WAL"; writing the
+/// boundary's own slot there would claim every block before it as indexed.
+#[test]
+fn a_never_indexed_store_is_left_never_indexed() {
+    let genesis = genesis_with_avvm();
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    let (unredeemed, _) = avvm_entry(&genesis, UNREDEEMED_AMOUNT);
+    schedule_allegra(&domain);
+
+    let blank = MemoryIndexStore::new();
+    assert!(
+        blank.cursor().unwrap().is_none(),
+        "the store starts unindexed"
+    );
+
+    // The boundary by hand rather than through `execute_work_unit`, which
+    // would reach for the domain's own indexes: one account shard, then the
+    // finalize pass that carries the deletion.
+    let ranges = dolos_cardano::shard::shard_key_ranges(0, 1);
+    let mut shard = dolos_cardano::estart::WorkContext::load_shard::<ToyDomain>(
+        domain.state(),
+        genesis.clone(),
+        Default::default(),
+        0,
+        1,
+        ranges.clone(),
+    )
+    .unwrap();
+    shard
+        .commit_shard::<ToyDomain>(domain.state(), domain.archive(), ranges)
+        .unwrap();
+
+    let mut context =
+        dolos_cardano::estart::WorkContext::load_finalize::<ToyDomain>(domain.state(), genesis)
+            .unwrap();
+
+    let slot = context
+        .chain_summary
+        .epoch_start(context.starting_epoch_no());
+
+    context
+        .commit_finalize::<ToyDomain>(domain.state(), domain.archive(), &blank, slot)
+        .unwrap();
+
+    assert!(
+        !is_unspent(&domain, &unredeemed),
+        "the unredeemed AVVM utxo survived the boundary"
+    );
+
+    assert_eq!(
+        blank.cursor().unwrap(),
+        Some(ChainPoint::Origin),
+        "the boundary claimed a never-indexed store as indexed up to its own slot"
+    );
 }
 
 /// A network whose Byron genesis distributes nothing through AVVM —

--- a/crates/cardano/tests/avvm_reclamation.rs
+++ b/crates/cardano/tests/avvm_reclamation.rs
@@ -1,0 +1,365 @@
+//! The Shelley→Allegra AVVM reclamation, driven through the real ESTART
+//! work unit.
+//!
+//! Crossing into Allegra the Haskell ledger deletes every unredeemed Byron
+//! genesis AVVM UTxO and returns its value to `reserves`. Dolos moved the pot
+//! and left the UTxOs in the store; these are the tests that say so. The
+//! harness is `ToyDomain` bound to a devnet genesis given the one thing it
+//! lacks — a non-empty `avvmDistr` — and the boundary is crossed through
+//! `execute_work_unit`, the same executor the node runs.
+
+use std::sync::Arc;
+
+use dolos_core::{
+    sync::execute_work_unit, ChainPoint, Domain as _, Genesis, IndexStore as _, IndexWriter as _,
+    StateStore as _, StateWriter as _, TxoRef, UtxoSetDelta,
+};
+use dolos_testing::toy_domain::ToyDomain;
+
+use dolos_cardano::{
+    estart::{AvvmReclamation, EstartWorkUnit},
+    indexes::utxo_dimensions,
+    pots::Pots,
+    EpochState, SingletonEntity as _,
+};
+
+/// Two base64url ed25519 public keys — the shape a Byron `avvmDistr`
+/// key has. One voucher is redeemed before the boundary, one is not.
+const REDEEMED_KEY: &str = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+const REDEEMED_AMOUNT: u64 = 7_000_000;
+const UNREDEEMED_KEY: &str = "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=";
+const UNREDEEMED_AMOUNT: u64 = 11_000_000;
+
+/// The devnet genesis with the one thing it lacks: a non-empty
+/// `avvmDistr`, which is what mainnet has and preprod/preview do not.
+/// Forced to start in Shelley so the first boundary the harness crosses
+/// is the one into Allegra.
+fn genesis_with_avvm() -> Arc<Genesis> {
+    let mut genesis = dolos_cardano::include::devnet::load();
+
+    genesis.byron.avvm_distr = [
+        (REDEEMED_KEY.to_string(), REDEEMED_AMOUNT.to_string()),
+        (UNREDEEMED_KEY.to_string(), UNREDEEMED_AMOUNT.to_string()),
+    ]
+    .into_iter()
+    .collect();
+
+    genesis.force_protocol = Some(2);
+
+    Arc::new(genesis)
+}
+
+/// The AVVM entry carrying `amount`, as `(ref, address)`.
+fn avvm_entry(genesis: &Genesis, amount: u64) -> (TxoRef, Vec<u8>) {
+    pallas::interop::hardano::configs::byron::genesis_avvm_utxos(&genesis.byron)
+        .into_iter()
+        .find(|(_, _, x)| *x == amount)
+        .map(|(tx, addr, _)| (TxoRef(tx, 0), addr.to_vec()))
+        .expect("the genesis carries an entry of that amount")
+}
+
+/// Consume a UTxO the way a transaction would, state and indexes both —
+/// this is what "the voucher was redeemed" looks like on disk.
+fn redeem(domain: &ToyDomain, txo: &TxoRef) {
+    let found = domain.state().get_utxos(vec![txo.clone()]).unwrap();
+    assert!(!found.is_empty(), "nothing to redeem at {txo:?}");
+
+    let delta = UtxoSetDelta {
+        consumed_utxo: found,
+        ..Default::default()
+    };
+
+    let writer = domain.state().start_writer().unwrap();
+    writer.apply_utxoset(&delta).unwrap();
+    writer.commit().unwrap();
+
+    let index_writer = domain.indexes().start_writer().unwrap();
+    index_writer
+        .apply(&dolos_cardano::indexes::index_delta_from_utxo_delta(
+            ChainPoint::Origin,
+            &delta,
+        ))
+        .unwrap();
+    index_writer.commit().unwrap();
+}
+
+/// Schedule the protocol bump that makes the next boundary the
+/// Shelley→Allegra one.
+fn schedule_allegra(domain: &ToyDomain) {
+    let mut epoch = dolos_cardano::load_epoch::<ToyDomain>(domain.state()).unwrap();
+
+    let live = epoch.pparams.unwrap_live().clone();
+    let next = dolos_cardano::forks::force_pparams_version(&live, &domain.genesis(), 2, 3).unwrap();
+    epoch.pparams.schedule(epoch.number, Some(next));
+
+    let writer = domain.state().start_writer().unwrap();
+    writer
+        .write_entity_typed(&EpochState::singleton_key(), &epoch)
+        .unwrap();
+    writer.commit().unwrap();
+}
+
+/// Run the whole ESTART work unit over the boundary that opens the next
+/// epoch — shards, finalize and all, through the same executor the node
+/// uses.
+fn cross_the_boundary(domain: &ToyDomain) {
+    let summary = dolos_cardano::eras::load_era_summary::<ToyDomain>(domain.state()).unwrap();
+    let epoch = dolos_cardano::load_epoch::<ToyDomain>(domain.state()).unwrap();
+    let slot = summary.epoch_start(epoch.number + 1);
+
+    let mut work = dolos_cardano::CardanoWorkUnit::Estart(Box::new(EstartWorkUnit::new(
+        slot,
+        domain.genesis(),
+    )));
+
+    execute_work_unit(domain, &mut work).unwrap();
+}
+
+fn pots(domain: &ToyDomain) -> Pots {
+    dolos_cardano::load_epoch::<ToyDomain>(domain.state())
+        .unwrap()
+        .initial_pots
+}
+
+fn is_unspent(domain: &ToyDomain, txo: &TxoRef) -> bool {
+    !domain
+        .state()
+        .get_utxos(vec![txo.clone()])
+        .unwrap()
+        .is_empty()
+}
+
+fn indexed_at(domain: &ToyDomain, address: &[u8]) -> usize {
+    domain
+        .indexes()
+        .utxos_by_tag(utxo_dimensions::ADDRESS, address)
+        .unwrap()
+        .len()
+}
+
+/// The whole event, in one crossing: the unredeemed voucher leaves the
+/// UTxO set and the by-address index, the redeemed one is untouched
+/// because it was already gone, every other genesis output stays, and
+/// `reserves` gains exactly what `utxos` lost.
+#[test]
+fn allegra_boundary_deletes_unredeemed_avvm_utxos() {
+    let genesis = genesis_with_avvm();
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    let (redeemed, redeemed_addr) = avvm_entry(&genesis, REDEEMED_AMOUNT);
+    let (unredeemed, unredeemed_addr) = avvm_entry(&genesis, UNREDEEMED_AMOUNT);
+
+    // A non-AVVM genesis output, to show the boundary reaches only the
+    // AVVM half of the distribution.
+    let (bystander, _, _) =
+        pallas::interop::hardano::configs::byron::genesis_non_avvm_utxos(&genesis.byron)
+            .into_iter()
+            .next()
+            .expect("the devnet genesis has non-AVVM balances");
+    let bystander = TxoRef(bystander, 0);
+
+    assert!(is_unspent(&domain, &redeemed));
+    assert!(is_unspent(&domain, &unredeemed));
+    assert_eq!(indexed_at(&domain, &unredeemed_addr), 1);
+
+    redeem(&domain, &redeemed);
+    schedule_allegra(&domain);
+
+    let before = pots(&domain);
+
+    cross_the_boundary(&domain);
+
+    let after = pots(&domain);
+
+    assert!(
+        !is_unspent(&domain, &unredeemed),
+        "the unredeemed AVVM utxo survived the boundary"
+    );
+    assert!(
+        is_unspent(&domain, &bystander),
+        "a non-AVVM genesis utxo was deleted"
+    );
+
+    assert_eq!(
+        indexed_at(&domain, &unredeemed_addr),
+        0,
+        "the by-address index still answers with the deleted utxo"
+    );
+    assert_eq!(indexed_at(&domain, &redeemed_addr), 0);
+
+    assert_eq!(after.reserves, before.reserves + UNREDEEMED_AMOUNT);
+    assert_eq!(after.utxos, before.utxos - UNREDEEMED_AMOUNT);
+    assert_eq!(after.max_supply(), before.max_supply());
+}
+
+/// A network whose Byron genesis distributes nothing through AVVM —
+/// preprod and preview — crosses the same boundary with nothing to
+/// reclaim and nothing to delete.
+#[test]
+fn empty_avvm_distribution_reclaims_nothing() {
+    let mut genesis = dolos_cardano::include::devnet::load();
+    genesis.force_protocol = Some(2);
+    let genesis = Arc::new(genesis);
+
+    assert!(genesis.byron.avvm_distr.is_empty());
+
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    let (bystander, _, _) =
+        pallas::interop::hardano::configs::byron::genesis_non_avvm_utxos(&genesis.byron)
+            .into_iter()
+            .next()
+            .unwrap();
+    let bystander = TxoRef(bystander, 0);
+
+    schedule_allegra(&domain);
+
+    let before = pots(&domain);
+
+    cross_the_boundary(&domain);
+
+    let after = pots(&domain);
+
+    assert!(is_unspent(&domain, &bystander));
+    assert_eq!(after.reserves, before.reserves);
+    assert_eq!(after.utxos, before.utxos);
+}
+
+/// The reclamation is one boundary's event, not every boundary's: a
+/// transition that is not Shelley→Allegra reads no AVVM census and
+/// deletes nothing, even with unredeemed vouchers sitting in the store.
+#[test]
+fn other_boundaries_leave_avvm_utxos_alone() {
+    let genesis = genesis_with_avvm();
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    let (unredeemed, _) = avvm_entry(&genesis, UNREDEEMED_AMOUNT);
+
+    // No scheduled protocol bump: the boundary is an ordinary one.
+    let before = pots(&domain);
+
+    cross_the_boundary(&domain);
+
+    let after = pots(&domain);
+
+    assert!(is_unspent(&domain, &unredeemed));
+    assert_eq!(after.reserves, before.reserves);
+    assert_eq!(after.utxos, before.utxos);
+}
+
+/// Put a UTxO (back) into the state store and the indexes — how a store
+/// built by a pre-fix binary looks after the boundary: the pots reclaimed,
+/// the rows still there.
+fn restore(domain: &ToyDomain, utxos: dolos_core::UtxoMap) {
+    let delta = UtxoSetDelta {
+        produced_utxo: utxos,
+        ..Default::default()
+    };
+
+    let writer = domain.state().start_writer().unwrap();
+    writer.apply_utxoset(&delta).unwrap();
+    writer.commit().unwrap();
+
+    let index_writer = domain.indexes().start_writer().unwrap();
+    index_writer
+        .apply(&dolos_cardano::indexes::index_delta_from_utxo_delta(
+            ChainPoint::Origin,
+            &delta,
+        ))
+        .unwrap();
+    index_writer.commit().unwrap();
+}
+
+/// `dolos doctor reclaim-avvm`'s repair, against the shape it exists for: a
+/// store that crossed the boundary under a pre-fix binary, so the pots are
+/// already right and the rows are still there. It deletes exactly the
+/// unredeemed refs, leaves the pots alone, and the second run has nothing
+/// left to do.
+#[test]
+fn the_repair_deletes_what_a_pre_fix_binary_left_behind() {
+    let genesis = genesis_with_avvm();
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    let (redeemed, _) = avvm_entry(&genesis, REDEEMED_AMOUNT);
+    let (unredeemed, unredeemed_addr) = avvm_entry(&genesis, UNREDEEMED_AMOUNT);
+
+    let (bystander, _, _) =
+        pallas::interop::hardano::configs::byron::genesis_non_avvm_utxos(&genesis.byron)
+            .into_iter()
+            .next()
+            .unwrap();
+    let bystander = TxoRef(bystander, 0);
+
+    let body = domain.state().get_utxos(vec![unredeemed.clone()]).unwrap();
+
+    redeem(&domain, &redeemed);
+    schedule_allegra(&domain);
+    cross_the_boundary(&domain);
+
+    // Undo the deletion the fixed binary just did: this is now, on disk,
+    // exactly the store the defect produced.
+    restore(&domain, body);
+    assert!(is_unspent(&domain, &unredeemed));
+
+    let repaired_pots = pots(&domain);
+
+    assert!(AvvmReclamation::boundary_crossed::<ToyDomain>(domain.state()).unwrap());
+
+    let census = AvvmReclamation::unredeemed::<ToyDomain>(domain.state(), &genesis).unwrap();
+
+    assert_eq!(census.utxos.len(), 1);
+    assert_eq!(census.total, UNREDEEMED_AMOUNT);
+    assert!(census.utxos.contains_key(&unredeemed));
+
+    census
+        .apply_deletion::<ToyDomain>(domain.state(), domain.indexes())
+        .unwrap();
+
+    assert!(!is_unspent(&domain, &unredeemed));
+    assert!(is_unspent(&domain, &bystander));
+    assert_eq!(indexed_at(&domain, &unredeemed_addr), 0);
+    assert_eq!(
+        pots(&domain),
+        repaired_pots,
+        "the repair moved a pot it was supposed to leave alone"
+    );
+
+    // Second run: nothing left, and running it anyway changes nothing.
+    let again = AvvmReclamation::unredeemed::<ToyDomain>(domain.state(), &genesis).unwrap();
+
+    assert!(again.is_empty());
+    assert_eq!(again.total, 0);
+
+    again
+        .apply_deletion::<ToyDomain>(domain.state(), domain.indexes())
+        .unwrap();
+
+    assert!(is_unspent(&domain, &bystander));
+    assert_eq!(pots(&domain), repaired_pots);
+}
+
+/// The guard the repair refuses on: a store that has not been through the
+/// Shelley→Allegra boundary yet, where the reclamation is still the ledger's
+/// to perform.
+#[test]
+fn the_boundary_crossing_is_readable_from_the_store() {
+    let genesis = genesis_with_avvm();
+    let domain = ToyDomain::new_with_genesis(genesis.clone(), None, None);
+
+    assert!(!AvvmReclamation::boundary_crossed::<ToyDomain>(domain.state()).unwrap());
+
+    schedule_allegra(&domain);
+    cross_the_boundary(&domain);
+
+    assert!(AvvmReclamation::boundary_crossed::<ToyDomain>(domain.state()).unwrap());
+}
+
+/// A network that never had a Shelley era — a devnet forced straight into a
+/// later protocol — reads as never having crossed, so the repair refuses
+/// there too rather than deleting on a store whose history has no boundary.
+#[test]
+fn a_store_that_never_had_shelley_reads_as_uncrossed() {
+    let domain = ToyDomain::new(None, None);
+
+    assert!(!AvvmReclamation::boundary_crossed::<ToyDomain>(domain.state()).unwrap());
+}

--- a/crates/cardano/tests/avvm_reclamation.rs
+++ b/crates/cardano/tests/avvm_reclamation.rs
@@ -166,6 +166,7 @@ fn allegra_boundary_deletes_unredeemed_avvm_utxos() {
     schedule_allegra(&domain);
 
     let before = pots(&domain);
+    let index_cursor = domain.indexes().cursor().unwrap();
 
     cross_the_boundary(&domain);
 
@@ -186,6 +187,14 @@ fn allegra_boundary_deletes_unredeemed_avvm_utxos() {
         "the by-address index still answers with the deleted utxo"
     );
     assert_eq!(indexed_at(&domain, &redeemed_addr), 0);
+
+    // The deletion changes what the index holds, never how far it has been
+    // advanced: the boundary's own slot is the state cursor's business.
+    assert_eq!(
+        domain.indexes().cursor().unwrap(),
+        index_cursor,
+        "the boundary deletion moved the index cursor"
+    );
 
     assert_eq!(after.reserves, before.reserves + UNREDEEMED_AMOUNT);
     assert_eq!(after.utxos, before.utxos - UNREDEEMED_AMOUNT);

--- a/src/bin/dolos/data/check/totals.rs
+++ b/src/bin/dolos/data/check/totals.rs
@@ -58,9 +58,32 @@
 //! - **`utxos` and `reserves` at the Shelley→Allegra boundary.** ESTART
 //!   reclaims the unredeemed AVVM UTxOs there, moving value from the one to the
 //!   other by an amount it reads out of the UTxO set and never records. Nothing
-//!   on disk reproduces it once those UTxOs are gone, so that single boundary
-//!   compares every pot except those two. Every other pot at it, and both of
-//!   them at every other boundary, are still compared.
+//!   on disk reproduces it, so that single boundary compares every pot except
+//!   those two. Every other pot at it, and both of them at every other
+//!   boundary, are still compared.
+//!
+//!   The skip stays, and is now permanent rather than incidental. Until the
+//!   reclamation deleted its UTxOs, the store kept accidental evidence of the
+//!   amount: the unredeemed refs were still in the set, untouched, so deriving
+//!   them from the Byron genesis and summing them reproduced the boundary
+//!   figure at any later tip. That is exactly the defect the deletion fixes —
+//!   the outputs the real chain destroyed are gone — and with them the only
+//!   thing on disk the amount could have been recovered from. Recording it
+//!   would mean a new field on the boundary's own snapshot, which is a schema
+//!   change and a separate concern from the deletion.
+//!
+//!   What the deletion *does* fix here is the tip comparison, which needed no
+//!   change to get it: `initial_pots.utxos` has the reclamation subtracted and
+//!   the live scan no longer holds the outputs, so the two finally agree on
+//!   mainnet.
+//!
+//! - **Not a gap, stated because it had to be checked:** the deleted outputs
+//!   are not double-counted as spends. `produced_utxos` / `consumed_utxos` come
+//!   from `RollingStats`, which only block application writes; the reclamation
+//!   goes straight through `StateWriter::apply_utxoset` in the boundary commit
+//!   and touches no rolling figure. It is a boundary event, attributed to
+//!   neither side of the transaction arithmetic — which is what makes the roll
+//!   forward above exact across it.
 //! - **A hand-off whose closing snapshot is incomplete** — no `EndStats`, or no
 //!   live pparams to say whether the Byron or the Shelley delta path applies.
 //!   The snapshot's completeness is check 4 (`epoch-log`)'s finding; this check

--- a/src/bin/dolos/doctor/mod.rs
+++ b/src/bin/dolos/doctor/mod.rs
@@ -6,6 +6,7 @@ use crate::feedback::Feedback;
 mod catchup_stores;
 mod check;
 mod rebuild_state;
+mod reclaim_avvm;
 mod reset_wal;
 mod rollback;
 mod update_entity;
@@ -24,6 +25,9 @@ pub enum Command {
 
     /// rebuild the state store by replaying the local archive
     RebuildState(rebuild_state::Args),
+
+    /// delete the unredeemed Byron AVVM utxos a pre-fix binary left behind
+    ReclaimAvvm(reclaim_avvm::Args),
 
     // Reset WAL position using state cursor
     ResetWal(reset_wal::Args),
@@ -53,6 +57,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         Command::Check(x) => check::run(config, x)?,
         Command::CatchupStores(x) => catchup_stores::run(config, x, feedback)?,
         Command::RebuildState(x) => rebuild_state::run(config, x, feedback)?,
+        Command::ReclaimAvvm(x) => reclaim_avvm::run(config, x)?,
         Command::ResetWal(x) => reset_wal::run(config, x, feedback)?,
         Command::WalIntegrity(x) => wal_integrity::run(config, x)?,
         Command::Rollback(x) => rollback::run(config, x)?,

--- a/src/bin/dolos/doctor/reclaim_avvm.rs
+++ b/src/bin/dolos/doctor/reclaim_avvm.rs
@@ -1,0 +1,128 @@
+//! Repair a store built before the Shelley→Allegra AVVM reclamation deleted
+//! its UTxOs.
+//!
+//! Every mainnet store any released dolos built carries the unredeemed Byron
+//! AVVM outputs the real chain destroyed in December 2020: the boundary moved
+//! their value from the `utxos` pot to `reserves` and left the rows in place.
+//! The fixed binary does both halves, but only for a store synced from genesis
+//! after the fix — an existing instance needs this.
+//!
+//! What it does and does not touch is the whole of its correctness:
+//!
+//! - It deletes the still-unspent AVVM refs from the state store and drops them
+//!   from the UTxO filter indexes.
+//! - It leaves the **pots alone**. They already had the reclamation applied;
+//!   adjusting them here would break the half that is currently right and turn
+//!   a one-sided overcount into an inconsistency nothing checks.
+//! - It derives the ref set from the Byron genesis on every run, through the
+//!   same `AvvmReclamation::genesis_refs` the boundary uses. A recorded census
+//!   is a record of one tip, never an input.
+//!
+//! It is a no-op on a store the fixed binary built (nothing left unspent), a
+//! no-op on preprod and preview (their `avvmDistr` is empty), and refuses to
+//! run on a store that has not yet crossed the boundary — there the reclamation
+//! is still ahead of it and deleting anything would pre-empt the ledger.
+
+use dolos_cardano::estart::AvvmReclamation;
+use dolos_core::config::RootConfig;
+use miette::Context as _;
+use pallas::ledger::traverse::MultiEraOutput;
+
+use dolos::adapters::{storage, DomainAdapter};
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    /// apply the deletion; without it the command only reports what it would
+    /// delete
+    #[arg(long, action)]
+    execute: bool,
+
+    /// print every ref it would delete, one `{tx_hash}#{index} {lovelace}`
+    /// per line
+    #[arg(long, action)]
+    list: bool,
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    crate::common::setup_tracing(&config.logging, &config.telemetry)?;
+
+    let genesis = crate::common::open_genesis_files(&config.genesis)?;
+
+    // State and indexes only: the repair touches neither the WAL nor the
+    // archive, and on a mainnet instance those are the expensive opens.
+    let state = crate::common::open_state_store(config)
+        .map_err(|e| miette::miette!("{e}"))
+        .context("opening the state store")?;
+    let indexes = storage::open_index_store(config)
+        .map_err(|e| miette::miette!("{e}"))
+        .context("opening the index store")?;
+
+    let derived = AvvmReclamation::genesis_refs(&genesis).len();
+
+    if derived == 0 {
+        println!("this network's byron genesis distributes nothing through AVVM; nothing to do");
+        return Ok(());
+    }
+
+    let crossed = AvvmReclamation::boundary_crossed::<DomainAdapter>(&state)
+        .map_err(|e| miette::miette!("{e}"))
+        .context("reading the shelley era summary")?;
+
+    if !crossed {
+        miette::bail!(
+            "this store has not crossed the shelley→allegra boundary yet; the reclamation is \
+             still ahead of it and deleting its utxos now would pre-empt the ledger"
+        );
+    }
+
+    let reclamation = AvvmReclamation::unredeemed::<DomainAdapter>(&state, &genesis)
+        .map_err(|e| miette::miette!("{e}"))
+        .context("reading the unredeemed AVVM utxos")?;
+
+    println!("AVVM REFS DERIVED : {derived}");
+    println!("STILL UNSPENT     : {}", reclamation.utxos.len());
+    println!("LOVELACE PRESENT  : {}", reclamation.total);
+
+    if args.list {
+        // Sorted, so the output diffs cleanly against a recorded census.
+        let mut listed: Vec<String> = reclamation
+            .utxos
+            .iter()
+            .map(|(txo, body)| {
+                let lovelace = MultiEraOutput::try_from(body.as_ref())
+                    .map(|x| x.value().coin())
+                    .unwrap_or_default();
+
+                format!("{}#{} {lovelace}", txo.0, txo.1)
+            })
+            .collect();
+
+        listed.sort();
+
+        for line in listed {
+            println!("{line}");
+        }
+    }
+
+    if reclamation.is_empty() {
+        println!("nothing to delete; this store is already repaired");
+        return Ok(());
+    }
+
+    if !args.execute {
+        println!("dry run; re-run with --execute to delete them");
+        return Ok(());
+    }
+
+    reclamation
+        .apply_deletion::<DomainAdapter>(&state, &indexes)
+        .map_err(|e| miette::miette!("{e}"))
+        .context("deleting the AVVM utxos")?;
+
+    println!(
+        "deleted {} utxos; the pots were left alone",
+        reclamation.utxos.len()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Plan: `plans/dolos-avvm-reclamation-utxo-deletion.md` (Brain/txpipe).
Research behind it: `solution/dolos/kb/pot-tip-divergence/02-avvm-reclamation-utxo-retention.md`.

## The defect

At the Shelley→Allegra boundary the Haskell ledger's `translateEra` deletes
every unredeemed Byron genesis AVVM UTxO and returns its value to `reserves`.
Dolos did only the second half. `compute_avvm_reclamation` derived the refs,
read which were still unspent, summed them, and **threw the refs away**;
`apply_shelley_delta` then moved the value from the `utxos` pot to `reserves`
under a comment describing a UTxO-set removal that never happened.

On mainnet that leaves **465 outputs** holding **318,200,635,000,000 lovelace**
in the store — the whole of the gap `dolos data check` reports, to the lovelace.
They are not inert: the serving APIs return them, ledger evaluation treats them
as spendable, and every stele cut from the store carries them forward. Preprod
and preview ship an empty `avvmDistr`, so mainnet is the only affected network.

## What changed

**The two halves are now one value.** `AvvmReclamation`
(`crates/cardano/src/estart/avvm.rs`) carries the census — the still-unspent
refs *and* their total. The pot delta takes `total`; the deletion takes `utxos`;
both come from the same read, in the same commit.

**Where the deletion sits:** the ESTART finalize commit, in the very state
transaction that applies the `EpochTransition` pot delta and advances the
cursor. That is the answer to the plan's open question — it has to be atomic
with the pot movement, or a crash produces a store where one half landed and
the other did not. The UTxO filter indexes lose the refs immediately after, in
the order the block path already uses (state, then indexes).

**Rollback** is deliberately untreated, argued rather than omitted: boundary
work units write no WAL entry at all, so `SyncExt::rollback` — which unwinds
*blocks* — undoes none of what ESTART does today (pots, snapshot rotation,
nonces, era transition). A deletion staged in the boundary commit is exactly as
recoverable as everything else there. The boundary is mainnet epoch 236
(December 2020), thousands of epochs behind any rollback window. Written up in
the `estart::avvm` module docs.

**`dolos doctor reclaim-avvm`** repairs a store an earlier binary built. It
derives the ref set from the Byron genesis on every run (never from a recorded
census, which is a record of one tip), deletes the still-unspent refs from state
and indexes, and **leaves the pots alone** — they already had the reclamation
applied. Dry run by default; `--execute` commits; `--list` prints
`{tx_hash}#{index} {lovelace}` sorted, so the output diffs against a recorded
census. It refuses a store that has not crossed the boundary (read from the
Shelley `EraSummary`'s `end`), and is a no-op on preprod/preview and on a store
the fixed binary built. It opens state and indexes only — never the WAL or the
archive, which on a mainnet instance are the expensive opens.

**The checker.** `totals.rs`'s module docs record both decisions the plan asked
for:

1. **The `AVVM_POTS` boundary skip stays, and is now permanent.** Until the
   deletion landed, the store kept accidental evidence of the reclaimed amount —
   the unredeemed refs sat in the set untouched, so deriving them from genesis
   and summing reproduced the boundary figure at any later tip. That is exactly
   the defect this fixes, and it removes the only thing on disk the amount could
   have been recovered from. Recording it would mean a new field on the
   boundary's snapshot: a schema change, and a separate concern. What the
   deletion *does* fix, with no checker change, is the **tip** comparison —
   `initial_pots.utxos` has the reclamation subtracted and the live scan no
   longer holds the outputs.
2. **No double-counting.** `produced_utxos`/`consumed_utxos` come from
   `RollingStats`, which only block application writes. The reclamation goes
   straight through `StateWriter::apply_utxoset` in the boundary commit and
   touches no rolling figure. It is a boundary event, attributed to neither side
   of the transaction arithmetic.

## Verification

`crates/cardano/tests/avvm_reclamation.rs` — six tests, driving the real ESTART
work unit through `execute_work_unit` against `ToyDomain` bound to a devnet
genesis given the one thing it lacks, a non-empty `avvmDistr` (the canonical
harness rebound, not a sibling variant):

- `allegra_boundary_deletes_unredeemed_avvm_utxos` — the unredeemed voucher
  leaves the UTxO set and the by-address index, the redeemed one and every
  non-AVVM genesis output are untouched, `reserves` gains exactly what `utxos`
  loses, max supply is conserved. **Fails on `main`** ("the unredeemed AVVM utxo
  survived the boundary"), passes here.
- `empty_avvm_distribution_reclaims_nothing` — preprod/preview's shape.
- `other_boundaries_leave_avvm_utxos_alone` — one boundary's event, not every
  boundary's.
- `the_repair_deletes_what_a_pre_fix_binary_left_behind` — reconstructs the
  defective on-disk shape (crossed boundary, pots reclaimed, rows restored),
  runs the repair, asserts exactly the unredeemed ref goes, the pots do not
  move, and the second run has nothing to do.
- `the_boundary_crossing_is_readable_from_the_store` and
  `a_store_that_never_had_shelley_reads_as_uncrossed` — the repair's guard.

Full local run of everything CI runs, all green:

- `cargo test --workspace --all-targets` — 40 test binaries, 0 failures
- `cargo test --workspace --all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` — 38 binaries, 0 failures
- `cargo test --test smoke -- --ignored` — 6 passed
- `cargo test --test sync --test snapshot -- --ignored` — 8 passed (includes `stele_roundtrip_for_preview_full_explicit`)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean

## Not verified here, and why

Three of the plan's done criteria need the founder's mainnet instance
(`~/dolos-instances/mainnet-gov`, ~205 GB plus 229 GB of segments on an external
volume, on a machine at 87–99 % full): the fresh-sync check past the boundary,
the repair against a copy of that store measured against the recorded 465 /
318,200,635,000,000 census, and `dolos data check` totals on the repaired
instance. The plan names that write as an escalation to the founder rather than
a step to take unilaterally; an escalation record on the plan asks for it.

## Migration note for v1.7

The repair **is** required before restoring from a stele cut by an unfixed
binary, and before publishing one. A stele is cut from the state store, so an
unrepaired mainnet store publishes the 465 rows and every restore inherits them;
a consumer restoring from an already-published unfixed cut has to run
`dolos doctor reclaim-avvm` afterwards. Sequence the repair before the mainnet
publish in `dolos-v1-7-release` workstream 2.

## Out of scope

The 1,000,000,000 supply residual (finding 1 of the research) is untouched by
design — its persistence after the repair is the evidence that this change moved
only what it should.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic reclamation of unredeemed AVVM outputs when crossing the Shelley-to-Allegra boundary.
  - Added the `avvm reclaim` diagnostic command to preview or execute cleanup of recoverable outputs and indexes.
  - Added reporting and sorted per-reference listing for reclamation checks.

- **Bug Fixes**
  - Reclaimed outputs are removed from state and indexes while preserving pots and total supply.
  - Added repair support for stores created before this fix, including safe repeated execution.

- **Documentation**
  - Clarified boundary comparison behavior and reclaimed-output accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->