### PR TITLE
experiment: the archive index on fjall — benchmark vehicle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ version = "1.7.0-alpha.0"
 dependencies = [
  "bincode 1.3.3",
  "dolos-core",
+ "dolos-redb3",
  "dolos-testing",
  "fjall",
  "pallas",

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -352,11 +352,60 @@ impl RedbArchiveConfig {
     }
 }
 
+/// Configuration for the Fjall archive backend.
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct FjallArchiveConfig {
+    /// Optional path override for the archive directory.
+    /// If relative, resolved from storage root.
+    /// If not specified, defaults to `<storage.path>/archive`.
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    /// Optional path override for block segment files.
+    /// If not specified, segment files are stored in the archive directory.
+    #[serde(default)]
+    pub blocks_path: Option<PathBuf>,
+    /// Size (in MB) of memory allocated for caching.
+    #[serde(default)]
+    pub cache: Option<usize>,
+    /// Maximum journal size in MB.
+    #[serde(default)]
+    pub max_journal_size: Option<usize>,
+    /// Flush journal after each commit.
+    #[serde(default)]
+    pub flush_on_commit: Option<bool>,
+    /// L0 compaction threshold (default: 4, lower = more aggressive).
+    #[serde(default)]
+    pub l0_threshold: Option<u8>,
+    /// Number of background compaction worker threads.
+    #[serde(default)]
+    pub worker_threads: Option<usize>,
+    /// Memtable size in MB before flush (default: 64).
+    #[serde(default)]
+    pub memtable_size_mb: Option<usize>,
+}
+
+impl FjallArchiveConfig {
+    pub fn is_default(&self) -> bool {
+        self.path.is_none()
+            && self.blocks_path.is_none()
+            && self.cache.is_none()
+            && self.max_journal_size.is_none()
+            && self.flush_on_commit.is_none()
+            && self.l0_threshold.is_none()
+            && self.worker_threads.is_none()
+            && self.memtable_size_mb.is_none()
+    }
+}
+
 /// Archive store configuration.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
 pub enum ArchiveStoreConfig {
     Redb(RedbArchiveConfig),
+    /// Experimental Fjall backend, a benchmark vehicle for the archive-index
+    /// backend evaluation. Block segment files are shared with the redb
+    /// backend; only the index moves.
+    Fjall(FjallArchiveConfig),
     /// In-memory backend (ephemeral, data lost on restart).
     #[serde(rename = "in_memory")]
     InMemory,
@@ -374,6 +423,7 @@ impl ArchiveStoreConfig {
     pub fn path(&self) -> Option<&PathBuf> {
         match self {
             Self::Redb(cfg) => cfg.path.as_ref(),
+            Self::Fjall(cfg) => cfg.path.as_ref(),
             Self::InMemory | Self::NoOp => None,
         }
     }
@@ -381,6 +431,7 @@ impl ArchiveStoreConfig {
     pub fn is_default(&self) -> bool {
         match self {
             Self::Redb(cfg) => cfg.is_default(),
+            Self::Fjall(cfg) => cfg.is_default(),
             Self::InMemory | Self::NoOp => false,
         }
     }
@@ -617,6 +668,9 @@ impl StorageConfig {
         match &self.archive {
             ArchiveStoreConfig::InMemory | ArchiveStoreConfig::NoOp => None,
             ArchiveStoreConfig::Redb(cfg) => {
+                Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "archive"))
+            }
+            ArchiveStoreConfig::Fjall(cfg) => {
                 Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "archive"))
             }
         }

--- a/crates/fjall/Cargo.toml
+++ b/crates/fjall/Cargo.toml
@@ -5,13 +5,14 @@ edition.workspace = true
 
 [dependencies]
 dolos-core = { path = "../core" }
+dolos-redb3 = { path = "../redb3" }
 fjall = "3.1.0"
 tracing.workspace = true
 thiserror.workspace = true
 bincode.workspace = true
 xxhash-rust.workspace = true
 pallas.workspace = true
+tempfile = "3"
 
 [dev-dependencies]
 dolos-testing = { path = "../testing" }
-tempfile = "3"

