### PR TITLE
fix(stelae): retry a read the OS interrupted instead of failing the layer

### DIFF
--- a/crates/stelae/src/digest.rs
+++ b/crates/stelae/src/digest.rs
@@ -15,7 +15,7 @@
 //! hashed on the way in, compressed, and hashed again on the way out. Nothing
 //! is buffered, so a layer of any size costs one sequential scan.
 
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 
 use sha2::{Digest as _, Sha256};
 
@@ -187,7 +187,7 @@ pub fn digest_reader<R: Read>(mut source: R) -> Result<(Digest, u64), Error> {
     let mut total = 0u64;
 
     loop {
-        let read = source.read(&mut buffer)?;
+        let read = read_uninterrupted(&mut source, &mut buffer)?;
         if read == 0 {
             break;
         }
@@ -243,7 +243,7 @@ fn digest_blob<R: Read, W: Write>(
         let mut buffer = [0u8; 64 * 1024];
 
         loop {
-            let read = decoder.read(&mut buffer)?;
+            let read = read_uninterrupted(&mut decoder, &mut buffer)?;
             if read == 0 {
                 break;
             }
@@ -277,6 +277,32 @@ fn digest_blob<R: Read, W: Write>(
         uncompressed_size,
         compressed_size,
     })
+}
+
+/// [`Read::read`], with `ErrorKind::Interrupted` treated as "read again".
+///
+/// A bare `read` propagates `Interrupted`; only `std`'s convenience readers
+/// (`io::copy`, `read_exact`, `read_to_end`) retry it, which is why the habit
+/// is easy to miss in a hand-written loop. Every loop in this crate that drives
+/// a source to EOF goes through here instead, because the sources are no longer
+/// local files: an `oci://` publish or restore reads a network stream for hours
+/// on a process that installs signal handlers, and a spurious mid-restore
+/// failure there costs the whole run and reads as corruption.
+///
+/// Unbounded, like `std`'s own readers: a source that returns `Interrupted`
+/// forever is a source that never delivers a byte, and inventing a retry
+/// ceiling here would turn "no progress" into a different error rather than
+/// into progress.
+pub(crate) fn read_uninterrupted<R: Read + ?Sized>(
+    source: &mut R,
+    buffer: &mut [u8],
+) -> std::io::Result<usize> {
+    loop {
+        match source.read(buffer) {
+            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            other => return other,
+        }
+    }
 }
 
 /// Hashes and counts every byte that passes through, in either direction.

--- a/crates/stelae/src/frame.rs
+++ b/crates/stelae/src/frame.rs
@@ -39,7 +39,7 @@ use std::{
     ops::Range,
 };
 
-use crate::{Error, LAYER_FORMAT_VERSION};
+use crate::{digest::read_uninterrupted, Error, LAYER_FORMAT_VERSION};
 
 /// Maximum nesting depth accepted by the canonical-form scanner.
 ///
@@ -882,7 +882,7 @@ impl<R: Read> RecordReader<R> {
             self.window.resize(required.min(self.limits.max_record), 0);
         }
 
-        let read = self.source.read(&mut self.window[self.filled..])?;
+        let read = read_uninterrupted(&mut self.source, &mut self.window[self.filled..])?;
 
         if read == 0 {
             self.eof = true;

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -117,7 +117,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{Read, Seek, SeekFrom, Write},
+    io::{Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
@@ -135,7 +135,7 @@ use oci_client::{
 pub use oci_client::Reference;
 
 use crate::{
-    digest::{LayerDigests, LayerWriter},
+    digest::{read_uninterrupted, LayerDigests, LayerWriter},
     frame::{CanonicalCbor, Limits, SeqWriter},
     inscription::{canonical_json, Inscription, LayerDescriptor},
     layer::LayerReader,
@@ -1593,7 +1593,7 @@ fn blob_stream(
             let mut filled = 0usize;
 
             while filled < chunk.len() {
-                match file.read(&mut chunk[filled..]) {
+                match read_uninterrupted(&mut file, &mut chunk[filled..]) {
                     Ok(0) => break,
                     Ok(read) => filled += read,
                     Err(e) => return Some((Err(e.into()), None)),

--- a/crates/stelae/tests/interrupted.rs
+++ b/crates/stelae/tests/interrupted.rs
@@ -1,0 +1,192 @@
+//! A read that was interrupted is not a read that failed.
+//!
+//! `Read::read` is allowed to return `ErrorKind::Interrupted` at any moment —
+//! on Unix that is a syscall cut short by a signal delivered to the process,
+//! and it says nothing about the source except "ask again". `std` retries it
+//! inside `io::copy`, `read_exact` and `read_to_end`, and nowhere else, so a
+//! hand-written loop over a bare `read` inherits the opposite behaviour by
+//! default: one signal, one aborted read, one failed layer.
+//!
+//! That was survivable while every source here was a local file. It is not now:
+//! an `oci://` publish or restore drives these same loops over a network stream
+//! for hours, inside a process that installs signal handlers, and a spurious
+//! failure mid-restore costs the whole run and reads to an operator like a
+//! corrupt stele.
+//!
+//! Every test below reads through [`Interrupting`], which raises `Interrupted`
+//! before *every* successful read and then hands over a few bytes.
+//! Interruptions therefore land between records and inside them, and the
+//! results — records, digests, sizes, content — must be indistinguishable from
+//! a read of the same bytes that was never interrupted.
+
+use std::io::{self, Read, Write as _};
+
+use stelae::{
+    digest::{digest_reader, read_blob, scan_blob},
+    frame::{encode, Limits, RecordReader, SeqWriter},
+    LayerWriter,
+};
+
+/// A source that returns `ErrorKind::Interrupted` before every successful read,
+/// and yields at most `chunk` bytes when it does succeed.
+///
+/// `chunk` is deliberately not a multiple of the record size: a source that
+/// only ever stopped on a record boundary would leave the harder half of the
+/// property — an interruption in the middle of a record the reader is still
+/// assembling — untested.
+struct Interrupting<'a> {
+    remaining: &'a [u8],
+    chunk: usize,
+    interrupt_next: bool,
+    interruptions: usize,
+}
+
+impl<'a> Interrupting<'a> {
+    fn new(bytes: &'a [u8], chunk: usize) -> Self {
+        Self {
+            remaining: bytes,
+            chunk,
+            interrupt_next: true,
+            interruptions: 0,
+        }
+    }
+}
+
+impl Read for Interrupting<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.interrupt_next {
+            self.interrupt_next = false;
+            self.interruptions += 1;
+            return Err(io::Error::new(io::ErrorKind::Interrupted, "signal"));
+        }
+
+        self.interrupt_next = true;
+
+        let take = self.chunk.min(buf.len()).min(self.remaining.len());
+        buf[..take].copy_from_slice(&self.remaining[..take]);
+        self.remaining = &self.remaining[take..];
+
+        Ok(take)
+    }
+}
+
+const RECORDS: u64 = 256;
+
+/// Not a divisor of any record's encoded length, so the cut points walk across
+/// record boundaries rather than lining up with them.
+const CHUNK: usize = 7;
+
+fn record(i: u64) -> stelae::CanonicalCbor {
+    encode(|e| {
+        e.array(2)?
+            .u64(i)?
+            .str("a repeated payload that compresses")?;
+        Ok(())
+    })
+    .unwrap()
+}
+
+fn sequence() -> Vec<u8> {
+    let mut writer = SeqWriter::new(Vec::new());
+
+    for i in 0..RECORDS {
+        writer.write_record(&record(i)).unwrap();
+    }
+
+    writer.into_inner()
+}
+
+fn layer_blob(content: &[u8]) -> Vec<u8> {
+    let mut writer = LayerWriter::new(Vec::new(), 9).unwrap();
+    writer.write_all(content).unwrap();
+    writer.finish().unwrap().0
+}
+
+/// `RecordReader::fill` refills a bounded window from the stream. An
+/// interruption there used to end the walk with an `Io` error partway through a
+/// layer; the whole sequence has to come out instead, in order, once.
+#[test]
+fn a_record_reader_walks_an_interrupted_stream_to_the_end() {
+    let bytes = sequence();
+
+    let mut source = Interrupting::new(&bytes, CHUNK);
+    let mut reader = RecordReader::with_limits(
+        &mut source,
+        Limits {
+            // Small enough that the window refills many times over the
+            // sequence, so the retry is exercised on every kind of boundary.
+            window: 128,
+            ..Default::default()
+        },
+    );
+
+    let mut seen = Vec::new();
+    while let Some(next) = reader.next_record() {
+        seen.push(next.unwrap().to_vec());
+    }
+
+    assert!(!reader.failed());
+    assert_eq!(reader.count(), RECORDS);
+    assert_eq!(
+        seen,
+        (0..RECORDS)
+            .map(|i| record(i).as_ref().to_vec())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        source.interruptions > RECORDS as usize,
+        "the source should have interrupted far more often than once per record, \
+         got {}",
+        source.interruptions
+    );
+}
+
+/// `digest_reader` is what checks a stored blob against the digest it is named
+/// by. An interruption must not turn a good blob into a failed verification.
+#[test]
+fn digest_reader_hashes_every_byte_of_an_interrupted_stream() {
+    let blob = layer_blob(&sequence());
+    let expected = digest_reader(blob.as_slice()).unwrap();
+
+    let interrupted = digest_reader(Interrupting::new(&blob, CHUNK)).unwrap();
+
+    assert_eq!(interrupted, expected);
+    assert_eq!(interrupted.1, blob.len() as u64);
+}
+
+/// Both blob readers run the decompressor over the stream, so the interruption
+/// surfaces underneath zstd rather than at the top of the loop. Digests, sizes
+/// and the uncompressed content all have to match the uninterrupted read.
+#[test]
+fn a_blob_reads_back_identically_through_interruptions() {
+    let content = sequence();
+    let blob = layer_blob(&content);
+    let expected = scan_blob(blob.as_slice()).unwrap();
+
+    let scanned = scan_blob(Interrupting::new(&blob, CHUNK)).unwrap();
+    assert_eq!(scanned, expected);
+
+    let (read, digests) =
+        read_blob(Interrupting::new(&blob, CHUNK), expected.uncompressed_size).unwrap();
+    assert_eq!(read, content);
+    assert_eq!(digests, expected);
+}
+
+/// The retry is for `Interrupted` and nothing else: a source that fails for a
+/// real reason still fails, and it fails at the loop that read it.
+#[test]
+fn a_real_io_error_still_ends_the_read() {
+    struct Broken;
+
+    impl Read for Broken {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::ConnectionReset, "peer went"))
+        }
+    }
+
+    assert!(digest_reader(Broken).is_err());
+    assert!(scan_blob(Broken).is_err());
+
+    let mut reader = RecordReader::new(Broken);
+    assert!(reader.next_record().unwrap().is_err());
+}

--- a/crates/stelae/tests/interrupted.rs
+++ b/crates/stelae/tests/interrupted.rs
@@ -1,17 +1,8 @@
 //! A read that was interrupted is not a read that failed.
 //!
-//! `Read::read` is allowed to return `ErrorKind::Interrupted` at any moment —
-//! on Unix that is a syscall cut short by a signal delivered to the process,
-//! and it says nothing about the source except "ask again". `std` retries it
-//! inside `io::copy`, `read_exact` and `read_to_end`, and nowhere else, so a
-//! hand-written loop over a bare `read` inherits the opposite behaviour by
-//! default: one signal, one aborted read, one failed layer.
-//!
-//! That was survivable while every source here was a local file. It is not now:
-//! an `oci://` publish or restore drives these same loops over a network stream
-//! for hours, inside a process that installs signal handlers, and a spurious
-//! failure mid-restore costs the whole run and reads to an operator like a
-//! corrupt stele.
+//! Why the crate retries `ErrorKind::Interrupted` at all is stated once, on
+//! `digest::read_uninterrupted`; what these tests add is that the three loops
+//! routed through it actually hold the property under interruption.
 //!
 //! Every test below reads through [`Interrupting`], which raises `Interrupted`
 //! before *every* successful read and then hands over a few bytes.


### PR DESCRIPTION
Plan: `plans/dolos-stelae-crate-hardening.md` (Brain/txpipe).

## An interrupted read was treated as a failed read

`digest::digest_reader`, `digest::digest_blob`, `frame::RecordReader::fill` and
`oci::blob_stream` each drive a source to EOF over a bare `Read::read` and
propagate whatever comes back. `std` does not retry `ErrorKind::Interrupted` on a bare `read` —
its convenience readers (`io::copy`, `read_exact`, `read_to_end`) do, which is
why the habit is easy to miss. So a syscall cut short by a signal ended the
read as a failure.

Survivable while every source was a local file. Not now: the same loops read a
network stream for hours on the shipped `oci://` publish and restore paths, in
a process that installs signal handlers, where a spurious failure mid-restore
costs the whole run and reads to an operator like a corrupt stele. The write
path already goes through `write_all`, which retries; this is the read side
catching up.

### What changed

- `digest::read_uninterrupted` — one crate-internal helper next to `Tap`, which
  is the existing home for io adapters shared across these modules. Unbounded,
  like `std`'s own readers: a source that returns `Interrupted` forever is a
  source that never delivers a byte, and a retry ceiling here would turn "no
  progress" into a different error rather than into progress.
- All four loops read through it. Nothing else in the crate changed; the
  pass-through adapters (`Tap`, `Meter`) still hand their inner `read` straight
  back, because retrying is the consuming loop's job.
- `oci::blob_stream` — the fourth, added after review. It fills an
  `UPLOAD_CHUNK` from the staging file on the publish path and turned any `Err`
  into a failed upload stream. It was outside the plan's stated scope and was
  first reported rather than changed; the owner then widened the plan, on the
  grounds that the claim the helper makes is about the loop *set*, not about the
  three loops the original finding happened to land on. `std::io::Read` leaves
  the import list with the last bare `read` that needed it.

  No new test for this one: `blob_stream` takes a concrete `File` and cannot be
  handed a fake source without being made generic, and applying an
  already-covered helper at a fourth call site is not a fourth behaviour to
  cover. `grep -n '\.read(' crates/stelae/src/*.rs` now returns only
  `digest.rs:301` (the helper) and the two adapter pass-throughs.
- `crates/stelae/tests/interrupted.rs` — a source that raises `Interrupted`
  before *every* successful read and then yields 7 bytes, so interruptions land
  between records and inside them. `RecordReader` must still yield all 256
  records in order; `digest_reader`, `scan_blob` and `read_blob` must return
  digests, sizes and content identical to an uninterrupted read of the same
  bytes. A fourth test pins that the retry is for `Interrupted` and nothing
  else — a `ConnectionReset` source still fails, at the loop that read it.

All three property tests fail on `main` without the source change (verified by
stashing it) and pass with it.

## Verification

Run on macOS (aarch64), against `main` at 135cfc68:

- `cargo test -p stelae` — 109 passed, 0 failed (73 unit, 4 interrupted, 3
  memory, 5 rfc8785, 21 toy_profile, 3 doc).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo deny check advisories` — `advisories ok`.
- `cargo tree -p stelae -e normal --all-features` — still matches no
  `^dolos(-|$)`; the crate boundary holds.
- `grep -n '\.read(' crates/stelae/src/*.rs` — three sites, all of them
  legitimate: the helper and the two `Read`-adapter pass-throughs. No
  drive-to-EOF loop is left outside `read_uninterrupted`.
- `cargo test -p dolos --test memory` — 20 consecutive runs, 20 passed, 0
  failed, thresholds unchanged. See below.

## Note: the flaky memory check is already fixed on `main`

The plan also carried a second finding — `tests/memory.rs` in the root package
failing at random because `stats_alloc`'s `Region` reads a process-wide counter
while the harness runs the file's tests in parallel. That was fixed in #1150
(2026-08-03), which put `serial_test::serial` on all six tests in the file;
because each test does its own seeding inside its body, the lock covers setup
as well, which is exactly the repair the plan asked for. Twenty consecutive
runs pass here with thresholds unchanged, so this PR changes nothing there.

## Note: `Test (windows-latest)` is skipped on PRs

The plan's done criterion asks for the CI matrix green on all three platforms.
#1251 (merged to `main` earlier today) gated `test-windows` on
`github.ref == 'refs/heads/main'` deliberately — Windows is the slowest job,
skips e2e, and a Windows-only break is caught by the merge run instead of
blocking the PR. So two of three platforms are green here and Windows runs on
merge. The change is platform-neutral either way: `ErrorKind::Interrupted` is
the EINTR case, which Windows does not raise, and the retry loop compiles and
behaves identically there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5jZPeQWaTgsjEXGJjqyKn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability when reads are temporarily interrupted, preventing valid operations from failing unexpectedly.
  * Record iteration, digest calculation, compressed data scanning, and blob reading now continue correctly after transient interruptions.
  * Genuine I/O errors continue to be reported normally.

* **Tests**
  * Added coverage for interrupted reads across records, digests, compressed data, and blob contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
