### PR TITLE
ci: run the Windows and full e2e jobs on merges to main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -86,8 +86,24 @@ jobs:
         run: cargo test --workspace --all-targets
 
       - name: Run e2e smoke tests
-        if: runner.os != 'Windows'
         run: cargo test --test smoke -- --ignored
+
+  # Windows is the slowest job and skips e2e, so on a PR it adds latency without
+  # coverage anyone acts on. A Windows-only break lands on main and is caught by
+  # the merge run instead of blocking the PR.
+  test-windows:
+    name: Test (windows-latest)
+    if: github.ref == 'refs/heads/main'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@1.91
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run unit tests
+        run: cargo test --workspace --all-targets
 
   # AGENTS.md prescribes verifying with `--all-features`, which enables
   # feature-gated code (notably the `strict` epoch-coherence assertions in
@@ -113,11 +129,12 @@ jobs:
           save-if: false
       - run: cargo test --workspace --all-targets --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp
 
-  # These sleep on a real relay rather than compute, and cover nothing
-  # platform-specific, so one run replaces the Linux and macOS copies. Smoke
-  # stays on the matrix for the OS-sensitive surface: ports, socket, shutdown.
+  # These sleep on a real relay rather than compute, so they are slow and only
+  # as reliable as the relay. Run them on merges to main; smoke stays on the
+  # matrix everywhere and covers ports, socket and shutdown on every PR.
   e2e:
     name: E2E (sync, snapshot)
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Stacked on #1251 — review that one first.

Two jobs dominate what a PR author waits on without telling them much.

**Windows** links far more slowly than the Unix runners and skips the e2e scenarios entirely, so it sets the critical path at 379s against ~240s for everything else while buying compile coverage and nothing else. Lifted out of the matrix into its own gated job rather than selecting the matrix by ref — that would keep it to one job, but only through a `fromJSON` conditional considerably harder to read than a plain `if`. As a bonus the matrix is now Unix-only, so the smoke step no longer needs its `runner.os != 'Windows'` guard.

**The full e2e scenarios** (`sync`, `snapshot`) sleep on a real relay rather than compute, which makes them both slow (260s, nearly all of it `thread::sleep`) and only as reliable as the relay — a poor thing to gate every PR on.

**Smoke stays on the matrix everywhere.** Every PR still covers daemon startup, port binding, socket-file lifecycle and graceful shutdown, on both Linux and macOS.

## Why the ref and not the event

Both work today: `on.push.branches` is already filtered to `[main]`, so a push to a PR branch fires only `pull_request`. But `github.event_name == 'push'` borrows its correctness from a filter ten lines away and would start matching silently if another branch were ever added there. On a `pull_request` the ref is `refs/pull/N/merge`, so the ref check states the intent where it's read.

## Tradeoff

Deliberate, and worth stating plainly: a Windows-only break, or a sync/snapshot regression, now lands on main and is caught by the merge run within minutes rather than blocking the PR that introduced it. It costs a red main and a follow-up fix instead of review latency on every unrelated change. Release builds are tag-triggered and cover Windows separately (`release.yml`), so nothing ships unbuilt.

If the team would rather not accept that, this PR can simply be dropped — #1251 stands on its own and delivers 9m40 → 6m24 without it.

## Expected

PR runs bounded by macOS at ~215s, so **~4 min**. Merges to main keep the full matrix plus e2e at ~6m24.

Note the Windows job now keys its cache off its own job name, so its first run after merge rebuilds cold once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)