--- a/crates/fjall/src/archive/log_keys.rs
+++ b/crates/fjall/src/archive/log_keys.rs
@@ -1,0 +1,136 @@
+//! Log key encoding for the unified archive-logs keyspace.
+//!
+//! All log namespaces share a single keyspace with namespace hash prefixes,
+//! the same layout lesson the state store's entities keyspace records:
+//! per-namespace LSM trees multiply segment files and blow the file-descriptor
+//! limit under heavy compaction.
+//!
+//! ## Key Format
+//!
+//! ```text
+//! Key:   [ns_hash:8][log_key:40]  (48 bytes total)
+//! Value: entity value bytes (CBOR encoded)
+//! ```
+//!
+//! The `log_key` is core's 40-byte [`LogKey`]: an 8-byte big-endian slot
+//! followed by a 32-byte entity key. Within one namespace, lexicographic
+//! order of the prefixed key equals `LogKey` order, which is what
+//! `iter_logs` range scans rely on.
+
+use dolos_core::{LogKey, Namespace};
+
+use crate::state::entity_keys::hash_namespace;
+
+/// Size of namespace hash prefix: 8 bytes (xxh3 truncated)
+pub const NS_HASH_SIZE: usize = 8;
+
+/// Size of core's log key: 8-byte temporal prefix + 32-byte entity key
+pub const LOG_KEY_SIZE: usize = 40;
+
+/// Total size of a prefixed log key: 48 bytes
+pub const PREFIXED_LOG_KEY_SIZE: usize = NS_HASH_SIZE + LOG_KEY_SIZE;
+
+/// Build a log key: `[ns_hash:8][log_key:40]`
+pub fn build_log_key(ns: Namespace, key: &LogKey) -> [u8; PREFIXED_LOG_KEY_SIZE] {
+    let mut result = [0u8; PREFIXED_LOG_KEY_SIZE];
+    result[..NS_HASH_SIZE].copy_from_slice(&hash_namespace(ns));
+    result[NS_HASH_SIZE..].copy_from_slice(key.as_ref());
+    result
+}
+
+/// Decode the 40-byte [`LogKey`] portion out of a stored key.
+///
+/// The input must be at least `PREFIXED_LOG_KEY_SIZE` bytes.
+pub fn decode_log_key(key: &[u8]) -> LogKey {
+    debug_assert!(key.len() >= PREFIXED_LOG_KEY_SIZE);
+    LogKey::from(&key[NS_HASH_SIZE..PREFIXED_LOG_KEY_SIZE])
+}
+
+/// Build a temporal bound within a namespace: `[ns_hash:8][slot:8]`.
+///
+/// Compared lexicographically against 48-byte stored keys, this 16-byte
+/// bound sorts before every key of the namespace whose temporal prefix is
+/// `>= slot` and after every key whose prefix is `< slot` — the exact
+/// boundary semantics redb gets from comparing 40-byte keys against an
+/// 8-byte `TemporalKey` bound, which prune and truncate must reproduce.
+pub fn build_temporal_bound(ns: Namespace, slot: u64) -> Vec<u8> {
+    let mut result = Vec::with_capacity(NS_HASH_SIZE + 8);
+    result.extend_from_slice(&hash_namespace(ns));
+    result.extend_from_slice(&slot.to_be_bytes());
+    result
+}
+
+/// Build the inclusive start of a namespace's key range: the bare 8-byte
+/// namespace hash, which sorts before every stored key of the namespace.
+pub fn namespace_start(ns: Namespace) -> Vec<u8> {
+    hash_namespace(ns).to_vec()
+}
+
+/// Build an exclusive end bound covering the whole namespace:
+/// `[ns_hash:8][0xff:41]`.
+///
+/// One byte longer than any stored key, so even a log key of all `0xff`
+/// sorts before it, while every key of the next namespace prefix sorts
+/// after it.
+pub fn namespace_end(ns: Namespace) -> Vec<u8> {
+    let mut result = Vec::with_capacity(PREFIXED_LOG_KEY_SIZE + 1);
+    result.extend_from_slice(&hash_namespace(ns));
+    result.extend_from_slice(&[0xff; LOG_KEY_SIZE + 1]);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn log_key(slot: u64, entity: u8) -> LogKey {
+        let mut bytes = [entity; LOG_KEY_SIZE];
+        bytes[..8].copy_from_slice(&slot.to_be_bytes());
+        LogKey::from(bytes.as_slice())
+    }
+
+    #[test]
+    fn prefixed_key_roundtrip() {
+        let key = log_key(42, 0xab);
+        let prefixed = build_log_key("account-epochs", &key);
+        assert_eq!(prefixed.len(), PREFIXED_LOG_KEY_SIZE);
+        assert_eq!(decode_log_key(&prefixed), key);
+    }
+
+    #[test]
+    fn namespace_isolation() {
+        let key = log_key(42, 0xab);
+        let a = build_log_key("account-epochs", &key);
+        let b = build_log_key("stakes", &key);
+        assert_ne!(a[..NS_HASH_SIZE], b[..NS_HASH_SIZE]);
+        assert_eq!(a[NS_HASH_SIZE..], b[NS_HASH_SIZE..]);
+    }
+
+    #[test]
+    fn key_order_matches_log_key_order() {
+        let earlier = build_log_key("stakes", &log_key(1, 0xff));
+        let later = build_log_key("stakes", &log_key(2, 0x00));
+        assert!(earlier < later);
+    }
+
+    #[test]
+    fn temporal_bound_splits_at_slot() {
+        let ns = "stakes";
+        let bound = build_temporal_bound(ns, 5);
+        let below = build_log_key(ns, &log_key(4, 0xff));
+        let at = build_log_key(ns, &log_key(5, 0x00));
+        assert!(below.as_slice() < bound.as_slice());
+        assert!(at.as_slice() > bound.as_slice());
+    }
+
+    #[test]
+    fn namespace_bounds_cover_all_keys() {
+        let ns = "epochs";
+        let start = namespace_start(ns);
+        let end = namespace_end(ns);
+        let min = build_log_key(ns, &LogKey::from([0u8; LOG_KEY_SIZE].as_slice()));
+        let max = build_log_key(ns, &LogKey::from([0xff; LOG_KEY_SIZE].as_slice()));
+        assert!(start.as_slice() < min.as_slice());
+        assert!(max.as_slice() < end.as_slice());
+    }
+}

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -1,0 +1,918 @@
+//! Fjall-based archive store implementation for Dolos.
+//!
+//! Benchmark vehicle for the archive-index backend evaluation: the redb
+//! archive keeps block bodies in flat segment files and holds two kinds of
+//! index rows — a blocks location table and the derived-log namespaces — in
+//! a copy-on-write B-tree. This module keeps the segment files (reusing the
+//! redb crate's [`flatfiles`] store as-is) and moves only the index rows
+//! into an LSM tree.
+//!
+//! ## Two Keyspace Design
+//!
+//! 1. **`archive-blocks`**: slot → packed 16-byte [`BlockLocation`]s, newest
+//!    first. Key is the 8-byte big-endian slot; the value encoding is
+//!    byte-identical to the redb blocks table, including the multi-location
+//!    case (a Byron epoch-boundary block sharing its slot with the first main
+//!    block of the epoch it opens).
+//!
+//! 2. **`archive-logs`**: all log namespaces with namespace hash prefix. Key:
+//!    `[ns_hash:8][log_key:40]` (48 bytes), mirroring the state store's unified
+//!    entities keyspace — one keyspace, not one per namespace, because
+//!    per-namespace LSM trees blow the file-descriptor limit during heavy
+//!    compaction.
+//!
+//! Unlike the redb writer, log batches are not reordered before insertion:
+//! shuffling exists to work around redb's half-split of ascending B-tree
+//! leaves, and an LSM memtable sorts its batch regardless of arrival order.
+
+use std::collections::{HashMap, VecDeque};
+use std::ops::{Bound, Range};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use dolos_core::{
+    config::FjallArchiveConfig, ArchiveError, ArchiveStore as CoreArchiveStore,
+    ArchiveWriter as CoreArchiveWriter, BlockBody, BlockSlot, ChainPoint, EntityValue, LogKey,
+    Namespace, RawBlock, StateSchema,
+};
+use fjall::{
+    compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
+    Readable, Snapshot,
+};
+use pallas::ledger::traverse::MultiEraBlock;
+
+use dolos_redb3::archive::flatfiles::{
+    decode_locations, encode_locations, BlockLocation, FlatFileStore,
+};
+
+use crate::Error;
+
+pub mod log_keys;
+
+use log_keys::{
+    build_log_key, build_temporal_bound, decode_log_key, namespace_end, namespace_start,
+    PREFIXED_LOG_KEY_SIZE,
+};
+
+/// Default cache size in MB
+const DEFAULT_CACHE_SIZE_MB: usize = 500;
+
+/// Keyspace names for the archive store
+mod keyspace_names {
+    /// Blocks location table (slot → packed BlockLocations)
+    pub const BLOCKS: &str = "archive-blocks";
+    /// Unified log namespaces keyspace
+    pub const LOGS: &str = "archive-logs";
+}
+
+fn io_err(e: std::io::Error) -> ArchiveError {
+    ArchiveError::InternalError(e.to_string())
+}
+
+fn fjall_err(e: fjall::Error) -> ArchiveError {
+    ArchiveError::from(Error::Fjall(e))
+}
+
+/// Fjall-based archive store.
+///
+/// Block bodies live in flat segment files (shared, byte-identical layout
+/// with the redb backend); only the location table and the log namespaces
+/// live in the LSM tree.
+#[derive(Clone)]
+pub struct ArchiveStore {
+    db: Database,
+    blocks: Keyspace,
+    logs: Keyspace,
+    flatfiles: Arc<FlatFileStore>,
+    schema: Arc<StateSchema>,
+    flush_on_commit: bool,
+    _tempdir: Option<Arc<tempfile::TempDir>>,
+}
+
+impl ArchiveStore {
+    /// Open or create an archive store.
+    ///
+    /// `path` is the archive **directory** (e.g. `<storage.path>/archive/`).
+    /// The fjall database is stored at `<path>/index`. Segment files are
+    /// stored in `config.blocks_path` if set, otherwise in `<path>/`.
+    pub fn open(
+        schema: StateSchema,
+        path: impl AsRef<Path>,
+        config: &FjallArchiveConfig,
+    ) -> Result<Self, Error> {
+        let path = path.as_ref();
+        std::fs::create_dir_all(path).map_err(|e| Error::Io(e.to_string()))?;
+
+        let cache_size = config.cache.unwrap_or(DEFAULT_CACHE_SIZE_MB);
+        let cache_bytes = (cache_size * 1024 * 1024) as u64;
+
+        let mut builder = Database::builder(path.join("index")).cache_size(cache_bytes);
+
+        if let Some(journal_mb) = config.max_journal_size {
+            builder = builder.max_journaling_size((journal_mb as u64) * 1024 * 1024);
+        }
+
+        if let Some(threads) = config.worker_threads {
+            builder = builder.worker_threads(threads);
+        }
+
+        let db = builder.open()?;
+
+        let segments_dir = config
+            .blocks_path
+            .clone()
+            .unwrap_or_else(|| path.to_path_buf());
+
+        let flatfiles = FlatFileStore::new(segments_dir).map_err(|e| Error::Io(e.to_string()))?;
+
+        Self::from_database(
+            db,
+            schema,
+            flatfiles,
+            config.flush_on_commit.unwrap_or(false),
+            config.l0_threshold,
+            config.memtable_size_mb,
+            None,
+        )
+    }
+
+    /// Create an archive store over temporary directories, for tests.
+    ///
+    /// Fjall has no in-memory backend; the tempdir guard is held by the
+    /// store and cleaned up when the last clone drops.
+    pub fn for_tempdir(schema: StateSchema) -> Result<Self, Error> {
+        let dir = tempfile::TempDir::new().map_err(|e| Error::Io(e.to_string()))?;
+
+        let db = Database::builder(dir.path().join("index")).open()?;
+
+        let flatfiles =
+            FlatFileStore::new(dir.path().to_path_buf()).map_err(|e| Error::Io(e.to_string()))?;
+
+        let mut store = Self::from_database(db, schema, flatfiles, false, None, None, None)?;
+        store._tempdir = Some(Arc::new(dir));
+
+        Ok(store)
+    }
+
+    fn from_database(
+        db: Database,
+        schema: StateSchema,
+        flatfiles: FlatFileStore,
+        flush_on_commit: bool,
+        l0_threshold: Option<u8>,
+        memtable_size_mb: Option<usize>,
+        tempdir: Option<Arc<tempfile::TempDir>>,
+    ) -> Result<Self, Error> {
+        let build_opts = || {
+            let mut opts = KeyspaceCreateOptions::default();
+
+            if let Some(threshold) = l0_threshold {
+                opts = opts
+                    .compaction_strategy(Arc::new(Leveled::default().with_l0_threshold(threshold)));
+            }
+
+            if let Some(size_mb) = memtable_size_mb {
+                opts = opts.max_memtable_size((size_mb as u64) * 1024 * 1024);
+            }
+
+            opts
+        };
+
+        let blocks = db.keyspace(keyspace_names::BLOCKS, build_opts)?;
+        let logs = db.keyspace(keyspace_names::LOGS, build_opts)?;
+
+        Ok(Self {
+            db,
+            blocks,
+            logs,
+            flatfiles: Arc::new(flatfiles),
+            schema: Arc::new(schema),
+            flush_on_commit,
+            _tempdir: tempdir,
+        })
+    }
+
+    /// Get a reference to the underlying database
+    pub fn database(&self) -> &Database {
+        &self.db
+    }
+
+    /// Per-keyspace disk footprint: `(name, bytes, path)`.
+    pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
+        vec![
+            (
+                keyspace_names::BLOCKS,
+                self.blocks.disk_space(),
+                self.blocks.path().to_path_buf(),
+            ),
+            (
+                keyspace_names::LOGS,
+                self.logs.disk_space(),
+                self.logs.path().to_path_buf(),
+            ),
+        ]
+    }
+
+    /// Gracefully shutdown the archive store.
+    ///
+    /// Persists all data and waits for outstanding flushes so fjall's drop
+    /// implementation cannot hang on a full worker channel.
+    pub fn shutdown(&self) -> Result<(), Error> {
+        use std::time::Duration;
+
+        tracing::info!("archive store: starting graceful shutdown");
+
+        self.db.persist(PersistMode::SyncAll)?;
+
+        let mut wait_count = 0;
+        while self.db.outstanding_flushes() > 0 {
+            std::thread::sleep(Duration::from_millis(10));
+            wait_count += 1;
+            if wait_count % 100 == 0 {
+                tracing::debug!(
+                    "archive store: waiting for {} outstanding flushes",
+                    self.db.outstanding_flushes()
+                );
+            }
+            if wait_count > 6000 {
+                tracing::warn!("archive store: timeout waiting for flushes, proceeding");
+                break;
+            }
+        }
+
+        tracing::info!("archive store: graceful shutdown complete");
+        Ok(())
+    }
+
+    fn check_namespace(&self, ns: Namespace) -> Result<(), ArchiveError> {
+        if !self.schema.contains_key(ns) {
+            return Err(ArchiveError::NamespaceNotFound(ns));
+        }
+        Ok(())
+    }
+
+    /// Every location recorded at `slot`, in stored order (newest first).
+    fn stored_locations(
+        &self,
+        snapshot: &Snapshot,
+        slot: BlockSlot,
+    ) -> Result<Vec<BlockLocation>, ArchiveError> {
+        let value = snapshot
+            .get(&self.blocks, slot.to_be_bytes())
+            .map_err(fjall_err)?;
+
+        match value {
+            Some(bytes) => Ok(decode_locations(&bytes).collect()),
+            None => Ok(vec![]),
+        }
+    }
+}
+
+/// Writer for batched archive operations.
+///
+/// Log writes go straight into the shared write batch: fjall applies a
+/// batch's items to the memtable in order, and the memtable replaces on an
+/// identical key, so the last write to a key within one batch is the one
+/// that survives — the same end state redb's writer reaches by collapsing
+/// each batch to its last writes. Blocks are buffered until `commit` so
+/// their bodies can be appended to the segment files (and fsynced) before
+/// any index entry that points at them is committed, the same crash window
+/// the redb writer keeps.
+///
+/// `overlay` is the writer-local view of every blocks-table slot this
+/// writer has touched. The write batch is invisible to reads until commit,
+/// so a second block landing at the same slot within one batch (a Byron
+/// boundary) and consecutive `undo`s at one slot resolve against the
+/// overlay first and the committed state second — the reads redb gets for
+/// free from its transaction seeing its own writes.
+pub struct ArchiveWriter {
+    store: ArchiveStore,
+    batch: Mutex<OwnedWriteBatch>,
+    pending_blocks: Mutex<Vec<(ChainPoint, RawBlock)>>,
+    overlay: Mutex<HashMap<BlockSlot, Vec<BlockLocation>>>,
+}
+
+impl ArchiveWriter {
+    fn resolve_locations(
+        &self,
+        overlay: &HashMap<BlockSlot, Vec<BlockLocation>>,
+        slot: BlockSlot,
+    ) -> Result<Vec<BlockLocation>, ArchiveError> {
+        if let Some(locations) = overlay.get(&slot) {
+            return Ok(locations.clone());
+        }
+
+        let snapshot = self.store.db.snapshot();
+        self.store.stored_locations(&snapshot, slot)
+    }
+}
+
+impl CoreArchiveWriter for ArchiveWriter {
+    fn apply(&self, point: &ChainPoint, block: &RawBlock) -> Result<(), ArchiveError> {
+        self.pending_blocks
+            .lock()
+            .unwrap()
+            .push((point.clone(), block.clone()));
+        Ok(())
+    }
+
+    fn write_log(
+        &self,
+        ns: Namespace,
+        key: &LogKey,
+        value: &EntityValue,
+    ) -> Result<(), ArchiveError> {
+        // The namespace is resolved here so an unknown one fails at the call
+        // that names it rather than at commit.
+        self.store.check_namespace(ns)?;
+
+        let mut batch = self.batch.lock().unwrap();
+        batch.insert(&self.store.logs, build_log_key(ns, key), value.as_slice());
+
+        Ok(())
+    }
+
+    /// Undo the block at `point`.
+    ///
+    /// A rollback walks the chain backwards, so at a slot holding more than
+    /// one block the one to remove is the newest — position 0 — and the slot
+    /// survives until its last block is gone. The segment file is truncated
+    /// at the removed block's offset immediately, mirroring the redb writer.
+    fn undo(&self, point: &ChainPoint) -> Result<(), ArchiveError> {
+        let slot = point.slot();
+
+        let mut overlay = self.overlay.lock().unwrap();
+        let mut locations = self.resolve_locations(&overlay, slot)?;
+
+        if locations.is_empty() {
+            return Ok(());
+        }
+
+        let removed = locations.remove(0);
+
+        let mut batch = self.batch.lock().unwrap();
+        if locations.is_empty() {
+            batch.remove(&self.store.blocks, slot.to_be_bytes());
+        } else {
+            batch.insert(
+                &self.store.blocks,
+                slot.to_be_bytes(),
+                encode_locations(&locations),
+            );
+        }
+        drop(batch);
+
+        overlay.insert(slot, locations);
+
+        self.store
+            .flatfiles
+            .truncate(removed.segment_id, removed.offset)
+            .map_err(io_err)?;
+
+        Ok(())
+    }
+
+    fn commit(self) -> Result<(), ArchiveError> {
+        // 1. Batch-append all pending blocks to flat files (fsync inside).
+        // 2. Insert all index entries into the write batch.
+        // 3. Commit the batch (log rows are already in it).
+        let pending = self.pending_blocks.into_inner().unwrap();
+        let mut overlay = self.overlay.into_inner().unwrap();
+        let mut batch = self.batch.into_inner().unwrap();
+
+        if !pending.is_empty() {
+            let items: Vec<(u32, &[u8])> = pending
+                .iter()
+                .map(|(point, block)| {
+                    let segment_id = BlockLocation::segment_for_slot(point.slot());
+                    (segment_id, block.as_slice())
+                })
+                .collect();
+
+            let locations = self.store.flatfiles.append_batch(&items).map_err(io_err)?;
+
+            let snapshot = self.store.db.snapshot();
+
+            for (i, (point, body)) in pending.iter().enumerate() {
+                let slot = point.slot();
+                let incoming = locations[i];
+
+                let existing = match overlay.get(&slot) {
+                    Some(locations) => locations.clone(),
+                    None => self.store.stored_locations(&snapshot, slot)?,
+                };
+
+                let merged = merge_location(existing, incoming, body, &self.store.flatfiles)?;
+
+                batch.insert(
+                    &self.store.blocks,
+                    slot.to_be_bytes(),
+                    encode_locations(&merged),
+                );
+                overlay.insert(slot, merged);
+            }
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        if self.store.flush_on_commit {
+            self.store
+                .db
+                .persist(PersistMode::Buffer)
+                .map_err(fjall_err)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Fold a newly written block into the locations already held at its slot.
+///
+/// An identical body means this block is being written again (a resumed
+/// restore rewriting the layer it was in the middle of): the entry that
+/// points at the original stays exactly where it is, and the copy just
+/// appended is the one nothing points at — dead space, not corruption.
+/// Repointing would move an index entry forward in the segment past a block
+/// it precedes in the chain, and `undo` truncates at the offset it removes,
+/// so that block's bytes would go with the cut.
+///
+/// Anything else is a second block at the same slot, and it takes position
+/// 0: blocks arrive in chain order, so the newcomer is the one the slot
+/// should resolve to.
+fn merge_location(
+    existing: Vec<BlockLocation>,
+    incoming: BlockLocation,
+    body: &RawBlock,
+    flatfiles: &FlatFileStore,
+) -> Result<Vec<BlockLocation>, ArchiveError> {
+    if existing.is_empty() {
+        return Ok(vec![incoming]);
+    }
+
+    for loc in existing.iter() {
+        if loc.length as usize != body.len() {
+            continue;
+        }
+
+        let stored = flatfiles.read(loc).map_err(io_err)?;
+
+        if stored == **body {
+            return Ok(existing);
+        }
+    }
+
+    let mut merged = existing;
+    merged.insert(0, incoming);
+
+    Ok(merged)
+}
+
+/// Iterator over a range of log rows within one namespace.
+///
+/// Fuses after the first error: a range scan that failed mid-way must not
+/// look like a shorter, complete result to a consumer that signs or
+/// compares what it read.
+pub struct LogIter {
+    inner: fjall::Iter,
+    done: bool,
+}
+
+impl Iterator for LogIter {
+    type Item = Result<(LogKey, EntityValue), ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let guard = self.inner.next()?;
+
+        match guard.into_inner() {
+            Ok((key, value)) => {
+                if key.len() < PREFIXED_LOG_KEY_SIZE {
+                    self.done = true;
+                    return Some(Err(ArchiveError::InternalError(format!(
+                        "malformed archive log key of {} bytes",
+                        key.len()
+                    ))));
+                }
+
+                Some(Ok((decode_log_key(&key), value.to_vec())))
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(fjall_err(e)))
+            }
+        }
+    }
+}
+
+/// Empty iterator for the unused multimap read surface.
+///
+/// The trait declares the associated type but no trait method returns it,
+/// and no log namespace is a multimap today.
+pub struct EmptyEntityValueIter;
+
+impl Iterator for EmptyEntityValueIter {
+    type Item = Result<EntityValue, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+type IndexEntry = (BlockSlot, BlockLocation);
+
+/// Iterator over a range of blocks, reading lazily from flat files.
+///
+/// A slot can hold more than one block, so an index entry expands to a run
+/// of locations and whatever is left of the entry each end is working
+/// through is buffered here. When one end's range runs dry it drains the
+/// other end's buffer, which is what keeps a forward and a backward walk
+/// from yielding a block twice or dropping one where they meet.
+pub struct BlockIter {
+    inner: fjall::Iter,
+    front: VecDeque<IndexEntry>,
+    back: VecDeque<IndexEntry>,
+    flatfiles: Arc<FlatFileStore>,
+}
+
+impl BlockIter {
+    fn decode_guard(guard: fjall::Guard) -> Option<(BlockSlot, Vec<BlockLocation>)> {
+        let (key, value) = guard.into_inner().ok()?;
+
+        let slot_bytes: [u8; 8] = key.as_ref().get(..8)?.try_into().ok()?;
+        let slot = u64::from_be_bytes(slot_bytes);
+
+        Some((slot, decode_locations(&value).collect()))
+    }
+
+    fn next_entry(&mut self) -> Option<IndexEntry> {
+        loop {
+            if let Some(entry) = self.front.pop_front() {
+                return Some(entry);
+            }
+
+            let Some(guard) = self.inner.next() else {
+                return self.back.pop_front();
+            };
+
+            let (slot, locations) = Self::decode_guard(guard)?;
+
+            self.front
+                .extend(locations.into_iter().rev().map(|loc| (slot, loc)));
+        }
+    }
+
+    fn next_entry_back(&mut self) -> Option<IndexEntry> {
+        loop {
+            if let Some(entry) = self.back.pop_back() {
+                return Some(entry);
+            }
+
+            let Some(guard) = self.inner.next_back() else {
+                return self.front.pop_back();
+            };
+
+            let (slot, locations) = Self::decode_guard(guard)?;
+
+            self.back
+                .extend(locations.into_iter().rev().map(|loc| (slot, loc)));
+        }
+    }
+}
+
+impl Iterator for BlockIter {
+    type Item = (BlockSlot, BlockBody);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (slot, loc) = self.next_entry()?;
+            match self.flatfiles.read(&loc) {
+                Ok(data) => return Some((slot, data)),
+                Err(_) => continue, // skip unreadable blocks
+            }
+        }
+    }
+}
+
+impl DoubleEndedIterator for BlockIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let (slot, loc) = self.next_entry_back()?;
+            match self.flatfiles.read(&loc) {
+                Ok(data) => return Some((slot, data)),
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+impl dolos_core::archive::Skippable for BlockIter {
+    fn skip_forward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.next_entry().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn skip_backward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.next_entry_back().is_none() {
+                break;
+            }
+        }
+    }
+}
+
+impl CoreArchiveStore for ArchiveStore {
+    type BlockIter<'a> = BlockIter;
+    type Writer = ArchiveWriter;
+    type LogIter = LogIter;
+    type EntityValueIter = EmptyEntityValueIter;
+
+    fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
+        Ok(ArchiveWriter {
+            batch: Mutex::new(self.db.batch()),
+            store: self.clone(),
+            pending_blocks: Mutex::new(Vec::new()),
+            overlay: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn read_logs(
+        &self,
+        ns: Namespace,
+        keys: &[&LogKey],
+    ) -> Result<Vec<Option<EntityValue>>, ArchiveError> {
+        self.check_namespace(ns)?;
+
+        let snapshot = self.db.snapshot();
+        let mut out = Vec::with_capacity(keys.len());
+
+        for key in keys {
+            let value = snapshot
+                .get(&self.logs, build_log_key(ns, key))
+                .map_err(fjall_err)?;
+            out.push(value.map(|v| v.as_ref().to_vec()));
+        }
+
+        Ok(out)
+    }
+
+    fn iter_logs(
+        &self,
+        ns: Namespace,
+        range: Range<LogKey>,
+    ) -> Result<Self::LogIter, ArchiveError> {
+        self.check_namespace(ns)?;
+
+        let start = build_log_key(ns, &range.start);
+        let end = build_log_key(ns, &range.end);
+
+        let snapshot = self.db.snapshot();
+        let inner = snapshot.range(&self.logs, start.as_slice()..end.as_slice());
+
+        Ok(LogIter { inner, done: false })
+    }
+
+    fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        let locations = self.stored_locations(&snapshot, *slot)?;
+
+        match locations.first() {
+            Some(loc) => Ok(Some(self.flatfiles.read(loc).map_err(io_err)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Every block the archive holds at `slot`, in chain order.
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        let locations = self.stored_locations(&snapshot, *slot)?;
+
+        locations
+            .into_iter()
+            .rev()
+            .map(|loc| self.flatfiles.read(&loc).map_err(io_err))
+            .collect()
+    }
+
+    fn get_range<'a>(
+        &self,
+        from: Option<BlockSlot>,
+        to: Option<BlockSlot>,
+    ) -> Result<Self::BlockIter<'a>, ArchiveError> {
+        let start = match from {
+            Some(slot) => Bound::Included(slot.to_be_bytes()),
+            None => Bound::Unbounded,
+        };
+        let end = match to {
+            Some(slot) => Bound::Excluded(slot.to_be_bytes()),
+            None => Bound::Unbounded,
+        };
+
+        let snapshot = self.db.snapshot();
+        let inner = snapshot.range(&self.blocks, (start, end));
+
+        Ok(BlockIter {
+            inner,
+            front: VecDeque::new(),
+            back: VecDeque::new(),
+            flatfiles: self.flatfiles.clone(),
+        })
+    }
+
+    fn find_intersect(&self, intersect: &[ChainPoint]) -> Result<Option<ChainPoint>, ArchiveError> {
+        for point in intersect {
+            let ChainPoint::Specific(slot, hash) = point else {
+                return Ok(Some(ChainPoint::Origin));
+            };
+
+            // A slot can hold more than one block, and an intersect names one
+            // of them by hash, so every block recorded there is a candidate.
+            for body in self.get_blocks_by_slot(slot)? {
+                let decoded =
+                    MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
+
+                if decoded.hash().eq(hash) {
+                    return Ok(Some(ChainPoint::Specific(decoded.slot(), decoded.hash())));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+
+        let Some(guard) = snapshot.last_key_value(&self.blocks) else {
+            return Ok(None);
+        };
+
+        let (key, value) = guard.into_inner().map_err(fjall_err)?;
+
+        let slot_bytes: [u8; 8] = key
+            .as_ref()
+            .get(..8)
+            .and_then(|b| b.try_into().ok())
+            .ok_or_else(|| ArchiveError::InternalError("malformed blocks key".to_string()))?;
+        let slot = u64::from_be_bytes(slot_bytes);
+
+        let loc = BlockLocation::from_bytes(&value);
+        let body = self.flatfiles.read(&loc).map_err(io_err)?;
+
+        Ok(Some((slot, body)))
+    }
+
+    fn prune_history(&self, max_slots: u64, max_prune: Option<u64>) -> Result<bool, ArchiveError> {
+        let snapshot = self.db.snapshot();
+
+        let first = snapshot
+            .first_key_value(&self.blocks)
+            .map(|guard| guard.key())
+            .transpose()
+            .map_err(fjall_err)?;
+
+        let Some(first) = first else {
+            tracing::debug!("no start point found on chain, skipping housekeeping");
+            return Ok(true);
+        };
+
+        let last = snapshot
+            .last_key_value(&self.blocks)
+            .map(|guard| guard.key())
+            .transpose()
+            .map_err(fjall_err)?;
+
+        let Some(last) = last else {
+            tracing::debug!("no tip found on chain, skipping housekeeping");
+            return Ok(true);
+        };
+
+        let start = u64::from_be_bytes(first.as_ref()[..8].try_into().unwrap());
+        let last = u64::from_be_bytes(last.as_ref()[..8].try_into().unwrap());
+
+        let delta = last.saturating_sub(start);
+        let excess = delta.saturating_sub(max_slots);
+
+        if excess == 0 {
+            tracing::debug!(delta, max_slots, "no pruning necessary on chain");
+            return Ok(true);
+        }
+
+        let (done, max_prune) = match max_prune {
+            Some(max) => (excess <= max, core::cmp::min(excess, max)),
+            None => (true, excess),
+        };
+
+        let prune_before = start + max_prune;
+
+        tracing::info!(
+            cutoff_slot = prune_before,
+            start,
+            excess,
+            "pruning archive for excess history"
+        );
+
+        let mut batch = self.db.batch();
+
+        // Blocks strictly before the cutoff slot.
+        let to_remove = snapshot.range(&self.blocks, ..prune_before.to_be_bytes().to_vec());
+        for guard in to_remove {
+            let key = guard.key().map_err(fjall_err)?;
+            batch.remove(&self.blocks, key);
+        }
+
+        let threshold_segment = BlockLocation::segment_for_slot(prune_before);
+        self.flatfiles
+            .delete_segments_before(threshold_segment)
+            .map_err(io_err)?;
+
+        // Log rows with a temporal prefix strictly before the cutoff, per
+        // namespace — the price of the shared keyspace's hash prefix.
+        for (&ns, _) in self.schema.iter() {
+            let range = snapshot.range(
+                &self.logs,
+                namespace_start(ns)..build_temporal_bound(ns, prune_before),
+            );
+            for guard in range {
+                let key = guard.key().map_err(fjall_err)?;
+                batch.remove(&self.logs, key);
+            }
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        Ok(done)
+    }
+
+    /// Drop everything the archive holds after `after`.
+    ///
+    /// The cut is by slot: the block at `after`'s slot survives (including a
+    /// second block sharing that slot), while log rows *at* the slot go with
+    /// the cut — the exact boundary redb's `remove_after` draws by comparing
+    /// full log keys against the bare 8-byte temporal prefix.
+    fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError> {
+        let slot = after.slot();
+        let snapshot = self.db.snapshot();
+
+        let mut batch = self.db.batch();
+
+        // Find the earliest location after `slot` to know where to truncate
+        // the segment file: a slot holding more than one block contributes
+        // all of them, so the cut lands before the earliest body it has to
+        // drop and none survives.
+        let mut earliest_after: Option<BlockLocation> = None;
+
+        if let Some(from) = slot.checked_add(1) {
+            let range = snapshot.range(&self.blocks, from.to_be_bytes().to_vec()..);
+
+            for guard in range {
+                let (key, value) = guard.into_inner().map_err(fjall_err)?;
+
+                for loc in decode_locations(&value) {
+                    match &earliest_after {
+                        None => earliest_after = Some(loc),
+                        Some(prev) => {
+                            if loc.segment_id < prev.segment_id
+                                || (loc.segment_id == prev.segment_id && loc.offset < prev.offset)
+                            {
+                                earliest_after = Some(loc);
+                            }
+                        }
+                    }
+                }
+
+                batch.remove(&self.blocks, key);
+            }
+        }
+
+        // Log rows with a temporal prefix at or after the cut slot.
+        for (&ns, _) in self.schema.iter() {
+            let range = snapshot.range(
+                &self.logs,
+                build_temporal_bound(ns, slot)..namespace_end(ns),
+            );
+            for guard in range {
+                let key = guard.key().map_err(fjall_err)?;
+                batch.remove(&self.logs, key);
+            }
+        }
+
+        if let Some(loc) = earliest_after {
+            self.flatfiles
+                .truncate(loc.segment_id, loc.offset)
+                .map_err(io_err)?;
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        Ok(())
+    }
+}

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -221,6 +221,11 @@ impl ArchiveStore {
         use std::time::Duration;
 
         tracing::info!("archive store: starting graceful shutdown");
+        tracing::info!(
+            flatfile_append_secs =
+                dolos_redb3::archive::flatfiles::cumulative_append_time().as_secs_f64(),
+            "archive store: cumulative flat-file append time"
+        );
 
         self.db.persist(PersistMode::SyncAll)?;
 

--- a/crates/fjall/src/lib.rs
+++ b/crates/fjall/src/lib.rs
@@ -10,10 +10,13 @@
 //! - [`index`]: Index store implementation for cross-cutting indexes
 //! - [`state`]: State store implementation for ledger state (UTxOs, entities,
 //!   datums)
+//! - [`archive`]: Archive store implementation (experimental benchmark vehicle;
+//!   block bodies stay in the redb crate's flat segment files)
 //! - [`keys`]: Shared key encoding utilities
 
-use dolos_core::{IndexError, StateError};
+use dolos_core::{ArchiveError, IndexError, StateError};
 
+pub mod archive;
 pub mod index;
 pub mod keys;
 pub mod state;
@@ -39,6 +42,9 @@ pub enum Error {
 
     #[error("keyspace not found: {0}")]
     KeyspaceNotFound(String),
+
+    #[error("io error: {0}")]
+    Io(String),
 }
 
 impl From<Error> for IndexError {
@@ -50,5 +56,11 @@ impl From<Error> for IndexError {
 impl From<Error> for StateError {
     fn from(error: Error) -> Self {
         StateError::InternalStoreError(error.to_string())
+    }
+}
+
+impl From<Error> for ArchiveError {
+    fn from(error: Error) -> Self {
+        ArchiveError::InternalError(error.to_string())
     }
 }

--- a/crates/redb3/src/archive/flatfiles.rs
+++ b/crates/redb3/src/archive/flatfiles.rs
@@ -78,6 +78,21 @@ fn segment_filename(segment_id: u32) -> String {
     format!("{:06}.segment", segment_id)
 }
 
+/// Wall-clock spent appending and fsyncing segment files, process-wide.
+///
+/// The archive-backend benchmark subtracts this from replay wall-clock to
+/// get index-attributable time: block bodies land on the same disk through
+/// the same code for every backend, and on a slow disk that shared cost is
+/// large enough to hide an index-path regression inside the total.
+static CUMULATIVE_APPEND_NANOS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Total time this process has spent in [`FlatFileStore::append_batch`].
+pub fn cumulative_append_time() -> std::time::Duration {
+    std::time::Duration::from_nanos(
+        CUMULATIVE_APPEND_NANOS.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
 /// Manages append-only segment files for block storage.
 pub struct FlatFileStore {
     segments_dir: PathBuf,
@@ -121,6 +136,16 @@ impl FlatFileStore {
     ///
     /// Returns a `BlockLocation` for each input item, in the same order.
     pub fn append_batch(&self, items: &[(u32, &[u8])]) -> io::Result<Vec<BlockLocation>> {
+        let started = std::time::Instant::now();
+        let result = self.append_batch_inner(items);
+        CUMULATIVE_APPEND_NANOS.fetch_add(
+            started.elapsed().as_nanos() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        result
+    }
+
+    fn append_batch_inner(&self, items: &[(u32, &[u8])]) -> io::Result<Vec<BlockLocation>> {
         let mut locations = Vec::with_capacity(items.len());
         let mut touched_segments: HashMap<u32, ()> = HashMap::new();
 

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -133,6 +133,10 @@ pub struct ArchiveStore {
 impl ArchiveStore {
     /// Gracefully shutdown the archive store.
     pub fn shutdown(&self) -> Result<(), RedbArchiveError> {
+        info!(
+            flatfile_append_secs = flatfiles::cumulative_append_time().as_secs_f64(),
+            "archive store: cumulative flat-file append time"
+        );
         Ok(())
     }
 

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -28,13 +28,9 @@ use redb_extras::buckets::BucketError;
 
 use crate::{build_tables, Error, Table, TableFootprint};
 
-// The one-time Byron EBB recovery scan (`examples/heal-byron-ebbs.rs`) reuses
-// these index definitions and the location packing rather than restating them.
-// It is the only thing that ever enables `maintenance`; the `dolos` binary
-// does not, so the crate's ordinary surface keeps them private.
-#[cfg(not(feature = "maintenance"))]
-pub(crate) mod flatfiles;
-#[cfg(feature = "maintenance")]
+// Flat segment files are backend-independent (std + tempfile only): the fjall
+// archive prototype reuses them as-is, so the module is public unconditionally.
+// A mergeable fjall backend would relocate it out of this crate instead.
 pub mod flatfiles;
 
 pub(crate) mod indexes;

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -581,7 +581,11 @@ fn assert_state_matches<S: StateStore>(restored: &S, original: &S) {
     assert_eq!(utxos_of(restored), utxos, "the utxo set");
 }
 
-fn assert_archive_matches<A: ArchiveStore>(restored: &A, original: &A) {
+// The two sides are independent type parameters: the restore target keeps a
+// concrete redb archive while the harness's archive follows the `ToyStores`
+// binding, so under `FjallStores` this compares across backends — which is
+// exactly the agreement the archive conformance suite wants proven here.
+fn assert_archive_matches<A: ArchiveStore, B: ArchiveStore>(restored: &A, original: &B) {
     let blocks = blocks_of(original);
     assert!(!blocks.is_empty(), "the fixture archived no blocks");
     assert_eq!(blocks_of(restored), blocks, "blocks");

--- a/crates/testing/src/toy_domain.rs
+++ b/crates/testing/src/toy_domain.rs
@@ -134,7 +134,7 @@ impl dolos_core::MempoolStore for Mempool {
     }
 }
 
-/// The state and index backends a [`ToyDomain`] is bound to.
+/// The state, index and archive backends a [`ToyDomain`] is bound to.
 ///
 /// A binding, not a variant: there is one harness domain, and this is the axis
 /// along which it is pointed at a backend. The two implementations below are
@@ -142,18 +142,20 @@ impl dolos_core::MempoolStore for Mempool {
 /// running on either is running on a live configuration rather than on a
 /// test-only store.
 ///
-/// The pair is one trait rather than two parameters because they are always
-/// chosen together, and because [`FjallStores`] has to keep a temporary
-/// directory alive for both.
+/// The set is one trait rather than separate parameters because the stores are
+/// always chosen together, and because [`FjallStores`] has to keep a temporary
+/// directory alive for all of them.
 pub trait ToyStores: Clone + Send + Sync + 'static {
     type State: StateStore;
     type Indexes: dolos_core::IndexStore;
+    type Archive: dolos_core::ArchiveStore;
 
-    /// Open a fresh, empty pair.
+    /// Open a fresh, empty set.
     fn open() -> Self;
 
     fn state(&self) -> &Self::State;
     fn indexes(&self) -> &Self::Indexes;
+    fn archive(&self) -> &Self::Archive;
 }
 
 /// The builtin in-memory stores: the default, and what almost every suite
@@ -168,16 +170,22 @@ pub trait ToyStores: Clone + Send + Sync + 'static {
 pub struct MemoryStores {
     state: MemoryStateStore,
     indexes: MemoryIndexStore,
+    archive: dolos_redb3::archive::ArchiveStore,
 }
 
 impl ToyStores for MemoryStores {
     type State = MemoryStateStore;
     type Indexes = MemoryIndexStore;
+    type Archive = dolos_redb3::archive::ArchiveStore;
 
     fn open() -> Self {
         Self {
             state: MemoryStateStore::new(),
             indexes: MemoryIndexStore::new(),
+            archive: dolos_redb3::archive::ArchiveStore::in_memory(
+                dolos_cardano::model::build_schema(),
+            )
+            .expect("opening the in-memory redb archive store"),
         }
     }
 
@@ -187,6 +195,10 @@ impl ToyStores for MemoryStores {
 
     fn indexes(&self) -> &Self::Indexes {
         &self.indexes
+    }
+
+    fn archive(&self) -> &Self::Archive {
+        &self.archive
     }
 }
 
@@ -203,12 +215,14 @@ impl ToyStores for MemoryStores {
 pub struct FjallStores {
     state: dolos_fjall::StateStore,
     indexes: dolos_fjall::IndexStore,
+    archive: dolos_fjall::archive::ArchiveStore,
     _dir: Arc<tempfile::TempDir>,
 }
 
 impl ToyStores for FjallStores {
     type State = dolos_fjall::StateStore;
     type Indexes = dolos_fjall::IndexStore;
+    type Archive = dolos_fjall::archive::ArchiveStore;
 
     fn open() -> Self {
         let dir = tempfile::tempdir().expect("temp dir for the fjall stores");
@@ -225,9 +239,17 @@ impl ToyStores for FjallStores {
         )
         .expect("opening the fjall index store");
 
+        let archive = dolos_fjall::archive::ArchiveStore::open(
+            dolos_cardano::model::build_schema(),
+            dir.path().join("archive"),
+            &dolos_core::config::FjallArchiveConfig::default(),
+        )
+        .expect("opening the fjall archive store");
+
         Self {
             state,
             indexes,
+            archive,
             _dir: Arc::new(dir),
         }
     }
@@ -239,10 +261,14 @@ impl ToyStores for FjallStores {
     fn indexes(&self) -> &Self::Indexes {
         &self.indexes
     }
+
+    fn archive(&self) -> &Self::Archive {
+        &self.archive
+    }
 }
 
-/// Minimal `Domain` implementation, with the archive on redb and the state and
-/// index stores chosen by [`ToyStores`].
+/// Minimal `Domain` implementation, with the state, index and archive stores
+/// chosen by [`ToyStores`].
 ///
 /// Defaults to [`MemoryStores`], so `ToyDomain` unqualified is the cheap
 /// in-memory harness every existing suite already binds.
@@ -251,7 +277,6 @@ pub struct ToyDomain<B: ToyStores = MemoryStores> {
     wal: dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>,
     chain: Arc<RwLock<dolos_cardano::CardanoLogic>>,
     stores: B,
-    archive: dolos_redb3::archive::ArchiveStore,
     mempool: Mempool,
     storage_config: StorageConfig,
     sync_config: SyncConfig,
@@ -306,10 +331,6 @@ impl<B: ToyStores> ToyDomain<B> {
 
         let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
 
-        let archive =
-            dolos_redb3::archive::ArchiveStore::in_memory(dolos_cardano::model::build_schema())
-                .unwrap();
-
         let chain = dolos_cardano::CardanoLogic::initialize::<Self>(
             config.clone(),
             stores.state(),
@@ -322,7 +343,6 @@ impl<B: ToyStores> ToyDomain<B> {
             stores,
             wal: dolos_redb3::wal::RedbWalStore::memory().unwrap(),
             chain: Arc::new(RwLock::new(chain)),
-            archive,
             mempool: Mempool {
                 pending: Arc::new(RwLock::new(Vec::new())),
             },
@@ -355,7 +375,7 @@ impl<B: ToyStores> ToyDomain<B> {
         let epoch = dolos_cardano::load_epoch::<Self>(domain.stores.state()).unwrap();
         let epoch_start = chain.epoch_start(epoch.number);
         let log_key = LogKey::from(TemporalKey::from(epoch_start));
-        let writer = domain.archive.start_writer().unwrap();
+        let writer = domain.stores.archive().start_writer().unwrap();
         writer.write_log_typed(&log_key, &epoch).unwrap();
         writer.commit().unwrap();
 
@@ -419,7 +439,7 @@ impl<B: ToyStores> dolos_core::Domain for ToyDomain<B> {
     type Entity = dolos_cardano::CardanoEntity;
     type EntityDelta = dolos_cardano::CardanoDelta;
     type Wal = dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>;
-    type Archive = dolos_redb3::archive::ArchiveStore;
+    type Archive = B::Archive;
     type State = B::State;
     type Chain = dolos_cardano::CardanoLogic;
     type WorkUnit = dolos_cardano::CardanoWorkUnit;
@@ -456,7 +476,7 @@ impl<B: ToyStores> dolos_core::Domain for ToyDomain<B> {
     }
 
     fn archive(&self) -> &Self::Archive {
-        &self.archive
+        self.stores.archive()
     }
 
     fn indexes(&self) -> &Self::Indexes {

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -700,6 +700,9 @@ impl ArchiveStoreBackend {
     ) -> Result<Self, ArchiveError> {
         match config {
             ArchiveStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
+            ArchiveStoreConfig::Fjall(_) => Err(ArchiveError::InternalError(
+                "the fjall archive backend is not wired yet".to_string(),
+            )),
             ArchiveStoreConfig::InMemory => Self::in_memory(schema),
             ArchiveStoreConfig::NoOp => Ok(Self::noop()),
         }

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -642,6 +642,7 @@ pub enum ArchiveStoreBackend {
     /// boundary log keys are slot-derived and identical under replay, so
     /// re-written log rows overwrite the originals in place.
     LogsOnly(dolos_redb3::archive::ArchiveStore),
+    Fjall(dolos_fjall::archive::ArchiveStore),
     NoOp(NoOpArchiveStore),
 }
 
@@ -655,6 +656,18 @@ impl ArchiveStoreBackend {
         Ok(Self::Redb(dolos_redb3::archive::ArchiveStore::open(
             schema, path, config,
         )?))
+    }
+
+    /// Open an archive store with the Fjall backend.
+    pub fn open_fjall(
+        path: impl AsRef<Path>,
+        schema: StateSchema,
+        config: &dolos_core::config::FjallArchiveConfig,
+    ) -> Result<Self, ArchiveError> {
+        Ok(Self::Fjall(
+            dolos_fjall::archive::ArchiveStore::open(schema, path, config)
+                .map_err(ArchiveError::from)?,
+        ))
     }
 
     /// Create a no-op archive store that discards all writes.
@@ -677,6 +690,7 @@ impl ArchiveStoreBackend {
     pub fn logs_only(&self) -> Option<Self> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => Some(Self::LogsOnly(s.clone())),
+            Self::Fjall(_) => None,
             Self::NoOp(_) => None,
         }
     }
@@ -700,9 +714,7 @@ impl ArchiveStoreBackend {
     ) -> Result<Self, ArchiveError> {
         match config {
             ArchiveStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
-            ArchiveStoreConfig::Fjall(_) => Err(ArchiveError::InternalError(
-                "the fjall archive backend is not wired yet".to_string(),
-            )),
+            ArchiveStoreConfig::Fjall(cfg) => Self::open_fjall(path, schema, cfg),
             ArchiveStoreConfig::InMemory => Self::in_memory(schema),
             ArchiveStoreConfig::NoOp => Ok(Self::noop()),
         }
@@ -713,6 +725,7 @@ impl ArchiveStoreBackend {
             Self::Redb(s) | Self::LogsOnly(s) => s
                 .shutdown()
                 .map_err(|e| ArchiveError::InternalError(e.to_string())),
+            Self::Fjall(s) => s.shutdown().map_err(ArchiveError::from),
             Self::NoOp(s) => s.shutdown(),
         }
     }
@@ -722,6 +735,7 @@ pub enum ArchiveWriterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::Writer>),
     /// Delegates `write_log` and `commit`; discards `apply` and `undo`.
     LogsOnly(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::Writer>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::Writer>),
     NoOp(NoOpArchiveWriter),
 }
 
@@ -730,6 +744,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
         match self {
             Self::Redb(w) => w.apply(point, block),
             Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.apply(point, block),
             Self::NoOp(w) => w.apply(point, block),
         }
     }
@@ -742,6 +757,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
     ) -> Result<(), ArchiveError> {
         match self {
             Self::Redb(w) | Self::LogsOnly(w) => w.write_log(ns, key, value),
+            Self::Fjall(w) => w.write_log(ns, key, value),
             Self::NoOp(w) => w.write_log(ns, key, value),
         }
     }
@@ -750,6 +766,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
         match self {
             Self::Redb(w) => w.undo(point),
             Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.undo(point),
             Self::NoOp(w) => w.undo(point),
         }
     }
@@ -757,6 +774,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
     fn commit(self) -> Result<(), ArchiveError> {
         match self {
             Self::Redb(w) | Self::LogsOnly(w) => (*w).commit(),
+            Self::Fjall(w) => (*w).commit(),
             Self::NoOp(w) => w.commit(),
         }
     }
@@ -764,6 +782,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
 
 pub enum ArchiveBlockIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::BlockIter<'static>>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::BlockIter<'static>>),
     NoOp(EmptyBlockIter),
 }
 
@@ -772,6 +791,7 @@ impl Iterator for ArchiveBlockIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -781,6 +801,7 @@ impl DoubleEndedIterator for ArchiveBlockIterBackend {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next_back(),
+            Self::Fjall(iter) => iter.next_back(),
             Self::NoOp(iter) => iter.next_back(),
         }
     }
@@ -790,6 +811,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
     fn skip_forward(&mut self, n: usize) {
         match self {
             Self::Redb(iter) => iter.skip_forward(n),
+            Self::Fjall(iter) => iter.skip_forward(n),
             Self::NoOp(iter) => iter.skip_forward(n),
         }
     }
@@ -797,6 +819,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
     fn skip_backward(&mut self, n: usize) {
         match self {
             Self::Redb(iter) => iter.skip_backward(n),
+            Self::Fjall(iter) => iter.skip_backward(n),
             Self::NoOp(iter) => iter.skip_backward(n),
         }
     }
@@ -804,6 +827,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
 
 pub enum ArchiveLogIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::LogIter>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::LogIter>),
     NoOp(EmptyLogIter),
 }
 
@@ -812,6 +836,7 @@ impl Iterator for ArchiveLogIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -819,6 +844,7 @@ impl Iterator for ArchiveLogIterBackend {
 
 pub enum ArchiveEntityValueIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::EntityValueIter>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::EntityValueIter>),
     NoOp(dolos_core::builtin::EmptyEntityValueIter),
 }
 
@@ -827,6 +853,7 @@ impl Iterator for ArchiveEntityValueIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -844,6 +871,8 @@ impl CoreArchiveStore for ArchiveStoreBackend {
                 .map(|writer| ArchiveWriterBackend::Redb(Box::new(writer))),
             Self::LogsOnly(s) => CoreArchiveStore::start_writer(s)
                 .map(|writer| ArchiveWriterBackend::LogsOnly(Box::new(writer))),
+            Self::Fjall(s) => CoreArchiveStore::start_writer(s)
+                .map(|writer| ArchiveWriterBackend::Fjall(Box::new(writer))),
             Self::NoOp(s) => CoreArchiveStore::start_writer(s).map(ArchiveWriterBackend::NoOp),
         }
     }
@@ -855,6 +884,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     ) -> Result<Vec<Option<EntityValue>>, ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::read_logs(s, ns, keys),
+            Self::Fjall(s) => CoreArchiveStore::read_logs(s, ns, keys),
             Self::NoOp(s) => CoreArchiveStore::read_logs(s, ns, keys),
         }
     }
@@ -867,6 +897,8 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::iter_logs(s, ns, range)
                 .map(|iter| ArchiveLogIterBackend::Redb(Box::new(iter))),
+            Self::Fjall(s) => CoreArchiveStore::iter_logs(s, ns, range)
+                .map(|iter| ArchiveLogIterBackend::Fjall(Box::new(iter))),
             Self::NoOp(s) => {
                 CoreArchiveStore::iter_logs(s, ns, range).map(ArchiveLogIterBackend::NoOp)
             }
@@ -876,6 +908,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_block_by_slot(s, slot),
+            Self::Fjall(s) => CoreArchiveStore::get_block_by_slot(s, slot),
             Self::NoOp(s) => CoreArchiveStore::get_block_by_slot(s, slot),
         }
     }
@@ -883,6 +916,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
+            Self::Fjall(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
             Self::NoOp(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
         }
     }
@@ -895,6 +929,8 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_range(s, from, to)
                 .map(|iter| ArchiveBlockIterBackend::Redb(Box::new(iter))),
+            Self::Fjall(s) => CoreArchiveStore::get_range(s, from, to)
+                .map(|iter| ArchiveBlockIterBackend::Fjall(Box::new(iter))),
             Self::NoOp(s) => {
                 CoreArchiveStore::get_range(s, from, to).map(ArchiveBlockIterBackend::NoOp)
             }
@@ -904,6 +940,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     fn find_intersect(&self, intersect: &[ChainPoint]) -> Result<Option<ChainPoint>, ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::find_intersect(s, intersect),
+            Self::Fjall(s) => CoreArchiveStore::find_intersect(s, intersect),
             Self::NoOp(s) => CoreArchiveStore::find_intersect(s, intersect),
         }
     }
@@ -911,6 +948,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_tip(s),
+            Self::Fjall(s) => CoreArchiveStore::get_tip(s),
             Self::NoOp(s) => CoreArchiveStore::get_tip(s),
         }
     }
@@ -920,6 +958,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
             Self::Redb(s) | Self::LogsOnly(s) => {
                 CoreArchiveStore::prune_history(s, max_slots, max_prune)
             }
+            Self::Fjall(s) => CoreArchiveStore::prune_history(s, max_slots, max_prune),
             Self::NoOp(s) => CoreArchiveStore::prune_history(s, max_slots, max_prune),
         }
     }
@@ -927,6 +966,7 @@ impl CoreArchiveStore for ArchiveStoreBackend {
     fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError> {
         match self {
             Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::truncate_front(s, after),
+            Self::Fjall(s) => CoreArchiveStore::truncate_front(s, after),
             Self::NoOp(s) => CoreArchiveStore::truncate_front(s, after),
         }
     }

--- a/src/bin/dolos/data/bench_archive.rs
+++ b/src/bin/dolos/data/bench_archive.rs
@@ -1,0 +1,444 @@
+//! Hidden benchmark harness for the archive-backend evaluation.
+//!
+//! Opens the archive of the configured instance read-only and measures the
+//! three access shapes the evaluation's read criterion names, plus the
+//! on-disk footprint. Config-driven: the same binary run against a redb
+//! instance and a fjall instance exercises the identical code path, and a
+//! shared `--seed` makes both runs measure the same sampled keys.
+//!
+//! The block point-read shape is split in two: slot→location resolution
+//! (via `Skippable`, which advances the index without touching a segment
+//! file) and the full body read. Block bodies live in identical flat files
+//! on the same disk for every backend, so only the resolution half can
+//! differ between them — the full read is reported for context.
+
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use miette::{Context as _, IntoDiagnostic as _};
+use serde_json::json;
+
+use dolos::storage::ArchiveStoreBackend;
+use dolos_cardano::eras::load_chain_summary_from_state;
+use dolos_core::{
+    archive::Skippable as _, config::RootConfig, ArchiveStore as _, BlockSlot, EntityKey, LogKey,
+    TemporalKey,
+};
+
+const LOGS_NS: &str = "account-epochs";
+
+/// Rough preprod/mainnet block interval, used only to size the sampling
+/// stride before the real population is known.
+const EST_SLOTS_PER_BLOCK: u64 = 20;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Number of sampled block slots for the point-read shape.
+    #[arg(long, default_value_t = 1000)]
+    samples: usize,
+
+    /// Number of sampled accounts for the rewards shape.
+    #[arg(long, default_value_t = 50)]
+    accounts: usize,
+
+    /// Number of sampled epochs for the per-epoch scan shape.
+    #[arg(long, default_value_t = 10)]
+    epochs: usize,
+
+    /// RNG seed, shared across backends so both measure the same keys.
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+
+    /// Which measurement to run: all, size, blocks, rewards, scan.
+    #[arg(long, default_value = "all")]
+    shape: String,
+}
+
+/// SplitMix64: deterministic, dependency-free, good enough to spread
+/// samples. Not for anything but picking offsets.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+        z ^ (z >> 31)
+    }
+}
+
+fn percentiles(mut samples: Vec<Duration>) -> serde_json::Value {
+    if samples.is_empty() {
+        return json!(null);
+    }
+
+    samples.sort();
+    let pick = |q: f64| samples[((samples.len() - 1) as f64 * q) as usize].as_secs_f64();
+
+    json!({
+        "count": samples.len(),
+        "p50_s": pick(0.50),
+        "p95_s": pick(0.95),
+        "max_s": samples.last().unwrap().as_secs_f64(),
+        "total_s": samples.iter().sum::<Duration>().as_secs_f64(),
+    })
+}
+
+fn dir_size(path: &std::path::Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+
+    entries
+        .flatten()
+        .map(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                dir_size(&path)
+            } else {
+                entry.metadata().map(|m| m.len()).unwrap_or(0)
+            }
+        })
+        .sum()
+}
+
+fn backend_name(archive: &ArchiveStoreBackend) -> &'static str {
+    match archive {
+        ArchiveStoreBackend::Redb(_) => "redb",
+        ArchiveStoreBackend::LogsOnly(_) => "redb (logs-only)",
+        ArchiveStoreBackend::Fjall(_) => "fjall",
+        ArchiveStoreBackend::NoOp(_) => "noop",
+    }
+}
+
+fn size_section(config: &RootConfig, archive: &ArchiveStoreBackend) -> serde_json::Value {
+    let mut out = serde_json::Map::new();
+
+    if let Some(path) = config.storage.archive_path() {
+        let mut entries = serde_json::Map::new();
+
+        if let Ok(dir) = std::fs::read_dir(&path) {
+            for entry in dir.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                let entry_path = entry.path();
+                let bytes = if entry_path.is_dir() {
+                    dir_size(&entry_path)
+                } else {
+                    entry.metadata().map(|m| m.len()).unwrap_or(0)
+                };
+                entries.insert(name, json!(bytes));
+            }
+        }
+
+        out.insert("archive_dir".into(), json!(path.display().to_string()));
+        out.insert("archive_dir_total_bytes".into(), json!(dir_size(&path)));
+        out.insert("archive_dir_entries".into(), entries.into());
+    }
+
+    let blocks_path = match &config.storage.archive {
+        dolos_core::config::ArchiveStoreConfig::Redb(cfg) => cfg.blocks_path.clone(),
+        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => cfg.blocks_path.clone(),
+        _ => None,
+    };
+
+    if let Some(path) = blocks_path {
+        out.insert("blocks_dir".into(), json!(path.display().to_string()));
+        out.insert("blocks_dir_total_bytes".into(), json!(dir_size(&path)));
+    }
+
+    if let ArchiveStoreBackend::Fjall(store) = archive {
+        let keyspaces: serde_json::Map<String, serde_json::Value> = store
+            .disk_usage()
+            .into_iter()
+            .map(|(name, bytes, path)| {
+                (
+                    name.to_string(),
+                    json!({ "bytes": bytes, "path": path.display().to_string() }),
+                )
+            })
+            .collect();
+        out.insert("fjall_keyspaces".into(), keyspaces.into());
+    }
+
+    out.into()
+}
+
+/// Stride-sample real block slots by walking the index, skipping entries
+/// without reading bodies. The `next()` per sample does read one body; this
+/// is setup, not a timed phase.
+fn sample_block_slots(
+    archive: &ArchiveStoreBackend,
+    samples: usize,
+) -> miette::Result<Vec<BlockSlot>> {
+    let Some((tip, _)) = archive.get_tip().into_diagnostic()? else {
+        return Ok(vec![]);
+    };
+
+    let first = archive
+        .get_range(None, None)
+        .into_diagnostic()?
+        .next()
+        .map(|(slot, _)| slot)
+        .unwrap_or(tip);
+
+    let est_blocks = (tip.saturating_sub(first) / EST_SLOTS_PER_BLOCK).max(1);
+    let stride = (est_blocks / samples as u64).max(1) as usize;
+
+    let mut slots = Vec::with_capacity(samples);
+    let mut iter = archive.get_range(None, None).into_diagnostic()?;
+
+    while slots.len() < samples {
+        let Some((slot, _)) = iter.next() else {
+            break;
+        };
+        slots.push(slot);
+        iter.skip_forward(stride - 1);
+    }
+
+    Ok(slots)
+}
+
+fn blocks_shape(
+    archive: &ArchiveStoreBackend,
+    slots: &[BlockSlot],
+    pass: &str,
+) -> miette::Result<serde_json::Value> {
+    let mut resolutions = Vec::with_capacity(slots.len());
+    let mut full_reads = Vec::with_capacity(slots.len());
+
+    for &slot in slots {
+        let started = Instant::now();
+        let mut iter = archive
+            .get_range(Some(slot), Some(slot + 1))
+            .into_diagnostic()?;
+        iter.skip_forward(1);
+        resolutions.push(started.elapsed());
+    }
+
+    for &slot in slots {
+        let started = Instant::now();
+        let body = archive.get_block_by_slot(&slot).into_diagnostic()?;
+        full_reads.push(started.elapsed());
+        miette::ensure!(body.is_some(), "sampled slot {slot} lost its block");
+    }
+
+    Ok(json!({
+        "pass": pass,
+        "location_resolution": percentiles(resolutions),
+        "full_read": percentiles(full_reads),
+    }))
+}
+
+/// Sample entity keys from the newest epoch that has rows, evenly spaced
+/// with a seeded offset, so both backends measure the same accounts. The
+/// tip epoch is usually still in progress and rowless, so the search walks
+/// back a bounded number of boundaries.
+fn sample_accounts(
+    archive: &ArchiveStoreBackend,
+    summary: &dolos_cardano::ChainSummary,
+    tip_epoch: u64,
+    accounts: usize,
+    rng: &mut Rng,
+) -> miette::Result<Vec<EntityKey>> {
+    let mut keys: Vec<EntityKey> = vec![];
+
+    for back in 1..=10u64 {
+        let Some(epoch) = tip_epoch.checked_sub(back) else {
+            break;
+        };
+
+        let start = summary.epoch_start(epoch);
+        let range =
+            LogKey::from(TemporalKey::from(start))..LogKey::from(TemporalKey::from(start + 1));
+
+        keys = archive
+            .iter_logs(LOGS_NS, range)
+            .into_diagnostic()?
+            .collect::<Result<Vec<_>, _>>()
+            .into_diagnostic()
+            .context("draining the sampling epoch")?
+            .into_iter()
+            .map(|(key, _)| EntityKey::from(key))
+            .collect();
+
+        if !keys.is_empty() {
+            break;
+        }
+    }
+
+    if keys.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let stride = (keys.len() / accounts.max(1)).max(1);
+    let offset = (rng.next() as usize) % stride;
+
+    Ok(keys
+        .into_iter()
+        .skip(offset)
+        .step_by(stride)
+        .take(accounts)
+        .collect())
+}
+
+/// The `by_stake_rewards` shape: for one account, a point read per epoch
+/// from genesis to the tip epoch (`crates/minibf/src/routes/accounts.rs`).
+fn rewards_shape(
+    archive: &ArchiveStoreBackend,
+    summary: &dolos_cardano::ChainSummary,
+    tip_epoch: u64,
+    accounts: &[EntityKey],
+    pass: &str,
+) -> miette::Result<serde_json::Value> {
+    let mut per_read = Vec::new();
+    let mut per_account = Vec::with_capacity(accounts.len());
+    let mut hits = 0usize;
+
+    for entity in accounts {
+        let account_started = Instant::now();
+
+        for epoch in 0..tip_epoch {
+            let slot = summary.epoch_start(epoch);
+            let key: LogKey = (TemporalKey::from(slot), entity.clone()).into();
+
+            let started = Instant::now();
+            let values = archive.read_logs(LOGS_NS, &[&key]).into_diagnostic()?;
+            per_read.push(started.elapsed());
+
+            if values[0].is_some() {
+                hits += 1;
+            }
+        }
+
+        per_account.push(account_started.elapsed());
+    }
+
+    Ok(json!({
+        "pass": pass,
+        "accounts": accounts.len(),
+        "epochs_per_account": tip_epoch,
+        "hits": hits,
+        "per_read": percentiles(per_read),
+        "per_account": percentiles(per_account),
+    }))
+}
+
+/// The `/epochs/{n}/stakes` shape: drain every account-epoch row of one
+/// epoch through a temporal-prefix range scan
+/// (`crates/minibf/src/routes/epochs/mod.rs`).
+fn scan_shape(
+    archive: &ArchiveStoreBackend,
+    summary: &dolos_cardano::ChainSummary,
+    tip_epoch: u64,
+    epochs: usize,
+    pass: &str,
+) -> miette::Result<serde_json::Value> {
+    let step = (tip_epoch / epochs.max(1) as u64).max(1);
+    let sampled: Vec<u64> = (0..tip_epoch).step_by(step as usize).collect();
+
+    let mut per_epoch = Vec::with_capacity(sampled.len());
+    let mut total_rows = 0u64;
+
+    for &epoch in &sampled {
+        let start = summary.epoch_start(epoch);
+        let range =
+            LogKey::from(TemporalKey::from(start))..LogKey::from(TemporalKey::from(start + 1));
+
+        let started = Instant::now();
+        let mut rows = 0u64;
+        for item in archive.iter_logs(LOGS_NS, range).into_diagnostic()? {
+            item.into_diagnostic()?;
+            rows += 1;
+        }
+        per_epoch.push(started.elapsed());
+        total_rows += rows;
+    }
+
+    let total_secs: f64 = per_epoch.iter().sum::<Duration>().as_secs_f64();
+
+    Ok(json!({
+        "pass": pass,
+        "epochs": sampled.len(),
+        "rows": total_rows,
+        "rows_per_sec": if total_secs > 0.0 { total_rows as f64 / total_secs } else { 0.0 },
+        "per_epoch": percentiles(per_epoch),
+    }))
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    crate::common::setup_tracing(&config.logging, &config.telemetry)?;
+
+    let archive = crate::common::open_archive_store(config)?;
+
+    let mut report = serde_json::Map::new();
+    report.insert("backend".into(), json!(backend_name(&archive)));
+    report.insert(
+        "args".into(),
+        json!({
+            "samples": args.samples,
+            "accounts": args.accounts,
+            "epochs": args.epochs,
+            "seed": args.seed,
+        }),
+    );
+
+    let run_all = args.shape == "all";
+
+    if run_all || args.shape == "size" {
+        report.insert("size".into(), size_section(config, &archive));
+    }
+
+    if run_all || args.shape == "blocks" {
+        let slots = sample_block_slots(&archive, args.samples)?;
+        report.insert(
+            "blocks".into(),
+            json!([
+                blocks_shape(&archive, &slots, "first")?,
+                blocks_shape(&archive, &slots, "warm")?,
+            ]),
+        );
+    }
+
+    if run_all || args.shape == "rewards" || args.shape == "scan" {
+        let state = crate::common::open_state_store(config)?;
+        let summary =
+            load_chain_summary_from_state(&state).map_err(|err| miette::miette!("{err:?}"))?;
+
+        let tip = archive
+            .get_tip()
+            .into_diagnostic()?
+            .map(|(slot, _)| slot)
+            .unwrap_or_default();
+        let (tip_epoch, _) = summary.slot_epoch(tip);
+
+        if run_all || args.shape == "rewards" {
+            let mut rng = Rng(args.seed);
+            let accounts = sample_accounts(&archive, &summary, tip_epoch, args.accounts, &mut rng)?;
+            report.insert(
+                "rewards".into(),
+                json!([
+                    rewards_shape(&archive, &summary, tip_epoch, &accounts, "first")?,
+                    rewards_shape(&archive, &summary, tip_epoch, &accounts, "warm")?,
+                ]),
+            );
+        }
+
+        if run_all || args.shape == "scan" {
+            report.insert(
+                "scan".into(),
+                json!([
+                    scan_shape(&archive, &summary, tip_epoch, args.epochs, "first")?,
+                    scan_shape(&archive, &summary, tip_epoch, args.epochs, "warm")?,
+                ]),
+            );
+        }
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::Value::Object(report)).unwrap()
+    );
+
+    Ok(())
+}

