### PR TITLE
feat: fjall archive backend as the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 /target
 tmp
-benches
 /data
 .env
 .opencode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Dolos uses four distinct storage backends, each serving a specific purpose:
 - **Purpose**: Historical block storage with temporal indexing
 - **Contents**: Raw blocks indexed by slot, entity logs keyed by `LogKey` (slot + entity key)
 - **Traits**: `ArchiveStore` (reads) + `ArchiveWriter` (batched writes)
-- **Database**: `<storage.path>/chain`
+- **Database**: `<storage.path>/archive` (index plus flat block segment files)
 
 ### WalStore (Write-Ahead Log)
 - **Purpose**: Crash recovery and rollback support
@@ -41,12 +41,12 @@ Dolos uses four distinct storage backends, each serving a specific purpose:
 <storage.path>/
 ├── wal      # Write-Ahead Log database
 ├── state    # Ledger state database
-├── chain    # Archive/block storage database
+├── archive  # Archive index plus flat block segment files
 ├── index    # Consolidated index database
 └── scratch  # not a store: stele layers staged in flight by a registry transfer
 ```
 
-Each database is a separate Redb or Fjall file with independent configuration for cache size and durability, depending on the chosen storage backend.
+Each database is a separate Redb or Fjall store with independent configuration for cache size and durability, depending on the chosen storage backend.
 
 ## Crate Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dolos-flatfiles"
+version = "1.7.0-alpha.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "dolos-minibf"
 version = "1.7.0-alpha.0"
 dependencies = [
@@ -1600,6 +1607,7 @@ version = "1.7.0-alpha.0"
 dependencies = [
  "bincode 1.3.3",
  "dolos-core",
+ "dolos-flatfiles",
  "dolos-testing",
  "futures-core",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ version = "1.7.0-alpha.0"
 dependencies = [
  "bincode 1.3.3",
  "dolos-core",
+ "dolos-flatfiles",
  "dolos-testing",
  "fjall",
  "pallas",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "console-subscriber",
  "csv",
  "csv-diff",
+ "divan",
  "dolos-cardano",
  "dolos-core",
  "dolos-fjall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ rustls = { version = "0.23", default-features = false, features = [
 
 [dev-dependencies]
 anyhow = "1.0"
+divan = "0.1.21"
 comfy-table = "7.1.1"
 csv = "1"
 csv-diff = "0.1"
@@ -125,6 +126,10 @@ stelae = { path = "crates/stelae" }
 
 [build-dependencies]
 vergen-gitcl = "9.1.0"
+
+[[bench]]
+name = "archive_backends"
+harness = false
 
 [[test]]
 name = "smoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ members = [
     "crates/cardano",
     "crates/core",
     "crates/fjall",
+    "crates/flatfiles",
     "crates/snapshot",
     "crates/stelae",
     "crates/testing",

--- a/benches/archive_backends.rs
+++ b/benches/archive_backends.rs
@@ -101,6 +101,16 @@ fn block_location_resolution<B: Backend>(bencher: divan::Bencher) {
     let (store, _dir) = populated::<B>();
     let slots = sampled_slots();
 
+    // skip_forward silently stops at exhaustion, so an empty range would
+    // "resolve" nothing and still time successfully; pin every sampled slot
+    // to a real block before the timed passes.
+    for &slot in &slots {
+        assert!(
+            store.get_block_by_slot(&slot).unwrap().is_some(),
+            "sampled slot missing from the population"
+        );
+    }
+
     bencher.bench_local(|| {
         for &slot in &slots {
             let mut iter = store.get_range(Some(slot), Some(slot + 1)).unwrap();

--- a/benches/archive_backends.rs
+++ b/benches/archive_backends.rs
@@ -1,0 +1,163 @@
+//! Regression guards for the archive backends' three read-shape families.
+//!
+//! Both backends are populated with the identical synthetic content from
+//! `dolos_testing::archive` and measured against the same keys, so a run
+//! compares redb and fjall on equal footing: block location resolution and
+//! full block reads (`get_block_by_slot`), the per-account reward point
+//! reads (`read_logs` per epoch), and the per-epoch temporal-prefix scan
+//! (`iter_logs`).
+//!
+//! These are *relative* regression guards on small tempdir populations.
+//! Absolute numbers say nothing about production behavior — the
+//! backend-adoption evaluation ran against full preprod replays — and under
+//! `cargo test` each bench body runs exactly once as a smoke pass.
+
+use dolos_core::{
+    archive::Skippable as _, ArchiveStore as CoreArchiveStore, NamespaceType, StateSchema,
+};
+use dolos_testing::archive::{populate_archive, ArchiveShape};
+
+/// The one namespace the log shapes exercise; the name is the real bulk
+/// namespace so the bench reads like the node.
+const NS: &str = "account-epochs";
+
+const SHAPE: ArchiveShape = ArchiveShape {
+    epochs: 4,
+    blocks_per_epoch: 250,
+    log_rows_per_epoch: 1000,
+    slots_per_epoch: 432_000,
+    seed: 0xA5C1_1BEE,
+};
+
+/// Sampled read keys per timed iteration: every 5th block (200 of 1000) and
+/// a 32-account stride across the 1000 entities.
+const BLOCK_SAMPLE_STRIDE: usize = 5;
+const ACCOUNT_SAMPLES: u64 = 32;
+
+fn schema() -> StateSchema {
+    let mut schema = StateSchema::default();
+    schema.insert(NS, NamespaceType::KeyValue);
+    schema
+}
+
+/// One archive backend under measurement, mirroring the conformance suite's
+/// seam (`tests/archive_conformance.rs`). Both backends open on a tempdir —
+/// redb's in-memory variant would swap its index to a different storage
+/// backend and skew the comparison.
+trait Backend {
+    type Store: CoreArchiveStore;
+
+    fn open(dir: &std::path::Path) -> Self::Store;
+}
+
+struct Redb;
+
+impl Backend for Redb {
+    type Store = dolos_redb3::archive::ArchiveStore;
+
+    fn open(dir: &std::path::Path) -> Self::Store {
+        dolos_redb3::archive::ArchiveStore::open(
+            schema(),
+            dir,
+            &dolos_core::config::RedbArchiveConfig::default(),
+        )
+        .expect("failed to open redb archive store")
+    }
+}
+
+struct Fjall;
+
+impl Backend for Fjall {
+    type Store = dolos_fjall::archive::ArchiveStore;
+
+    fn open(dir: &std::path::Path) -> Self::Store {
+        // Single worker thread so CI runners are not oversubscribed; the
+        // rest are the backend's own defaults.
+        let config = dolos_core::config::FjallArchiveConfig {
+            cache: Some(16),
+            flush_on_commit: Some(false),
+            worker_threads: Some(1),
+            ..Default::default()
+        };
+
+        dolos_fjall::archive::ArchiveStore::open(schema(), dir, &config)
+            .expect("failed to open fjall archive store")
+    }
+}
+
+fn populated<B: Backend>() -> (B::Store, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let store = B::open(dir.path());
+    populate_archive(&store, NS, &SHAPE).expect("failed to populate archive");
+    (store, dir)
+}
+
+fn sampled_slots() -> Vec<u64> {
+    SHAPE.block_slots().step_by(BLOCK_SAMPLE_STRIDE).collect()
+}
+
+#[divan::bench(types = [Redb, Fjall], sample_count = 50)]
+fn block_location_resolution<B: Backend>(bencher: divan::Bencher) {
+    let (store, _dir) = populated::<B>();
+    let slots = sampled_slots();
+
+    bencher.bench_local(|| {
+        for &slot in &slots {
+            let mut iter = store.get_range(Some(slot), Some(slot + 1)).unwrap();
+            iter.skip_forward(1);
+            divan::black_box(&iter);
+        }
+    });
+}
+
+#[divan::bench(types = [Redb, Fjall], sample_count = 50)]
+fn block_full_read<B: Backend>(bencher: divan::Bencher) {
+    let (store, _dir) = populated::<B>();
+    let slots = sampled_slots();
+
+    bencher.bench_local(|| {
+        for &slot in &slots {
+            let body = store.get_block_by_slot(&slot).unwrap();
+            assert!(
+                divan::black_box(body).is_some(),
+                "sampled slot lost its block"
+            );
+        }
+    });
+}
+
+#[divan::bench(types = [Redb, Fjall], sample_count = 50)]
+fn rewards_point_reads<B: Backend>(bencher: divan::Bencher) {
+    let (store, _dir) = populated::<B>();
+    let account_stride = SHAPE.log_rows_per_epoch / ACCOUNT_SAMPLES;
+
+    bencher.bench_local(|| {
+        for account in 0..ACCOUNT_SAMPLES {
+            for epoch in 0..SHAPE.epochs {
+                let key = SHAPE.log_key(epoch, account * account_stride);
+                let hits = store.read_logs(NS, &[&key]).unwrap();
+                assert!(divan::black_box(hits)[0].is_some(), "sampled row missing");
+            }
+        }
+    });
+}
+
+#[divan::bench(types = [Redb, Fjall], sample_count = 50)]
+fn epoch_scan<B: Backend>(bencher: divan::Bencher) {
+    let (store, _dir) = populated::<B>();
+    let scanned_epoch = SHAPE.epochs / 2;
+    let range = SHAPE.log_key(scanned_epoch, 0)..SHAPE.log_key(scanned_epoch + 1, 0);
+
+    bencher.bench_local(|| {
+        let mut rows = 0u64;
+        for row in store.iter_logs(NS, range.clone()).unwrap() {
+            divan::black_box(row.unwrap());
+            rows += 1;
+        }
+        assert_eq!(rows, SHAPE.log_rows_per_epoch, "epoch drain lost rows");
+    });
+}
+
+fn main() {
+    divan::main();
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -316,11 +316,13 @@ impl StateStoreConfig {
         }
     }
 
+    /// Whether this selection round-trips through `Default`: true only for
+    /// the default variant carrying no explicit options, so an explicit
+    /// non-default backend choice survives re-serialization.
     pub fn is_default(&self) -> bool {
         match self {
             Self::Fjall(cfg) => cfg.is_default(),
-            Self::Redb(cfg) => cfg.is_default(),
-            Self::InMemory => false,
+            Self::Redb(_) | Self::InMemory => false,
         }
     }
 }
@@ -352,11 +354,62 @@ impl RedbArchiveConfig {
     }
 }
 
+/// Configuration for the Fjall archive backend.
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct FjallArchiveConfig {
+    /// Optional path override for the archive directory.
+    /// If relative, resolved from storage root.
+    /// If not specified, defaults to `<storage.path>/archive`.
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    /// Optional path override for block segment files.
+    /// If not specified, segment files are stored in the archive directory.
+    #[serde(default)]
+    pub blocks_path: Option<PathBuf>,
+    /// Size (in MB) of memory allocated for caching.
+    #[serde(default)]
+    pub cache: Option<usize>,
+    /// Maximum journal size in MB.
+    #[serde(default)]
+    pub max_journal_size: Option<usize>,
+    /// Flush journal after each commit.
+    #[serde(default)]
+    pub flush_on_commit: Option<bool>,
+    /// L0 compaction threshold (default: 4, lower = more aggressive).
+    #[serde(default)]
+    pub l0_threshold: Option<u8>,
+    /// Number of background compaction worker threads.
+    #[serde(default)]
+    pub worker_threads: Option<usize>,
+    /// Memtable size in MB before flush (default: 64).
+    #[serde(default)]
+    pub memtable_size_mb: Option<usize>,
+}
+
+impl FjallArchiveConfig {
+    pub fn is_default(&self) -> bool {
+        self.path.is_none()
+            && self.blocks_path.is_none()
+            && self.cache.is_none()
+            && self.max_journal_size.is_none()
+            && self.flush_on_commit.is_none()
+            && self.l0_threshold.is_none()
+            && self.worker_threads.is_none()
+            && self.memtable_size_mb.is_none()
+    }
+}
+
 /// Archive store configuration.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
 pub enum ArchiveStoreConfig {
+    /// Redb backend, supported via explicit configuration. Reads and writes
+    /// the archive index as a single redb file; block segment files are
+    /// shared with the fjall backend.
     Redb(RedbArchiveConfig),
+    /// Fjall backend, the default. Block segment files are shared with the
+    /// redb backend; only the index differs.
+    Fjall(FjallArchiveConfig),
     /// In-memory backend (ephemeral, data lost on restart).
     #[serde(rename = "in_memory")]
     InMemory,
@@ -366,7 +419,7 @@ pub enum ArchiveStoreConfig {
 
 impl Default for ArchiveStoreConfig {
     fn default() -> Self {
-        Self::Redb(RedbArchiveConfig::default())
+        Self::Fjall(FjallArchiveConfig::default())
     }
 }
 
@@ -374,14 +427,19 @@ impl ArchiveStoreConfig {
     pub fn path(&self) -> Option<&PathBuf> {
         match self {
             Self::Redb(cfg) => cfg.path.as_ref(),
+            Self::Fjall(cfg) => cfg.path.as_ref(),
             Self::InMemory | Self::NoOp => None,
         }
     }
 
+    /// Whether this selection round-trips through `Default`: true only for
+    /// the default variant carrying no explicit options. Any other variant
+    /// must survive re-serialization even with an empty options set — a bare
+    /// `backend = "redb"` is an explicit choice, not the default.
     pub fn is_default(&self) -> bool {
         match self {
-            Self::Redb(cfg) => cfg.is_default(),
-            Self::InMemory | Self::NoOp => false,
+            Self::Fjall(cfg) => cfg.is_default(),
+            Self::Redb(_) | Self::InMemory | Self::NoOp => false,
         }
     }
 }
@@ -485,11 +543,13 @@ impl IndexStoreConfig {
         }
     }
 
+    /// Whether this selection round-trips through `Default`: true only for
+    /// the default variant carrying no explicit options, so an explicit
+    /// non-default backend choice survives re-serialization.
     pub fn is_default(&self) -> bool {
         match self {
             Self::Fjall(cfg) => cfg.is_default(),
-            Self::Redb(cfg) => cfg.is_default(),
-            Self::InMemory | Self::NoOp => false,
+            Self::Redb(_) | Self::InMemory | Self::NoOp => false,
         }
     }
 }
@@ -617,6 +677,9 @@ impl StorageConfig {
         match &self.archive {
             ArchiveStoreConfig::InMemory | ArchiveStoreConfig::NoOp => None,
             ArchiveStoreConfig::Redb(cfg) => {
+                Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "archive"))
+            }
+            ArchiveStoreConfig::Fjall(cfg) => {
                 Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "archive"))
             }
         }
@@ -1262,4 +1325,42 @@ pub struct RootConfig {
 
     #[serde(default, skip_serializing_if = "TelemetryConfig::is_default")]
     pub telemetry: TelemetryConfig,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An explicit `backend = "redb"` with no options must not be treated as
+    /// the default: dropping it on re-serialization would silently flip the
+    /// archive to fjall on the next load.
+    #[test]
+    fn explicit_non_default_backend_survives_reserialization() {
+        let storage = StorageConfig {
+            archive: ArchiveStoreConfig::Redb(RedbArchiveConfig::default()),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&storage).unwrap();
+        let restored: StorageConfig = serde_json::from_value(json).unwrap();
+
+        assert!(matches!(restored.archive, ArchiveStoreConfig::Redb(_)));
+    }
+
+    #[test]
+    fn default_backend_selections_are_not_serialized() {
+        let json = serde_json::to_value(StorageConfig::default()).unwrap();
+
+        assert!(json.get("archive").is_none());
+        assert!(json.get("state").is_none());
+        assert!(json.get("index").is_none());
+    }
+
+    #[test]
+    fn the_default_archive_backend_is_fjall() {
+        assert!(matches!(
+            ArchiveStoreConfig::default(),
+            ArchiveStoreConfig::Fjall(cfg) if cfg.is_default()
+        ));
+    }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -414,6 +414,7 @@ pub enum ArchiveStoreConfig {
     #[serde(rename = "in_memory")]
     InMemory,
     /// No-op backend that discards all writes and returns empty results.
+    #[serde(rename = "no_op", alias = "noop")]
     NoOp,
 }
 
@@ -524,6 +525,7 @@ pub enum IndexStoreConfig {
     Fjall(FjallIndexConfig),
     /// No-op backend that discards all writes and returns empty results: an
     /// explicit opt-out of the index layer.
+    #[serde(rename = "no_op", alias = "noop")]
     NoOp,
 }
 
@@ -1362,5 +1364,29 @@ mod tests {
             ArchiveStoreConfig::default(),
             ArchiveStoreConfig::Fjall(cfg) if cfg.is_default()
         ));
+    }
+
+    /// The docs spell the opt-out backend `no_op`; the historical serde
+    /// lowercase of `NoOp` was `noop`. Both must parse, and serialization
+    /// must emit the documented spelling.
+    #[test]
+    fn no_op_backend_accepts_both_spellings_and_serializes_documented_one() {
+        use serde_json::json;
+
+        for spelling in ["no_op", "noop"] {
+            let archive: ArchiveStoreConfig =
+                serde_json::from_value(json!({ "backend": spelling })).unwrap();
+            assert!(matches!(archive, ArchiveStoreConfig::NoOp));
+
+            let index: IndexStoreConfig =
+                serde_json::from_value(json!({ "backend": spelling })).unwrap();
+            assert!(matches!(index, IndexStoreConfig::NoOp));
+        }
+
+        let json = serde_json::to_value(ArchiveStoreConfig::NoOp).unwrap();
+        assert_eq!(json["backend"], "no_op");
+
+        let json = serde_json::to_value(IndexStoreConfig::NoOp).unwrap();
+        assert_eq!(json["backend"], "no_op");
     }
 }

--- a/crates/fjall/Cargo.toml
+++ b/crates/fjall/Cargo.toml
@@ -5,13 +5,14 @@ edition.workspace = true
 
 [dependencies]
 dolos-core = { path = "../core" }
+dolos-flatfiles = { path = "../flatfiles" }
 fjall = "3.1.0"
 tracing.workspace = true
 thiserror.workspace = true
 bincode.workspace = true
 xxhash-rust.workspace = true
 pallas.workspace = true
+tempfile = "3"
 
 [dev-dependencies]
 dolos-testing = { path = "../testing" }
-tempfile = "3"

--- a/crates/fjall/src/archive/log_keys.rs
+++ b/crates/fjall/src/archive/log_keys.rs
@@ -1,0 +1,136 @@
+//! Log key encoding for the unified archive-logs keyspace.
+//!
+//! All log namespaces share a single keyspace with namespace hash prefixes,
+//! the same layout lesson the state store's entities keyspace records:
+//! per-namespace LSM trees multiply segment files and blow the file-descriptor
+//! limit under heavy compaction.
+//!
+//! ## Key Format
+//!
+//! ```text
+//! Key:   [ns_hash:8][log_key:40]  (48 bytes total)
+//! Value: entity value bytes (CBOR encoded)
+//! ```
+//!
+//! The `log_key` is core's 40-byte [`LogKey`]: an 8-byte big-endian slot
+//! followed by a 32-byte entity key. Within one namespace, lexicographic
+//! order of the prefixed key equals `LogKey` order, which is what
+//! `iter_logs` range scans rely on.
+
+use dolos_core::{LogKey, Namespace};
+
+use crate::state::entity_keys::hash_namespace;
+
+/// Size of namespace hash prefix: 8 bytes (xxh3 truncated)
+pub const NS_HASH_SIZE: usize = 8;
+
+/// Size of core's log key: 8-byte temporal prefix + 32-byte entity key
+pub const LOG_KEY_SIZE: usize = 40;
+
+/// Total size of a prefixed log key: 48 bytes
+pub const PREFIXED_LOG_KEY_SIZE: usize = NS_HASH_SIZE + LOG_KEY_SIZE;
+
+/// Build a log key: `[ns_hash:8][log_key:40]`
+pub fn build_log_key(ns: Namespace, key: &LogKey) -> [u8; PREFIXED_LOG_KEY_SIZE] {
+    let mut result = [0u8; PREFIXED_LOG_KEY_SIZE];
+    result[..NS_HASH_SIZE].copy_from_slice(&hash_namespace(ns));
+    result[NS_HASH_SIZE..].copy_from_slice(key.as_ref());
+    result
+}
+
+/// Decode the 40-byte [`LogKey`] portion out of a stored key.
+///
+/// The input must be at least `PREFIXED_LOG_KEY_SIZE` bytes.
+pub fn decode_log_key(key: &[u8]) -> LogKey {
+    debug_assert!(key.len() >= PREFIXED_LOG_KEY_SIZE);
+    LogKey::from(&key[NS_HASH_SIZE..PREFIXED_LOG_KEY_SIZE])
+}
+
+/// Build a temporal bound within a namespace: `[ns_hash:8][slot:8]`.
+///
+/// Compared lexicographically against 48-byte stored keys, this 16-byte
+/// bound sorts before every key of the namespace whose temporal prefix is
+/// `>= slot` and after every key whose prefix is `< slot` — the exact
+/// boundary semantics redb gets from comparing 40-byte keys against an
+/// 8-byte `TemporalKey` bound, which prune and truncate must reproduce.
+pub fn build_temporal_bound(ns: Namespace, slot: u64) -> Vec<u8> {
+    let mut result = Vec::with_capacity(NS_HASH_SIZE + 8);
+    result.extend_from_slice(&hash_namespace(ns));
+    result.extend_from_slice(&slot.to_be_bytes());
+    result
+}
+
+/// Build the inclusive start of a namespace's key range: the bare 8-byte
+/// namespace hash, which sorts before every stored key of the namespace.
+pub fn namespace_start(ns: Namespace) -> Vec<u8> {
+    hash_namespace(ns).to_vec()
+}
+
+/// Build an exclusive end bound covering the whole namespace:
+/// `[ns_hash:8][0xff:41]`.
+///
+/// One byte longer than any stored key, so even a log key of all `0xff`
+/// sorts before it, while every key of the next namespace prefix sorts
+/// after it.
+pub fn namespace_end(ns: Namespace) -> Vec<u8> {
+    let mut result = Vec::with_capacity(PREFIXED_LOG_KEY_SIZE + 1);
+    result.extend_from_slice(&hash_namespace(ns));
+    result.extend_from_slice(&[0xff; LOG_KEY_SIZE + 1]);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn log_key(slot: u64, entity: u8) -> LogKey {
+        let mut bytes = [entity; LOG_KEY_SIZE];
+        bytes[..8].copy_from_slice(&slot.to_be_bytes());
+        LogKey::from(bytes.as_slice())
+    }
+
+    #[test]
+    fn prefixed_key_roundtrip() {
+        let key = log_key(42, 0xab);
+        let prefixed = build_log_key("account-epochs", &key);
+        assert_eq!(prefixed.len(), PREFIXED_LOG_KEY_SIZE);
+        assert_eq!(decode_log_key(&prefixed), key);
+    }
+
+    #[test]
+    fn namespace_isolation() {
+        let key = log_key(42, 0xab);
+        let a = build_log_key("account-epochs", &key);
+        let b = build_log_key("stakes", &key);
+        assert_ne!(a[..NS_HASH_SIZE], b[..NS_HASH_SIZE]);
+        assert_eq!(a[NS_HASH_SIZE..], b[NS_HASH_SIZE..]);
+    }
+
+    #[test]
+    fn key_order_matches_log_key_order() {
+        let earlier = build_log_key("stakes", &log_key(1, 0xff));
+        let later = build_log_key("stakes", &log_key(2, 0x00));
+        assert!(earlier < later);
+    }
+
+    #[test]
+    fn temporal_bound_splits_at_slot() {
+        let ns = "stakes";
+        let bound = build_temporal_bound(ns, 5);
+        let below = build_log_key(ns, &log_key(4, 0xff));
+        let at = build_log_key(ns, &log_key(5, 0x00));
+        assert!(below.as_slice() < bound.as_slice());
+        assert!(at.as_slice() > bound.as_slice());
+    }
+
+    #[test]
+    fn namespace_bounds_cover_all_keys() {
+        let ns = "epochs";
+        let start = namespace_start(ns);
+        let end = namespace_end(ns);
+        let min = build_log_key(ns, &LogKey::from([0u8; LOG_KEY_SIZE].as_slice()));
+        let max = build_log_key(ns, &LogKey::from([0xff; LOG_KEY_SIZE].as_slice()));
+        assert!(start.as_slice() < min.as_slice());
+        assert!(max.as_slice() < end.as_slice());
+    }
+}

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -210,6 +210,19 @@ impl ArchiveStore {
         ]
     }
 
