### PR TITLE
perf(snapshot): band the index traversal across a run of epochs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ anyhow = "1.0"
 comfy-table = "7.1.1"
 csv = "1"
 csv-diff = "0.1"
-nix = { version = "0.30.1", features = ["signal"] }
+nix = { version = "0.30.1", features = ["signal", "resource"] }
 serde = { workspace = true }
 tempfile = "3.20.0"
 toml = "0.8.13"

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -866,10 +866,19 @@ where
     // Banded rather than one window at a time: an index layer costs a pass over
     // the whole store, so this loop is where a first publish's O(N²) lives.
     // See [`IndexBand`].
+    //
+    // No `landed` here, unlike the loops around it: a band tells the
+    // predecessor about each of its layers the moment that layer exists, rather
+    // than when the band it belongs to is over. See [`write_indexes`].
     for band in plan.epochs.chunks(plan.band.epochs()) {
-        for descriptor in write_indexes(stele, plan, indexes, band, previous, &mut cursor)? {
-            landed(descriptor, previous, &mut layers)?;
-        }
+        layers.extend(write_indexes(
+            stele,
+            plan,
+            indexes,
+            band,
+            previous,
+            &mut cursor,
+        )?);
     }
 
     // Kind-major, like the two loops above: the inscription lists layers in