--- a/src/bin/dolos/data/cardinality_stats.rs
+++ b/src/bin/dolos/data/cardinality_stats.rs
@@ -102,6 +102,9 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     // This command requires direct redb access
     let archive = match archive {
         ArchiveStoreBackend::Redb(s) | ArchiveStoreBackend::LogsOnly(s) => s,
+        ArchiveStoreBackend::Fjall(_) => {
+            bail!("cardinality-stats command is not available for the fjall archive backend")
+        }
         ArchiveStoreBackend::NoOp(_) => {
             bail!("cardinality-stats command is not available for noop archive backend")
         }

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -165,6 +165,9 @@ pub fn run(
         }
         ArchiveStoreBackend::Redb(s) if !args.skip_sanitization => prepare_archive(s, &pb)?,
         ArchiveStoreBackend::Redb(_) | ArchiveStoreBackend::LogsOnly(_) => {}
+        ArchiveStoreBackend::Fjall(_) => {
+            bail!("export command is not available for the fjall archive prototype")
+        }
         ArchiveStoreBackend::NoOp(_) => {
             bail!("export command is not available for noop archive backend")
         }

--- a/src/bin/dolos/data/mod.rs
+++ b/src/bin/dolos/data/mod.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
 
+mod bench_archive;
 mod cardinality_stats;
 mod check;
 mod clear_state;
@@ -68,6 +69,9 @@ pub enum Command {
     Housekeeping(housekeeping::Args),
     /// imports blocks from immutable DB into archive store only
     ImportArchive(import_archive::Args),
+    /// measures archive access shapes for the backend evaluation
+    #[command(hide = true)]
+    BenchArchive(bench_archive::Args),
 }
 
 #[derive(Debug, Parser)]
@@ -101,6 +105,7 @@ pub fn run(
         Command::Stats(x) => stats::run(config, x)?,
         Command::Housekeeping(x) => housekeeping::run(config, x)?,
         Command::ImportArchive(x) => import_archive::run(config, x, feedback)?,
+        Command::BenchArchive(x) => bench_archive::run(config, x)?,
     }
 
     Ok(())

--- a/src/bin/dolos/data/prune_chain.rs
+++ b/src/bin/dolos/data/prune_chain.rs
@@ -50,6 +50,10 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
             info!("chain segment trimmed");
         }