+    /// Fully compact both keyspaces and sync the result to disk.
+    ///
+    /// The export path runs this as its sanitization step — the LSM analogue
+    /// of redb's pre-export compaction — so an exported database directory
+    /// carries settled segments rather than journal backlog and stale levels.
+    pub fn compact(&self) -> Result<(), Error> {
+        self.blocks.major_compact()?;
+        self.logs.major_compact()?;
+        self.db.persist(PersistMode::SyncAll)?;
+
+        Ok(())
+    }
+
     /// Gracefully shutdown the archive store.
     ///
     /// Persists all data and waits for outstanding flushes so fjall's drop

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -1,0 +1,915 @@
+//! Fjall-based archive store implementation for Dolos.
+//!
+//! The archive keeps block bodies in flat segment files ([`dolos_flatfiles`],
+//! shared byte for byte with the redb backend) and holds two kinds of index
+//! rows — a blocks location table and the derived-log namespaces — in an LSM
+//! tree. Behavior is pinned to the redb archive by the shared conformance
+//! suite (`tests/archive_conformance.rs`).
+//!
+//! ## Two Keyspace Design
+//!
+//! 1. **`archive-blocks`**: slot → packed 16-byte [`BlockLocation`]s, newest
+//!    first. Key is the 8-byte big-endian slot; the value encoding is
+//!    byte-identical to the redb blocks table, including the multi-location
+//!    case (a Byron epoch-boundary block sharing its slot with the first main
+//!    block of the epoch it opens).
+//!
+//! 2. **`archive-logs`**: all log namespaces with namespace hash prefix. Key:
+//!    `[ns_hash:8][log_key:40]` (48 bytes), mirroring the state store's unified
+//!    entities keyspace — one keyspace, not one per namespace, because
+//!    per-namespace LSM trees blow the file-descriptor limit during heavy
+//!    compaction.
+//!
+//! Unlike the redb writer, log batches are not reordered before insertion:
+//! shuffling exists to work around redb's half-split of ascending B-tree
+//! leaves, and an LSM memtable sorts its batch regardless of arrival order.
+
+use std::collections::{HashMap, VecDeque};
+use std::ops::{Bound, Range};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use dolos_core::{
+    config::FjallArchiveConfig, ArchiveError, ArchiveStore as CoreArchiveStore,
+    ArchiveWriter as CoreArchiveWriter, BlockBody, BlockSlot, ChainPoint, EntityValue, LogKey,
+    Namespace, RawBlock, StateSchema,
+};
+use fjall::{
+    compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
+    Readable, Snapshot,
+};
+use pallas::ledger::traverse::MultiEraBlock;
+
+use dolos_flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
+
+use crate::Error;
+
+pub mod log_keys;
+
+use log_keys::{
+    build_log_key, build_temporal_bound, decode_log_key, namespace_end, namespace_start,
+    PREFIXED_LOG_KEY_SIZE,
+};
+
+/// Default cache size in MB
+const DEFAULT_CACHE_SIZE_MB: usize = 500;
+
+/// Keyspace names for the archive store
+mod keyspace_names {
+    /// Blocks location table (slot → packed BlockLocations)
+    pub const BLOCKS: &str = "archive-blocks";
+    /// Unified log namespaces keyspace
+    pub const LOGS: &str = "archive-logs";
+}
+
+fn io_err(e: std::io::Error) -> ArchiveError {
+    ArchiveError::InternalError(e.to_string())
+}
+
+fn fjall_err(e: fjall::Error) -> ArchiveError {
+    ArchiveError::from(Error::Fjall(e))
+}
+
+/// Fjall-based archive store.
+///
+/// Block bodies live in flat segment files (shared, byte-identical layout
+/// with the redb backend); only the location table and the log namespaces
+/// live in the LSM tree.
+#[derive(Clone)]
+pub struct ArchiveStore {
+    db: Database,
+    blocks: Keyspace,
+    logs: Keyspace,
+    flatfiles: Arc<FlatFileStore>,
+    schema: Arc<StateSchema>,
+    flush_on_commit: bool,
+    _tempdir: Option<Arc<tempfile::TempDir>>,
+}
+
+impl ArchiveStore {
+    /// Open or create an archive store.
+    ///
+    /// `path` is the archive **directory** (e.g. `<storage.path>/archive/`).
+    /// The fjall database is stored at `<path>/index`. Segment files are
+    /// stored in `config.blocks_path` if set, otherwise in `<path>/`.
+    pub fn open(
+        schema: StateSchema,
+        path: impl AsRef<Path>,
+        config: &FjallArchiveConfig,
+    ) -> Result<Self, Error> {
+        let path = path.as_ref();
+        std::fs::create_dir_all(path).map_err(|e| Error::Io(e.to_string()))?;
+
+        let cache_size = config.cache.unwrap_or(DEFAULT_CACHE_SIZE_MB);
+        let cache_bytes = (cache_size * 1024 * 1024) as u64;
+
+        let mut builder = Database::builder(path.join("index")).cache_size(cache_bytes);
+
+        if let Some(journal_mb) = config.max_journal_size {
+            builder = builder.max_journaling_size((journal_mb as u64) * 1024 * 1024);
+        }
+
+        if let Some(threads) = config.worker_threads {
+            builder = builder.worker_threads(threads);
+        }
+
+        let db = builder.open()?;
+
+        let segments_dir = config
+            .blocks_path
+            .clone()
+            .unwrap_or_else(|| path.to_path_buf());
+
+        let flatfiles = FlatFileStore::new(segments_dir).map_err(|e| Error::Io(e.to_string()))?;
+
+        Self::from_database(
+            db,
+            schema,
+            flatfiles,
+            config.flush_on_commit.unwrap_or(false),
+            config.l0_threshold,
+            config.memtable_size_mb,
+            None,
+        )
+    }
+
+    /// Create an archive store over temporary directories, for tests.
+    ///
+    /// Fjall has no in-memory backend; the tempdir guard is held by the
+    /// store and cleaned up when the last clone drops.
+    pub fn for_tempdir(schema: StateSchema) -> Result<Self, Error> {
+        let dir = tempfile::TempDir::new().map_err(|e| Error::Io(e.to_string()))?;
+
+        let db = Database::builder(dir.path().join("index")).open()?;
+
+        let flatfiles =
+            FlatFileStore::new(dir.path().to_path_buf()).map_err(|e| Error::Io(e.to_string()))?;
+
+        let mut store = Self::from_database(db, schema, flatfiles, false, None, None, None)?;
+        store._tempdir = Some(Arc::new(dir));
+
+        Ok(store)
+    }
+
+    fn from_database(
+        db: Database,
+        schema: StateSchema,
+        flatfiles: FlatFileStore,
+        flush_on_commit: bool,
+        l0_threshold: Option<u8>,
+        memtable_size_mb: Option<usize>,
+        tempdir: Option<Arc<tempfile::TempDir>>,
+    ) -> Result<Self, Error> {
+        let build_opts = || {
+            let mut opts = KeyspaceCreateOptions::default();
+
+            if let Some(threshold) = l0_threshold {
+                opts = opts
+                    .compaction_strategy(Arc::new(Leveled::default().with_l0_threshold(threshold)));
+            }
+
+            if let Some(size_mb) = memtable_size_mb {
+                opts = opts.max_memtable_size((size_mb as u64) * 1024 * 1024);
+            }
+
+            opts
+        };
+
+        let blocks = db.keyspace(keyspace_names::BLOCKS, build_opts)?;
+        let logs = db.keyspace(keyspace_names::LOGS, build_opts)?;
+
+        Ok(Self {
+            db,
+            blocks,
+            logs,
+            flatfiles: Arc::new(flatfiles),
+            schema: Arc::new(schema),
+            flush_on_commit,
+            _tempdir: tempdir,
+        })
+    }
+
+    /// Get a reference to the underlying database
+    pub fn database(&self) -> &Database {
+        &self.db
+    }
+
+    /// Per-keyspace disk footprint: `(name, bytes, path)`.
+    pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
+        vec![
+            (
+                keyspace_names::BLOCKS,
+                self.blocks.disk_space(),
+                self.blocks.path().to_path_buf(),
+            ),
+            (
+                keyspace_names::LOGS,
+                self.logs.disk_space(),
+                self.logs.path().to_path_buf(),
+            ),
+        ]
+    }
+
+    /// Gracefully shutdown the archive store.
+    ///
+    /// Persists all data and waits for outstanding flushes so fjall's drop
+    /// implementation cannot hang on a full worker channel.
+    pub fn shutdown(&self) -> Result<(), Error> {
+        use std::time::Duration;
+
+        tracing::info!("archive store: starting graceful shutdown");
+
+        self.db.persist(PersistMode::SyncAll)?;
+
+        let mut wait_count = 0;
+        while self.db.outstanding_flushes() > 0 {
+            std::thread::sleep(Duration::from_millis(10));
+            wait_count += 1;
+            if wait_count % 100 == 0 {
+                tracing::debug!(
+                    "archive store: waiting for {} outstanding flushes",
+                    self.db.outstanding_flushes()
+                );
+            }
+            if wait_count > 6000 {
+                tracing::warn!("archive store: timeout waiting for flushes, proceeding");
+                break;
+            }
+        }
+
+        tracing::info!("archive store: graceful shutdown complete");
+        Ok(())
+    }
+
+    fn check_namespace(&self, ns: Namespace) -> Result<(), ArchiveError> {
+        if !self.schema.contains_key(ns) {
+            return Err(ArchiveError::NamespaceNotFound(ns));
+        }
+        Ok(())
+    }
+
+    /// Every location recorded at `slot`, in stored order (newest first).
+    fn stored_locations(
+        &self,
+        snapshot: &Snapshot,
+        slot: BlockSlot,
+    ) -> Result<Vec<BlockLocation>, ArchiveError> {
+        let value = snapshot
+            .get(&self.blocks, slot.to_be_bytes())
+            .map_err(fjall_err)?;
+
+        match value {
+            Some(bytes) => Ok(decode_locations(&bytes).collect()),
+            None => Ok(vec![]),
+        }
+    }
+}
+
+/// Writer for batched archive operations.
+///
+/// Log writes go straight into the shared write batch: fjall applies a
+/// batch's items to the memtable in order, and the memtable replaces on an
+/// identical key, so the last write to a key within one batch is the one
+/// that survives — the same end state redb's writer reaches by collapsing
+/// each batch to its last writes. Blocks are buffered until `commit` so
+/// their bodies can be appended to the segment files (and fsynced) before
+/// any index entry that points at them is committed, the same crash window
+/// the redb writer keeps.
+///
+/// `overlay` is the writer-local view of every blocks-table slot this
+/// writer has touched. The write batch is invisible to reads until commit,
+/// so a second block landing at the same slot within one batch (a Byron
+/// boundary) and consecutive `undo`s at one slot resolve against the
+/// overlay first and the committed state second — the reads redb gets for
+/// free from its transaction seeing its own writes.
+pub struct ArchiveWriter {
+    store: ArchiveStore,
+    batch: Mutex<OwnedWriteBatch>,
+    pending_blocks: Mutex<Vec<(ChainPoint, RawBlock)>>,
+    overlay: Mutex<HashMap<BlockSlot, Vec<BlockLocation>>>,
+}
+
+impl ArchiveWriter {
+    fn resolve_locations(
+        &self,
+        overlay: &HashMap<BlockSlot, Vec<BlockLocation>>,
+        slot: BlockSlot,
+    ) -> Result<Vec<BlockLocation>, ArchiveError> {
+        if let Some(locations) = overlay.get(&slot) {
+            return Ok(locations.clone());
+        }
+
+        let snapshot = self.store.db.snapshot();
+        self.store.stored_locations(&snapshot, slot)
+    }
+}
+
+impl CoreArchiveWriter for ArchiveWriter {
+    fn apply(&self, point: &ChainPoint, block: &RawBlock) -> Result<(), ArchiveError> {
+        self.pending_blocks
+            .lock()
+            .unwrap()
+            .push((point.clone(), block.clone()));
+        Ok(())
+    }
+
+    fn write_log(
+        &self,
+        ns: Namespace,
+        key: &LogKey,
+        value: &EntityValue,
+    ) -> Result<(), ArchiveError> {
+        // The namespace is resolved here so an unknown one fails at the call
+        // that names it rather than at commit.
+        self.store.check_namespace(ns)?;
+
+        let mut batch = self.batch.lock().unwrap();
+        batch.insert(&self.store.logs, build_log_key(ns, key), value.as_slice());
+
+        Ok(())
+    }
+
+    /// Undo the block at `point`.
+    ///
+    /// A rollback walks the chain backwards, so at a slot holding more than
+    /// one block the one to remove is the newest — position 0 — and the slot
+    /// survives until its last block is gone. The segment file is truncated
+    /// at the removed block's offset immediately, mirroring the redb writer.
+    fn undo(&self, point: &ChainPoint) -> Result<(), ArchiveError> {
+        let slot = point.slot();
+
+        let mut overlay = self.overlay.lock().unwrap();
+        let mut locations = self.resolve_locations(&overlay, slot)?;
+
+        if locations.is_empty() {
+            return Ok(());
+        }
+
+        let removed = locations.remove(0);
+
+        let mut batch = self.batch.lock().unwrap();
+        if locations.is_empty() {
+            batch.remove(&self.store.blocks, slot.to_be_bytes());
+        } else {
+            batch.insert(
+                &self.store.blocks,
+                slot.to_be_bytes(),
+                encode_locations(&locations),
+            );
+        }
+        drop(batch);
+
+        overlay.insert(slot, locations);
+
+        self.store
+            .flatfiles
+            .truncate(removed.segment_id, removed.offset)
+            .map_err(io_err)?;
+
+        Ok(())
+    }
+
+    fn commit(self) -> Result<(), ArchiveError> {
+        // 1. Batch-append all pending blocks to flat files (fsync inside).
+        // 2. Insert all index entries into the write batch.
+        // 3. Commit the batch (log rows are already in it).
+        let pending = self.pending_blocks.into_inner().unwrap();
+        let mut overlay = self.overlay.into_inner().unwrap();
+        let mut batch = self.batch.into_inner().unwrap();
+
+        if !pending.is_empty() {
+            let items: Vec<(u32, &[u8])> = pending
+                .iter()
+                .map(|(point, block)| {
+                    let segment_id = BlockLocation::segment_for_slot(point.slot());
+                    (segment_id, block.as_slice())
+                })
+                .collect();
+
+            let locations = self.store.flatfiles.append_batch(&items).map_err(io_err)?;
+
+            let snapshot = self.store.db.snapshot();
+
+            for (i, (point, body)) in pending.iter().enumerate() {
+                let slot = point.slot();
+                let incoming = locations[i];
+
+                let existing = match overlay.get(&slot) {
+                    Some(locations) => locations.clone(),
+                    None => self.store.stored_locations(&snapshot, slot)?,
+                };
+
+                let merged = merge_location(existing, incoming, body, &self.store.flatfiles)?;
+
+                batch.insert(
+                    &self.store.blocks,
+                    slot.to_be_bytes(),
+                    encode_locations(&merged),
+                );
+                overlay.insert(slot, merged);
+            }
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        if self.store.flush_on_commit {
+            self.store
+                .db
+                .persist(PersistMode::Buffer)
+                .map_err(fjall_err)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Fold a newly written block into the locations already held at its slot.
+///
+/// An identical body means this block is being written again (a resumed
+/// restore rewriting the layer it was in the middle of): the entry that
+/// points at the original stays exactly where it is, and the copy just
+/// appended is the one nothing points at — dead space, not corruption.
+/// Repointing would move an index entry forward in the segment past a block
+/// it precedes in the chain, and `undo` truncates at the offset it removes,
+/// so that block's bytes would go with the cut.
+///
+/// Anything else is a second block at the same slot, and it takes position
+/// 0: blocks arrive in chain order, so the newcomer is the one the slot
+/// should resolve to.
+fn merge_location(
+    existing: Vec<BlockLocation>,
+    incoming: BlockLocation,
+    body: &RawBlock,
+    flatfiles: &FlatFileStore,
+) -> Result<Vec<BlockLocation>, ArchiveError> {
+    if existing.is_empty() {
+        return Ok(vec![incoming]);
+    }
+
+    for loc in existing.iter() {
+        if loc.length as usize != body.len() {
+            continue;
+        }
+
+        let stored = flatfiles.read(loc).map_err(io_err)?;
+
+        if stored == **body {
+            return Ok(existing);
+        }
+    }
+
+    let mut merged = existing;
+    merged.insert(0, incoming);
+
+    Ok(merged)
+}
+
+/// Iterator over a range of log rows within one namespace.
+///
+/// Fuses after the first error: a range scan that failed mid-way must not
+/// look like a shorter, complete result to a consumer that signs or
+/// compares what it read.
+pub struct LogIter {
+    inner: fjall::Iter,
+    done: bool,
+}
+
+impl Iterator for LogIter {
+    type Item = Result<(LogKey, EntityValue), ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let guard = self.inner.next()?;
+
+        match guard.into_inner() {
+            Ok((key, value)) => {
+                if key.len() < PREFIXED_LOG_KEY_SIZE {
+                    self.done = true;
+                    return Some(Err(ArchiveError::InternalError(format!(
+                        "malformed archive log key of {} bytes",
+                        key.len()
+                    ))));
+                }
+
+                Some(Ok((decode_log_key(&key), value.to_vec())))
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(fjall_err(e)))
+            }
+        }
+    }
+}
+
+/// Empty iterator for the unused multimap read surface.
+///
+/// The trait declares the associated type but no trait method returns it,
+/// and no log namespace is a multimap today.
+pub struct EmptyEntityValueIter;
+
+impl Iterator for EmptyEntityValueIter {
+    type Item = Result<EntityValue, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+type IndexEntry = (BlockSlot, BlockLocation);
+
+/// Iterator over a range of blocks, reading lazily from flat files.
+///
+/// A slot can hold more than one block, so an index entry expands to a run
+/// of locations and whatever is left of the entry each end is working
+/// through is buffered here. When one end's range runs dry it drains the
+/// other end's buffer, which is what keeps a forward and a backward walk
+/// from yielding a block twice or dropping one where they meet.
+pub struct BlockIter {
+    inner: fjall::Iter,
+    front: VecDeque<IndexEntry>,
+    back: VecDeque<IndexEntry>,
+    flatfiles: Arc<FlatFileStore>,
+}
+
+impl BlockIter {
+    fn decode_guard(guard: fjall::Guard) -> Option<(BlockSlot, Vec<BlockLocation>)> {
+        let (key, value) = guard.into_inner().ok()?;
+
+        let slot_bytes: [u8; 8] = key.as_ref().get(..8)?.try_into().ok()?;
+        let slot = u64::from_be_bytes(slot_bytes);
+
+        Some((slot, decode_locations(&value).collect()))
+    }
+
+    fn next_entry(&mut self) -> Option<IndexEntry> {
+        loop {
+            if let Some(entry) = self.front.pop_front() {
+                return Some(entry);
+            }
+
+            let Some(guard) = self.inner.next() else {
+                return self.back.pop_front();
+            };
+
+            let (slot, locations) = Self::decode_guard(guard)?;
+
+            self.front
+                .extend(locations.into_iter().rev().map(|loc| (slot, loc)));
+        }
+    }
+
+    fn next_entry_back(&mut self) -> Option<IndexEntry> {
+        loop {
+            if let Some(entry) = self.back.pop_back() {
+                return Some(entry);
+            }
+
+            let Some(guard) = self.inner.next_back() else {
+                return self.front.pop_back();
+            };
+
+            let (slot, locations) = Self::decode_guard(guard)?;
+
+            self.back
+                .extend(locations.into_iter().rev().map(|loc| (slot, loc)));
+        }
+    }
+}
+
+impl Iterator for BlockIter {
+    type Item = (BlockSlot, BlockBody);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (slot, loc) = self.next_entry()?;
+            match self.flatfiles.read(&loc) {
+                Ok(data) => return Some((slot, data)),
+                Err(_) => continue, // skip unreadable blocks
+            }
+        }
+    }
+}
+
+impl DoubleEndedIterator for BlockIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let (slot, loc) = self.next_entry_back()?;
+            match self.flatfiles.read(&loc) {
+                Ok(data) => return Some((slot, data)),
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+impl dolos_core::archive::Skippable for BlockIter {
+    fn skip_forward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.next_entry().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn skip_backward(&mut self, n: usize) {
+        for _ in 0..n {
+            if self.next_entry_back().is_none() {
+                break;
+            }
+        }
+    }
+}
+
+impl CoreArchiveStore for ArchiveStore {
+    type BlockIter<'a> = BlockIter;
+    type Writer = ArchiveWriter;
+    type LogIter = LogIter;
+    type EntityValueIter = EmptyEntityValueIter;
+
+    fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
+        Ok(ArchiveWriter {
+            batch: Mutex::new(self.db.batch()),
+            store: self.clone(),
+            pending_blocks: Mutex::new(Vec::new()),
+            overlay: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn read_logs(
+        &self,
+        ns: Namespace,
+        keys: &[&LogKey],
+    ) -> Result<Vec<Option<EntityValue>>, ArchiveError> {
+        self.check_namespace(ns)?;
+
+        let snapshot = self.db.snapshot();
+        let mut out = Vec::with_capacity(keys.len());
+
+        for key in keys {
+            let value = snapshot
+                .get(&self.logs, build_log_key(ns, key))
+                .map_err(fjall_err)?;
+            out.push(value.map(|v| v.as_ref().to_vec()));
+        }
+
+        Ok(out)
+    }
+
+    fn iter_logs(
+        &self,
+        ns: Namespace,
+        range: Range<LogKey>,
+    ) -> Result<Self::LogIter, ArchiveError> {
+        self.check_namespace(ns)?;
+
+        let start = build_log_key(ns, &range.start);
+        let end = build_log_key(ns, &range.end);
+
+        let snapshot = self.db.snapshot();
+        let inner = snapshot.range(&self.logs, start.as_slice()..end.as_slice());
+
+        Ok(LogIter { inner, done: false })
+    }
+
+    fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        let locations = self.stored_locations(&snapshot, *slot)?;
+
+        match locations.first() {
+            Some(loc) => Ok(Some(self.flatfiles.read(loc).map_err(io_err)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Every block the archive holds at `slot`, in chain order.
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        let locations = self.stored_locations(&snapshot, *slot)?;
+
+        locations
+            .into_iter()
+            .rev()
+            .map(|loc| self.flatfiles.read(&loc).map_err(io_err))
+            .collect()
+    }
+
+    fn get_range<'a>(
+        &self,
+        from: Option<BlockSlot>,
+        to: Option<BlockSlot>,
+    ) -> Result<Self::BlockIter<'a>, ArchiveError> {
+        let start = match from {
+            Some(slot) => Bound::Included(slot.to_be_bytes()),
+            None => Bound::Unbounded,
+        };
+        let end = match to {
+            Some(slot) => Bound::Excluded(slot.to_be_bytes()),
+            None => Bound::Unbounded,
+        };
+
+        let snapshot = self.db.snapshot();
+        let inner = snapshot.range(&self.blocks, (start, end));
+
+        Ok(BlockIter {
+            inner,
+            front: VecDeque::new(),
+            back: VecDeque::new(),
+            flatfiles: self.flatfiles.clone(),
+        })
+    }
+
+    fn find_intersect(&self, intersect: &[ChainPoint]) -> Result<Option<ChainPoint>, ArchiveError> {
+        for point in intersect {
+            let ChainPoint::Specific(slot, hash) = point else {
+                return Ok(Some(ChainPoint::Origin));
+            };
+
+            // A slot can hold more than one block, and an intersect names one
+            // of them by hash, so every block recorded there is a candidate.
+            for body in self.get_blocks_by_slot(slot)? {
+                let decoded =
+                    MultiEraBlock::decode(&body).map_err(ArchiveError::BlockDecodingError)?;
+
+                if decoded.hash().eq(hash) {
+                    return Ok(Some(ChainPoint::Specific(decoded.slot(), decoded.hash())));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+
+        let Some(guard) = snapshot.last_key_value(&self.blocks) else {
+            return Ok(None);
+        };
+
+        let (key, value) = guard.into_inner().map_err(fjall_err)?;
+
+        let slot_bytes: [u8; 8] = key
+            .as_ref()
+            .get(..8)
+            .and_then(|b| b.try_into().ok())
+            .ok_or_else(|| ArchiveError::InternalError("malformed blocks key".to_string()))?;
+        let slot = u64::from_be_bytes(slot_bytes);
+
+        let loc = BlockLocation::from_bytes(&value);
+        let body = self.flatfiles.read(&loc).map_err(io_err)?;
+
+        Ok(Some((slot, body)))
+    }
+
+    fn prune_history(&self, max_slots: u64, max_prune: Option<u64>) -> Result<bool, ArchiveError> {
+        let snapshot = self.db.snapshot();
+
+        let first = snapshot
+            .first_key_value(&self.blocks)
+            .map(|guard| guard.key())
+            .transpose()
+            .map_err(fjall_err)?;
+
+        let Some(first) = first else {
+            tracing::debug!("no start point found on chain, skipping housekeeping");
+            return Ok(true);
+        };
+
+        let last = snapshot
+            .last_key_value(&self.blocks)
+            .map(|guard| guard.key())
+            .transpose()
+            .map_err(fjall_err)?;
+
+        let Some(last) = last else {
+            tracing::debug!("no tip found on chain, skipping housekeeping");
+            return Ok(true);
+        };
+
+        let start = u64::from_be_bytes(first.as_ref()[..8].try_into().unwrap());
+        let last = u64::from_be_bytes(last.as_ref()[..8].try_into().unwrap());
+
+        let delta = last.saturating_sub(start);
+        let excess = delta.saturating_sub(max_slots);
+
+        if excess == 0 {
+            tracing::debug!(delta, max_slots, "no pruning necessary on chain");
+            return Ok(true);
+        }
+
+        let (done, max_prune) = match max_prune {
+            Some(max) => (excess <= max, core::cmp::min(excess, max)),
+            None => (true, excess),
+        };
+
+        let prune_before = start + max_prune;
+
+        tracing::info!(
+            cutoff_slot = prune_before,
+            start,
+            excess,
+            "pruning archive for excess history"
+        );
+
+        let mut batch = self.db.batch();
+
+        // Blocks strictly before the cutoff slot.
+        let to_remove = snapshot.range(&self.blocks, ..prune_before.to_be_bytes().to_vec());
+        for guard in to_remove {
+            let key = guard.key().map_err(fjall_err)?;
+            batch.remove(&self.blocks, key);
+        }
+
+        let threshold_segment = BlockLocation::segment_for_slot(prune_before);
+        self.flatfiles
+            .delete_segments_before(threshold_segment)
+            .map_err(io_err)?;
+
+        // Log rows with a temporal prefix strictly before the cutoff, per
+        // namespace — the price of the shared keyspace's hash prefix.
+        for (&ns, _) in self.schema.iter() {
+            let range = snapshot.range(
+                &self.logs,
+                namespace_start(ns)..build_temporal_bound(ns, prune_before),
+            );
+            for guard in range {
+                let key = guard.key().map_err(fjall_err)?;
+                batch.remove(&self.logs, key);
+            }
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        Ok(done)
+    }
+
+    /// Drop everything the archive holds after `after`.
+    ///
+    /// The cut is by slot: the block at `after`'s slot survives (including a
+    /// second block sharing that slot), while log rows *at* the slot go with
+    /// the cut — the exact boundary redb's `remove_after` draws by comparing
+    /// full log keys against the bare 8-byte temporal prefix.
+    fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError> {
+        let slot = after.slot();
+        let snapshot = self.db.snapshot();
+
+        let mut batch = self.db.batch();
+
+        // Find the earliest location after `slot` to know where to truncate
+        // the segment file: a slot holding more than one block contributes
+        // all of them, so the cut lands before the earliest body it has to
+        // drop and none survives.
+        let mut earliest_after: Option<BlockLocation> = None;
+
+        if let Some(from) = slot.checked_add(1) {
+            let range = snapshot.range(&self.blocks, from.to_be_bytes().to_vec()..);
+
+            for guard in range {
+                let (key, value) = guard.into_inner().map_err(fjall_err)?;
+
+                for loc in decode_locations(&value) {
+                    match &earliest_after {
+                        None => earliest_after = Some(loc),
+                        Some(prev) => {
+                            if loc.segment_id < prev.segment_id
+                                || (loc.segment_id == prev.segment_id && loc.offset < prev.offset)
+                            {
+                                earliest_after = Some(loc);
+                            }
+                        }
+                    }
+                }
+
+                batch.remove(&self.blocks, key);
+            }
+        }
+
+        // Log rows with a temporal prefix at or after the cut slot.
+        for (&ns, _) in self.schema.iter() {
+            let range = snapshot.range(
+                &self.logs,
+                build_temporal_bound(ns, slot)..namespace_end(ns),
+            );
+            for guard in range {
+                let key = guard.key().map_err(fjall_err)?;
+                batch.remove(&self.logs, key);
+            }
+        }
+
+        if let Some(loc) = earliest_after {
+            self.flatfiles
+                .truncate(loc.segment_id, loc.offset)
+                .map_err(io_err)?;
+        }
+
+        let batch = batch.durability(Some(PersistMode::Buffer));
+        batch.commit().map_err(fjall_err)?;
+
+        Ok(())
+    }
+}

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -199,6 +199,18 @@ impl IndexStore {
         &self.block_tags
     }
 
+    /// Per-keyspace disk footprint: `(name, bytes, path)`.
+    pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
+        [
+            (keyspace_names::CURSOR, &self.cursor),
+            (keyspace_names::EXACT, &self.exact),
+            (keyspace_names::UTXO_TAGS, &self.utxo_tags),
+            (keyspace_names::BLOCK_TAGS, &self.block_tags),
+        ]
+        .map(|(name, ks)| (name, ks.disk_space(), ks.path().to_path_buf()))
+        .to_vec()
+    }
+
     /// Gracefully shutdown the index store.
     ///
     /// This method ensures all pending work is completed before the database

--- a/crates/fjall/src/lib.rs
+++ b/crates/fjall/src/lib.rs
@@ -10,10 +10,13 @@
 //! - [`index`]: Index store implementation for cross-cutting indexes
 //! - [`state`]: State store implementation for ledger state (UTxOs, entities,
 //!   datums)
+//! - [`archive`]: Archive store implementation (block bodies stay in the shared
+//!   flat segment files from `dolos-flatfiles`)
 //! - [`keys`]: Shared key encoding utilities
 
-use dolos_core::{IndexError, StateError};
+use dolos_core::{ArchiveError, IndexError, StateError};
 
+pub mod archive;
 pub mod index;
 pub mod keys;
 pub mod state;
@@ -39,6 +42,9 @@ pub enum Error {
 
     #[error("keyspace not found: {0}")]
     KeyspaceNotFound(String),
+
+    #[error("io error: {0}")]
+    Io(String),
 }
 
 impl From<Error> for IndexError {
@@ -50,5 +56,11 @@ impl From<Error> for IndexError {
 impl From<Error> for StateError {
     fn from(error: Error) -> Self {
         StateError::InternalStoreError(error.to_string())
+    }
+}
+
+impl From<Error> for ArchiveError {
+    fn from(error: Error) -> Self {
+        ArchiveError::InternalError(error.to_string())
     }
 }

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -153,6 +153,17 @@ impl StateStore {
         &self.entities
     }
 
+    /// Per-keyspace disk footprint: `(name, bytes, path)`.
+    pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
+        [
+            (keyspace_names::CURSOR, &self.cursor),
+            (keyspace_names::UTXOS, &self.utxos),
+            (keyspace_names::ENTITIES, &self.entities),
+        ]
+        .map(|(name, ks)| (name, ks.disk_space(), ks.path().to_path_buf()))
+        .to_vec()
+    }
+
     /// Gracefully shutdown the state store.
     ///
     /// This method ensures all pending work is completed before the database

--- a/crates/flatfiles/Cargo.toml
+++ b/crates/flatfiles/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dolos-flatfiles"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+tempfile = "3"

--- a/crates/flatfiles/src/lib.rs
+++ b/crates/flatfiles/src/lib.rs
@@ -1,3 +1,12 @@
+//! Flat segment files for archived block bodies.
+//!
+//! Bodies are appended to numbered segment files (one Cardano epoch per
+//! segment) and addressed by packed [`BlockLocation`]s stored in whichever
+//! archive index backend is in use. The layout is backend-independent: the
+//! redb and fjall archive stores share these files byte for byte, which is
+//! why this crate depends on nothing but the standard library (plus
+//! `tempfile` for throwaway stores).
+
 use std::collections::{hash_map::Entry, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};

--- a/crates/redb3/Cargo.toml
+++ b/crates/redb3/Cargo.toml
@@ -21,6 +21,7 @@ xxhash-rust.workspace = true
 tempfile = "3"
 
 dolos-core = { path = "../core" }
+dolos-flatfiles = { path = "../flatfiles" }
 
 redb = { version = "^3.1" }
 redb-extras = "0.6.1"

--- a/crates/redb3/examples/heal-byron-ebbs.rs
+++ b/crates/redb3/examples/heal-byron-ebbs.rs
@@ -49,9 +49,7 @@ use std::path::{Path, PathBuf};
 use pallas::ledger::traverse::{probe, MultiEraBlock};
 use redb::{Database, ReadableDatabase as _, ReadableTable as _};
 
-use dolos_redb3::archive::flatfiles::{
-    decode_locations, encode_locations, BlockLocation, FlatFileStore,
-};
+use dolos_flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
 use dolos_redb3::archive::tables::BlocksTable;
 
 type BoxError = Box<dyn std::error::Error>;

--- a/crates/redb3/src/archive/mod.rs
+++ b/crates/redb3/src/archive/mod.rs
@@ -29,13 +29,10 @@ use redb_extras::buckets::BucketError;
 use crate::{build_tables, Error, Table, TableFootprint};
 
 // The one-time Byron EBB recovery scan (`examples/heal-byron-ebbs.rs`) reuses
-// these index definitions and the location packing rather than restating them.
-// It is the only thing that ever enables `maintenance`; the `dolos` binary
-// does not, so the crate's ordinary surface keeps them private.
-#[cfg(not(feature = "maintenance"))]
-pub(crate) mod flatfiles;
-#[cfg(feature = "maintenance")]
-pub mod flatfiles;
+// these index definitions rather than restating them. It is the only thing
+// that ever enables `maintenance`; the `dolos` binary does not, so the
+// crate's ordinary surface keeps them private.
+use dolos_flatfiles as flatfiles;
 
 pub(crate) mod indexes;
 

--- a/crates/redb3/src/archive/tables.rs
+++ b/crates/redb3/src/archive/tables.rs
@@ -3,7 +3,7 @@ use tracing::trace;
 
 use dolos_core::{BlockBody, BlockSlot, ChainPoint, RawBlock};
 
-use super::flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
+use dolos_flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
 
 type Error = super::RedbArchiveError;
 

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -77,22 +77,22 @@ pub fn harness<B: ToyStores>() -> ToyDomain<B> {
 /// An archive, state and index store with nothing in them: where a restore
 /// writes.
 ///
-/// The same three backends [`harness`] binds, so a comparison between a
-/// restored node and a replayed one is about the drivers and not about the
-/// stores.
+/// The same three backends [`harness`] binds — the archive included, via the
+/// `ToyStores` binding — so a comparison between a restored node and a
+/// replayed one is about the drivers and not about the stores, and the
+/// fjall-bound suites exercise a restore *into* a fjall archive.
 pub struct Blank<B: ToyStores> {
-    pub archive: dolos_redb3::archive::ArchiveStore,
+    pub archive: B::Archive,
     pub stores: B,
 }
 
 impl<B: ToyStores> Blank<B> {
     pub fn open() -> Self {
+        let stores = B::open();
+
         Self {
-            archive: dolos_redb3::archive::ArchiveStore::in_memory(
-                dolos_cardano::model::build_schema(),
-            )
-            .unwrap(),
-            stores: B::open(),
+            archive: stores.archive().clone(),
+            stores,
         }
     }
 

--- a/crates/testing/src/archive.rs
+++ b/crates/testing/src/archive.rs
@@ -1,0 +1,125 @@
+//! Deterministic archive populations for benchmarks and stress tests.
+//!
+//! [`populate_archive`] writes the same blocks and log rows into any
+//! [`ArchiveStore`] implementation, so two backends populated from the same
+//! [`ArchiveShape`] hold identical content and can be measured against the
+//! same keys. Randomness comes from an inlined SplitMix64 over the shape's
+//! seed rather than `rand`, so a population is reproducible from the shape
+//! alone.
+
+use std::sync::Arc;
+
+use dolos_core::{
+    ArchiveError, ArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, EntityKey, LogKey,
+    Namespace, TemporalKey,
+};
+
+/// SplitMix64: tiny, seedable, and good enough to size filler payloads.
+#[derive(Clone)]
+pub struct SplitMix64(pub u64);
+
+impl SplitMix64 {
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+}
+
+/// The dimensions of a synthetic archive population.
+///
+/// Blocks are laid out at evenly strided slots within each epoch; log rows
+/// are written per epoch under that epoch's starting slot, one row for each
+/// of `log_rows_per_epoch` entities. Entity keys depend only on the entity
+/// index, so the same entities recur across epochs — the layout the
+/// per-account reward reads walk in production.
+#[derive(Clone)]
+pub struct ArchiveShape {
+    pub epochs: u64,
+    pub blocks_per_epoch: u64,
+    pub log_rows_per_epoch: u64,
+    pub slots_per_epoch: u64,
+    pub seed: u64,
+}
+
+impl ArchiveShape {
+    pub fn epoch_start(&self, epoch: u64) -> BlockSlot {
+        epoch * self.slots_per_epoch
+    }
+
+    /// Every block slot the population writes, in ascending order. Callers
+    /// sample read keys from this instead of scanning the store, so both
+    /// backends measure exactly the keys that exist.
+    pub fn block_slots(&self) -> impl Iterator<Item = BlockSlot> + '_ {
+        let stride = (self.slots_per_epoch / self.blocks_per_epoch).max(1);
+
+        (0..self.epochs).flat_map(move |epoch| {
+            (0..self.blocks_per_epoch).map(move |i| self.epoch_start(epoch) + i * stride)
+        })
+    }
+
+    /// The stable key of entity `i`, identical in every epoch.
+    pub fn entity(&self, i: u64) -> EntityKey {
+        let mut bytes = [0u8; 32];
+        for chunk in bytes.chunks_exact_mut(8) {
+            chunk.copy_from_slice(&i.to_be_bytes());
+        }
+        EntityKey::from(&bytes)
+    }
+
+    /// The log key of entity `i` at `epoch`'s boundary.
+    pub fn log_key(&self, epoch: u64, i: u64) -> LogKey {
+        LogKey::from((TemporalKey::from(self.epoch_start(epoch)), self.entity(i)))
+    }
+}
+
+fn block_point(slot: BlockSlot) -> ChainPoint {
+    let mut bytes = [0u8; 32];
+    for chunk in bytes.chunks_exact_mut(8) {
+        chunk.copy_from_slice(&slot.to_be_bytes());
+    }
+    ChainPoint::Specific(slot, pallas::crypto::hash::Hash::new(bytes))
+}
+
+fn filler(rng: &mut SplitMix64, len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        out.extend_from_slice(&rng.next_u64().to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+/// Write `shape` into `store`: one committed writer per epoch carrying that
+/// epoch's blocks (~1-2 KiB bodies) and its log rows (~30-60 B values) under
+/// `ns`, which must exist in the store's schema.
+pub fn populate_archive<S: ArchiveStore>(
+    store: &S,
+    ns: Namespace,
+    shape: &ArchiveShape,
+) -> Result<(), ArchiveError> {
+    let mut rng = SplitMix64(shape.seed);
+    let stride = (shape.slots_per_epoch / shape.blocks_per_epoch).max(1);
+
+    for epoch in 0..shape.epochs {
+        let writer = store.start_writer()?;
+        let epoch_start = shape.epoch_start(epoch);
+
+        for i in 0..shape.blocks_per_epoch {
+            let slot = epoch_start + i * stride;
+            let len = 1024 + (rng.next_u64() % 1024) as usize;
+            writer.apply(&block_point(slot), &Arc::new(filler(&mut rng, len)))?;
+        }
+
+        for i in 0..shape.log_rows_per_epoch {
+            let len = 30 + (rng.next_u64() % 31) as usize;
+            writer.write_log(ns, &shape.log_key(epoch, i), &filler(&mut rng, len))?;
+        }
+
+        writer.commit()?;
+    }
+
+    Ok(())
+}

--- a/crates/testing/src/archive.rs
+++ b/crates/testing/src/archive.rs
@@ -49,14 +49,19 @@ impl ArchiveShape {
         epoch * self.slots_per_epoch
     }
 
+    /// The gap between consecutive block slots inside one epoch. Shared by
+    /// [`Self::block_slots`] and [`populate_archive`] so the slots callers
+    /// sample are exactly the slots the population wrote.
+    pub fn stride(&self) -> u64 {
+        (self.slots_per_epoch / self.blocks_per_epoch).max(1)
+    }
+
     /// Every block slot the population writes, in ascending order. Callers
     /// sample read keys from this instead of scanning the store, so both
     /// backends measure exactly the keys that exist.
     pub fn block_slots(&self) -> impl Iterator<Item = BlockSlot> + '_ {
-        let stride = (self.slots_per_epoch / self.blocks_per_epoch).max(1);
-
         (0..self.epochs).flat_map(move |epoch| {
-            (0..self.blocks_per_epoch).map(move |i| self.epoch_start(epoch) + i * stride)
+            (0..self.blocks_per_epoch).map(move |i| self.epoch_start(epoch) + i * self.stride())
         })
     }
 
@@ -101,7 +106,7 @@ pub fn populate_archive<S: ArchiveStore>(
     shape: &ArchiveShape,
 ) -> Result<(), ArchiveError> {
     let mut rng = SplitMix64(shape.seed);
-    let stride = (shape.slots_per_epoch / shape.blocks_per_epoch).max(1);
+    let stride = shape.stride();
 
     for epoch in 0..shape.epochs {
         let writer = store.start_writer()?;

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -20,6 +20,7 @@ use rand::Rng;
 
 use dolos_core::*;
 
+pub mod archive;
 pub mod blocks;
 pub mod faults;
 pub mod synthetic;

--- a/crates/testing/src/toy_domain.rs
+++ b/crates/testing/src/toy_domain.rs
@@ -134,7 +134,7 @@ impl dolos_core::MempoolStore for Mempool {
     }
 }
 
-/// The state and index backends a [`ToyDomain`] is bound to.
+/// The state, index and archive backends a [`ToyDomain`] is bound to.
 ///
 /// A binding, not a variant: there is one harness domain, and this is the axis
 /// along which it is pointed at a backend. The two implementations below are
@@ -142,18 +142,20 @@ impl dolos_core::MempoolStore for Mempool {
 /// running on either is running on a live configuration rather than on a
 /// test-only store.
 ///
-/// The pair is one trait rather than two parameters because they are always
-/// chosen together, and because [`FjallStores`] has to keep a temporary
-/// directory alive for both.
+/// The set is one trait rather than separate parameters because the stores are
+/// always chosen together, and because [`FjallStores`] has to keep a temporary
+/// directory alive for all of them.
 pub trait ToyStores: Clone + Send + Sync + 'static {
     type State: StateStore;
     type Indexes: dolos_core::IndexStore;
+    type Archive: dolos_core::ArchiveStore;
 
-    /// Open a fresh, empty pair.
+    /// Open a fresh, empty set.
     fn open() -> Self;
 
     fn state(&self) -> &Self::State;
     fn indexes(&self) -> &Self::Indexes;
+    fn archive(&self) -> &Self::Archive;
 }
 
 /// The builtin in-memory stores: the default, and what almost every suite
@@ -168,16 +170,22 @@ pub trait ToyStores: Clone + Send + Sync + 'static {
 pub struct MemoryStores {
     state: MemoryStateStore,
     indexes: MemoryIndexStore,
+    archive: dolos_redb3::archive::ArchiveStore,
 }
 
 impl ToyStores for MemoryStores {
     type State = MemoryStateStore;
     type Indexes = MemoryIndexStore;
+    type Archive = dolos_redb3::archive::ArchiveStore;
 
     fn open() -> Self {
         Self {
             state: MemoryStateStore::new(),
             indexes: MemoryIndexStore::new(),
+            archive: dolos_redb3::archive::ArchiveStore::in_memory(
+                dolos_cardano::model::build_schema(),
+            )
+            .expect("opening the in-memory redb archive store"),
         }
     }
 
@@ -187,6 +195,10 @@ impl ToyStores for MemoryStores {
 
     fn indexes(&self) -> &Self::Indexes {
         &self.indexes
+    }
+
+    fn archive(&self) -> &Self::Archive {
+        &self.archive
     }
 }
 
@@ -203,12 +215,14 @@ impl ToyStores for MemoryStores {
 pub struct FjallStores {
     state: dolos_fjall::StateStore,
     indexes: dolos_fjall::IndexStore,
+    archive: dolos_fjall::archive::ArchiveStore,
     _dir: Arc<tempfile::TempDir>,
 }
 
 impl ToyStores for FjallStores {
     type State = dolos_fjall::StateStore;
     type Indexes = dolos_fjall::IndexStore;
+    type Archive = dolos_fjall::archive::ArchiveStore;
 
     fn open() -> Self {
         let dir = tempfile::tempdir().expect("temp dir for the fjall stores");
@@ -225,9 +239,17 @@ impl ToyStores for FjallStores {
         )
         .expect("opening the fjall index store");
 
+        let archive = dolos_fjall::archive::ArchiveStore::open(
+            dolos_cardano::model::build_schema(),
+            dir.path().join("archive"),
+            &dolos_core::config::FjallArchiveConfig::default(),
+        )
+        .expect("opening the fjall archive store");
+
         Self {
             state,
             indexes,
+            archive,
             _dir: Arc::new(dir),
         }
     }
@@ -239,10 +261,14 @@ impl ToyStores for FjallStores {
     fn indexes(&self) -> &Self::Indexes {
         &self.indexes
     }
+
+    fn archive(&self) -> &Self::Archive {
+        &self.archive
+    }
 }
 
-/// Minimal `Domain` implementation, with the archive on redb and the state and
-/// index stores chosen by [`ToyStores`].
+/// Minimal `Domain` implementation, with the state, index and archive stores
+/// chosen by [`ToyStores`].
 ///
 /// Defaults to [`MemoryStores`], so `ToyDomain` unqualified is the cheap
 /// in-memory harness every existing suite already binds.
@@ -251,7 +277,6 @@ pub struct ToyDomain<B: ToyStores = MemoryStores> {
     wal: dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>,
     chain: Arc<RwLock<dolos_cardano::CardanoLogic>>,
     stores: B,
-    archive: dolos_redb3::archive::ArchiveStore,
     mempool: Mempool,
     storage_config: StorageConfig,
     sync_config: SyncConfig,
@@ -306,10 +331,6 @@ impl<B: ToyStores> ToyDomain<B> {
 
         let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
 
-        let archive =
-            dolos_redb3::archive::ArchiveStore::in_memory(dolos_cardano::model::build_schema())
-                .unwrap();
-
         let chain = dolos_cardano::CardanoLogic::initialize::<Self>(
             config.clone(),
             stores.state(),
@@ -322,7 +343,6 @@ impl<B: ToyStores> ToyDomain<B> {
             stores,
             wal: dolos_redb3::wal::RedbWalStore::memory().unwrap(),
             chain: Arc::new(RwLock::new(chain)),
-            archive,
             mempool: Mempool {
                 pending: Arc::new(RwLock::new(Vec::new())),
             },
@@ -355,7 +375,7 @@ impl<B: ToyStores> ToyDomain<B> {
         let epoch = dolos_cardano::load_epoch::<Self>(domain.stores.state()).unwrap();
         let epoch_start = chain.epoch_start(epoch.number);
         let log_key = LogKey::from(TemporalKey::from(epoch_start));
-        let writer = domain.archive.start_writer().unwrap();
+        let writer = domain.stores.archive().start_writer().unwrap();
         writer.write_log_typed(&log_key, &epoch).unwrap();
         writer.commit().unwrap();
 
@@ -419,7 +439,7 @@ impl<B: ToyStores> dolos_core::Domain for ToyDomain<B> {
     type Entity = dolos_cardano::CardanoEntity;
     type EntityDelta = dolos_cardano::CardanoDelta;
     type Wal = dolos_redb3::wal::RedbWalStore<dolos_cardano::CardanoDelta>;
-    type Archive = dolos_redb3::archive::ArchiveStore;
+    type Archive = B::Archive;
     type State = B::State;
     type Chain = dolos_cardano::CardanoLogic;
     type WorkUnit = dolos_cardano::CardanoWorkUnit;
@@ -456,7 +476,7 @@ impl<B: ToyStores> dolos_core::Domain for ToyDomain<B> {
     }
 
     fn archive(&self) -> &Self::Archive {
-        &self.archive
+        self.stores.archive()
     }
 
     fn indexes(&self) -> &Self::Indexes {

--- a/docs/content/architecture/data-layer.mdx
+++ b/docs/content/architecture/data-layer.mdx
@@ -32,8 +32,8 @@ Each store is defined as a trait in `dolos-core` — `WalStore`, `StateStore`, `
 
 Available backends:
 
-- **redb** (`dolos-redb3`) — an embedded ACID B+tree store. It backs the WAL (the only WAL implementation), and can back state, archive, and indexes.
-- **fjall** (`dolos-fjall`) — an LSM-tree engine tuned for write-heavy workloads with many hot keys, available for the state and index stores.
+- **redb** (`dolos-redb3`) — an embedded ACID B+tree store. It backs the WAL (the only WAL implementation) and remains a supported archive backend via explicit configuration; its state and index implementations are deprecated and refused at startup.
+- **fjall** (`dolos-fjall`) — an LSM-tree engine tuned for write-heavy workloads with many hot keys. The default backend for the state, index, and archive stores. Both archive backends share the same flat block segment files; only the index format differs.
 - **no-op** — a store that silently discards writes, used to *disable* the archive and/or index stores.
 - **in-memory** — non-persistent stores for testing and ephemeral nodes. State and indexes have builtin implementations in `dolos-core` backed by ordered maps, which serve their traits in full; the WAL, archive, and mempool use redb's memory backend instead.
 

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -151,17 +151,23 @@ sized for the data; a mainnet transfer stages gigabytes. The first two take
 
 ### `storage.archive` section
 
-| property    | type    | example   |
-| ----------- | ------- | --------- |
-| backend     | string  | "redb"    |
-| path        | string  | "archive" |
-| blocks_path | string  | "blocks" |
-| cache       | integer | 500       |
+| property         | type    | example   |
+| ---------------- | ------- | --------- |
+| backend          | string  | "fjall"   |
+| path             | string  | "archive" |
+| blocks_path      | string  | "blocks"  |
+| cache            | integer | 500       |
+| max_journal_size | integer | 1024      |
+| flush_on_commit  | boolean | false     |
+| l0_threshold     | integer | 4         |
+| worker_threads   | integer | 4         |
+| memtable_size_mb | integer | 64        |
 
-- `backend`: `redb`, `in_memory`, or `no_op` (defaults to `redb`).
+- `backend`: `fjall`, `redb`, `in_memory`, or `no_op` (defaults to `fjall`). Unlike the state and index stores, `redb` remains a supported archive backend when selected explicitly. Both persistent backends share the same block segment file layout; only the index format differs, so an archive written by one cannot be opened by the other without re-bootstrapping.
 - `path`: optional override for the archive path (defaults to `<storage.path>/archive`).
-- `blocks_path`: optional override for block segment files (Redb only).
-- `cache`: size (MB) of the archive cache (Redb only).
+- `blocks_path`: optional override for block segment files (both persistent backends).
+- `cache`: size (MB) of the archive index cache (both persistent backends).
+- `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.
 
 ### `storage.index` section
 

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -700,6 +700,9 @@ impl ArchiveStoreBackend {
     ) -> Result<Self, ArchiveError> {
         match config {
             ArchiveStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
+            ArchiveStoreConfig::Fjall(_) => Err(ArchiveError::InternalError(
+                "the fjall archive backend is not wired yet".to_string(),
+            )),
             ArchiveStoreConfig::InMemory => Self::in_memory(schema),
             ArchiveStoreConfig::NoOp => Ok(Self::noop()),
         }

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -632,16 +632,20 @@ impl CoreStateStore for StateStoreBackend {
 #[derive(Clone)]
 pub enum ArchiveStoreBackend {
     Redb(dolos_redb3::archive::ArchiveStore),
-    /// Write-gated view over an already-open redb archive: reads and
-    /// derived-log writes pass through, block appends and undos are
-    /// discarded.
+    /// Write-gated view over an already-open archive: reads and derived-log
+    /// writes pass through, block appends and undos are discarded.
     ///
     /// This exists for replays over an archive that already holds the chain
     /// (`dolos doctor rebuild-state --rewrite-logs`): block appends are not
-    /// idempotent — replaying them would double every segment file — while
-    /// boundary log keys are slot-derived and identical under replay, so
-    /// re-written log rows overwrite the originals in place.
-    LogsOnly(dolos_redb3::archive::ArchiveStore),
+    /// idempotent — replaying them would double every shared segment file,
+    /// whichever backend owns the index — while boundary log keys are
+    /// slot-derived and identical under replay, so re-written log rows
+    /// overwrite the originals in place.
+    ///
+    /// [`Self::logs_only`] is the sole constructor, and it never nests one
+    /// gate inside another.
+    LogsOnly(Box<ArchiveStoreBackend>),
+    Fjall(dolos_fjall::archive::ArchiveStore),
     NoOp(NoOpArchiveStore),
 }
 
@@ -657,26 +661,39 @@ impl ArchiveStoreBackend {
         )?))
     }
 
+    /// Open an archive store with the Fjall backend.
+    pub fn open_fjall(
+        path: impl AsRef<Path>,
+        schema: StateSchema,
+        config: &dolos_core::config::FjallArchiveConfig,
+    ) -> Result<Self, ArchiveError> {
+        Ok(Self::Fjall(
+            dolos_fjall::archive::ArchiveStore::open(schema, path, config)
+                .map_err(ArchiveError::from)?,
+        ))
+    }
+
     /// Create a no-op archive store that discards all writes.
     pub fn noop() -> Self {
         Self::NoOp(NoOpArchiveStore)
     }
 
-    /// Wrap this backend's already-open redb store in a [`Self::LogsOnly`]
-    /// write gate.
+    /// Wrap this backend's already-open store in a [`Self::LogsOnly`] write
+    /// gate.
     ///
     /// Clones the handle out of the open store rather than opening the path
     /// again, because redb refuses to open the same file twice. Returns
-    /// `None` when there is no redb store to wrap.
+    /// `None` when there is no persistent store to wrap.
     ///
-    /// The result therefore *aliases* the store it came from: both share one
-    /// `Arc<Database>`. Anything reaching for exclusive database access —
-    /// `db_mut`, and so redb compaction — must refuse a `LogsOnly` value
-    /// rather than treat it as a `Redb` one, because `Arc::get_mut` cannot
-    /// succeed while the original handle is alive.
+    /// The result therefore *aliases* the store it came from: both share the
+    /// same underlying handle. Anything reaching for exclusive database
+    /// access — `db_mut`, and so redb compaction — must refuse a `LogsOnly`
+    /// value rather than unwrap it, because `Arc::get_mut` cannot succeed
+    /// while the original handle is alive.
     pub fn logs_only(&self) -> Option<Self> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => Some(Self::LogsOnly(s.clone())),
+            Self::LogsOnly(_) => Some(self.clone()),
+            Self::Redb(_) | Self::Fjall(_) => Some(Self::LogsOnly(Box::new(self.clone()))),
             Self::NoOp(_) => None,
         }
     }
@@ -700,9 +717,7 @@ impl ArchiveStoreBackend {
     ) -> Result<Self, ArchiveError> {
         match config {
             ArchiveStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
-            ArchiveStoreConfig::Fjall(_) => Err(ArchiveError::InternalError(
-                "the fjall archive backend is not wired yet".to_string(),
-            )),
+            ArchiveStoreConfig::Fjall(cfg) => Self::open_fjall(path, schema, cfg),
             ArchiveStoreConfig::InMemory => Self::in_memory(schema),
             ArchiveStoreConfig::NoOp => Ok(Self::noop()),
         }
@@ -710,9 +725,11 @@ impl ArchiveStoreBackend {
 
     pub fn shutdown(&self) -> Result<(), ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => s
+            Self::Redb(s) => s
                 .shutdown()
                 .map_err(|e| ArchiveError::InternalError(e.to_string())),
+            Self::LogsOnly(inner) => inner.shutdown(),
+            Self::Fjall(s) => s.shutdown().map_err(ArchiveError::from),
             Self::NoOp(s) => s.shutdown(),
         }
     }
@@ -721,7 +738,8 @@ impl ArchiveStoreBackend {
 pub enum ArchiveWriterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::Writer>),
     /// Delegates `write_log` and `commit`; discards `apply` and `undo`.
-    LogsOnly(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::Writer>),
+    LogsOnly(Box<ArchiveWriterBackend>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::Writer>),
     NoOp(NoOpArchiveWriter),
 }
 
@@ -730,6 +748,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
         match self {
             Self::Redb(w) => w.apply(point, block),
             Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.apply(point, block),
             Self::NoOp(w) => w.apply(point, block),
         }
     }
@@ -741,7 +760,9 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
         value: &EntityValue,
     ) -> Result<(), ArchiveError> {
         match self {
-            Self::Redb(w) | Self::LogsOnly(w) => w.write_log(ns, key, value),
+            Self::Redb(w) => w.write_log(ns, key, value),
+            Self::LogsOnly(w) => w.write_log(ns, key, value),
+            Self::Fjall(w) => w.write_log(ns, key, value),
             Self::NoOp(w) => w.write_log(ns, key, value),
         }
     }
@@ -750,13 +771,16 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
         match self {
             Self::Redb(w) => w.undo(point),
             Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.undo(point),
             Self::NoOp(w) => w.undo(point),
         }
     }
 
     fn commit(self) -> Result<(), ArchiveError> {
         match self {
-            Self::Redb(w) | Self::LogsOnly(w) => (*w).commit(),
+            Self::Redb(w) => (*w).commit(),
+            Self::LogsOnly(w) => (*w).commit(),
+            Self::Fjall(w) => (*w).commit(),
             Self::NoOp(w) => w.commit(),
         }
     }
@@ -764,6 +788,7 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
 
 pub enum ArchiveBlockIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::BlockIter<'static>>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::BlockIter<'static>>),
     NoOp(EmptyBlockIter),
 }
 
@@ -772,6 +797,7 @@ impl Iterator for ArchiveBlockIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -781,6 +807,7 @@ impl DoubleEndedIterator for ArchiveBlockIterBackend {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next_back(),
+            Self::Fjall(iter) => iter.next_back(),
             Self::NoOp(iter) => iter.next_back(),
         }
     }
@@ -790,6 +817,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
     fn skip_forward(&mut self, n: usize) {
         match self {
             Self::Redb(iter) => iter.skip_forward(n),
+            Self::Fjall(iter) => iter.skip_forward(n),
             Self::NoOp(iter) => iter.skip_forward(n),
         }
     }
@@ -797,6 +825,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
     fn skip_backward(&mut self, n: usize) {
         match self {
             Self::Redb(iter) => iter.skip_backward(n),
+            Self::Fjall(iter) => iter.skip_backward(n),
             Self::NoOp(iter) => iter.skip_backward(n),
         }
     }
@@ -804,6 +833,7 @@ impl dolos_core::archive::Skippable for ArchiveBlockIterBackend {
 
 pub enum ArchiveLogIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::LogIter>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::LogIter>),
     NoOp(EmptyLogIter),
 }
 
@@ -812,6 +842,7 @@ impl Iterator for ArchiveLogIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -819,6 +850,7 @@ impl Iterator for ArchiveLogIterBackend {
 
 pub enum ArchiveEntityValueIterBackend {
     Redb(Box<<dolos_redb3::archive::ArchiveStore as CoreArchiveStore>::EntityValueIter>),
+    Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::EntityValueIter>),
     NoOp(dolos_core::builtin::EmptyEntityValueIter),
 }
 
@@ -827,6 +859,7 @@ impl Iterator for ArchiveEntityValueIterBackend {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Redb(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
             Self::NoOp(iter) => iter.next(),
         }
     }
@@ -842,8 +875,10 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         match self {
             Self::Redb(s) => CoreArchiveStore::start_writer(s)
                 .map(|writer| ArchiveWriterBackend::Redb(Box::new(writer))),
-            Self::LogsOnly(s) => CoreArchiveStore::start_writer(s)
+            Self::LogsOnly(inner) => CoreArchiveStore::start_writer(inner.as_ref())
                 .map(|writer| ArchiveWriterBackend::LogsOnly(Box::new(writer))),
+            Self::Fjall(s) => CoreArchiveStore::start_writer(s)
+                .map(|writer| ArchiveWriterBackend::Fjall(Box::new(writer))),
             Self::NoOp(s) => CoreArchiveStore::start_writer(s).map(ArchiveWriterBackend::NoOp),
         }
     }
@@ -854,7 +889,9 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         keys: &[&LogKey],
     ) -> Result<Vec<Option<EntityValue>>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::read_logs(s, ns, keys),
+            Self::Redb(s) => CoreArchiveStore::read_logs(s, ns, keys),
+            Self::LogsOnly(inner) => CoreArchiveStore::read_logs(inner.as_ref(), ns, keys),
+            Self::Fjall(s) => CoreArchiveStore::read_logs(s, ns, keys),
             Self::NoOp(s) => CoreArchiveStore::read_logs(s, ns, keys),
         }
     }
@@ -865,8 +902,11 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         range: Range<LogKey>,
     ) -> Result<Self::LogIter, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::iter_logs(s, ns, range)
+            Self::Redb(s) => CoreArchiveStore::iter_logs(s, ns, range)
                 .map(|iter| ArchiveLogIterBackend::Redb(Box::new(iter))),
+            Self::LogsOnly(inner) => CoreArchiveStore::iter_logs(inner.as_ref(), ns, range),
+            Self::Fjall(s) => CoreArchiveStore::iter_logs(s, ns, range)
+                .map(|iter| ArchiveLogIterBackend::Fjall(Box::new(iter))),
             Self::NoOp(s) => {
                 CoreArchiveStore::iter_logs(s, ns, range).map(ArchiveLogIterBackend::NoOp)
             }
@@ -875,14 +915,18 @@ impl CoreArchiveStore for ArchiveStoreBackend {
 
     fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_block_by_slot(s, slot),
+            Self::Redb(s) => CoreArchiveStore::get_block_by_slot(s, slot),
+            Self::LogsOnly(inner) => CoreArchiveStore::get_block_by_slot(inner.as_ref(), slot),
+            Self::Fjall(s) => CoreArchiveStore::get_block_by_slot(s, slot),
             Self::NoOp(s) => CoreArchiveStore::get_block_by_slot(s, slot),
         }
     }
 
     fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
+            Self::Redb(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
+            Self::LogsOnly(inner) => CoreArchiveStore::get_blocks_by_slot(inner.as_ref(), slot),
+            Self::Fjall(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
             Self::NoOp(s) => CoreArchiveStore::get_blocks_by_slot(s, slot),
         }
     }
@@ -893,8 +937,11 @@ impl CoreArchiveStore for ArchiveStoreBackend {
         to: Option<BlockSlot>,
     ) -> Result<Self::BlockIter<'a>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_range(s, from, to)
+            Self::Redb(s) => CoreArchiveStore::get_range(s, from, to)
                 .map(|iter| ArchiveBlockIterBackend::Redb(Box::new(iter))),
+            Self::LogsOnly(inner) => CoreArchiveStore::get_range(inner.as_ref(), from, to),
+            Self::Fjall(s) => CoreArchiveStore::get_range(s, from, to)
+                .map(|iter| ArchiveBlockIterBackend::Fjall(Box::new(iter))),
             Self::NoOp(s) => {
                 CoreArchiveStore::get_range(s, from, to).map(ArchiveBlockIterBackend::NoOp)
             }
@@ -903,30 +950,38 @@ impl CoreArchiveStore for ArchiveStoreBackend {
 
     fn find_intersect(&self, intersect: &[ChainPoint]) -> Result<Option<ChainPoint>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::find_intersect(s, intersect),
+            Self::Redb(s) => CoreArchiveStore::find_intersect(s, intersect),
+            Self::LogsOnly(inner) => CoreArchiveStore::find_intersect(inner.as_ref(), intersect),
+            Self::Fjall(s) => CoreArchiveStore::find_intersect(s, intersect),
             Self::NoOp(s) => CoreArchiveStore::find_intersect(s, intersect),
         }
     }
 
     fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::get_tip(s),
+            Self::Redb(s) => CoreArchiveStore::get_tip(s),
+            Self::LogsOnly(inner) => CoreArchiveStore::get_tip(inner.as_ref()),
+            Self::Fjall(s) => CoreArchiveStore::get_tip(s),
             Self::NoOp(s) => CoreArchiveStore::get_tip(s),
         }
     }
 
     fn prune_history(&self, max_slots: u64, max_prune: Option<u64>) -> Result<bool, ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => {
-                CoreArchiveStore::prune_history(s, max_slots, max_prune)
+            Self::Redb(s) => CoreArchiveStore::prune_history(s, max_slots, max_prune),
+            Self::LogsOnly(inner) => {
+                CoreArchiveStore::prune_history(inner.as_ref(), max_slots, max_prune)
             }
+            Self::Fjall(s) => CoreArchiveStore::prune_history(s, max_slots, max_prune),
             Self::NoOp(s) => CoreArchiveStore::prune_history(s, max_slots, max_prune),
         }
     }
 
     fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError> {
         match self {
-            Self::Redb(s) | Self::LogsOnly(s) => CoreArchiveStore::truncate_front(s, after),
+            Self::Redb(s) => CoreArchiveStore::truncate_front(s, after),
+            Self::LogsOnly(inner) => CoreArchiveStore::truncate_front(inner.as_ref(), after),
+            Self::Fjall(s) => CoreArchiveStore::truncate_front(s, after),
             Self::NoOp(s) => CoreArchiveStore::truncate_front(s, after),
         }
     }