@@ -1497,6 +1506,23 @@ fn log_key_range(slots: &Range<BlockSlot>) -> Range<LogKey> {
 /// are routed to no one. Same for a window an operator's `--epochs` left out
 /// between two that stayed — the traversal spans the band in one range and
 /// cannot exclude either, so the routing does.
+///
+/// ## Each layer is recorded when it exists, not when the band ends
+///
+/// [`Predecessor::landed`] is what an interrupted publish resumes from, so this
+/// calls it per layer — an inherited one before the traversal starts, a built
+/// one the moment its sink finishes — instead of once for the band on the way
+/// out. The difference is only visible when a publish dies mid-band, which is
+/// exactly when the record is worth having: an inherited layer the transport is
+/// already carrying stays recorded even though the band it sat in never
+/// finished. That is also why this function, alone among the layer writers,
+/// does its own recording rather than leaving it to [`landed`].
+///
+/// What banding does cost is resume *granularity* for the layers it builds: K
+/// sinks finish together, so a death inside a traversal loses that band's built
+/// index layers rather than the ones before the dying epoch. There is nothing
+/// to save there — resuming into the middle of a band would have to re-traverse
+/// the store for the rest of it anyway.
 fn write_indexes<W: SteleWriter, I: IndexStore>(
     stele: &W,
     plan: &Plan,
@@ -1521,6 +1547,8 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
         match adopted {
             Some(descriptor) => {
                 cursor.close(at, INDEXES, Outcome::Inherited);
+
+                previous.landed(&descriptor)?;
                 descriptors.push(Some(descriptor));
             }
             None => {
@@ -1568,6 +1596,7 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
         let descriptor = layer.sink.finish()?.descriptor;
         cursor.close(layer.at, INDEXES, Outcome::Transferred);
 
+        previous.landed(&descriptor)?;
         descriptors[layer.position] = Some(descriptor);
     }
 

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -55,14 +55,14 @@
 //! records, but obtaining them means a Mithril aggregator and a certificate
 //! check, which is publisher plumbing. No restore, no signatures.
 
-use std::{collections::BTreeMap, ops::Range};
+use std::{collections::BTreeMap, num::NonZeroUsize, ops::Range};
 
 use dolos_cardano::{
     eras::ChainSummary, indexes::archive_dimensions, pallas::ledger::traverse::MultiEraBlock,
 };
 use dolos_core::{
-    ArchiveStore, BlockSlot, ChainPoint, EntityKey, IndexStore, LogKey, Namespace, StateStore,
-    TemporalKey,
+    ArchiveStore, BlockSlot, ChainPoint, EntityKey, IndexRecord, IndexStore, LogKey, Namespace,
+    StateStore, TemporalKey,
 };
 use stelae::{
     inscription::{HistoryEntry, Inscription, LayerDescriptor},
@@ -107,6 +107,98 @@ impl EpochWindow {
     }
 }
 
+/// How many `indexes` layers one traversal of the index store fills.
+///
+/// ## Why a publish needs a band at all
+///
+/// Neither index traversal can seek to a slot — a tag's slot is the last
+/// component of its key and an exact record's slot is its stored *value* — so
+/// reading one epoch out of the store costs a pass over the whole of it. One
+/// pass per epoch makes a first publish of N epochs O(N²): measured at 800 ms
+/// per epoch against an eight-epoch store and 3.0 s against a thirty-two-epoch
+/// one, which extrapolates to hours of nothing but index traversal on mainnet.
+///
+/// A band routes one pass into K sinks at once — the move the state pass makes
+/// with its shard sinks — so N epochs cost ⌈N/K⌉ passes rather than N.
+///
+/// ## Why K is not simply N
+///
+/// Every open sink holds a zstd compression context at
+/// [`COMPRESSION_LEVEL`](crate::COMPRESSION_LEVEL), and those contexts are the
+/// resident cost of holding layers open: measured at 10.3 MiB apiece, so K = N
+/// on mainnet would be a multi-gigabyte resident set — exactly what
+/// streaming-writes exists to prevent. K is therefore a memory budget divided
+/// by that figure and not a taste: [`IndexBand::DEFAULT`] is the largest band
+/// that keeps the index pass inside a **1 GiB** ceiling, and an operator with
+/// less to spend narrows it with `--index-band`.
+///
+/// Banding reorders *when* records are read and never which layer they land in
+/// or in what order, so K is invisible in the bytes: the export golden and the
+/// two-backend determinism test hold across every value of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexBand(NonZeroUsize);
+
+impl IndexBand {
+    /// The resident cost of one open layer sink.
+    ///
+    /// A zstd compression context at level 9 and the framing around it.
+    /// Measured at **10.3 MiB** by `measure_layer_sink_residency` in the root
+    /// package's `tests/index_roundtrip.rs` — thirty-two sinks opened against a
+    /// real stele and each given records to compress, since a context that has
+    /// never compressed anything has not yet allocated its window. Pinned above
+    /// the measurement rather than at it, so a zstd whose level-9 parameters
+    /// grow does not silently overrun the ceiling.
+    ///
+    /// A constant because [`DEFAULT`](IndexBand::DEFAULT) is arithmetic over it
+    /// rather than a number someone liked.
+    pub const SINK_BYTES: usize = 12 * 1024 * 1024;
+
+    /// What the index pass may hold resident.
+    ///
+    /// A publish is a batch job an operator starts on a node that is already
+    /// holding a ledger, so this is a budget for one *phase* of it rather than
+    /// for the process. A gigabyte buys 85 epochs per traversal, which takes
+    /// mainnet's ~580 epochs from 580 passes to seven; the next gigabyte buys
+    /// the difference between seven passes and four, which is the wrong trade.
+    pub const CEILING_BYTES: usize = 1024 * 1024 * 1024;
+
+    /// The band a publish takes unless an operator narrows it.
+    pub const DEFAULT: Self = match NonZeroUsize::new(Self::CEILING_BYTES / Self::SINK_BYTES) {
+        Some(epochs) => Self(epochs),
+        // Unreachable: the ceiling is larger than one sink. A `const` panic
+        // rather than a fallback, so a ceiling edited below one sink's cost
+        // fails to compile instead of silently banding by one.
+        None => panic!("the index band ceiling has to hold at least one sink"),
+    };
+
+    /// A band of `epochs` layers. Zero is not representable, which is the
+    /// refusal: a band of no epochs would traverse and write nothing.
+    pub fn new(epochs: NonZeroUsize) -> Self {
+        Self(epochs)
+    }
+
+    pub fn epochs(&self) -> usize {
+        self.0.get()
+    }
+
+    /// What this band budgets for the sinks it holds open, for a caller
+    /// reporting the trade it is making.
+    ///
+    /// The budget rather than a measurement:
+    /// [`SINK_BYTES`](IndexBand::SINK_BYTES) is pinned above what a sink
+    /// was measured to cost, so this is an upper bound and reads a little
+    /// high on purpose.
+    pub fn resident_bytes(&self) -> usize {
+        self.epochs() * Self::SINK_BYTES
+    }
+}
+
+impl Default for IndexBand {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 /// What a publish covers: where the node stands, and which epochs its layers
 /// describe.
 ///
@@ -129,6 +221,16 @@ pub struct Plan {
     /// derived from `summary` — which epochs are worth a dump is operational
     /// (decision 0026).
     pub retained: RetainedEpochs,
+    /// How many `indexes` layers one traversal of the index store fills.
+    ///
+    /// Execution rather than geometry, and the one field here that is: it
+    /// changes neither which layers this publish writes nor a byte of what is
+    /// in them, only how many passes over the index store it takes to fill
+    /// them. It rides on the plan because every driver that walks these stores
+    /// — [`export`], [`reproduce`], [`verify_reproduction`] — pays the same
+    /// cost and should take the same band without each call site spelling it.
+    /// See [`IndexBand`].
+    pub band: IndexBand,
 }
 
 impl Plan {
@@ -171,7 +273,19 @@ impl Plan {
             sequence: tip_epoch,
             epochs,
             retained,
+            band: IndexBand::DEFAULT,
         })
+    }
+
+    /// Take a band other than [`IndexBand::DEFAULT`].
+    ///
+    /// The same builder shape as [`restrict_epochs`](Plan::restrict_epochs),
+    /// and for the same reason: the CLI is where an operator's choice is
+    /// spelled, and it applies it to a plan the rules already built.
+    pub fn with_band(mut self, band: IndexBand) -> Self {
+        self.band = band;
+
+        self
     }
 
     /// Keep only the epoch layers within `first..=last`.
@@ -749,12 +863,13 @@ where
         )?;
     }
 
-    for window in &plan.epochs {
-        landed(
-            write_indexes(stele, plan, indexes, window, previous, &mut cursor)?,
-            previous,
-            &mut layers,
-        )?;
+    // Banded rather than one window at a time: an index layer costs a pass over
+    // the whole store, so this loop is where a first publish's O(N²) lives.
+    // See [`IndexBand`].
+    for band in plan.epochs.chunks(plan.band.epochs()) {
+        for descriptor in write_indexes(stele, plan, indexes, band, previous, &mut cursor)? {
+            landed(descriptor, previous, &mut layers)?;
+        }
     }
 
     // Kind-major, like the two loops above: the inscription lists layers in
@@ -1353,71 +1468,164 @@ fn log_key_range(slots: &Range<BlockSlot>) -> Range<LogKey> {
     LogKey::from(TemporalKey::from(slots.start))..LogKey::from(TemporalKey::from(slots.end))
 }
 
-/// One epoch's index records: every tag, then every exact record.
+/// One band of epochs' index records: every tag, then every exact record,
+/// each routed to the layer whose epoch its slot falls in.
 ///
 /// Both runs come out of the store in the order the layer requires, which the
-/// trait promises and the `OrderCheck` holds it to.
+/// trait promises and the per-layer `OrderCheck` holds it to. Restricting one
+/// ascending run to a sub-range of it is still that run, so a layer receives
+/// exactly the records — and exactly the order — a pass over its own epoch
+/// alone would have handed it. That is why banding is invisible in the bytes.
 ///
-/// ## This is a scan, not a seek
+/// ## This is a scan, not a seek, which is why it is banded
 ///
 /// Neither traversal can seek to a slot — a tag's slot is the last component of
-/// its key and an exact record's slot is its stored *value* — so one epoch
-/// layer costs a pass over the whole index store, and a publish of N epochs
-/// costs N of them. Measured at 800 ms per epoch against an eight-epoch store
-/// and 3.0 s against a thirty-two-epoch one; the extrapolation to mainnet and
-/// the banded traversal that answers it are in
-/// `plans/dolos-stelae-publish-cost.md`. It is stated here because a reader of
-/// this loop should not have to rediscover it.
+/// its key and an exact record's slot is its stored *value* — so a pass here
+/// costs a walk of the whole index store however few epochs it fills. One epoch
+/// per pass makes a first publish O(N²); [`IndexBand`] is what turns that into
+/// ⌈N/K⌉ passes, and carries the measurement K is sized on.
+///
+/// ## Positions are handed out before anything is written
+///
+/// K layers are announced, then one traversal fills them, then they close —
+/// the shape [`write_state`] already needs for its shard sinks and the
+/// [`Cursor`] already supports. An observer therefore sees the band in flight,
+/// through the same seam and not a second one.
+///
+/// A window in the band whose layer is **inherited** opens and closes with
+/// nothing between: it costs no sink, and the records that fall in its slots
+/// are routed to no one. Same for a window an operator's `--epochs` left out
+/// between two that stayed — the traversal spans the band in one range and
+/// cannot exclude either, so the routing does.
 fn write_indexes<W: SteleWriter, I: IndexStore>(
     stele: &W,
     plan: &Plan,
     store: &I,
-    window: &EpochWindow,
+    band: &[EpochWindow],
     previous: &dyn Predecessor,
     cursor: &mut Cursor<'_>,
-) -> Result<LayerDescriptor, Error> {
-    let scope = window.scope(plan.network.magic());
+) -> Result<Vec<LayerDescriptor>, Error> {
+    let mut descriptors: Vec<Option<LayerDescriptor>> = Vec::with_capacity(band.len());
+    let mut building = Vec::with_capacity(band.len());
 
-    // The layer this saves the most: a publish that inherits a closed epoch's
-    // index layer skips a whole pass over the index store, which is the cost
-    // the doc comment above measures.
-    let (spec, adopted) = inherit(&scope, INDEXES, previous)?;
-    let at = cursor.open(INDEXES, &spec.scope);
+    for window in band {
+        let scope = window.scope(plan.network.magic());
 
-    if let Some(descriptor) = adopted {
-        cursor.close(at, INDEXES, Outcome::Inherited);
+        // The layer this saves the most: a publish that inherits a closed
+        // epoch's index layer costs no sink and no share of a pass.
+        let (spec, adopted) = inherit(&scope, INDEXES, previous)?;
+        let at = cursor.open(INDEXES, &spec.scope);
 
-        return Ok(descriptor);
+        let position = descriptors.len();
+
+        match adopted {
+            Some(descriptor) => {
+                cursor.close(at, INDEXES, Outcome::Inherited);
+                descriptors.push(Some(descriptor));
+            }
+            None => {
+                descriptors.push(None);
+                building.push(Building {
+                    slots: window.slots(),
+                    at,
+                    position,
+                    sink: sink(stele, &spec)?,
+                    order: indexes::OrderCheck::default(),
+                });
+            }
+        }
     }
 
-    let mut sink = sink(stele, &spec)?;
-    let mut order = indexes::OrderCheck::default();
+    // Every layer in the band was inherited: the store is not touched at all,
+    // which is the whole point of asking the predecessor first.
+    if building.is_empty() {
+        return Ok(descriptors.into_iter().flatten().collect());
+    }
+
+    // One span over the band. `building` is ascending and its windows are
+    // disjoint, so the first one's start and the last one's end bound
+    // everything any of them wants.
+    let slots = building[0].slots.start
+        ..building
+            .last()
+            .expect("the band has at least one layer to build")
+            .slots
+            .end;
+
     let mut records = cursor.records();
 
-    let slots = window.slots();
-
     for tag in store.iter_archive_tags(&archive_dimensions::ALL, slots.clone())? {
-        let record = tag?.into();
-
-        order.check(&record)?;
-        sink.write_record(&indexes::encode(&record)?)?;
-        records.tick();
+        route_index(&mut building, tag?.into(), &mut records)?;
     }
 
     for exact in store.iter_exact_records(slots)? {
-        let record = exact?.into();
-
-        order.check(&record)?;
-        sink.write_record(&indexes::encode(&record)?)?;
-        records.tick();
+        route_index(&mut building, exact?.into(), &mut records)?;
     }
 
     records.flush();
 
-    let descriptor = sink.finish()?.descriptor;
-    cursor.close(at, INDEXES, Outcome::Transferred);
+    for layer in building {
+        let descriptor = layer.sink.finish()?.descriptor;
+        cursor.close(layer.at, INDEXES, Outcome::Transferred);
 
-    Ok(descriptor)
+        descriptors[layer.position] = Some(descriptor);
+    }
+
+    debug_assert!(
+        descriptors.iter().all(Option::is_some),
+        "every layer the band announced has to have been filled or inherited",
+    );
+
+    Ok(descriptors.into_iter().flatten().collect())
+}
+
+/// One `indexes` layer being filled by a band's traversal.
+struct Building<K> {
+    /// The half-open slot range this layer's epoch covers — what a record is
+    /// routed by.
+    slots: Range<BlockSlot>,
+    /// The position [`Cursor::open`] handed out for it.
+    at: usize,
+    /// Where its descriptor belongs among the band's, so the inscription still
+    /// lists a kind's layers by ascending epoch whatever mix of inherited and
+    /// built the band held.
+    position: usize,
+    sink: K,
+    order: indexes::OrderCheck,
+}
+
+/// Send one index record to the layer whose epoch its slot falls in.
+///
+/// A binary search rather than a walk of the band: this runs once per record,
+/// and a mainnet index store holds hundreds of millions of them.
+///
+/// A record that lands in no layer is **dropped on purpose** — see
+/// [`write_indexes`] for the two ways the band's span can cover a slot no layer
+/// in it wants. The layer's own `OrderCheck` is what catches a routing mistake
+/// in the other direction: a record sent to the wrong layer arrives out of
+/// order there, or breaks the order of the layer it was taken from.
+fn route_index<K: RecordSink>(
+    building: &mut [Building<K>],
+    record: IndexRecord,
+    records: &mut Records<'_>,
+) -> Result<(), Error> {
+    let slot = indexes::slot_of(&record);
+
+    let above = building.partition_point(|layer| layer.slots.start <= slot);
+
+    let Some(layer) = above.checked_sub(1).map(|at| &mut building[at]) else {
+        return Ok(());
+    };
+
+    if !layer.slots.contains(&slot) {
+        return Ok(());
+    }
+
+    layer.order.check(&record)?;
+    layer.sink.write_record(&indexes::encode(&record)?)?;
+    records.tick();
+
+    Ok(())
 }
 
 /// The state tip: seventeen kinds, walked one namespace at a time.
@@ -1929,6 +2137,7 @@ mod chain_tests {
             sequence: 3,
             epochs: vec![],
             retained: RetainedEpochs::default(),
+            band: IndexBand::DEFAULT,
         }
     }
 

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -180,17 +180,6 @@ impl IndexBand {
     pub fn epochs(&self) -> usize {
         self.0.get()
     }
-
-    /// What this band budgets for the sinks it holds open, for a caller
-    /// reporting the trade it is making.
-    ///
-    /// The budget rather than a measurement:
-    /// [`SINK_BYTES`](IndexBand::SINK_BYTES) is pinned above what a sink
-    /// was measured to cost, so this is an upper bound and reads a little
-    /// high on purpose.
-    pub fn resident_bytes(&self) -> usize {
-        self.epochs() * Self::SINK_BYTES
-    }
 }
 
 impl Default for IndexBand {

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -865,11 +865,8 @@ where
 
     // Banded rather than one window at a time: an index layer costs a pass over
     // the whole store, so this loop is where a first publish's O(N²) lives.
-    // See [`IndexBand`].
-    //
-    // No `landed` here, unlike the loops around it: a band tells the
-    // predecessor about each of its layers the moment that layer exists, rather
-    // than when the band it belongs to is over. See [`write_indexes`].
+    // See [`IndexBand`], and [`write_indexes`] for why no `landed` call sits
+    // here as it does in the loops around it.
     for band in plan.epochs.chunks(plan.band.epochs()) {
         layers.extend(write_indexes(
             stele,
@@ -1488,11 +1485,10 @@ fn log_key_range(slots: &Range<BlockSlot>) -> Range<LogKey> {
 ///
 /// ## This is a scan, not a seek, which is why it is banded
 ///
-/// Neither traversal can seek to a slot — a tag's slot is the last component of
-/// its key and an exact record's slot is its stored *value* — so a pass here
-/// costs a walk of the whole index store however few epochs it fills. One epoch
-/// per pass makes a first publish O(N²); [`IndexBand`] is what turns that into
-/// ⌈N/K⌉ passes, and carries the measurement K is sized on.
+/// Neither traversal can seek to a slot, so a pass here costs a walk of the
+/// whole index store however few epochs it fills, and one epoch per pass makes
+/// a first publish O(N²). [`IndexBand`] states why the store cannot seek, what
+/// turns that into ⌈N/K⌉ passes, and the measurement K is sized on.
 ///
 /// ## Positions are handed out before anything is written
 ///

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -1341,10 +1341,6 @@ fn a_silent_publish_writes_exactly_what_a_watched_one_does() {
     );
 }
 
-// --------------------------------------------------------------------------
-// 6. Banding: fewer traversals, the same bytes
-// --------------------------------------------------------------------------
-
 /// An index store that counts how many traversals were *constructed* over it.
 ///
 /// The count is the property under test and inspection is not: banding is a

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -29,7 +29,13 @@ mod common;
 mod node;
 mod watcher;
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use common::read_both_ways;
 use dolos_cardano::{
@@ -39,8 +45,8 @@ use dolos_cardano::{
 use dolos_core::{
     builtin::{MemoryIndexStore, MemoryStateStore},
     ArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, Domain, EntityKey, ExactRecord,
-    IndexRecord, IndexStore, LogKey, Namespace, StateStore, StateWriter as _, TagRecord,
-    TemporalKey,
+    IndexRecord, IndexStore, IndexWriter as _, LogKey, Namespace, StateStore, StateWriter as _,
+    TagRecord, TemporalKey,
 };
 use dolos_snapshot::{
     export::{self, EpochWindow, Plan},
@@ -1333,4 +1339,250 @@ fn a_silent_publish_writes_exactly_what_a_watched_one_does() {
         with.canonicalize().unwrap(),
         without.canonicalize().unwrap(),
     );
+}
+
+// --------------------------------------------------------------------------
+// 6. Banding: fewer traversals, the same bytes
+// --------------------------------------------------------------------------
+
+/// An index store that counts how many traversals were *constructed* over it.
+///
+/// The count is the property under test and inspection is not: banding is a
+/// claim about how many times the store is walked, and a reader satisfying
+/// themselves by looking at the loop is exactly what stops being true the next
+/// time someone edits it. Every other method delegates, so an export sees the
+/// store it would have seen.
+#[derive(Clone)]
+struct Counted<S> {
+    inner: S,
+    tags: Arc<AtomicUsize>,
+    exacts: Arc<AtomicUsize>,
+}
+
+impl<S: IndexStore> Counted<S> {
+    fn new(inner: S) -> Self {
+        Self {
+            inner,
+            tags: Arc::default(),
+            exacts: Arc::default(),
+        }
+    }
+
+    /// Traversals built over the store: tag runs and exact runs separately,
+    /// because a band that fixed one and not the other would still be O(N²).
+    fn traversals(&self) -> (usize, usize) {
+        (
+            self.tags.load(Ordering::Relaxed),
+            self.exacts.load(Ordering::Relaxed),
+        )
+    }
+}
+
+impl<S: IndexStore> IndexStore for Counted<S> {
+    type Writer = S::Writer;
+    type SlotIter = S::SlotIter;
+    type TagIter = S::TagIter;
+    type ExactIter = S::ExactIter;
+
+    fn start_writer(&self) -> Result<Self::Writer, dolos_core::IndexError> {
+        self.inner.start_writer()
+    }
+
+    fn initialize_schema(&self) -> Result<(), dolos_core::IndexError> {
+        self.inner.initialize_schema()
+    }
+
+    fn copy(&self, target: &Self) -> Result<(), dolos_core::IndexError> {
+        self.inner.copy(&target.inner)
+    }
+
+    fn cursor(&self) -> Result<Option<ChainPoint>, dolos_core::IndexError> {
+        self.inner.cursor()
+    }
+
+    fn utxos_by_tag(
+        &self,
+        dimension: dolos_core::TagDimension,
+        key: &[u8],
+    ) -> Result<dolos_core::UtxoSet, dolos_core::IndexError> {
+        self.inner.utxos_by_tag(dimension, key)
+    }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+        self.inner.slot_by_block_hash(hash)
+    }
+
+    fn slot_by_block_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+        self.inner.slot_by_block_number(number)
+    }
+
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+        self.inner.slot_by_tx_hash(hash)
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: dolos_core::TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, dolos_core::IndexError> {
+        self.inner.slots_by_tag(dimension, key, start, end)
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[dolos_core::TagDimension],
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::TagIter, dolos_core::IndexError> {
+        self.tags.fetch_add(1, Ordering::Relaxed);
+
+        self.inner.iter_archive_tags(dimensions, slots)
+    }
+
+    fn iter_exact_records(
+        &self,
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::ExactIter, dolos_core::IndexError> {
+        self.exacts.fetch_add(1, Ordering::Relaxed);
+
+        self.inner.iter_exact_records(slots)
+    }
+}
+
+/// Index records spread across the skeleton's three epochs, so a band that
+/// misrouted one would produce a layer that is short and a layer that is long.
+///
+/// Two blocks per epoch, each carrying tags in every dimension and the three
+/// exact kinds a block produces. Nothing here has to be a real ledger: what the
+/// banded pass does with a record is decided by its slot alone.
+fn index_across_the_skeleton() -> MemoryIndexStore {
+    let store = MemoryIndexStore::new();
+    let writer = store.start_writer().unwrap();
+
+    let mut archive = Vec::new();
+
+    for epoch in 0..3u64 {
+        for block in 0..2u64 {
+            let slot = epoch * 100 + block * 40 + 10;
+
+            archive.push(dolos_core::ArchiveIndexDelta {
+                slot,
+                block_hash: vec![slot as u8; 32],
+                block_number: Some(slot),
+                tx_hashes: vec![vec![0x80 | slot as u8; 32]],
+                tags: archive_dimensions::ALL
+                    .into_iter()
+                    .map(|dimension| dolos_core::Tag::new(dimension, vec![slot as u8; 28]))
+                    .collect(),
+            });
+        }
+    }
+
+    writer
+        .apply(&dolos_core::IndexDelta {
+            cursor: ChainPoint::Slot(SKELETON_SLOT),
+            utxo: Default::default(),
+            archive,
+        })
+        .unwrap();
+
+    store
+}
+
+/// Export the seeded skeleton at `band`, and report what it cost and what it
+/// produced.
+fn export_banded(band: usize) -> (usize, usize, usize, Vec<u8>) {
+    let temp = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(temp.path()).unwrap();
+
+    let (archive, state, _) = empty_stores();
+    let indexes = Counted::new(index_across_the_skeleton());
+
+    let plan = Plan::new(
+        &skeleton_summary(),
+        Network::for_magic(dolos_snapshot::MAINNET_MAGIC),
+        skeleton_point(),
+        Default::default(),
+    )
+    .unwrap()
+    .with_band(export::IndexBand::new(band.try_into().unwrap()));
+
+    let watcher = Arc::new(Watcher::default());
+
+    let inscription = export::export(
+        &stele,
+        &plan,
+        &archive,
+        &state,
+        &indexes,
+        None,
+        &export::First,
+        &watcher.observer(),
+    )
+    .unwrap();
+
+    watcher.assert_well_formed(inscription.layers.len());
+
+    let (tags, exacts) = indexes.traversals();
+
+    (
+        tags,
+        exacts,
+        watcher.peak_open(INDEXES),
+        inscription.canonicalize().unwrap(),
+    )
+}
+
+/// Done criterion 1: N epochs cost ⌈N/K⌉ index traversals, counted rather than
+/// inspected.
+///
+/// Both runs are counted — tags and exact records — because they are two
+/// separate scans of the store and banding one without the other would leave
+/// the publish O(N²) with half the constant.
+///
+/// The peak is what an operator's progress display shows and what bounds the
+/// memory: K layers of `indexes` open across one walk, never more.
+#[test]
+fn a_band_costs_one_index_traversal_however_many_epochs_it_covers() {
+    for (band, traversals) in [(1usize, 3usize), (2, 2), (3, 1), (4, 1)] {
+        let (tags, exacts, peak, _) = export_banded(band);
+
+        assert_eq!(
+            (tags, exacts),
+            (traversals, traversals),
+            "a band of {band} over three epochs",
+        );
+
+        assert_eq!(
+            peak,
+            band.min(3),
+            "a band of {band} held the wrong number of index layers open",
+        );
+    }
+}
+
+/// Done criterion 3, from the side a golden cannot reach: the golden pins one
+/// band's bytes, and this pins that *every* band produces those bytes.
+///
+/// Banding reorders when records are read, never which layer they land in or in
+/// what order — so the canonical document is a function of the stores and not
+/// of the band. Compared as bytes rather than as digests, so a divergence says
+/// where.
+#[test]
+fn banding_moves_no_bytes() {
+    let (.., unbanded) = export_banded(1);
+
+    for band in [2usize, 3, 4, 64] {
+        let (.., banded) = export_banded(band);
+
+        assert_eq!(
+            String::from_utf8(banded).unwrap(),
+            String::from_utf8(unbanded.clone()).unwrap(),
+            "a band of {band} produced a different document",
+        );
+    }
 }

--- a/crates/snapshot/tests/watcher/mod.rs
+++ b/crates/snapshot/tests/watcher/mod.rs
@@ -16,7 +16,7 @@
 // binary does not reach look dead to it. They are not.
 #![allow(dead_code)]
 
-use std::sync::Mutex;
+use std::{collections::BTreeMap, sync::Mutex};
 
 use stelae::progress::{Event, Observer, Outcome, Progress};
 
@@ -56,6 +56,13 @@ struct Stream {
     /// checking it is how a byte delta escaping into the gap between layers
     /// gets caught.
     trailing: usize,
+    /// Layers of each kind open right now, and the most that were ever open at
+    /// once. A driver that holds several open across one walk of a store — the
+    /// state pass over its shards, the index pass over a band — is reporting
+    /// exactly that through this seam, and the peak is the only thing in the
+    /// stream that says so.
+    live: BTreeMap<String, usize>,
+    peak: BTreeMap<String, usize>,
 }
 
 /// Everything a run said about itself.
@@ -79,19 +86,32 @@ impl Progress for Watcher {
                 total,
                 kind,
                 scope,
-            } => stream.opened.push(layer(index, total, kind, scope)),
+            } => {
+                stream.opened.push(layer(index, total, kind, scope));
+
+                let live = stream.live.entry(kind.to_owned()).or_default();
+                *live += 1;
+
+                let live = *live;
+                let peak = stream.peak.entry(kind.to_owned()).or_default();
+                *peak = (*peak).max(live);
+            }
 
             Event::LayerFinished {
                 index,
                 total,
                 kind,
                 outcome,
-            } => stream.closed.push(Closed {
-                index,
-                total,
-                kind: kind.to_owned(),
-                outcome,
-            }),
+            } => {
+                stream.closed.push(Closed {
+                    index,
+                    total,
+                    kind: kind.to_owned(),
+                    outcome,
+                });
+
+                *stream.live.entry(kind.to_owned()).or_default() -= 1;
+            }
 
             Event::Records(moved) => {
                 if stream.settled() {
@@ -149,6 +169,11 @@ impl Watcher {
             .iter()
             .filter(|closed| closed.outcome == outcome)
             .count()
+    }
+
+    /// The most layers of `kind` the run held open at the same time.
+    pub fn peak_open(&self, kind: &str) -> usize {
+        self.0.lock().unwrap().peak.get(kind).copied().unwrap_or(0)
     }
 
     pub fn records(&self) -> u64 {

--- a/crates/snapshot/tests/watcher/mod.rs
+++ b/crates/snapshot/tests/watcher/mod.rs
@@ -110,7 +110,19 @@ impl Progress for Watcher {
                     outcome,
                 });
 
-                *stream.live.entry(kind.to_owned()).or_default() -= 1;
+                // A finish with no open layer to match is exactly the
+                // malformation this harness exists to catch, so it fails here
+                // rather than wrapping a `usize` and leaving `peak` unreadable
+                // in a release build.
+                let Some(live) = stream.live.get_mut(kind) else {
+                    panic!("a `{kind}` layer finished without one having started");
+                };
+
+                let Some(left) = live.checked_sub(1) else {
+                    panic!("more `{kind}` layers finished than were started");
+                };
+
+                *live = left;
             }
 
             Event::Records(moved) => {
@@ -260,6 +272,14 @@ impl Watcher {
         assert_eq!(
             stream.trailing, 0,
             "records or bytes were reported after the last layer closed"
+        );
+
+        let open: Vec<(&String, &usize)> =
+            stream.live.iter().filter(|(_, live)| **live > 0).collect();
+
+        assert!(
+            open.is_empty(),
+            "the run ended with layers still open: {open:?}"
         );
     }
 }

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -61,6 +61,13 @@ pub struct Args {
     #[arg(long, value_name = "RANGE")]
     epochs: Option<EpochRange>,
 
+    /// epochs whose index layers one traversal of the index store fills; a
+    /// larger band trades resident memory for fewer traversals, and changes
+    /// nothing about the stele it produces. Defaults to the measured value
+    /// that keeps the index pass inside 1 GiB
+    #[arg(long, value_name = "EPOCHS")]
+    index_band: Option<std::num::NonZeroUsize>,
+
     /// canonical inscription of the stele this one follows, as
     /// `inspect --json` or a published `inscription.json` holds it; without it
     /// the reproduction carries no history, which is a different digest
@@ -88,6 +95,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     .context("planning the reproduction")?;
 
     let plan = super::restrict(plan, args.epochs);
+    let plan = super::banded(plan, args.index_band);
 
     super::report_plan(&plan)?;
 

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -22,7 +22,10 @@
 
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
-use dolos_snapshot::{export::Plan, RetainedEpochs};
+use dolos_snapshot::{
+    export::{IndexBand, Plan},
+    RetainedEpochs,
+};
 use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::feedback::Feedback;
@@ -168,6 +171,24 @@ pub fn restrict(plan: Plan, range: Option<EpochRange>) -> Plan {
     }
 }
 
+/// Apply an operator's index band to a plan, or leave the measured default.
+///
+/// The one place any command spells the mapping, for the reason [`restrict`] is
+/// shared: `publish`, `digest` and `verify --reproduce` all pay the same index
+/// traversals, and a knob one of them spelled its own way would be a knob an
+/// operator has to learn three times.
+///
+/// Unlike [`restrict`], this changes nothing about the document: banding
+/// reorders when index records are read, never which layer they land in. Two
+/// runs at different bands produce the same digest, which is why a
+/// reproduction is free to band differently than the publish it checks.
+pub fn banded(plan: Plan, band: Option<std::num::NonZeroUsize>) -> Plan {
+    match band {
+        Some(band) => plan.with_band(IndexBand::new(band)),
+        None => plan,
+    }
+}
+
 /// The report every command opens with: where the node stands and what the
 /// selection covers.
 ///
@@ -185,6 +206,12 @@ pub fn report_plan(plan: &Plan) -> miette::Result<()> {
     );
     eprintln!("cursor:   {}", plan.cursor);
     eprintln!("sequence: {} (tag {tag})", plan.sequence);
+
+    eprintln!(
+        "band:     {} epochs per index traversal ({} MiB budgeted)",
+        plan.band.epochs(),
+        plan.band.resident_bytes() / (1024 * 1024),
+    );
 
     match (plan.epochs.first(), plan.epochs.last()) {
         (Some(first), Some(last)) => eprintln!(

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -207,10 +207,14 @@ pub fn report_plan(plan: &Plan) -> miette::Result<()> {
     eprintln!("cursor:   {}", plan.cursor);
     eprintln!("sequence: {} (tag {tag})", plan.sequence);
 
+    // Clamped to the epochs actually selected, because the band chunks them:
+    // a `--epochs 500..502` publish opens three sinks whatever the band says,
+    // and the unclamped budget would overstate it by orders of magnitude.
+    let band = plan.band.epochs().min(plan.epochs.len());
+
     eprintln!(
-        "band:     {} epochs per index traversal ({} MiB budgeted)",
-        plan.band.epochs(),
-        plan.band.resident_bytes() / (1024 * 1024),
+        "band:     {band} epochs per index traversal ({} MiB budgeted)",
+        band.saturating_mul(IndexBand::SINK_BYTES) / (1024 * 1024),
     );
 
     match (plan.epochs.first(), plan.epochs.last()) {

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -56,6 +56,13 @@ pub struct Args {
     #[arg(long, value_name = "DIR", conflicts_with = "output_dir")]
     scratch_dir: Option<PathBuf>,
 
+    /// epochs whose index layers one traversal of the index store fills; a
+    /// larger band trades resident memory for fewer traversals, and changes
+    /// nothing about the stele it produces. Defaults to the measured value
+    /// that keeps the index pass inside 1 GiB
+    #[arg(long, value_name = "EPOCHS")]
+    index_band: Option<std::num::NonZeroUsize>,
+
     /// report what would be written and exit
     #[arg(long, action)]
     dry_run: bool,
@@ -85,6 +92,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     .context("planning the publish")?;
 
     let plan = super::restrict(plan, args.epochs);
+    let plan = super::banded(plan, args.index_band);
 
     super::report_plan(&plan)?;
 

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -66,6 +66,13 @@ pub struct Args {
     #[arg(long, action)]
     reproduce: bool,
 
+    /// epochs whose index layers one traversal of the index store fills; a
+    /// larger band trades resident memory for fewer traversals, and changes
+    /// nothing about the stele it produces. Defaults to the measured value
+    /// that keeps the index pass inside 1 GiB
+    #[arg(long, value_name = "EPOCHS", requires = "reproduce")]
+    index_band: Option<std::num::NonZeroUsize>,
+
     /// epochs the reproduction builds layers for, e.g. `500..520`, `500..=520`
     /// or `500`; defaults to every epoch below the cursor, and must match what
     /// the stele was published with
@@ -132,6 +139,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     .context("planning the reproduction")?;
 
     let plan = super::restrict(plan, args.epochs);
+    let plan = super::banded(plan, args.index_band);
 
     super::report_plan(&plan)?;
 

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -1083,6 +1083,267 @@ fn measure_one_epoch_iteration_cost() {
     assert_eq!(exacts.len() as u64, written.exacts_per_epoch);
 }
 
+/// Peak resident set of this process, in bytes.
+///
+/// `ru_maxrss` is a **high-water mark** and never falls, which is what makes it
+/// the right instrument here — the question is what a publish peaked at, not
+/// what it holds at the moment anyone looks — and also what makes a *delta*
+/// between two of these the only honest way to attribute memory to a phase.
+///
+/// The unit is not portable: macOS reports bytes and Linux kilobytes. Both are
+/// spelled out rather than papered over, because a figure that is a thousand
+/// times wrong is worse than no figure.
+fn max_rss_bytes() -> u64 {
+    let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)
+        .expect("getrusage failed");
+
+    let raw = usage.max_rss().max(0) as u64;
+
+    match cfg!(target_os = "macos") {
+        true => raw,
+        false => raw * 1024,
+    }
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// What holding one `indexes` layer open costs resident.
+///
+/// [`IndexBand`](dolos_snapshot::export::IndexBand) divides a memory ceiling by
+/// this number to arrive at K, so the number has to come from somewhere other
+/// than a guess about zstd's internals. Sinks are opened one at a time against
+/// a real stele and each is given records to compress, because a compression
+/// context that has never compressed anything has not yet allocated its
+/// window — a measurement taken before that would say a sink is nearly free.
+///
+/// Run with:
+/// `cargo test --release --test index_roundtrip -- --ignored --nocapture
+/// measure_layer_sink_residency`
+#[test]
+#[ignore = "measurement, not an assertion"]
+fn measure_layer_sink_residency() {
+    use dolos_snapshot::{DolosProfile, EpochScope, Scope as _, COMPRESSION_LEVEL, INDEXES};
+    use stelae::transport::{RecordSink as _, SteleWriter as _};
+
+    const SINKS: u64 = 32;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let stele = stelae::dir::SteleDir::create(temp.path()).expect("create stele");
+
+    // A record for every sink to chew on, built once: the point is the
+    // compressor's resident state, not the bytes handed to it.
+    let record = dolos_snapshot::layers::indexes::encode(&IndexRecord::Tag(TagRecord::new(
+        archive_dimensions::ADDRESS,
+        [0x5a; 8],
+        1,
+    )))
+    .expect("encode");
+
+    let base = max_rss_bytes();
+    let mut sinks = Vec::new();
+
+    for epoch in 0..SINKS {
+        let spec = EpochScope {
+            network_magic: dolos_snapshot::MAINNET_MAGIC,
+            epoch,
+            start_slot: epoch * EPOCH_LEN,
+            end_slot: (epoch + 1) * EPOCH_LEN - 1,
+        }
+        .layer_spec(INDEXES)
+        .expect("layer spec");
+
+        let mut sink = stele
+            .layer_sink(&DolosProfile, &spec, COMPRESSION_LEVEL)
+            .expect("layer sink");
+
+        // Enough to drive the encoder past its lazy initialisation, and enough
+        // again that a buffer growing with the data would show.
+        for _ in 0..8_192 {
+            sink.write_record(&record).expect("write record");
+        }
+
+        sinks.push(sink);
+    }
+
+    let held = max_rss_bytes();
+
+    println!("--- layer sink residency (zstd level {COMPRESSION_LEVEL}) ---");
+    println!(
+        "{SINKS} sinks open: {:.1} MiB resident above baseline, {:.1} MiB each",
+        mib(held - base),
+        mib(held - base) / SINKS as f64,
+    );
+    println!(
+        "IndexBand::SINK_BYTES is pinned at {:.1} MiB",
+        mib(dolos_snapshot::export::IndexBand::SINK_BYTES as u64),
+    );
+
+    // Kept alive to here on purpose: a sink dropped early is a sink whose
+    // memory the measurement above did not see.
+    drop(sinks);
+}
+
+/// The whole-publish figure the banding is sized on: what a first publish of a
+/// store this deep costs, banded and unbanded.
+///
+/// The stele is written for real — compressed, framed and landed in a
+/// directory — because the claim is about a publish and not about a loop. Only
+/// the index store is seeded: `blocks`, `log-*` and `state-*` are already
+/// O(range) and would add the same constant to both arms while making the run
+/// several times longer. What is left is exactly the term this measures.
+///
+/// Both arms produce the same document, and that is asserted rather than
+/// assumed — a speed-up that moved the bytes would not be one.
+///
+/// Run with:
+/// `cargo test --release --test index_roundtrip -- --ignored --nocapture
+/// measure_banded_publish_cost`, and `DOLOS_INDEX_COST_EPOCHS=32` for the
+/// deeper store [`measure_one_epoch_iteration_cost`] also reports.
+#[test]
+#[ignore = "measurement, not an assertion"]
+fn measure_banded_publish_cost() {
+    use dolos_snapshot::export::IndexBand;
+
+    let (store, _guard) = Fjall::open();
+
+    let epochs = cost_epochs();
+    let spec = cost_spec(epochs);
+
+    let started = std::time::Instant::now();
+    let written = seed_deltas(&spec, &mut |delta| apply(&store, &delta));
+    let seeding = started.elapsed();
+
+    println!("--- banded publish cost ---");
+    println!(
+        "store: {epochs} epochs, {} tag records, {} exact records (seeded in {seeding:.1?})",
+        written.tags(),
+        written.exacts(),
+    );
+
+    // The banded arm runs **first**, and the order is the measurement rather
+    // than a preference. `ru_maxrss` is a high-water mark, so only the first
+    // arm's delta is that arm's own; the second reports what it added above the
+    // first. What this plan has to state is the peak of a *banded* publish, so
+    // that is the arm that goes first — and it leaves the unbanded arm running
+    // against the warmer page cache, which is the direction that understates
+    // the improvement rather than inventing it.
+    let bands = [("banded", IndexBand::DEFAULT.epochs()), ("unbanded", 1)];
+
+    let mut documents = Vec::new();
+
+    for (label, band) in bands {
+        let before = max_rss_bytes();
+        let started = std::time::Instant::now();
+
+        let (inscription, temp) = publish_at_band(&store, epochs, band);
+
+        let elapsed = started.elapsed();
+        let peak = max_rss_bytes();
+
+        let traversals = epochs.div_ceil(band as u64);
+
+        println!(
+            "{label:>9} (K={band:>3}): {traversals:>3} traversals, {elapsed:>10.1?}, \
+             peak rss {:>8.1} MiB (+{:.1} MiB above the mark this arm started at)",
+            mib(peak),
+            mib(peak.saturating_sub(before)),
+        );
+
+        documents.push(inscription.canonicalize().expect("canonicalize"));
+
+        // Held until the figures are printed, then released: the stele on disk
+        // is the size of the index store and the next arm wants the space.
+        drop(temp);
+    }
+
+    assert_eq!(
+        documents[0], documents[1],
+        "the banded publish produced a different document",
+    );
+}
+
+/// Publish the seeded index store at `band`, into a directory that lives as
+/// long as the returned guard.
+fn publish_at_band<S: CoreIndexStore>(
+    store: &S,
+    epochs: u64,
+    band: usize,
+) -> (stelae::inscription::Inscription, tempfile::TempDir) {
+    use dolos_core::{StateStore as _, StateWriter as _};
+    use dolos_snapshot::{
+        export::{IndexBand, Plan},
+        Network,
+    };
+
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let archive =
+        dolos_redb3::archive::ArchiveStore::in_memory(dolos_cardano::model::build_schema())
+            .expect("archive store");
+
+    let state = dolos_core::builtin::MemoryStateStore::new();
+
+    // The publish stands on the last slot the seed wrote to, so its plan covers
+    // every epoch in the store and nothing beyond it.
+    let tip = ChainPoint::Specific(
+        epochs * EPOCH_LEN - 1,
+        dolos_core::BlockHash::new([0xab; 32]),
+    );
+
+    let writer = state.start_writer().expect("state writer");
+    writer.set_cursor(tip.clone()).expect("set cursor");
+    writer.commit().expect("commit");
+
+    let plan = Plan::new(
+        &cost_summary(),
+        Network::for_magic(dolos_snapshot::MAINNET_MAGIC),
+        tip,
+        Default::default(),
+    )
+    .expect("plan")
+    .with_band(IndexBand::new(
+        band.try_into().expect("a band of no epochs"),
+    ));
+
+    let inscription = dolos_snapshot::export::publish(
+        temp.path().join("stele"),
+        &plan,
+        &archive,
+        &state,
+        store,
+        None,
+        &stelae::progress::Observer::silent(),
+    )
+    .expect("publish");
+
+    (inscription, temp)
+}
+
+/// One era of [`EPOCH_LEN`]-slot epochs from slot zero — the geometry
+/// [`epoch_slots`] already seeds against, stated in the form a [`Plan`] reads.
+fn cost_summary() -> dolos_cardano::eras::ChainSummary {
+    let mut chain = dolos_cardano::eras::ChainSummary::default();
+
+    chain.append_era(
+        6,
+        dolos_cardano::model::EraSummary {
+            start: dolos_cardano::EraBoundary {
+                epoch: 0,
+                slot: 0,
+                timestamp: 0,
+            },
+            end: None,
+            epoch_length: EPOCH_LEN,
+            slot_length: 1,
+            protocol: 6,
+        },
+    );
+
+    chain
+}
+
 /// `ArchiveIndexDelta` carries its block and transaction hashes as `Vec<u8>`,
 /// so nothing upstream enforces their width — a malformed hash reaches storage
 /// as a plain byte slice.


### PR DESCRIPTION
Plan: `plans/dolos-stelae-publish-cost.md`

## The problem

An `indexes` layer costs a full scan of the index store: neither
`iter_archive_tags` nor `iter_exact_records` can seek to a slot — a tag's slot
is the tail of its key and an exact record's slot is its stored *value*. One
pass per epoch makes a first publish of N epochs O(N²), and on mainnet that is
hours of nothing but index traversal.

## What changed

`write_indexes` now takes a **band** of epoch windows instead of one. It opens
the band's sinks, runs **one** pass over each of the two traversals, and routes
every record to the layer whose epoch its slot falls in — the move
`write_state` already makes with its sixteen shard sinks. N epochs cost ⌈N/K⌉
passes.

K is a memory budget divided by a measurement, not a taste. `IndexBand`
carries both: a layer sink costs **10.3 MiB** resident (a zstd context at level
9), `SINK_BYTES` is pinned above it at 12 MiB, and a **1 GiB** ceiling gives
`IndexBand::DEFAULT` = **85 epochs per traversal**. `--index-band` narrows it
on `snapshot publish`, `digest` and `verify --reproduce`, all three of which
pay the same traversals.

Banding reorders *when* records are read, never which layer they land in or in
what order: restricting one ascending run to a sub-range of it is still that
run. The bytes do not move.

## Measurements

Apple M4, fjall, release. Fixture: mainnet-shaped epochs (21,600 blocks, 30
tags/block, every dimension).

`measure_one_epoch_iteration_cost`, re-run — it reproduces the figures the plan
was filed on:

| store depth | one epoch sliced out |
|---|---|
| 8 epochs | 864 ms (the plan's 800 ms) |
| 32 epochs | 3.576 s (the plan's 3.0 s) |

`measure_banded_publish_cost`, a whole publish at the same depths:

| store depth | banded (K=85) | unbanded (K=1) | |
|---|---|---|---|
| 8 epochs | **1** traversal, **3.7 s** | 8 traversals, 9.5 s | 2.6× |
| 32 epochs | **1** traversal, **14.2 s** | 32 traversals, **120.0 s** | 8.4× |

Peak RSS of the banded 32-epoch publish: **963.7 MiB**, of which **+231.2 MiB**
is attributable to the run — inside the stated ceiling. The banded arm runs
first on purpose: `ru_maxrss` is a high-water mark, so only the first arm's
delta is its own, and it leaves the unbanded arm the warmer page cache, which
understates the improvement rather than inventing it.

Extrapolated to mainnet's ~580 epochs at this fixture's density (well under
mainnet's), one full traversal is ~65 s. Unbanded: 580 × 65 s ≈ **10.4 hours**.
Banded: ⌈580/85⌉ = 7 × 65 s ≈ **7.6 minutes**. The plan's escalation risk —
"if banding is not enough the answer is a slot-seekable index encoding" — does
not fire: banding is enough, and no store change is proposed.

## Verification

- `crates/snapshot/tests/export.rs`: a `Counted<S>` index store proves the
  traversal count is ⌈N/K⌉ by **counting iterator constructions**, not by
  inspection — 1→3, 2→2, 3→1, 4→1 over the three-epoch skeleton, tags and
  exacts counted separately. A second test pins that every band produces
  byte-identical canonical documents.
- The watcher now tracks peak concurrently-open layers per kind, so "K layers
  in flight" is asserted through the existing observer seam rather than a
  parallel channel.
- The export golden and the two-backend determinism test are **unchanged** and
  pass.
- `cargo test --all-features`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `cargo +nightly fmt --all -- --check`, `cargo deny check
  advisories` all pass; `cargo tree -p stelae -e normal` matches nothing
  `^dolos(-|$)`.

## Not in scope

No index store change, no parallelism, no change to the `blocks`, `log-{ns}` or
`state-{ns}` passes — all three are scope decisions the plan makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAz8YvgA5pcFB7JJ41VyDd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `--index-band` setting to snapshot digest, publish, and verify commands.
  - Configure how many epochs are processed during each index traversal.
  - Snapshot plans now display the selected epoch band and estimated memory budget.

- **Performance**
  - Large snapshot exports can limit concurrent index-layer activity and reduce memory usage.
  - Export results remain consistent across different band sizes.

- **Tests**
  - Added coverage for traversal efficiency, memory behavior, layer concurrency, and output equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->