+        ArchiveStoreBackend::Fjall(_) => {
+            // The LSM tree compacts in the background on its own schedule.
+            info!("fjall archive, background compaction handles reclamation");
+        }
         ArchiveStoreBackend::NoOp(_) => {
             // No compaction needed for noop
             info!("noop archive, skipping compaction");

--- a/src/bin/dolos/data/stats.rs
+++ b/src/bin/dolos/data/stats.rs
@@ -58,7 +58,10 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
                 serde_json::Value::Object(tables.collect()),
             );
         }
-        ArchiveStoreBackend::NoOp(_) => (),
+        // The fjall archive's on-disk footprint is reported per keyspace by
+        // `dolos data bench-archive`; redb's page-level TableStats have no
+        // LSM equivalent here.
+        ArchiveStoreBackend::Fjall(_) | ArchiveStoreBackend::NoOp(_) => (),
     }
 
     if json.is_empty() {

--- a/src/bin/dolos/doctor/rebuild_state.rs
+++ b/src/bin/dolos/doctor/rebuild_state.rs
@@ -123,10 +123,13 @@ fn check_wipe_scope(config: &RootConfig, state_path: &std::path::Path) -> miette
 
     // Segment files can live outside the archive directory; the backend takes
     // `blocks_path` verbatim, so this check does too.
-    if let dolos_core::config::ArchiveStoreConfig::Redb(cfg) = &config.storage.archive {
-        if let Some(path) = &cfg.blocks_path {
-            others.push(("archive segments", path.clone()));
-        }
+    let blocks_path = match &config.storage.archive {
+        dolos_core::config::ArchiveStoreConfig::Redb(cfg) => cfg.blocks_path.as_ref(),
+        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => cfg.blocks_path.as_ref(),
+        _ => None,
+    };
+    if let Some(path) = blocks_path {
+        others.push(("archive segments", path.clone()));
     }
 
     for (what, path) in others {

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1,0 +1,1156 @@
+//! Backend conformance for the archive store contract.
+//!
+//! Every test is written against the `ArchiveStore`/`ArchiveWriter` traits
+//! and instantiated per backend by the `conformance_suite!` macro at the
+//! bottom, so redb — the shipping backend — pins the semantics the fjall
+//! prototype must match: block reads and walks (including the Byron
+//! boundary slot family), undo's segment truncation, prune and truncate
+//! boundaries, and the log namespaces' write/read/range behavior.
+//!
+//! The block tests are ports of the redb crate's inline archive tests
+//! (`crates/redb3/src/archive/tests.rs`); the log tests are new here, since
+//! the redb suite exercised logs only through backend-specific internals.
+
+use std::sync::Arc;
+
+use dolos_core::{
+    ArchiveStore as CoreArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, EntityKey, LogKey,
+    NamespaceType, RawBlock, StateSchema, TemporalKey,
+};
+
+use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
+
+/// The namespaces the log tests write to. Two are enough to pin isolation;
+/// the names are the real ones so the suite reads like the node.
+const NS_A: &str = "account-epochs";
+const NS_B: &str = "stakes";
+
+fn schema() -> StateSchema {
+    let mut schema = StateSchema::default();
+    schema.insert(NS_A, NamespaceType::KeyValue);
+    schema.insert(NS_B, NamespaceType::KeyValue);
+    schema
+}
+
+/// One archive backend under test.
+///
+/// The guard carries whatever the backend needs kept alive for the store to
+/// stay usable — a temp directory for the on-disk one, nothing for the
+/// in-memory one.
+trait Backend {
+    type Store: CoreArchiveStore;
+    type Guard;
+
+    /// A fresh, empty store.
+    fn open() -> (Self::Store, Self::Guard);
+}
+
+struct Redb;
+
+impl Backend for Redb {
+    type Store = dolos_redb3::archive::ArchiveStore;
+    type Guard = ();
+
+    fn open() -> (Self::Store, Self::Guard) {
+        (
+            dolos_redb3::archive::ArchiveStore::in_memory(schema())
+                .expect("failed to open redb archive store"),
+            (),
+        )
+    }
+}
+
+struct Fjall;
+
+impl Backend for Fjall {
+    type Store = dolos_fjall::archive::ArchiveStore;
+    type Guard = tempfile::TempDir;
+
+    fn open() -> (Self::Store, Self::Guard) {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+
+        // Only the fields this suite cares about; the rest are the backend's
+        // own defaults rather than a re-listing of them that can go stale.
+        let config = dolos_core::config::FjallArchiveConfig {
+            cache: Some(16),
+            flush_on_commit: Some(false),
+            worker_threads: Some(1),
+            ..Default::default()
+        };
+
+        let store = dolos_fjall::archive::ArchiveStore::open(schema(), dir.path(), &config)
+            .expect("failed to open fjall archive store");
+
+        (store, dir)
+    }
+}
+
+fn point(slot: u64) -> ChainPoint {
+    ChainPoint::Specific(slot, pallas::crypto::hash::Hash::new([0u8; 32]))
+}
+
+fn fake_block(slot: u64) -> Vec<u8> {
+    format!("block_data_for_slot_{slot}").into_bytes()
+}
+
+fn bodies(items: Vec<(BlockSlot, Vec<u8>)>) -> Vec<Vec<u8>> {
+    items.into_iter().map(|(_, body)| body).collect()
+}
+
+fn stored_slots<S: CoreArchiveStore>(store: &S) -> Vec<BlockSlot> {
+    store
+        .get_range(None, None)
+        .unwrap()
+        .map(|(s, _)| s)
+        .collect()
+}
+
+fn log_key(slot: u64, entity: u8) -> LogKey {
+    let temporal = TemporalKey::from(slot);
+    let entity = EntityKey::from(&[entity; 32]);
+    LogKey::from((temporal, entity))
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: basics
+// ---------------------------------------------------------------------------
+
+fn write_and_read_block<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+}
+
+fn batch_write_and_read<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30, 40, 50] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    for slot in [10, 20, 30, 40, 50] {
+        assert_eq!(
+            store.get_block_by_slot(&slot).unwrap(),
+            Some(fake_block(slot))
+        );
+    }
+
+    assert_eq!(store.get_block_by_slot(&15).unwrap(), None);
+}
+
+fn undo_truncates<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .apply(&point(200), &Arc::new(fake_block(200)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(200)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&200).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+}
+
+fn undo_cross_segment<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let slot_seg0 = 100;
+    let slot_seg1 = 432_001;
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(slot_seg0), &Arc::new(fake_block(slot_seg0)))
+        .unwrap();
+    writer
+        .apply(&point(slot_seg1), &Arc::new(fake_block(slot_seg1)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(slot_seg1)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&slot_seg1).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&slot_seg0).unwrap(),
+        Some(fake_block(slot_seg0))
+    );
+}
+
+fn range_iteration<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30, 40, 50] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(Some(15), Some(45)).unwrap().collect();
+    let result_slots: Vec<u64> = items.iter().map(|(s, _)| *s).collect();
+    assert_eq!(result_slots, vec![20, 30, 40]);
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(None, None).unwrap().collect();
+    assert_eq!(items.len(), 5);
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(None, None).unwrap().rev().collect();
+    let result_slots: Vec<u64> = items.iter().map(|(s, _)| *s).collect();
+    assert_eq!(result_slots, vec![50, 40, 30, 20, 10]);
+}
+
+fn tip_and_first<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    assert_eq!(store.get_tip().unwrap(), None);
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .apply(&point(500), &Arc::new(fake_block(500)))
+        .unwrap();
+    writer
+        .apply(&point(300), &Arc::new(fake_block(300)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, 500);
+    assert_eq!(tip_body, fake_block(500));
+}
+
+fn multiple_commits<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(200), &Arc::new(fake_block(200)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&200).unwrap(),
+        Some(fake_block(200))
+    );
+}
+
+fn cross_segment_writes<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    let slots = [0, 431_999, 432_000, 432_001, 864_000];
+    for &slot in &slots {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    for &slot in &slots {
+        assert_eq!(
+            store.get_block_by_slot(&slot).unwrap(),
+            Some(fake_block(slot)),
+            "failed to read slot {slot}"
+        );
+    }
+}
+
+fn write_after_undo<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(100)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), None);
+
+    let new_block = b"new_block_data".to_vec();
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(new_block.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(new_block));
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: prune and truncate
+// ---------------------------------------------------------------------------
+
+fn prune_history<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 432_100, 864_100] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    // Tip is 864_100; keeping 500_000 slots prunes before 364_100.
+    let done = store.prune_history(500_000, None).unwrap();
+    assert!(done, "unbatched prune must finish in one call");
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), None);
+    assert_eq!(store.get_block_by_slot(&200).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&432_100).unwrap(),
+        Some(fake_block(432_100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&864_100).unwrap(),
+        Some(fake_block(864_100))
+    );
+}
+
+fn prune_history_no_excess_is_noop<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let done = store.prune_history(1_000, Some(10)).unwrap();
+    assert!(done, "no-excess prune must report done");
+    assert_eq!(stored_slots(&store), vec![100, 200, 300], "nothing removed");
+}
+
+fn prune_history_batched_converges<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [0, 100, 200, 300, 400, 500] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let max_slots = 100;
+    let max_prune = 150;
+
+    let done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+    assert!(!done, "large backlog should not finish in one batch");
+    let after_first = stored_slots(&store);
+    assert_eq!(
+        after_first.first(),
+        Some(&200),
+        "batch must advance the start"
+    );
+    assert_eq!(
+        store.get_tip().unwrap().map(|(s, _)| s),
+        Some(500),
+        "tip preserved across batches"
+    );
+
+    let mut done = false;
+    let mut rounds = 1;
+    while !done {
+        done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+        rounds += 1;
+        assert!(rounds < 100, "batched pruning did not converge");
+    }
+
+    assert_eq!(
+        stored_slots(&store),
+        vec![400, 500],
+        "only the window remains"
+    );
+}
+
+fn truncate_front<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300, 400, 500] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&point(300)).unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&200).unwrap(),
+        Some(fake_block(200))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&300).unwrap(),
+        Some(fake_block(300))
+    );
+    assert_eq!(store.get_block_by_slot(&400).unwrap(), None);
+    assert_eq!(store.get_block_by_slot(&500).unwrap(), None);
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: a slot holding more than one block (opaque payloads)
+// ---------------------------------------------------------------------------
+
+fn a_slot_keeps_every_block_written_to_it<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second.clone()));
+
+    assert_eq!(
+        store.get_blocks_by_slot(&100).unwrap(),
+        vec![first.clone(), second.clone()]
+    );
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+fn a_slot_keeps_blocks_written_in_separate_batches<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for body in [&first, &second] {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second.clone()]
+    );
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second));
+}
+
+fn writing_the_same_block_again_leaves_one_copy<B: Backend>() {
+    let (store, _guard) = B::open();
+    let body = fake_block(100);
+
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(store.get_blocks_by_slot(&100).unwrap(), vec![body.clone()]);
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![body]
+    );
+}
+
+fn rewriting_a_shared_slot_keeps_both_blocks_in_order<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+        writer
+            .apply(&point(100), &Arc::new(second.clone()))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+fn rewriting_the_older_block_at_a_shared_slot_leaves_undo_sound<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(100)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(first.clone()));
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: the Byron boundary family (an EBB shares its slot with the first
+// main block of the epoch it opens)
+// ---------------------------------------------------------------------------
+
+fn boundary(epoch: u64) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let ebb = make_byron_ebb(epoch, pallas::crypto::hash::Hash::new([7u8; 32]));
+    let slot = byron_ebb_slot(epoch);
+    let main = make_conway_block_with_prev(slot, ebb.0.hash(), epoch);
+
+    (ebb, main)
+}
+
+fn write_boundary<S: CoreArchiveStore>(
+    store: &S,
+    epoch: u64,
+) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let (ebb, main) = boundary(epoch);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    (ebb, main)
+}
+
+fn an_ebb_survives_the_block_that_shares_its_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+    let slot = ebb.0.slot();
+
+    assert_eq!(
+        store.get_block_by_slot(&slot).unwrap().as_ref(),
+        Some(main.1.as_ref())
+    );
+
+    let items = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(items, vec![ebb.1.as_ref().clone(), main.1.as_ref().clone()]);
+}
+
+fn a_boundary_slot_reverses_into_chain_order<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let items = bodies(store.get_range(None, None).unwrap().rev().collect());
+    assert_eq!(items, vec![main.1.as_ref().clone(), ebb.1.as_ref().clone()]);
+}
+
+fn several_boundaries_interleave_with_ordinary_blocks<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    let mid = make_conway_block_with_prev(byron_ebb_slot(1) + 5, main1.0.hash(), 100);
+    let tail = make_conway_block_with_prev(byron_ebb_slot(2) + 5, main2.0.hash(), 200);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &mid, &ebb2, &main2, &tail] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let expected: Vec<Vec<u8>> = [&ebb1, &main1, &mid, &ebb2, &main2, &tail]
+        .iter()
+        .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+        .collect();
+
+    let forward = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(forward, expected);
+
+    let mut backward = bodies(store.get_range(None, None).unwrap().rev().collect());
+    backward.reverse();
+    assert_eq!(backward, expected);
+}
+
+fn walking_from_both_ends_covers_every_block_once<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    for front_first in [0usize, 1, 2, 3, 4] {
+        let mut iter = store.get_range(None, None).unwrap();
+        let mut seen = Vec::new();
+
+        for _ in 0..front_first {
+            if let Some((_, body)) = iter.next() {
+                seen.push(body);
+            }
+        }
+
+        let mut back = Vec::new();
+        while let Some((_, body)) = iter.next_back() {
+            back.push(body);
+        }
+        back.reverse();
+        seen.extend(back);
+
+        let expected: Vec<Vec<u8>> = [&ebb1, &main1, &ebb2, &main2]
+            .iter()
+            .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+            .collect();
+
+        assert_eq!(seen, expected, "split after {front_first} from the front");
+    }
+}
+
+fn skipping_counts_the_ebb<B: Backend>() {
+    use dolos_core::archive::Skippable as _;
+
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_forward(1);
+    assert_eq!(iter.next().map(|(_, b)| b), Some(main.1.as_ref().clone()));
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_backward(1);
+    assert_eq!(
+        iter.next_back().map(|(_, b)| b),
+        Some(ebb.1.as_ref().clone())
+    );
+}
+
+fn the_tip_is_the_ebb_until_its_epochs_first_block_arrives<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let writer = store.start_writer().unwrap();
+    writer.apply(&earlier.0, &earlier.1).unwrap();
+    writer.commit().unwrap();
+
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, ebb.0.slot());
+    assert_eq!(&tip_body, ebb.1.as_ref());
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, main.0.slot());
+    assert_eq!(&tip_body, main.1.as_ref());
+}
+
+fn undo_unwinds_a_boundary_slot_in_reverse_arrival_order<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&main.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&main.0.slot()).unwrap().as_ref(),
+        Some(ebb.1.as_ref())
+    );
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone(), ebb.1.as_ref().clone()]
+    );
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&ebb.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+
+    assert_eq!(store.get_block_by_slot(&main.0.slot()).unwrap(), None);
+}
+
+fn truncate_front_drops_an_ebb_past_the_cut<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&earlier.0).unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+
+    // The segment was truncated at the EBB's offset, so the archive can be
+    // written forward again from there.
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![
+            earlier.1.as_ref().clone(),
+            ebb.1.as_ref().clone(),
+            main.1.as_ref().clone()
+        ]
+    );
+}
+
+fn remove_before_prunes_every_block_at_a_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.prune_history(1, None).unwrap();
+
+    assert_eq!(
+        stored_slots(&store),
+        vec![byron_ebb_slot(2), byron_ebb_slot(2)]
+    );
+}
+
+fn find_intersect_resolves_an_ebb_by_its_own_hash<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&main.0)).unwrap(),
+        Some(main.0.clone())
+    );
+
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&ebb.0)).unwrap(),
+        Some(ebb.0.clone())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Logs
+// ---------------------------------------------------------------------------
+
+fn log_roundtrip<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let rows = [
+        (log_key(10, 0xaa), b"row_10_aa".to_vec()),
+        (log_key(10, 0xbb), b"row_10_bb".to_vec()),
+        (log_key(20, 0xaa), b"row_20_aa".to_vec()),
+    ];
+
+    let writer = store.start_writer().unwrap();
+    for (key, value) in &rows {
+        writer.write_log(NS_A, key, value).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let keys: Vec<&LogKey> = rows.iter().map(|(k, _)| k).collect();
+    let read = store.read_logs(NS_A, &keys).unwrap();
+    assert_eq!(
+        read,
+        rows.iter()
+            .map(|(_, v)| Some(v.clone()))
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&log_key(30, 0xaa)]).unwrap(),
+        vec![None]
+    );
+
+    // A full iteration yields every row in key order.
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, rows.to_vec());
+}
+
+fn log_namespaces_are_isolated<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    writer.write_log(NS_A, &key, &b"in_a".to_vec()).unwrap();
+    writer.write_log(NS_B, &key, &b"in_b".to_vec()).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&key]).unwrap(),
+        vec![Some(b"in_a".to_vec())]
+    );
+    assert_eq!(
+        store.read_logs(NS_B, &[&key]).unwrap(),
+        vec![Some(b"in_b".to_vec())]
+    );
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_B, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, vec![(key, b"in_b".to_vec())]);
+}
+
+fn log_range_is_start_inclusive_end_exclusive<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, log_key(10, 0x01)..log_key(30, 0x01))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    let slots: Vec<LogKey> = walked.into_iter().map(|(k, _)| k).collect();
+    assert_eq!(slots, vec![log_key(10, 0x01), log_key(20, 0x01)]);
+}
+
+fn the_last_write_to_a_log_key_wins<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .write_log(NS_A, &key, &b"superseded".to_vec())
+        .unwrap();
+    writer.write_log(NS_A, &key, &b"final".to_vec()).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&key]).unwrap(),
+        vec![Some(b"final".to_vec())]
+    );
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, vec![(key, b"final".to_vec())]);
+}
+
+fn an_unknown_namespace_is_refused<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    assert!(writer
+        .write_log("no-such-namespace", &key, &b"x".to_vec())
+        .is_err());
+
+    assert!(store.read_logs("no-such-namespace", &[&key]).is_err());
+    assert!(store
+        .iter_logs("no-such-namespace", LogKey::full_range())
+        .is_err());
+}
+
+fn prune_keeps_logs_at_the_cutoff_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(0), &Arc::new(fake_block(0))).unwrap();
+    writer
+        .apply(&point(1_000), &Arc::new(fake_block(1_000)))
+        .unwrap();
+    for slot in [499, 500, 501] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    // Start 0, tip 1000, window 500: prune before slot 500. A log row's
+    // temporal prefix at exactly the cutoff survives; anything before it
+    // goes.
+    let done = store.prune_history(500, None).unwrap();
+    assert!(done);
+
+    let walked: Vec<LogKey> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .map(|r| r.unwrap().0)
+        .collect();
+    assert_eq!(walked, vec![log_key(500, 0x01), log_key(501, 0x01)]);
+}
+
+fn truncate_front_drops_logs_at_the_cut_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    for slot in [199, 200, 201] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&point(200)).unwrap();
+
+    // The block at the cut slot survives; log rows at the cut slot go with
+    // everything after it. This asymmetry is what the redb backend does —
+    // its block removal is strictly-after while its log removal compares
+    // full keys against the bare temporal prefix — and both backends must
+    // agree on it.
+    assert_eq!(stored_slots(&store), vec![100, 200]);
+
+    let walked: Vec<LogKey> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .map(|r| r.unwrap().0)
+        .collect();
+    assert_eq!(walked, vec![log_key(199, 0x01)]);
+}
+
+fn logs_and_blocks_share_one_writer_commit<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .write_log(NS_A, &log_key(100, 0x01), &b"epoch_row".to_vec())
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.read_logs(NS_A, &[&log_key(100, 0x01)]).unwrap(),
+        vec![Some(b"epoch_row".to_vec())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-backend agreement: both backends walk identical data identically
+// ---------------------------------------------------------------------------
+
+/// The two backends, fed the same writes, return byte-identical logs and
+/// blocks. This is the in-process half of the dump-logs comparison the
+/// benchmark protocol runs on a real replay.
+#[test]
+fn backends_agree_on_identical_writes() {
+    let (redb, _g1) = Redb::open();
+    let (fjall, _g2) = Fjall::open();
+
+    let seed_rows: Vec<(LogKey, Vec<u8>)> = (0u64..50)
+        .map(|i| {
+            (
+                log_key(i / 5, (i % 5) as u8),
+                format!("row_{i}").into_bytes(),
+            )
+        })
+        .collect();
+
+    for store in [&redb as &dyn WriteSurface, &fjall as &dyn WriteSurface] {
+        store.write(&seed_rows);
+    }
+
+    let from_redb: Vec<(LogKey, Vec<u8>)> = redb
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    let from_fjall: Vec<(LogKey, Vec<u8>)> = fjall
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    assert_eq!(from_redb, from_fjall);
+}
+
+/// Object-safe helper so the agreement test writes through both backends
+/// with one code path.
+trait WriteSurface {
+    fn write(&self, rows: &[(LogKey, Vec<u8>)]);
+}
+
+impl<S: CoreArchiveStore> WriteSurface for S {
+    fn write(&self, rows: &[(LogKey, Vec<u8>)]) {
+        let writer = self.start_writer().unwrap();
+        for (key, value) in rows {
+            writer.write_log(NS_A, key, value).unwrap();
+        }
+        writer.commit().unwrap();
+    }
+}
+
+/// Declare the whole suite for one backend. Adding a backend is one line.
+macro_rules! conformance_suite {
+    ($module:ident, $backend:ty, [$($name:ident),* $(,)?]) => {
+        mod $module {
+            use super::*;
+
+            $(
+                #[test]
+                fn $name() {
+                    super::$name::<$backend>();
+                }
+            )*
+        }
+    };
+}
+
+macro_rules! full_suite {
+    ($module:ident, $backend:ty) => {
+        conformance_suite!(
+            $module,
+            $backend,
+            [
+                write_and_read_block,
+                batch_write_and_read,
+                undo_truncates,
+                undo_cross_segment,
+                range_iteration,
+                tip_and_first,
+                multiple_commits,
+                cross_segment_writes,
+                write_after_undo,
+                prune_history,
+                prune_history_no_excess_is_noop,
+                prune_history_batched_converges,
+                truncate_front,
+                a_slot_keeps_every_block_written_to_it,
+                a_slot_keeps_blocks_written_in_separate_batches,
+                writing_the_same_block_again_leaves_one_copy,
+                rewriting_a_shared_slot_keeps_both_blocks_in_order,
+                rewriting_the_older_block_at_a_shared_slot_leaves_undo_sound,
+                an_ebb_survives_the_block_that_shares_its_slot,
+                a_boundary_slot_reverses_into_chain_order,
+                several_boundaries_interleave_with_ordinary_blocks,
+                walking_from_both_ends_covers_every_block_once,
+                skipping_counts_the_ebb,
+                the_tip_is_the_ebb_until_its_epochs_first_block_arrives,
+                undo_unwinds_a_boundary_slot_in_reverse_arrival_order,
+                truncate_front_drops_an_ebb_past_the_cut,
+                remove_before_prunes_every_block_at_a_slot,
+                find_intersect_resolves_an_ebb_by_its_own_hash,
+                log_roundtrip,
+                log_namespaces_are_isolated,
+                log_range_is_start_inclusive_end_exclusive,
+                the_last_write_to_a_log_key_wins,
+                an_unknown_namespace_is_refused,
+                prune_keeps_logs_at_the_cutoff_slot,
+                truncate_front_drops_logs_at_the_cut_slot,
+                logs_and_blocks_share_one_writer_commit,
+            ]
+        );
+    };
+}
+
+full_suite!(redb, Redb);
+full_suite!(fjall, Fjall);


### PR DESCRIPTION
**Not for merge.** This branch exists to produce four numbers: archive-index size, replay wall-clock, and read p50/p95 on the three real access shapes, fjall vs optimized redb, per the archive-backend evaluation in the org brain (`plans/dolos-archive-fjall-backend.md`). The verdict lands as a decision record; if it is *adopt*, a separate code-change-request productionizes for the v1.8+ line.

## What's here

- **`crates/fjall/src/archive/`** — the archive store on fjall. Two keyspaces: `archive-blocks` keeps the redb blocks table's value encoding byte-for-byte (slot → packed 16-byte locations, newest first, Byron EBB multi-block case included); `archive-logs` holds all log namespaces as `[ns_hash:8][log_key:40]`, the state store's unified-keyspace pattern. Block bodies stay in the flat segment files, reused from `dolos-redb3` as-is. No log-batch shuffle: that works around redb's half-split of ascending B-tree leaves, and an LSM memtable sorts its batch regardless.
- **`ArchiveStoreConfig::Fjall`** + adapter fan-out. `prune-chain` works through the trait; `export`, `cardinality-stats`, `rebuild-state --rewrite-logs` refuse the prototype with clear messages.
- **`tests/archive_conformance.rs`** — the redb archive tests rewritten against the trait surface and run against *both* backends, plus log semantics (roundtrip, isolation, range bounds, last-write-wins, prune/truncate temporal boundaries). redb pins the semantics; the port doesn't grade its own homework. `ToyStores` gains the archive as a third bound store, so the snapshot determinism/restore suites exercise the fjall archive through the canonical harness.
- **`dolos data bench-archive`** (hidden) — measures the three read shapes plus per-keyspace disk footprint, config-driven so both backends run identical code, seeded so both measure the same keys. Block point reads are split into slot→location resolution (the only backend-differing component) and full body read, and `FlatFileStore` now meters cumulative append/fsync time — block bodies are identical shared cost on the same disk, big enough to bury an index-path difference inside totals.

## Productionization deltas (out of scope here, listed for the follow-up)

- Relocate `flatfiles` out of `dolos-redb3` instead of coupling the crates (it is std+tempfile only).
- Crash-consistency review of the fjall commit path (currently mirrors redb's window: bodies fsynced before the index commit).
- `doctor`/`export`/stelae-restore write paths for the fjall archive.
- `data stats` footprint reporting for LSM keyspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Results (benchmark complete, 2026-08-23)

Sequential solo replays of the `preprod-20260814` mithril snapshot (~308 epochs), same machine, machine idle, binary `94cf84a3`. Correctness gate passed before any number was recorded: conformance suite green on both backends, `dump-logs` byte-identical per namespace (`account-epochs`, `stakes`, `epochs`) across the two replays.

| measurement | redb (optimized) | fjall | outcome |
|---|---|---|---|
| archive-index size (settled) | 906 MB allocated / 1,174 MB apparent | 468 MB (blocks 128 + logs 341) | **−48.3%** (criterion ≥30% ✓) |
| mainnet extrapolation | ~68.7 GB | ~36.1 GB | −47.4% |
| replay wall-clock | 9,309 s | 9,695 s | **1.041×** (≤1.25× ✓); index-attributable ≈1.10× after subtracting 5,432 s metered flatfile time |
| `get_block_by_slot` full path, warm p95 | 11.1 µs | 17.4 µs | 1.57× (≤2× ✓); slot→location split 3.77× warm, ~3 µs absolute |
| `by_stake_rewards` per-read p95 cold/warm | 1,365 µs / 1.4 µs | 124 µs / 2.0 µs | 0.09× / 1.44× ✓ (cold per-account 6× faster) |
| `/epochs/{n}/stakes` per-epoch p95 cold/warm | 28.5 ms / 1.7 ms | 4.6 ms / 3.5 ms | 0.16× cold ✓ / 2.04× warm (grazes; cold 6× faster) |

**Verdict: adopt** — recorded as decision 0029 in the org brain; productionization is a follow-up code-change-request in the v1.8+ line. This PR stays a draft and does not merge.

Identical seeded populations on both sides: 772 block slots, 7,937 reward hits, 156,293 scanned rows. Compression contributes only 16.3% of the size win (fjall 3.1 defaults leave L0/L1 uncompressed); the rest is structural vs redb's ~62% leaf fill, hence network-independent and safe to extrapolate.
