### PR TITLE
test: compare the cross-backend archive walk against the seeded rows

### DIFF
--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1070,7 +1070,7 @@ fn backends_agree_on_identical_writes() {
         .collect::<Result<_, _>>()
         .unwrap();
 
-    assert_eq!(from_redb.len(), seed_rows.len(), "the walk lost rows");
+    assert_eq!(from_redb, seed_rows, "the walk must return the seeded rows");
     assert_eq!(from_redb, from_fjall);
 }
 


### PR DESCRIPTION
Follow-up to #1257, addressing the one CodeRabbit comment that arrived after the merge: `backends_agree_on_identical_writes` compared row *counts*, which duplicated or unrelated rows could satisfy. The seeds are unique and written in ascending `LogKey` order, so the walk is now compared against them verbatim before the two backends are compared to each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)