--- a/src/bin/dolos/data/cardinality_stats.rs
+++ b/src/bin/dolos/data/cardinality_stats.rs
@@ -101,7 +101,14 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
     // This command requires direct redb access
     let archive = match archive {
-        ArchiveStoreBackend::Redb(s) | ArchiveStoreBackend::LogsOnly(s) => s,
+        ArchiveStoreBackend::Redb(s) => s,
+        ArchiveStoreBackend::Fjall(_) | ArchiveStoreBackend::LogsOnly(_) => {
+            bail!(
+                "cardinality-stats is a redb forensics tool (it walks redb table \
+                 internals); configure `backend = \"redb\"` under [storage.archive] \
+                 to use it"
+            )
+        }
         ArchiveStoreBackend::NoOp(_) => {
             bail!("cardinality-stats command is not available for noop archive backend")
         }

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -158,16 +158,21 @@ pub fn run(
     let mut stores = crate::common::open_data_stores(config)?;
     let root = crate::common::ensure_storage_path(config)?;
 
-    // prepare_archive requires direct redb access
     match &mut stores.archive {
         ArchiveStoreBackend::LogsOnly(_) if !args.skip_sanitization => {
             bail!("archive sanitization needs exclusive access to the archive database")
         }
+        // Sanitization requires direct backend access: redb compacts and
+        // integrity-checks the database file, fjall major-compacts both
+        // keyspaces (an LSM has no offline integrity check to run).
         ArchiveStoreBackend::Redb(s) if !args.skip_sanitization => prepare_archive(s, &pb)?,
-        ArchiveStoreBackend::Redb(_) | ArchiveStoreBackend::LogsOnly(_) => {}
-        ArchiveStoreBackend::Fjall(_) => {
-            bail!("export command is not available for the fjall archive prototype")
+        ArchiveStoreBackend::Fjall(s) if !args.skip_sanitization => {
+            pb.set_message("compacting archive");
+            s.compact().into_diagnostic()?;
         }
+        ArchiveStoreBackend::Redb(_)
+        | ArchiveStoreBackend::LogsOnly(_)
+        | ArchiveStoreBackend::Fjall(_) => {}
         ArchiveStoreBackend::NoOp(_) => {
             bail!("export command is not available for noop archive backend")
         }

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -165,6 +165,9 @@ pub fn run(
         }
         ArchiveStoreBackend::Redb(s) if !args.skip_sanitization => prepare_archive(s, &pb)?,
         ArchiveStoreBackend::Redb(_) | ArchiveStoreBackend::LogsOnly(_) => {}
+        ArchiveStoreBackend::Fjall(_) => {
+            bail!("export command is not available for the fjall archive prototype")
+        }
         ArchiveStoreBackend::NoOp(_) => {
             bail!("export command is not available for noop archive backend")
         }

--- a/src/bin/dolos/data/prune_chain.rs
+++ b/src/bin/dolos/data/prune_chain.rs
@@ -50,6 +50,10 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
             info!("chain segment trimmed");
         }
+        ArchiveStoreBackend::Fjall(_) => {
+            // The LSM tree compacts in the background on its own schedule.
+            info!("fjall archive, background compaction handles reclamation");
+        }
         ArchiveStoreBackend::NoOp(_) => {
             // No compaction needed for noop
             info!("noop archive, skipping compaction");

--- a/src/bin/dolos/data/prune_chain.rs
+++ b/src/bin/dolos/data/prune_chain.rs
@@ -50,9 +50,13 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
             info!("chain segment trimmed");
         }
-        ArchiveStoreBackend::Fjall(_) => {
-            // The LSM tree compacts in the background on its own schedule.
-            info!("fjall archive, background compaction handles reclamation");
+        ArchiveStoreBackend::Fjall(s) => {
+            // Background compaction would reclaim the space eventually; a
+            // major compaction makes the prune's effect immediate, matching
+            // what the command promises for redb.
+            s.compact().into_diagnostic()?;
+
+            info!("chain segment trimmed");
         }
         ArchiveStoreBackend::NoOp(_) => {
             // No compaction needed for noop

--- a/src/bin/dolos/data/stats.rs
+++ b/src/bin/dolos/data/stats.rs
@@ -28,21 +28,33 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
 
     let mut json = serde_json::Map::new();
 
-    // Every store is reported if and only if it is on redb; a backend that is
-    // not gets left out rather than aborting the command. The live backend set
-    // puts state and indexes on fjall and leaves the archive on redb, so
-    // aborting on the first non-redb store would report nothing at all on a
-    // normally configured node.
-    if let StateStoreBackend::Redb(state) = &stores.state {
-        let stats = state.utxoset_stats().into_diagnostic()?;
+    // Each engine reports the shape it actually has: redb gets per-table
+    // B-tree footprints (rows, leaf fill, page counts), fjall gets per-keyspace
+    // disk footprints — LSM trees have no leaf-fill analogue and faking one
+    // would mislead. Stores on neither engine are left out rather than
+    // aborting the command.
+    match &stores.state {
+        StateStoreBackend::Redb(state) => {
+            let stats = state.utxoset_stats().into_diagnostic()?;
 
-        json.insert("state".to_string(), section(stats));
+            json.insert("state".to_string(), redb_section(stats));
+        }
+        StateStoreBackend::Fjall(state) => {
+            json.insert("state".to_string(), fjall_section(state.disk_usage()));
+        }
+        StateStoreBackend::Memory(_) => (),
     }
 
-    if let IndexStoreBackend::Redb(indexes) = &stores.indexes {
-        let stats = indexes.utxo_index_stats().into_diagnostic()?;
+    match &stores.indexes {
+        IndexStoreBackend::Redb(indexes) => {
+            let stats = indexes.utxo_index_stats().into_diagnostic()?;
 
-        json.insert("indexes".to_string(), section(stats));
+            json.insert("indexes".to_string(), redb_section(stats));
+        }
+        IndexStoreBackend::Fjall(indexes) => {
+            json.insert("indexes".to_string(), fjall_section(indexes.disk_usage()));
+        }
+        IndexStoreBackend::Memory(_) | IndexStoreBackend::NoOp(_) => (),
     }
 
     match &stores.archive {
@@ -51,20 +63,22 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
 
             let tables = stats
                 .into_iter()
-                .map(|(name, footprint)| (name, footprint_to_json(&footprint)));
+                .map(|(name, footprint)| (name, footprint_to_json(&footprint)))
+                .collect();
 
             json.insert(
                 "archive".to_string(),
-                serde_json::Value::Object(tables.collect()),
+                json!({ "engine": "redb", "tables": serde_json::Value::Object(tables) }),
             );
         }
-        ArchiveStoreBackend::Fjall(_)
-        | ArchiveStoreBackend::LogsOnly(_)
-        | ArchiveStoreBackend::NoOp(_) => (),
+        ArchiveStoreBackend::Fjall(archive) => {
+            json.insert("archive".to_string(), fjall_section(archive.disk_usage()));
+        }
+        ArchiveStoreBackend::LogsOnly(_) | ArchiveStoreBackend::NoOp(_) => (),
     }
 
     if json.is_empty() {
-        bail!("stats command is only available for redb backends, none are configured");
+        bail!("no persistent store backends are configured, nothing to report");
     }
 
     println!("{}", serde_json::to_string_pretty(&json).unwrap());
@@ -72,15 +86,32 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
     Ok(())
 }
 
-fn section<'a>(
+fn redb_section<'a>(
     stats: impl IntoIterator<Item = (&'a str, dolos_redb3::redb::TableStats)>,
 ) -> serde_json::Value {
-    let tables = stats.into_iter().map(|(name, stats)| {
-        (
-            name.to_string(),
-            footprint_to_json(&TableFootprint::new(None, stats)),
-        )
-    });
+    let tables: serde_json::Map<_, _> = stats
+        .into_iter()
+        .map(|(name, stats)| {
+            (
+                name.to_string(),
+                footprint_to_json(&TableFootprint::new(None, stats)),
+            )
+        })
+        .collect();
 
-    serde_json::Value::Object(tables.collect())
+    json!({ "engine": "redb", "tables": serde_json::Value::Object(tables) })
+}
+
+fn fjall_section(usage: Vec<(&'static str, u64, std::path::PathBuf)>) -> serde_json::Value {
+    let keyspaces: serde_json::Map<_, _> = usage
+        .into_iter()
+        .map(|(name, bytes, path)| {
+            (
+                name.to_string(),
+                json!({ "disk_bytes": bytes, "path": path.display().to_string() }),
+            )
+        })
+        .collect();
+
+    json!({ "engine": "fjall", "keyspaces": serde_json::Value::Object(keyspaces) })
 }

--- a/src/bin/dolos/data/stats.rs
+++ b/src/bin/dolos/data/stats.rs
@@ -46,7 +46,7 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
     }
 
     match &stores.archive {
-        ArchiveStoreBackend::Redb(archive) | ArchiveStoreBackend::LogsOnly(archive) => {
+        ArchiveStoreBackend::Redb(archive) => {
             let stats = archive.stats().into_diagnostic()?;
 
             let tables = stats
@@ -58,7 +58,9 @@ pub fn run(config: &RootConfig, _args: &Args) -> miette::Result<()> {
                 serde_json::Value::Object(tables.collect()),
             );
         }
-        ArchiveStoreBackend::NoOp(_) => (),
+        ArchiveStoreBackend::Fjall(_)
+        | ArchiveStoreBackend::LogsOnly(_)
+        | ArchiveStoreBackend::NoOp(_) => (),
     }
 
     if json.is_empty() {

--- a/src/bin/dolos/doctor/rebuild_state.rs
+++ b/src/bin/dolos/doctor/rebuild_state.rs
@@ -123,10 +123,13 @@ fn check_wipe_scope(config: &RootConfig, state_path: &std::path::Path) -> miette
 
     // Segment files can live outside the archive directory; the backend takes
     // `blocks_path` verbatim, so this check does too.
-    if let dolos_core::config::ArchiveStoreConfig::Redb(cfg) = &config.storage.archive {
-        if let Some(path) = &cfg.blocks_path {
-            others.push(("archive segments", path.clone()));
-        }
+    let blocks_path = match &config.storage.archive {
+        dolos_core::config::ArchiveStoreConfig::Redb(cfg) => cfg.blocks_path.as_ref(),
+        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => cfg.blocks_path.as_ref(),
+        _ => None,
+    };
+    if let Some(path) = blocks_path {
+        others.push(("archive segments", path.clone()));
     }
 
     for (what, path) in others {
@@ -401,7 +404,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     let domain_archive = if args.rewrite_logs {
         archive
             .logs_only()
-            .ok_or_else(|| miette::miette!("--rewrite-logs needs a persistent redb archive"))?
+            .ok_or_else(|| miette::miette!("--rewrite-logs needs a persistent archive"))?
     } else {
         ArchiveStoreBackend::noop()
     };

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1,0 +1,1156 @@
+//! Backend conformance for the archive store contract.
+//!
+//! Every test is written against the `ArchiveStore`/`ArchiveWriter` traits
+//! and instantiated per backend by the `conformance_suite!` macro at the
+//! bottom, so redb — the shipping backend — pins the semantics the fjall
+//! prototype must match: block reads and walks (including the Byron
+//! boundary slot family), undo's segment truncation, prune and truncate
+//! boundaries, and the log namespaces' write/read/range behavior.
+//!
+//! The block tests are ports of the redb crate's inline archive tests
+//! (`crates/redb3/src/archive/tests.rs`); the log tests are new here, since
+//! the redb suite exercised logs only through backend-specific internals.
+
+use std::sync::Arc;
+
+use dolos_core::{
+    ArchiveStore as CoreArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, EntityKey, LogKey,
+    NamespaceType, RawBlock, StateSchema, TemporalKey,
+};
+
+use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
+
+/// The namespaces the log tests write to. Two are enough to pin isolation;
+/// the names are the real ones so the suite reads like the node.
+const NS_A: &str = "account-epochs";
+const NS_B: &str = "stakes";
+
+fn schema() -> StateSchema {
+    let mut schema = StateSchema::default();
+    schema.insert(NS_A, NamespaceType::KeyValue);
+    schema.insert(NS_B, NamespaceType::KeyValue);
+    schema
+}
+
+/// One archive backend under test.
+///
+/// The guard carries whatever the backend needs kept alive for the store to
+/// stay usable — a temp directory for the on-disk one, nothing for the
+/// in-memory one.
+trait Backend {
+    type Store: CoreArchiveStore;
+    type Guard;
+
+    /// A fresh, empty store.
+    fn open() -> (Self::Store, Self::Guard);
+}
+
+struct Redb;
+
+impl Backend for Redb {
+    type Store = dolos_redb3::archive::ArchiveStore;
+    type Guard = ();
+
+    fn open() -> (Self::Store, Self::Guard) {
+        (
+            dolos_redb3::archive::ArchiveStore::in_memory(schema())
+                .expect("failed to open redb archive store"),
+            (),
+        )
+    }
+}
+
+struct Fjall;
+
+impl Backend for Fjall {
+    type Store = dolos_fjall::archive::ArchiveStore;
+    type Guard = tempfile::TempDir;
+
+    fn open() -> (Self::Store, Self::Guard) {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+
+        // Only the fields this suite cares about; the rest are the backend's
+        // own defaults rather than a re-listing of them that can go stale.
+        let config = dolos_core::config::FjallArchiveConfig {
+            cache: Some(16),
+            flush_on_commit: Some(false),
+            worker_threads: Some(1),
+            ..Default::default()
+        };
+
+        let store = dolos_fjall::archive::ArchiveStore::open(schema(), dir.path(), &config)
+            .expect("failed to open fjall archive store");
+
+        (store, dir)
+    }
+}
+
+fn point(slot: u64) -> ChainPoint {
+    ChainPoint::Specific(slot, pallas::crypto::hash::Hash::new([0u8; 32]))
+}
+
+fn fake_block(slot: u64) -> Vec<u8> {
+    format!("block_data_for_slot_{slot}").into_bytes()
+}
+
+fn bodies(items: Vec<(BlockSlot, Vec<u8>)>) -> Vec<Vec<u8>> {
+    items.into_iter().map(|(_, body)| body).collect()
+}
+
+fn stored_slots<S: CoreArchiveStore>(store: &S) -> Vec<BlockSlot> {
+    store
+        .get_range(None, None)
+        .unwrap()
+        .map(|(s, _)| s)
+        .collect()
+}
+
+fn log_key(slot: u64, entity: u8) -> LogKey {
+    let temporal = TemporalKey::from(slot);
+    let entity = EntityKey::from(&[entity; 32]);
+    LogKey::from((temporal, entity))
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: basics
+// ---------------------------------------------------------------------------
+
+fn write_and_read_block<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+}
+
+fn batch_write_and_read<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30, 40, 50] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    for slot in [10, 20, 30, 40, 50] {
+        assert_eq!(
+            store.get_block_by_slot(&slot).unwrap(),
+            Some(fake_block(slot))
+        );
+    }
+
+    assert_eq!(store.get_block_by_slot(&15).unwrap(), None);
+}
+
+fn undo_truncates<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .apply(&point(200), &Arc::new(fake_block(200)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(200)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&200).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+}
+
+fn undo_cross_segment<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let slot_seg0 = 100;
+    let slot_seg1 = 432_001;
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(slot_seg0), &Arc::new(fake_block(slot_seg0)))
+        .unwrap();
+    writer
+        .apply(&point(slot_seg1), &Arc::new(fake_block(slot_seg1)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(slot_seg1)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&slot_seg1).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&slot_seg0).unwrap(),
+        Some(fake_block(slot_seg0))
+    );
+}
+
+fn range_iteration<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30, 40, 50] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(Some(15), Some(45)).unwrap().collect();
+    let result_slots: Vec<u64> = items.iter().map(|(s, _)| *s).collect();
+    assert_eq!(result_slots, vec![20, 30, 40]);
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(None, None).unwrap().collect();
+    assert_eq!(items.len(), 5);
+
+    let items: Vec<(BlockSlot, Vec<u8>)> = store.get_range(None, None).unwrap().rev().collect();
+    let result_slots: Vec<u64> = items.iter().map(|(s, _)| *s).collect();
+    assert_eq!(result_slots, vec![50, 40, 30, 20, 10]);
+}
+
+fn tip_and_first<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    assert_eq!(store.get_tip().unwrap(), None);
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .apply(&point(500), &Arc::new(fake_block(500)))
+        .unwrap();
+    writer
+        .apply(&point(300), &Arc::new(fake_block(300)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, 500);
+    assert_eq!(tip_body, fake_block(500));
+}
+
+fn multiple_commits<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(200), &Arc::new(fake_block(200)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&200).unwrap(),
+        Some(fake_block(200))
+    );
+}
+
+fn cross_segment_writes<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    let slots = [0, 431_999, 432_000, 432_001, 864_000];
+    for &slot in &slots {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    for &slot in &slots {
+        assert_eq!(
+            store.get_block_by_slot(&slot).unwrap(),
+            Some(fake_block(slot)),
+            "failed to read slot {slot}"
+        );
+    }
+}
+
+fn write_after_undo<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(100)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), None);
+
+    let new_block = b"new_block_data".to_vec();
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(new_block.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(new_block));
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: prune and truncate
+// ---------------------------------------------------------------------------
+
+fn prune_history<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 432_100, 864_100] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    // Tip is 864_100; keeping 500_000 slots prunes before 364_100.
+    let done = store.prune_history(500_000, None).unwrap();
+    assert!(done, "unbatched prune must finish in one call");
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), None);
+    assert_eq!(store.get_block_by_slot(&200).unwrap(), None);
+    assert_eq!(
+        store.get_block_by_slot(&432_100).unwrap(),
+        Some(fake_block(432_100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&864_100).unwrap(),
+        Some(fake_block(864_100))
+    );
+}
+
+fn prune_history_no_excess_is_noop<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let done = store.prune_history(1_000, Some(10)).unwrap();
+    assert!(done, "no-excess prune must report done");
+    assert_eq!(stored_slots(&store), vec![100, 200, 300], "nothing removed");
+}
+
+fn prune_history_batched_converges<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [0, 100, 200, 300, 400, 500] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let max_slots = 100;
+    let max_prune = 150;
+
+    let done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+    assert!(!done, "large backlog should not finish in one batch");
+    let after_first = stored_slots(&store);
+    assert_eq!(
+        after_first.first(),
+        Some(&200),
+        "batch must advance the start"
+    );
+    assert_eq!(
+        store.get_tip().unwrap().map(|(s, _)| s),
+        Some(500),
+        "tip preserved across batches"
+    );
+
+    let mut done = false;
+    let mut rounds = 1;
+    while !done {
+        done = store.prune_history(max_slots, Some(max_prune)).unwrap();
+        rounds += 1;
+        assert!(rounds < 100, "batched pruning did not converge");
+    }
+
+    assert_eq!(
+        stored_slots(&store),
+        vec![400, 500],
+        "only the window remains"
+    );
+}
+
+fn truncate_front<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300, 400, 500] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&point(300)).unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&200).unwrap(),
+        Some(fake_block(200))
+    );
+    assert_eq!(
+        store.get_block_by_slot(&300).unwrap(),
+        Some(fake_block(300))
+    );
+    assert_eq!(store.get_block_by_slot(&400).unwrap(), None);
+    assert_eq!(store.get_block_by_slot(&500).unwrap(), None);
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: a slot holding more than one block (opaque payloads)
+// ---------------------------------------------------------------------------
+
+fn a_slot_keeps_every_block_written_to_it<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second.clone()));
+
+    assert_eq!(
+        store.get_blocks_by_slot(&100).unwrap(),
+        vec![first.clone(), second.clone()]
+    );
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+fn a_slot_keeps_blocks_written_in_separate_batches<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for body in [&first, &second] {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second.clone()]
+    );
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(second));
+}
+
+fn writing_the_same_block_again_leaves_one_copy<B: Backend>() {
+    let (store, _guard) = B::open();
+    let body = fake_block(100);
+
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(body.clone())).unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(store.get_blocks_by_slot(&100).unwrap(), vec![body.clone()]);
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![body]
+    );
+}
+
+fn rewriting_a_shared_slot_keeps_both_blocks_in_order<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    for _ in 0..2 {
+        let writer = store.start_writer().unwrap();
+        writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+        writer
+            .apply(&point(100), &Arc::new(second.clone()))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first, second]
+    );
+}
+
+fn rewriting_the_older_block_at_a_shared_slot_leaves_undo_sound<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let first = b"first_at_slot_100".to_vec();
+    let second = b"second_at_slot_100".to_vec();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer
+        .apply(&point(100), &Arc::new(second.clone()))
+        .unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(100), &Arc::new(first.clone())).unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&point(100)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.get_block_by_slot(&100).unwrap(), Some(first.clone()));
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![first]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Blocks: the Byron boundary family (an EBB shares its slot with the first
+// main block of the epoch it opens)
+// ---------------------------------------------------------------------------
+
+fn boundary(epoch: u64) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let ebb = make_byron_ebb(epoch, pallas::crypto::hash::Hash::new([7u8; 32]));
+    let slot = byron_ebb_slot(epoch);
+    let main = make_conway_block_with_prev(slot, ebb.0.hash(), epoch);
+
+    (ebb, main)
+}
+
+fn write_boundary<S: CoreArchiveStore>(
+    store: &S,
+    epoch: u64,
+) -> ((ChainPoint, RawBlock), (ChainPoint, RawBlock)) {
+    let (ebb, main) = boundary(epoch);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    (ebb, main)
+}
+
+fn an_ebb_survives_the_block_that_shares_its_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+    let slot = ebb.0.slot();
+
+    assert_eq!(
+        store.get_block_by_slot(&slot).unwrap().as_ref(),
+        Some(main.1.as_ref())
+    );
+
+    let items = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(items, vec![ebb.1.as_ref().clone(), main.1.as_ref().clone()]);
+}
+
+fn a_boundary_slot_reverses_into_chain_order<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let items = bodies(store.get_range(None, None).unwrap().rev().collect());
+    assert_eq!(items, vec![main.1.as_ref().clone(), ebb.1.as_ref().clone()]);
+}
+
+fn several_boundaries_interleave_with_ordinary_blocks<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    let mid = make_conway_block_with_prev(byron_ebb_slot(1) + 5, main1.0.hash(), 100);
+    let tail = make_conway_block_with_prev(byron_ebb_slot(2) + 5, main2.0.hash(), 200);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &mid, &ebb2, &main2, &tail] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let expected: Vec<Vec<u8>> = [&ebb1, &main1, &mid, &ebb2, &main2, &tail]
+        .iter()
+        .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+        .collect();
+
+    let forward = bodies(store.get_range(None, None).unwrap().collect());
+    assert_eq!(forward, expected);
+
+    let mut backward = bodies(store.get_range(None, None).unwrap().rev().collect());
+    backward.reverse();
+    assert_eq!(backward, expected);
+}
+
+fn walking_from_both_ends_covers_every_block_once<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    for front_first in [0usize, 1, 2, 3, 4] {
+        let mut iter = store.get_range(None, None).unwrap();
+        let mut seen = Vec::new();
+
+        for _ in 0..front_first {
+            if let Some((_, body)) = iter.next() {
+                seen.push(body);
+            }
+        }
+
+        let mut back = Vec::new();
+        while let Some((_, body)) = iter.next_back() {
+            back.push(body);
+        }
+        back.reverse();
+        seen.extend(back);
+
+        let expected: Vec<Vec<u8>> = [&ebb1, &main1, &ebb2, &main2]
+            .iter()
+            .map(|(_, body): &&(ChainPoint, RawBlock)| body.as_ref().clone())
+            .collect();
+
+        assert_eq!(seen, expected, "split after {front_first} from the front");
+    }
+}
+
+fn skipping_counts_the_ebb<B: Backend>() {
+    use dolos_core::archive::Skippable as _;
+
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_forward(1);
+    assert_eq!(iter.next().map(|(_, b)| b), Some(main.1.as_ref().clone()));
+
+    let mut iter = store.get_range(None, None).unwrap();
+    iter.skip_backward(1);
+    assert_eq!(
+        iter.next_back().map(|(_, b)| b),
+        Some(ebb.1.as_ref().clone())
+    );
+}
+
+fn the_tip_is_the_ebb_until_its_epochs_first_block_arrives<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let writer = store.start_writer().unwrap();
+    writer.apply(&earlier.0, &earlier.1).unwrap();
+    writer.commit().unwrap();
+
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&ebb.0, &ebb.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, ebb.0.slot());
+    assert_eq!(&tip_body, ebb.1.as_ref());
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&main.0, &main.1).unwrap();
+    writer.commit().unwrap();
+
+    let (tip_slot, tip_body) = store.get_tip().unwrap().unwrap();
+    assert_eq!(tip_slot, main.0.slot());
+    assert_eq!(&tip_body, main.1.as_ref());
+}
+
+fn undo_unwinds_a_boundary_slot_in_reverse_arrival_order<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&main.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&main.0.slot()).unwrap().as_ref(),
+        Some(ebb.1.as_ref())
+    );
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone(), ebb.1.as_ref().clone()]
+    );
+
+    let writer = store.start_writer().unwrap();
+    writer.undo(&ebb.0).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+
+    assert_eq!(store.get_block_by_slot(&main.0.slot()).unwrap(), None);
+}
+
+fn truncate_front_drops_an_ebb_past_the_cut<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let earlier = make_conway_block_with_prev(byron_ebb_slot(1) - 10, None, 0);
+    let (ebb, main) = boundary(1);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&earlier, &ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&earlier.0).unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![earlier.1.as_ref().clone()]
+    );
+
+    // The segment was truncated at the EBB's offset, so the archive can be
+    // written forward again from there.
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb, &main] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    assert_eq!(
+        bodies(store.get_range(None, None).unwrap().collect()),
+        vec![
+            earlier.1.as_ref().clone(),
+            ebb.1.as_ref().clone(),
+            main.1.as_ref().clone()
+        ]
+    );
+}
+
+fn remove_before_prunes_every_block_at_a_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let (ebb1, main1) = boundary(1);
+    let (ebb2, main2) = boundary(2);
+
+    let writer = store.start_writer().unwrap();
+    for (point, body) in [&ebb1, &main1, &ebb2, &main2] {
+        writer.apply(point, body).unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.prune_history(1, None).unwrap();
+
+    assert_eq!(
+        stored_slots(&store),
+        vec![byron_ebb_slot(2), byron_ebb_slot(2)]
+    );
+}
+
+fn find_intersect_resolves_an_ebb_by_its_own_hash<B: Backend>() {
+    let (store, _guard) = B::open();
+    let (ebb, main) = write_boundary(&store, 3);
+
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&main.0)).unwrap(),
+        Some(main.0.clone())
+    );
+
+    assert_eq!(
+        store.find_intersect(std::slice::from_ref(&ebb.0)).unwrap(),
+        Some(ebb.0.clone())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Logs
+// ---------------------------------------------------------------------------
+
+fn log_roundtrip<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let rows = [
+        (log_key(10, 0xaa), b"row_10_aa".to_vec()),
+        (log_key(10, 0xbb), b"row_10_bb".to_vec()),
+        (log_key(20, 0xaa), b"row_20_aa".to_vec()),
+    ];
+
+    let writer = store.start_writer().unwrap();
+    for (key, value) in &rows {
+        writer.write_log(NS_A, key, value).unwrap();
+    }
+    writer.commit().unwrap();
+
+    let keys: Vec<&LogKey> = rows.iter().map(|(k, _)| k).collect();
+    let read = store.read_logs(NS_A, &keys).unwrap();
+    assert_eq!(
+        read,
+        rows.iter()
+            .map(|(_, v)| Some(v.clone()))
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&log_key(30, 0xaa)]).unwrap(),
+        vec![None]
+    );
+
+    // A full iteration yields every row in key order.
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, rows.to_vec());
+}
+
+fn log_namespaces_are_isolated<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    writer.write_log(NS_A, &key, &b"in_a".to_vec()).unwrap();
+    writer.write_log(NS_B, &key, &b"in_b".to_vec()).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&key]).unwrap(),
+        vec![Some(b"in_a".to_vec())]
+    );
+    assert_eq!(
+        store.read_logs(NS_B, &[&key]).unwrap(),
+        vec![Some(b"in_b".to_vec())]
+    );
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_B, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, vec![(key, b"in_b".to_vec())]);
+}
+
+fn log_range_is_start_inclusive_end_exclusive<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [10, 20, 30] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, log_key(10, 0x01)..log_key(30, 0x01))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    let slots: Vec<LogKey> = walked.into_iter().map(|(k, _)| k).collect();
+    assert_eq!(slots, vec![log_key(10, 0x01), log_key(20, 0x01)]);
+}
+
+fn the_last_write_to_a_log_key_wins<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .write_log(NS_A, &key, &b"superseded".to_vec())
+        .unwrap();
+    writer.write_log(NS_A, &key, &b"final".to_vec()).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.read_logs(NS_A, &[&key]).unwrap(),
+        vec![Some(b"final".to_vec())]
+    );
+
+    let walked: Vec<(LogKey, Vec<u8>)> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(walked, vec![(key, b"final".to_vec())]);
+}
+
+fn an_unknown_namespace_is_refused<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = log_key(10, 0xaa);
+
+    let writer = store.start_writer().unwrap();
+    assert!(writer
+        .write_log("no-such-namespace", &key, &b"x".to_vec())
+        .is_err());
+
+    assert!(store.read_logs("no-such-namespace", &[&key]).is_err());
+    assert!(store
+        .iter_logs("no-such-namespace", LogKey::full_range())
+        .is_err());
+}
+
+fn prune_keeps_logs_at_the_cutoff_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply(&point(0), &Arc::new(fake_block(0))).unwrap();
+    writer
+        .apply(&point(1_000), &Arc::new(fake_block(1_000)))
+        .unwrap();
+    for slot in [499, 500, 501] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    // Start 0, tip 1000, window 500: prune before slot 500. A log row's
+    // temporal prefix at exactly the cutoff survives; anything before it
+    // goes.
+    let done = store.prune_history(500, None).unwrap();
+    assert!(done);
+
+    let walked: Vec<LogKey> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .map(|r| r.unwrap().0)
+        .collect();
+    assert_eq!(walked, vec![log_key(500, 0x01), log_key(501, 0x01)]);
+}
+
+fn truncate_front_drops_logs_at_the_cut_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    for slot in [100, 200, 300] {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+    }
+    for slot in [199, 200, 201] {
+        writer
+            .write_log(NS_A, &log_key(slot, 0x01), &slot.to_be_bytes().to_vec())
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    store.truncate_front(&point(200)).unwrap();
+
+    // The block at the cut slot survives; log rows at the cut slot go with
+    // everything after it. This asymmetry is what the redb backend does —
+    // its block removal is strictly-after while its log removal compares
+    // full keys against the bare temporal prefix — and both backends must
+    // agree on it.
+    assert_eq!(stored_slots(&store), vec![100, 200]);
+
+    let walked: Vec<LogKey> = store
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .map(|r| r.unwrap().0)
+        .collect();
+    assert_eq!(walked, vec![log_key(199, 0x01)]);
+}
+
+fn logs_and_blocks_share_one_writer_commit<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer
+        .write_log(NS_A, &log_key(100, 0x01), &b"epoch_row".to_vec())
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100))
+    );
+    assert_eq!(
+        store.read_logs(NS_A, &[&log_key(100, 0x01)]).unwrap(),
+        vec![Some(b"epoch_row".to_vec())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-backend agreement: both backends walk identical data identically
+// ---------------------------------------------------------------------------
+
+/// The two backends, fed the same writes, return byte-identical logs and
+/// blocks. This is the in-process half of the dump-logs comparison the
+/// benchmark protocol runs on a real replay.
+#[test]
+fn backends_agree_on_identical_writes() {
+    let (redb, _g1) = Redb::open();
+    let (fjall, _g2) = Fjall::open();
+
+    let seed_rows: Vec<(LogKey, Vec<u8>)> = (0u64..50)
+        .map(|i| {
+            (
+                log_key(i / 5, (i % 5) as u8),
+                format!("row_{i}").into_bytes(),
+            )
+        })
+        .collect();
+
+    for store in [&redb as &dyn WriteSurface, &fjall as &dyn WriteSurface] {
+        store.write(&seed_rows);
+    }
+
+    let from_redb: Vec<(LogKey, Vec<u8>)> = redb
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    let from_fjall: Vec<(LogKey, Vec<u8>)> = fjall
+        .iter_logs(NS_A, LogKey::full_range())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    assert_eq!(from_redb, from_fjall);
+}
+
+/// Object-safe helper so the agreement test writes through both backends
+/// with one code path.
+trait WriteSurface {
+    fn write(&self, rows: &[(LogKey, Vec<u8>)]);
+}
+
+impl<S: CoreArchiveStore> WriteSurface for S {
+    fn write(&self, rows: &[(LogKey, Vec<u8>)]) {
+        let writer = self.start_writer().unwrap();
+        for (key, value) in rows {
+            writer.write_log(NS_A, key, value).unwrap();
+        }
+        writer.commit().unwrap();
+    }
+}
+
+/// Declare the whole suite for one backend. Adding a backend is one line.
+macro_rules! conformance_suite {
+    ($module:ident, $backend:ty, [$($name:ident),* $(,)?]) => {
+        mod $module {
+            use super::*;
+
+            $(
+                #[test]
+                fn $name() {
+                    super::$name::<$backend>();
+                }
+            )*
+        }
+    };
+}
+
+macro_rules! full_suite {
+    ($module:ident, $backend:ty) => {
+        conformance_suite!(
+            $module,
+            $backend,
+            [
+                write_and_read_block,
+                batch_write_and_read,
+                undo_truncates,
+                undo_cross_segment,
+                range_iteration,
+                tip_and_first,
+                multiple_commits,
+                cross_segment_writes,
+                write_after_undo,
+                prune_history,
+                prune_history_no_excess_is_noop,
+                prune_history_batched_converges,
+                truncate_front,
+                a_slot_keeps_every_block_written_to_it,
+                a_slot_keeps_blocks_written_in_separate_batches,
+                writing_the_same_block_again_leaves_one_copy,
+                rewriting_a_shared_slot_keeps_both_blocks_in_order,
+                rewriting_the_older_block_at_a_shared_slot_leaves_undo_sound,
+                an_ebb_survives_the_block_that_shares_its_slot,
+                a_boundary_slot_reverses_into_chain_order,
+                several_boundaries_interleave_with_ordinary_blocks,
+                walking_from_both_ends_covers_every_block_once,
+                skipping_counts_the_ebb,
+                the_tip_is_the_ebb_until_its_epochs_first_block_arrives,
+                undo_unwinds_a_boundary_slot_in_reverse_arrival_order,
+                truncate_front_drops_an_ebb_past_the_cut,
+                remove_before_prunes_every_block_at_a_slot,
+                find_intersect_resolves_an_ebb_by_its_own_hash,
+                log_roundtrip,
+                log_namespaces_are_isolated,
+                log_range_is_start_inclusive_end_exclusive,
+                the_last_write_to_a_log_key_wins,
+                an_unknown_namespace_is_refused,
+                prune_keeps_logs_at_the_cutoff_slot,
+                truncate_front_drops_logs_at_the_cut_slot,
+                logs_and_blocks_share_one_writer_commit,
+            ]
+        );
+    };
+}
+
+full_suite!(redb, Redb);
+full_suite!(fjall, Fjall);

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1070,6 +1070,7 @@ fn backends_agree_on_identical_writes() {
         .collect::<Result<_, _>>()
         .unwrap();
 
+    assert_eq!(from_redb.len(), seed_rows.len(), "the walk lost rows");
     assert_eq!(from_redb, from_fjall);
 }
 


### PR DESCRIPTION
## What

Makes fjall the default archive index backend, keeping redb fully supported via an explicit `backend = "redb"`. Productionizes the prototype evaluated in #1256, where fjall beat optimized redb on the adoption criteria over full preprod replays: archive index **−48.3%** on disk (~36 GB vs ~69 GB extrapolated to mainnet), replay wall-clock **1.041×**, and read p95 within bounds on the three real access shapes (with the per-account rewards and epoch-stakes *cold* paths several-fold faster).

- **`dolos-flatfiles`**: the flat block segment files move to a leaf crate (std + tempfile only). They were never redb-specific; both backends share them byte for byte, and `dolos-fjall` no longer depends on `dolos-redb3`.
- **`crates/fjall/src/archive/`**: the fjall archive store — an `archive-blocks` keyspace (value encoding byte-identical to redb's blocks table) and one `archive-logs` keyspace keyed `[ns_hash:8][log_key:40]`, prune/truncate boundaries ported exactly.
- **Config**: `ArchiveStoreConfig` defaults to fjall. `is_default()` on the store enums is now variant-aware, so an explicit `backend = "redb"` with no options survives re-serialization instead of silently flipping to the default.
- **Adapters**: full fan-out for the fjall archive; the `LogsOnly` write gate becomes a generic wrapper (the duplicate-body hazard lives in the shared segment files, not in either index), so `doctor rebuild-state --rewrite-logs` works on both backends.
- **Conformance**: a backend-agnostic archive suite (37 tests × both backends, redb pinning semantics); `ToyStores` gains the archive as a bound store and the snapshot suites' restore target follows the binding — restore-into-fjall, including kill/resume, is exercised.
- **CLI**: `data stats` reports every engine in its own shape (redb tables vs fjall keyspaces); `data export` gains fjall sanitization (major compaction + sync); `data prune-chain` compacts the fjall archive; `cardinality-stats` says plainly it is redb forensics.
- **Benches**: divan benchmarks (`benches/archive_backends.rs`) compare the backends on identical deterministic populations across the three read-shape families; single-pass under `cargo test`.

## Compatibility

The two archive backends share the segment files but not the index format — an archive written by one cannot be opened by the other. No migration path is provided on purpose: v1.7 already requires a full re-bootstrap due to breaking data-structure changes, so pre-existing archives are discarded regardless. Operators who want to stay on redb set `backend = "redb"` under `[storage.archive]` (the `preview-full-explicit` e2e scenario pins exactly this).

## Testing

- Full workspace suite green (`--all-targets`, 1441 tests), nightly fmt, clippy `-D warnings`, cargo-deny advisories/bans.
- Smoke against real preprod instances from the #1256 evaluation: `data stats` reports fjall keyspaces on a default install and redb tables on an explicit-redb one; `data export` compacts and tars a fjall archive.
- Bench run ratios point the same directions as the full-scale evaluation.

Supersedes #1256 (the experiment vehicle, to be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fjall as the default storage backend for state, indexes, and archives.
  * Added configurable Fjall archive storage, including caching, compaction, journaling, and block segment paths.
  * Added archive support across reads, logs, pruning, truncation, statistics, and maintenance commands.
  * Added storage disk-usage reporting for persistent keyspaces and archive data.
* **Documentation**
  * Updated storage architecture and configuration guidance for Fjall and Redb backends.
* **Tests**
  * Added comprehensive cross-backend archive compatibility and behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->