### PR TITLE
feat(snapshot): add the `snapshot backfill` publisher driver

### DIFF
--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -112,10 +112,15 @@ The `storage` section controls how Dolos stores data in the local file system. E
 - `version`: storage schema version (`v0` - `v3`).
 
 Besides the stores, this directory holds `scratch/`: where `dolos snapshot
-publish`, `dolos bootstrap stelae` and `dolos snapshot verify` stage the layers
-they move over an OCI registry. It defaults here because this volume is already
-sized for the data; a mainnet transfer stages gigabytes. The first two take
-`--scratch-dir` to point somewhere else.
+publish`, `dolos snapshot backfill`, `dolos bootstrap stelae` and `dolos
+snapshot verify` stage the layers they move over an OCI registry. It defaults
+here because this volume is already sized for the data; a mainnet transfer
+stages gigabytes. All but `verify` take `--scratch-dir` to point somewhere
+else.
+
+`dolos snapshot backfill` adds `mithril/`, the immutable window it replays
+from, for the same reason — the download is data-volume sized, and the command
+deletes the files it has consumed as it goes. `--download-dir` moves it.
 
 ### `storage.wal` section
 
@@ -413,7 +418,9 @@ The `snapshot` section controls bootstrap from a snapshot archive.
 
 The `stelae` section controls how this node reaches a **stele registry** — the OCI
 repositories `dolos bootstrap stelae --source oci://…` restores from and
-`dolos snapshot publish --repo oci://…` publishes into.
+`dolos snapshot publish --repo oci://…` publishes into. `dolos snapshot
+backfill --repo oci://…` reads the same section: it is `publish` run in a loop,
+replaying mithril history one epoch at a time and publishing at each boundary.
 
 ### `stelae.registry` section
 

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -15,35 +15,35 @@ use dolos::prelude::*;
 #[derive(Debug, clap::Args, Clone)]
 pub struct Args {
     #[arg(long, default_value = "./snapshot")]
-    download_dir: String,
+    pub(crate) download_dir: String,
 
     /// Skip the Mithril certificate validation
     #[arg(long, action)]
-    skip_validation: bool,
+    pub(crate) skip_validation: bool,
 
     /// Assume the snapshot is already available in the download dir
     #[arg(long, action)]
-    skip_download: bool,
+    pub(crate) skip_download: bool,
 
     /// Retain downloaded snapshot instead of deleting it
     #[arg(long, action)]
-    retain_snapshot: bool,
+    pub(crate) retain_snapshot: bool,
 
     /// Number of blocks to process in each chunk, more is faster but uses more
     /// memory
     #[arg(long, default_value = "500")]
-    chunk_size: usize,
+    pub(crate) chunk_size: usize,
 
     #[arg(long)]
-    start_from: Option<ChainPoint>,
+    pub(crate) start_from: Option<ChainPoint>,
 
     /// Start downloading from this immutable file number (inclusive)
     #[arg(long)]
-    download_start: Option<u64>,
+    pub(crate) download_start: Option<u64>,
 
     /// Download up to this immutable file number (inclusive)
     #[arg(long)]
-    download_end: Option<u64>,
+    pub(crate) download_end: Option<u64>,
 }
 
 impl Default for Args {
@@ -170,7 +170,7 @@ impl mithril_client::feedback::FeedbackReceiver for MithrilFeedback {
 }
 
 /// Scan the immutable directory for the highest immutable file number present.
-fn highest_existing_immutable(immutable_dir: &Path) -> Option<u64> {
+pub(crate) fn highest_existing_immutable(immutable_dir: &Path) -> Option<u64> {
     let entries = std::fs::read_dir(immutable_dir).ok()?;
     let mut max: Option<u64> = None;
     for entry in entries.flatten() {
@@ -239,17 +239,39 @@ fn plan_download(args: &Args, immutable_dir: &Path, last_immutable: u64) -> Down
     }
 }
 
-async fn fetch_snapshot(
+/// One aggregator client configuration, shared by the fetch and the beacon
+/// query so the two cannot drift apart on discovery or key handling.
+fn client_builder(config: &MithrilConfig) -> ClientBuilder {
+    ClientBuilder::new(AggregatorDiscoveryType::Url(config.aggregator.clone()))
+        .set_genesis_verification_key(mithril_client::GenesisVerificationKey::JsonHex(
+            config.genesis_key.clone(),
+        ))
+}
+
+/// The highest immutable file number any aggregator snapshot covers.
+///
+/// What `snapshot backfill` sizes its next download window against, and how it
+/// knows the aggregator has nothing past the files already on disk.
+pub(crate) async fn latest_immutable_file(config: &MithrilConfig) -> MithrilResult<u64> {
+    let client = client_builder(config).build()?;
+
+    let snapshots = client.cardano_database_v2().list().await?;
+
+    snapshots
+        .iter()
+        .map(|snapshot| snapshot.beacon.immutable_file_number)
+        .max()
+        .ok_or(MithrilError::msg("no snapshot available"))
+}
+
+pub(crate) async fn fetch_snapshot(
     args: &Args,
     config: &MithrilConfig,
     feedback: &Feedback,
 ) -> MithrilResult<()> {
     let feedback = MithrilFeedback::new(feedback);
 
-    let client = ClientBuilder::new(AggregatorDiscoveryType::Url(config.aggregator.clone()))
-        .set_genesis_verification_key(mithril_client::GenesisVerificationKey::JsonHex(
-            config.genesis_key.clone(),
-        ))
+    let client = client_builder(config)
         .add_feedback_receiver(Arc::new(feedback))
         .build()?;
 

--- a/src/bin/dolos/bootstrap/mod.rs
+++ b/src/bin/dolos/bootstrap/mod.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use crate::feedback::Feedback;
 use dolos_core::{StateStore, WalStore};
 
-mod mithril;
+pub(crate) mod mithril;
 mod ranged;
 mod relay;
 mod snapshot;

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -148,6 +148,19 @@ pub fn stele_scratch_dir(config: &StorageConfig, chosen: Option<&std::path::Path
 }
 
 pub fn setup_domain(config: &RootConfig) -> miette::Result<DomainAdapter> {
+    setup_domain_with_stop_epoch(config, None)
+}
+
+/// The same domain [`setup_domain`] assembles, with `chain.stop_epoch` forced.
+///
+/// For callers that replay to a chosen epoch boundary over the live stores —
+/// `snapshot backfill` — the way `doctor rebuild-state` forces it on the
+/// domain it hand-builds. A `Some` here overrides whatever the configuration
+/// says; `None` leaves it alone.
+pub fn setup_domain_with_stop_epoch(
+    config: &RootConfig,
+    stop_epoch: Option<u64>,
+) -> miette::Result<DomainAdapter> {
     let stores = open_data_stores(config).map_err(|e| match e {
         Error::WalError(WalError::IncompatibleVersion { found, expected }) => miette::miette!(
             help = format!(
@@ -162,7 +175,11 @@ pub fn setup_domain(config: &RootConfig) -> miette::Result<DomainAdapter> {
     let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
     let chain = config.chain.clone();
 
-    let ChainConfig::Cardano(chain_config) = chain;
+    let ChainConfig::Cardano(mut chain_config) = chain;
+
+    if stop_epoch.is_some() {
+        chain_config.stop_epoch = stop_epoch;
+    }
 
     let chain = dolos_cardano::CardanoLogic::initialize::<DomainAdapter>(
         chain_config,
@@ -333,7 +350,7 @@ pub fn open_genesis_files(config: &GenesisConfig) -> miette::Result<Genesis> {
 
 #[inline]
 #[cfg(unix)]
-async fn wait_for_exit_signal() {
+pub(crate) async fn wait_for_exit_signal() {
     let mut sigterm =
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
 
@@ -349,7 +366,7 @@ async fn wait_for_exit_signal() {
 
 #[inline]
 #[cfg(windows)]
-async fn wait_for_exit_signal() {
+pub(crate) async fn wait_for_exit_signal() {
     tokio::signal::ctrl_c().await.unwrap()
 }
 

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -383,6 +383,114 @@ pub fn hook_exit_token() -> CancellationToken {
     cancel
 }
 
+/// Attempts a transient-prone external gets before its failure is fatal.
+///
+/// Bounded on purpose. The preprod G1 backfill measured why the retry exists —
+/// four container exits between 06:39Z and 08:53Z on 2026-08-23, each one
+/// paying a store restore, a window re-download and the in-flight epoch's
+/// re-replay for what a half-minute wait would have absorbed — and the same
+/// measurement is why it is not open-ended: a misconfigured aggregator or a
+/// repository the credentials cannot read has to keep failing, and keep
+/// failing while whoever launched the run is still watching.
+const RETRY_ATTEMPTS: u32 = 4;
+
+/// The first wait between attempts; each later one doubles it. Three waits of
+/// 5s, 10s and 20s put the ceiling at 35 seconds of patience.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(5);
+
+/// Sleep, unless a shutdown is requested first. `false` means it was.
+///
+/// Sliced rather than slept in one call so a signal that arrives during a
+/// backoff is honoured at the next slice instead of at the end of the wait —
+/// the driver's whole shutdown budget is a container's SIGTERM grace period,
+/// which a 20-second sleep would eat.
+fn sleep_unless_aborted(delay: Duration, abort: &dyn Fn() -> bool) -> bool {
+    const SLICE: Duration = Duration::from_millis(250);
+
+    let mut left = delay;
+
+    while !left.is_zero() {
+        if abort() {
+            return false;
+        }
+
+        let slice = left.min(SLICE);
+        std::thread::sleep(slice);
+        left -= slice;
+    }
+
+    !abort()
+}
+
+/// Run `op`, retrying a failure with exponential backoff, then let it be fatal.
+///
+/// The last attempt's error is returned untouched, so every caller keeps the
+/// diagnostic it had before the retry was wrapped around it — the retry moves
+/// where the fatal path is reached, never what it says. Nothing here decides a
+/// failure is transient: the classification the alternative would need does not
+/// exist at these seams (an aggregator's errors arrive as opaque strings), and
+/// guessing it wrong reinstates exactly the fatal exits this is here to absorb.
+/// What bounds the patience is [`RETRY_ATTEMPTS`], not a judgement about the
+/// error.
+///
+/// `abort` is polled between and during the waits, so a shutdown ends the run
+/// on the failure in hand rather than after the remaining backoff. Callers with
+/// no shutdown to observe pass `&|| false`.
+///
+/// Only for operations that are safe to simply run again: reads, and downloads
+/// whose destination is rewritten from the same arguments.
+pub fn retry_transient<T, E, F>(what: &str, abort: &dyn Fn() -> bool, op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    E: std::fmt::Display,
+{
+    retry_bounded(what, RETRY_ATTEMPTS, RETRY_BASE_DELAY, abort, op)
+}
+
+/// [`retry_transient`] with its two constants spelled out, so the tests can
+/// exercise the loop without waiting out a real backoff.
+fn retry_bounded<T, E, F>(
+    what: &str,
+    attempts: u32,
+    base_delay: Duration,
+    abort: &dyn Fn() -> bool,
+    mut op: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    E: std::fmt::Display,
+{
+    let mut delay = base_delay;
+
+    for attempt in 1..attempts {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if abort() {
+                    return Err(err);
+                }
+
+                tracing::warn!(
+                    what,
+                    attempt,
+                    remaining = attempts - attempt,
+                    backoff_secs = delay.as_secs(),
+                    error = %err,
+                    "transient failure; retrying",
+                );
+
+                if !sleep_unless_aborted(delay, abort) {
+                    return Err(err);
+                }
+
+                delay = delay.saturating_mul(2);
+            }
+        }
+    }
+
+    op()
+}
+
 pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationToken) {
     loop {
         tokio::select! {
@@ -430,6 +538,85 @@ mod tests {
 
     use super::*;
     use crate::init::OFFICIAL_REGISTRY_PASSWORD;
+
+    /// The retry loop, with the real backoff replaced by none of it.
+    fn retried<T, E: std::fmt::Display>(
+        abort: &dyn Fn() -> bool,
+        op: impl FnMut() -> Result<T, E>,
+    ) -> Result<T, E> {
+        super::retry_bounded("a test", super::RETRY_ATTEMPTS, Duration::ZERO, abort, op)
+    }
+
+    #[test]
+    fn a_call_that_succeeds_is_made_once() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+            Ok(7)
+        });
+
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls, 1, "a success must not be retried");
+    }
+
+    #[test]
+    fn a_transient_failure_is_absorbed() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+
+            if calls < 3 {
+                Err("the aggregator hung up".to_owned())
+            } else {
+                Ok(7)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls, 3, "the loop stops at the first success");
+    }
+
+    #[test]
+    fn patience_is_bounded_and_the_last_error_is_the_one_raised() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+            Err(format!("attempt {calls} failed"))
+        });
+
+        assert_eq!(
+            calls, RETRY_ATTEMPTS as usize,
+            "a persistent failure must still reach the fatal path",
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            format!("attempt {RETRY_ATTEMPTS} failed"),
+            "the caller keeps the diagnostic the final attempt produced",
+        );
+    }
+
+    #[test]
+    fn a_shutdown_ends_the_run_on_the_failure_in_hand() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| true, || {
+            calls += 1;
+            Err("interrupted".to_owned())
+        });
+
+        assert_eq!(calls, 1, "a requested shutdown is not waited out");
+        assert_eq!(result.unwrap_err(), "interrupted");
+    }
+
+    #[test]
+    fn a_shutdown_during_a_backoff_cuts_the_wait_short() {
+        assert!(!sleep_unless_aborted(Duration::from_secs(60), &|| true));
+        assert!(sleep_unless_aborted(Duration::ZERO, &|| false));
+    }
 
     fn storage(path: &str) -> StorageConfig {
         let document = format!(

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -1,0 +1,846 @@
+//! `dolos snapshot backfill` — replay mithril history one epoch at a time,
+//! publishing a stele at each boundary.
+//!
+//! The publisher driver: one restart-safe loop that acquires immutable files
+//! from mithril in bounded windows, replays them to the next epoch boundary
+//! under `stop_epoch`, publishes the resulting sequence into an OCI repository
+//! in-process, prunes behind itself, and repeats until the aggregator has
+//! nothing further. A premature rerun — cron firing before a new epoch is
+//! available — finds the repository up to date and exits zero without writing.
+//!
+//! Downloads resume from the directory's own contents when any immutable
+//! files are present. When none are — a cold container start, whose disk
+//! keeps nothing and whose store was just restored from the registry — the
+//! start is derived from the cursor's chunk file instead, a margin early,
+//! so a restart costs one window rather than the chain so far.
+//!
+//! The reader never opens the highest downloaded file — pallas pops it as
+//! "not really immutable" — so at the aggregator tip the replay stands at
+//! most one chunk (~21600 slots, about six hours) behind the mithril beacon.
+//! That lag is steady state, not loss: the next run picks the chunk up once
+//! the beacon moves past it.
+//!
+//! Each iteration *opens* by publishing the sequence the cursor already stands
+//! at, then extends the replay by one epoch. Publishing on entry rather than
+//! right after the boundary import is what makes every crash window resumable:
+//! a rerun that finds the boundary reached but unpublished publishes it before
+//! moving on, instead of replaying past it and leaving a gap no later stele
+//! could close.
+//!
+//! This module is orchestration only: it composes the mithril fetch, the
+//! import lifecycle, and the publish path `snapshot publish --repo` uses, and
+//! changes none of them.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use clap::Parser;
+use dolos_core::config::RootConfig;
+use dolos_core::{Domain as _, DomainError, ImportExt as _, StateStore as _, WalStore as _};
+use dolos_snapshot::{export, registry::Repository};
+use indicatif::ProgressBar;
+use itertools::Itertools as _;
+use miette::{bail, Context as _, IntoDiagnostic as _};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::feedback::Feedback;
+use dolos::adapters::DomainAdapter;
+
+/// Blocks handed to `import_blocks` per batch.
+const IMPORT_CHUNK: usize = 100;
+
+/// Files of margin kept around the cursor's own immutable file, on both of
+/// the convention's uses: cleanup spares this many files behind the consumed
+/// threshold, and a download start derived from the cursor backs up this
+/// many files. Early is the cheap direction — a re-downloaded file's blocks
+/// at or before the cursor are skipped on import — while late would leave
+/// the immutable reader without the cursor's own chunk.
+const IMMUTABLE_FILE_MARGIN: u64 = 2;
+
+/// Slots per immutable chunk file — a node packaging convention, not a
+/// protocol invariant. Used to pick files safe to delete and, on a cold
+/// start whose download dir is empty, to derive where downloading resumes;
+/// never to plan how far a replay goes. Both uses carry
+/// [`IMMUTABLE_FILE_MARGIN`], and a derivation that still lands past the
+/// cursor's chunk is caught by the stalled-window check rather than trusted.
+const SLOTS_PER_IMMUTABLE_FILE: u64 = 21_600;
+
+/// Where the mithril window lands when the operator names nowhere: beside the
+/// stores, so the bytes stay on the data mount.
+const DOWNLOAD_DIR: &str = "mithril";
+
+const INTERRUPTED: &str =
+    "interrupted by a shutdown signal; the stores are consistent and a rerun resumes here";
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// OCI repository to publish into, e.g.
+    /// `oci://ghcr.io/txpipe/dolos-mainnet`
+    #[arg(long, value_name = "OCI_URL")]
+    repo: Repository,
+
+    /// talk to the repository over plaintext HTTP rather than HTTPS; for a
+    /// registry on a loopback address or a mirror inside a cluster, and for
+    /// nothing reachable from outside one
+    #[arg(long, action)]
+    insecure: bool,
+
+    /// directory to stage layers in while they are uploaded; defaults to
+    /// `<storage.path>/scratch`
+    #[arg(long, value_name = "DIR")]
+    scratch_dir: Option<PathBuf>,
+
+    /// directory the mithril immutable files are downloaded into; defaults to
+    /// `<storage.path>/mithril`
+    #[arg(long, value_name = "DIR")]
+    download_dir: Option<PathBuf>,
+
+    /// immutable files fetched per download round
+    #[arg(long, default_value = "40")]
+    window: u64,
+
+    /// stop after publishing this sequence; for smoke tests
+    #[arg(long, value_name = "N")]
+    until_epoch: Option<u64>,
+
+    /// skip the mithril digest and merkle validation; the certificate chain
+    /// is still verified. local smoke tests only
+    #[arg(long, action)]
+    skip_validation: bool,
+}
+
+/// What an iteration's opening publish decided about the run.
+enum Step {
+    /// Replay toward `target`'s boundary. `prune` says whether history behind
+    /// the cursor may be dropped first — true only once the publish step has
+    /// run, because pruning at tip T is safe exactly when everything below T
+    /// is already in the repository.
+    Extend { target: u64, prune: bool },
+    /// `--until-epoch` is published; the run is over.
+    Done,
+}
+
+/// How an epoch's replay ended.
+enum Advance {
+    /// `stop_epoch` fired: the cursor stands on the target epoch's first
+    /// block.
+    Boundary { cursor_slot: u64 },
+    /// The local files ran out and the aggregator has nothing newer.
+    MithrilExhausted,
+    /// A shutdown signal arrived; everything imported so far is committed.
+    Cancelled,
+}
+
+/// One import pass over the files on disk.
+enum Import {
+    Boundary,
+    /// The files ran out before the boundary. Deliberately silent about how
+    /// many blocks the pass imported: on a sparse chain zero is an ordinary
+    /// answer, so nothing downstream may treat it as evidence.
+    Exhausted,
+    Cancelled,
+}
+
+/// The epoch the next replay stops at: one past the cursor's, or 1 from a
+/// fresh store.
+fn target_epoch(cursor_epoch: Option<u64>) -> u64 {
+    cursor_epoch.map_or(1, |epoch| epoch + 1)
+}
+
+/// The file a download round resumes from, or `None` for the beginning.
+///
+/// The directory's own contents stay authoritative when any files are
+/// present — that is what re-fetches a possibly truncated highest file. An
+/// empty directory with a cursor is a cold container start: the store was
+/// restored from the registry onto a disk that keeps nothing, and resuming
+/// from file zero would re-download the whole chain, so the start is derived
+/// from the cursor's own chunk file instead, a margin early.
+fn resume_file(highest: Option<u64>, cursor_slot: Option<u64>) -> Option<u64> {
+    highest.or_else(|| {
+        cursor_slot
+            .map(|slot| (slot / SLOTS_PER_IMMUTABLE_FILE).saturating_sub(IMMUTABLE_FILE_MARGIN))
+    })
+}
+
+/// The next download round, as `(download_start, download_end)`, or `None`
+/// when the aggregator has nothing past what is on disk.
+///
+/// The resume file is deliberately re-fetched rather than skipped: an
+/// interrupted download may have left it truncated, and it has not been
+/// verified yet.
+fn next_window(resume: Option<u64>, window: u64, beacon: u64) -> Option<(Option<u64>, u64)> {
+    match resume {
+        Some(resume) if beacon <= resume => None,
+        Some(resume) => Some((Some(resume), beacon.min(resume + window))),
+        None => Some((None, beacon.min(window))),
+    }
+}
+
+/// Whether a download round actually landed new files.
+///
+/// The stall test, and it is asked of file numbers rather than block counts
+/// on purpose: a window of legitimately empty chunks advances the files while
+/// importing nothing, and that is an ordinary round on a sparse chain. A
+/// fetch that left the highest file where it was is the hard error. `Option`
+/// ordering puts an absent highest below every present one, so the first
+/// window into an empty directory counts as an advance.
+fn fetch_advanced(before: Option<u64>, after: Option<u64>) -> bool {
+    after > before
+}
+
+/// Immutable files strictly below this number sit wholly behind the cursor,
+/// margin included, and are safe to delete.
+fn consumed_below(cursor_slot: u64) -> u64 {
+    (cursor_slot / SLOTS_PER_IMMUTABLE_FILE).saturating_sub(IMMUTABLE_FILE_MARGIN)
+}
+
+/// What the immutable directory holds, for a diagnostic.
+fn dir_contents(immutable_dir: &Path) -> String {
+    let Ok(entries) = std::fs::read_dir(immutable_dir) else {
+        return "an unreadable immutable dir".to_owned();
+    };
+
+    let mut numbers: Vec<u64> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.split('.').next().and_then(|s| s.parse().ok())
+        })
+        .collect();
+
+    numbers.sort_unstable();
+    numbers.dedup();
+
+    match (numbers.first(), numbers.last()) {
+        (Some(first), Some(last)) => {
+            format!("files {first:05}..={last:05} ({} of them)", numbers.len())
+        }
+        _ => "no immutable files".to_owned(),
+    }
+}
+
+/// Delete the numbered immutable files the replay has consumed.
+fn cleanup_consumed(immutable_dir: &Path, cursor_slot: u64) -> miette::Result<()> {
+    let threshold = consumed_below(cursor_slot);
+
+    if threshold == 0 {
+        return Ok(());
+    }
+
+    let Ok(entries) = std::fs::read_dir(immutable_dir) else {
+        return Ok(());
+    };
+
+    let mut removed = 0u64;
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+
+        let Some(number) = name.split('.').next().and_then(|s| s.parse::<u64>().ok()) else {
+            continue;
+        };
+
+        if number < threshold {
+            std::fs::remove_file(entry.path())
+                .into_diagnostic()
+                .with_context(|| format!("removing the consumed immutable file {name}"))?;
+
+            removed += 1;
+        }
+    }
+
+    if removed > 0 {
+        info!(removed, threshold, "removed consumed immutable files");
+    }
+
+    Ok(())
+}
+
+/// SIGTERM/SIGINT as a token the synchronous loop polls between chunks.
+///
+/// The driver has no ambient tokio runtime for `hook_exit_token`, so the
+/// signal wait gets a dedicated thread with a current-thread runtime of its
+/// own.
+fn spawn_exit_watcher() -> miette::Result<CancellationToken> {
+    let cancel = CancellationToken::new();
+    let hooked = cancel.clone();
+
+    std::thread::Builder::new()
+        .name("exit-signal".to_owned())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("building the signal-wait runtime");
+
+            runtime.block_on(async {
+                crate::common::wait_for_exit_signal().await;
+                tracing::warn!("shutdown requested; stopping at the next chunk");
+                hooked.cancel();
+            });
+        })
+        .into_diagnostic()
+        .context("spawning the signal-wait thread")?;
+
+    Ok(cancel)
+}
+
+fn dir_argument(dir: &Path) -> miette::Result<String> {
+    dir.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| miette::miette!("the download dir {} is not valid UTF-8", dir.display()))
+}
+
+/// Everything an iteration needs and the CLI already settled.
+struct Driver<'a> {
+    config: &'a RootConfig,
+    args: &'a Args,
+    feedback: &'a Feedback,
+    /// For the async mithril calls only. The registry client owns a
+    /// current-thread runtime of its own and must never run inside this one,
+    /// so every publish stays on the plain thread.
+    runtime: tokio::runtime::Runtime,
+    cancel: CancellationToken,
+    download_dir: PathBuf,
+    immutable_dir: PathBuf,
+}
+
+impl Driver<'_> {
+    /// Publish the sequence the cursor stands at, and name the next target.
+    ///
+    /// Also reseeds the WAL from the state cursor before anything else opens
+    /// the domain: `import_blocks` skips the WAL by design, so a run that
+    /// died mid-import left the state ahead of it, and the next domain open
+    /// would refuse with `InconsistentState`.
+    fn publish_pending(&self) -> miette::Result<Step> {
+        let stores = crate::common::open_data_stores(self.config)
+            .into_diagnostic()
+            .context("opening the data stores")?;
+
+        let cursor = stores
+            .state
+            .read_cursor()
+            .into_diagnostic()
+            .context("reading the state cursor")?;
+
+        let Some(cursor) = cursor else {
+            return Ok(Step::Extend {
+                target: target_epoch(None),
+                prune: false,
+            });
+        };
+
+        if cursor.is_fully_defined() {
+            stores
+                .wal
+                .reset_to(&cursor)
+                .into_diagnostic()
+                .context("seeding the WAL from the state cursor")?;
+        }
+
+        let summary = dolos_cardano::eras::load_chain_summary_from_state(&stores.state)
+            .map_err(|err| miette::miette!("loading the chain summary: {err:?}"))?;
+
+        let (epoch, _) = summary.slot_epoch(cursor.slot());
+
+        // Nothing publishable yet: a sequence-0 stele would be epoch 0's
+        // mid-epoch sliver, which no consumer chains from.
+        if epoch == 0 {
+            return Ok(Step::Extend {
+                target: target_epoch(Some(epoch)),
+                prune: false,
+            });
+        }
+
+        let genesis = crate::common::open_genesis_files(&self.config.genesis)?;
+
+        let plan = export::plan(
+            &stores.state,
+            u64::from(genesis.network_magic()),
+            super::retained_epochs(self.config)?,
+        )
+        .into_diagnostic()
+        .context("planning the publish")?;
+
+        super::report_plan(&plan)?;
+
+        let publish = super::publish::RepositoryPublish {
+            repo: &self.args.repo,
+            insecure: self.args.insecure,
+            scratch_dir: self.args.scratch_dir.as_deref(),
+            rebuild: false,
+            dry_run: false,
+            require_new: false,
+        };
+
+        super::publish::to_repository(self.config, &publish, &plan, &stores, self.feedback)?;
+
+        if self
+            .args
+            .until_epoch
+            .is_some_and(|until| plan.sequence >= until)
+        {
+            println!(
+                "sequence {} published; stopping at --until-epoch",
+                plan.sequence
+            );
+
+            return Ok(Step::Done);
+        }
+
+        Ok(Step::Extend {
+            target: target_epoch(Some(epoch)),
+            prune: true,
+        })
+    }
+
+    /// Replay toward `target`'s boundary inside a domain that stops there.
+    fn extend(&self, target: u64, prune: bool) -> miette::Result<Advance> {
+        let domain = crate::common::setup_domain_with_stop_epoch(self.config, Some(target))?;
+
+        let result = self.advance_domain(&domain, prune);
+
+        // Shut down even when the replay failed: fjall in particular has
+        // background work to flush before the handle drops.
+        let shutdown = domain.shutdown();
+
+        let advance = result?;
+        shutdown.map_err(|e| miette::miette!("shutting down the domain: {e}"))?;
+
+        Ok(advance)
+    }
+
+    /// Import what is on disk, fetching windows from mithril whenever the
+    /// files run out, until the boundary, the aggregator's tip, or a signal.
+    fn advance_domain(&self, domain: &DomainAdapter, prune: bool) -> miette::Result<Advance> {
+        let mithril = self
+            .config
+            .mithril
+            .as_ref()
+            .ok_or_else(|| miette::miette!("missing mithril config"))?;
+
+        // After the publish and before the next epoch goes in, never between
+        // a boundary and its publish: pruning at tip T drops history below
+        // `T - max_history` only, and every later publish reads blocks at or
+        // above the T it was standing at when its predecessor was published.
+        if prune {
+            let rounds = domain
+                .drain_housekeeping(None)
+                .map_err(|e| miette::miette!("{e}"))
+                .context("pruning excess history")?;
+
+            info!(rounds, "housekeeping drained");
+        }
+
+        let progress = self.feedback.slot_progress_bar();
+        progress.set_message("replaying immutable blocks");
+
+        let outcome = loop {
+            if self.cancel.is_cancelled() {
+                break Advance::Cancelled;
+            }
+
+            match self.import_available(domain, &progress)? {
+                Import::Boundary => {
+                    let cursor_slot = domain
+                        .state
+                        .read_cursor()
+                        .into_diagnostic()
+                        .context("reading the state cursor at the boundary")?
+                        .map(|cursor| cursor.slot())
+                        .unwrap_or_default();
+
+                    break Advance::Boundary { cursor_slot };
+                }
+                Import::Cancelled => break Advance::Cancelled,
+                // Zero blocks imported is not a stall: on a sparse chain a
+                // whole window of chunks can legitimately be empty, and the
+                // replay simply needs those slot ranges walked. Keep
+                // fetching; the stall check below speaks in file numbers.
+                Import::Exhausted => {}
+            }
+
+            let Some(beacon) = self
+                .runtime
+                .block_on(async {
+                    tokio::select! {
+                        beacon = crate::bootstrap::mithril::latest_immutable_file(mithril) => {
+                            beacon.map(Some)
+                        }
+                        _ = self.cancel.cancelled() => Ok(None),
+                    }
+                })
+                .map_err(|err| miette::miette!(err.to_string()))
+                .context("listing mithril snapshots")?
+            else {
+                break Advance::Cancelled;
+            };
+
+            let highest =
+                crate::bootstrap::mithril::highest_existing_immutable(&self.immutable_dir);
+
+            let cursor_slot = domain
+                .state
+                .read_cursor()
+                .into_diagnostic()
+                .context("reading the state cursor")?
+                .map(|cursor| cursor.slot());
+
+            let resume = resume_file(highest, cursor_slot);
+
+            let Some((start, end)) = next_window(resume, self.args.window, beacon) else {
+                break Advance::MithrilExhausted;
+            };
+
+            info!(
+                ?start,
+                end, beacon, "fetching an immutable window from mithril"
+            );
+
+            let fetch = crate::bootstrap::mithril::Args {
+                download_dir: dir_argument(&self.download_dir)?,
+                skip_validation: self.args.skip_validation,
+                download_start: start,
+                download_end: Some(end),
+                ..Default::default()
+            };
+
+            let fetched = self
+                .runtime
+                .block_on(async {
+                    tokio::select! {
+                        fetched = crate::bootstrap::mithril::fetch_snapshot(
+                            &fetch,
+                            mithril,
+                            self.feedback,
+                        ) => fetched.map(Some),
+                        _ = self.cancel.cancelled() => Ok(None),
+                    }
+                })
+                .map_err(|err| miette::miette!(err.to_string()))
+                .context("fetching a mithril immutable window")?;
+
+            if fetched.is_none() {
+                break Advance::Cancelled;
+            }
+
+            // The one stall that is a hard error, and it is measured in file
+            // numbers, never blocks: a fetch that left the highest file
+            // where it was returned nothing new — a misconfigured range or
+            // a download failure — and every later round would only repeat
+            // it.
+            let after = crate::bootstrap::mithril::highest_existing_immutable(&self.immutable_dir);
+
+            if !fetch_advanced(highest, after) {
+                let cursor_slot = cursor_slot.unwrap_or_default();
+
+                bail!(
+                    "the fetched immutable window {:05}..={end:05} did not advance the \
+                     downloaded files (highest was {highest:?}, still {after:?}); mithril \
+                     returned nothing new for the state cursor at slot {cursor_slot} — the \
+                     immutable dir holds {}",
+                    start.unwrap_or(0),
+                    dir_contents(&self.immutable_dir),
+                );
+            }
+        };
+
+        // Whatever ended the replay, the chunks it committed are in the state
+        // and the WAL must agree before the next domain open.
+        self.seed_wal(domain)?;
+
+        progress.abandon_with_message("replay round complete");
+
+        Ok(outcome)
+    }
+
+    /// Import everything on disk past the cursor, in chunks.
+    fn import_available(
+        &self,
+        domain: &DomainAdapter,
+        progress: &ProgressBar,
+    ) -> miette::Result<Import> {
+        use pallas::network::miniprotocols::Point;
+
+        // Before the first download the immutable dir does not exist at all;
+        // that is the caller's cue to fetch, not an error.
+        if !self.immutable_dir.is_dir() {
+            return Ok(Import::Exhausted);
+        }
+
+        // Nothing to walk yet, same cue. Deliberately *not* `get_tip`: on a
+        // sparse chain the second-highest chunk can be empty, and `get_tip`
+        // reads only that one chunk and answers `None` for the whole db —
+        // with full unimported chunks sitting right there. The walk from the
+        // cursor is the only reader that tells the truth here.
+        if crate::bootstrap::mithril::highest_existing_immutable(&self.immutable_dir).is_none() {
+            return Ok(Import::Exhausted);
+        }
+
+        let cursor = domain
+            .state
+            .read_cursor()
+            .into_diagnostic()
+            .context("reading the state cursor")?;
+
+        let point: Point = cursor
+            .map(|c| c.try_into().unwrap())
+            .unwrap_or(Point::Origin);
+
+        let mut iter = pallas::interop::hardano::storage::immutable::read_blocks_from_point(
+            &self.immutable_dir,
+            point.clone(),
+        )
+        .map_err(|err| miette::miette!(err.to_string()))
+        .context("iterating the local immutable db")?;
+
+        // unless we're starting from the origin of the chain, the iterator
+        // stands on the last block already imported; skip it rather than
+        // import it twice
+        if point != Point::Origin {
+            iter.next();
+        }
+
+        for batch in iter.chunks(IMPORT_CHUNK).into_iter() {
+            let batch: Vec<_> = batch
+                .try_collect()
+                .into_diagnostic()
+                .context("reading block data")?;
+
+            let batch: Vec<_> = batch.into_iter().map(Arc::new).collect();
+
+            match domain.import_blocks(batch) {
+                Ok(last) => progress.set_position(last),
+                Err(DomainError::StopEpochReached) => return Ok(Import::Boundary),
+                Err(e) => {
+                    return Err(miette::miette!("{e}"))
+                        .context("importing an immutable block chunk")
+                }
+            }
+
+            if self.cancel.is_cancelled() {
+                return Ok(Import::Cancelled);
+            }
+        }
+
+        // A yield of nothing is not a verdict: the walk exhausts silently at
+        // the retained edge, empty chunks contribute no blocks, and a chunk
+        // read error truncates the iterator the same way. Whether anything
+        // more is coming is the fetch loop's question, answered in file
+        // numbers, never in block counts.
+        Ok(Import::Exhausted)
+    }
+
+    /// Reseed the WAL from the state cursor, so the next domain open finds
+    /// the two agreeing.
+    fn seed_wal(&self, domain: &DomainAdapter) -> miette::Result<()> {
+        let cursor = domain
+            .state
+            .read_cursor()
+            .into_diagnostic()
+            .context("reading the state cursor")?;
+
+        let Some(cursor) = cursor else {
+            return Ok(());
+        };
+
+        if !cursor.is_fully_defined() {
+            bail!(
+                "state cursor at slot {} has no block hash, cannot seed the WAL",
+                cursor.slot(),
+            );
+        }
+
+        domain
+            .wal
+            .reset_to(&cursor)
+            .into_diagnostic()
+            .context("seeding the WAL from the state cursor")
+    }
+}
+
+pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {
+    crate::common::setup_tracing(&config.logging, &config.telemetry)?;
+
+    if args.window == 0 {
+        bail!("--window must be at least 1");
+    }
+
+    if config.mithril.is_none() {
+        bail!("missing mithril config");
+    }
+
+    let download_dir = args
+        .download_dir
+        .clone()
+        .unwrap_or_else(|| config.storage.path.join(DOWNLOAD_DIR));
+
+    std::fs::create_dir_all(&download_dir)
+        .into_diagnostic()
+        .with_context(|| format!("creating the download dir {}", download_dir.display()))?;
+
+    let driver = Driver {
+        config,
+        args,
+        feedback,
+        runtime: tokio::runtime::Runtime::new()
+            .into_diagnostic()
+            .context("creating the tokio runtime for mithril downloads")?,
+        cancel: spawn_exit_watcher()?,
+        immutable_dir: download_dir.join("immutable"),
+        download_dir,
+    };
+
+    loop {
+        if driver.cancel.is_cancelled() {
+            bail!(INTERRUPTED);
+        }
+
+        let (target, prune) = match driver.publish_pending()? {
+            Step::Done => return Ok(()),
+            Step::Extend { target, prune } => (target, prune),
+        };
+
+        info!(target, "replaying toward the next epoch boundary");
+
+        match driver.extend(target, prune)? {
+            Advance::Boundary { cursor_slot } => {
+                cleanup_consumed(&driver.immutable_dir, cursor_slot)?;
+            }
+            Advance::MithrilExhausted => {
+                println!("the repository is up to date with mithril; nothing left to backfill");
+                return Ok(());
+            }
+            Advance::Cancelled => bail!(INTERRUPTED),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_first_target_is_epoch_one_and_every_later_one_follows_the_cursor() {
+        assert_eq!(target_epoch(None), 1);
+        assert_eq!(target_epoch(Some(0)), 1);
+        assert_eq!(target_epoch(Some(499)), 500);
+    }
+
+    #[test]
+    fn an_empty_download_dir_resumes_from_the_cursors_own_file() {
+        // empty dir with a cursor: the cursor's chunk file, a margin early
+        assert_eq!(
+            resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE * 6000)),
+            Some(5998),
+        );
+
+        // mid-file slots land in the same file before the margin applies
+        assert_eq!(
+            resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE * 6000 + 5)),
+            Some(5998),
+        );
+
+        // the margin floors at the first file
+        assert_eq!(resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE)), Some(0));
+        assert_eq!(resume_file(None, Some(0)), Some(0));
+
+        // empty dir, fresh store: the beginning
+        assert_eq!(resume_file(None, None), None);
+        assert_eq!(
+            next_window(resume_file(None, None), 40, 1000),
+            Some((None, 40))
+        );
+
+        // files on disk stay authoritative, wherever the cursor is
+        assert_eq!(
+            resume_file(Some(120), Some(SLOTS_PER_IMMUTABLE_FILE * 6000)),
+            Some(120),
+        );
+    }
+
+    #[test]
+    fn only_a_fetch_that_leaves_the_files_where_they_were_is_a_stall() {
+        // the first window into an empty dir is an advance
+        assert!(fetch_advanced(None, Some(0)));
+
+        // new files landed — even when every one of them is an empty chunk
+        // and the import that follows adds zero blocks, the loop goes on
+        assert!(fetch_advanced(Some(5), Some(6)));
+
+        // nothing new on disk after a fetch: the hard error
+        assert!(!fetch_advanced(Some(5), Some(5)));
+        assert!(!fetch_advanced(Some(5), None));
+        assert!(!fetch_advanced(None, None));
+    }
+
+    #[test]
+    fn windows_advance_from_the_highest_existing_file() {
+        // a fresh dir starts at the beginning, one window deep
+        assert_eq!(next_window(None, 40, 1000), Some((None, 40)));
+
+        // a short chain clamps to the beacon
+        assert_eq!(next_window(None, 40, 7), Some((None, 7)));
+
+        // resuming re-fetches the highest file: it may be truncated
+        assert_eq!(next_window(Some(100), 40, 1000), Some((Some(100), 140)));
+
+        // the last window clamps to the beacon
+        assert_eq!(next_window(Some(990), 40, 1000), Some((Some(990), 1000)));
+
+        // nothing newer than what is on disk
+        assert_eq!(next_window(Some(1000), 40, 1000), None);
+        assert_eq!(next_window(Some(1001), 40, 1000), None);
+    }
+
+    #[test]
+    fn cleanup_keeps_a_margin_behind_the_cursor() {
+        assert_eq!(consumed_below(0), 0);
+        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 2), 0);
+        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 3), 1);
+        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 10 + 5), 8);
+    }
+
+    #[test]
+    fn cleanup_removes_only_consumed_numbered_files() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for n in 0..6u64 {
+            for ext in ["chunk", "primary", "secondary"] {
+                std::fs::write(dir.path().join(format!("{n:05}.{ext}")), []).unwrap();
+            }
+        }
+
+        std::fs::write(dir.path().join("lock"), []).unwrap();
+
+        // threshold 3: files 0..=2 consumed, 3..=5 and non-numeric names stay
+        cleanup_consumed(dir.path(), SLOTS_PER_IMMUTABLE_FILE * 5).unwrap();
+
+        let mut remaining: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+
+        remaining.sort();
+
+        assert_eq!(
+            remaining,
+            [
+                "00003.chunk",
+                "00003.primary",
+                "00003.secondary",
+                "00004.chunk",
+                "00004.primary",
+                "00004.secondary",
+                "00005.chunk",
+                "00005.primary",
+                "00005.secondary",
+                "lock",
+            ],
+        );
+    }
+}

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -27,6 +27,16 @@
 //! moving on, instead of replaying past it and leaving a gap no later stele
 //! could close.
 //!
+//! The two externals — the mithril aggregator and the repository — are
+//! retried with backoff before their failure is fatal, because a checkpoint
+//! architecture absorbs a transient failure correctly and expensively: the
+//! preprod G1 run took four such exits in two hours and kept publishing, at
+//! ~40% of its throughput, each incident paying a restore, a window
+//! re-download and the in-flight epoch's re-replay. The patience is bounded
+//! at [`common::retry_transient`](crate::common::retry_transient)'s four
+//! attempts, so an aggregator that is wrong rather than flaky still fails,
+//! and fails while an operator is watching.
+//!
 //! This module is orchestration only: it composes the mithril fetch, the
 //! import lifecycle, and the publish path `snapshot publish --repo` uses, and
 //! changes none of them.
@@ -463,18 +473,29 @@ impl Driver<'_> {
                 Import::Exhausted => {}
             }
 
-            let Some(beacon) = self
-                .runtime
-                .block_on(async {
-                    tokio::select! {
-                        beacon = crate::bootstrap::mithril::latest_immutable_file(mithril) => {
-                            beacon.map(Some)
+            // Retried before it is fatal: the aggregator is the driver's most
+            // transient-prone external, and a beacon query it drops costs a
+            // whole restart — a restore, a window re-download and the
+            // in-flight epoch again — for a read that would have answered on
+            // the next attempt. A cancellation resolves to `Ok(None)` rather
+            // than an error, so a shutdown is never something the retry waits
+            // out.
+            let Some(beacon) = crate::common::retry_transient(
+                "listing mithril snapshots",
+                &|| self.cancel.is_cancelled(),
+                || {
+                    self.runtime.block_on(async {
+                        tokio::select! {
+                            beacon = crate::bootstrap::mithril::latest_immutable_file(mithril) => {
+                                beacon.map(Some)
+                            }
+                            _ = self.cancel.cancelled() => Ok(None),
                         }
-                        _ = self.cancel.cancelled() => Ok(None),
-                    }
-                })
-                .map_err(|err| miette::miette!(err.to_string()))
-                .context("listing mithril snapshots")?
+                    })
+                },
+            )
+            .map_err(|err| miette::miette!(err.to_string()))
+            .context("listing mithril snapshots")?
             else {
                 break Advance::Cancelled;
             };
@@ -508,20 +529,29 @@ impl Driver<'_> {
                 ..Default::default()
             };
 
-            let fetched = self
-                .runtime
-                .block_on(async {
-                    tokio::select! {
-                        fetched = crate::bootstrap::mithril::fetch_snapshot(
-                            &fetch,
-                            mithril,
-                            self.feedback,
-                        ) => fetched.map(Some),
-                        _ = self.cancel.cancelled() => Ok(None),
-                    }
-                })
-                .map_err(|err| miette::miette!(err.to_string()))
-                .context("fetching a mithril immutable window")?;
+            // Safe to simply run again: the window is named by explicit
+            // `download_start`/`download_end` arguments, so a retry plans the
+            // identical download and rewrites the same files — the same thing
+            // a restart would do, minus the store restore and the epoch's
+            // re-replay that made these failures expensive.
+            let fetched = crate::common::retry_transient(
+                "fetching a mithril immutable window",
+                &|| self.cancel.is_cancelled(),
+                || {
+                    self.runtime.block_on(async {
+                        tokio::select! {
+                            fetched = crate::bootstrap::mithril::fetch_snapshot(
+                                &fetch,
+                                mithril,
+                                self.feedback,
+                            ) => fetched.map(Some),
+                            _ = self.cancel.cancelled() => Ok(None),
+                        }
+                    })
+                },
+            )
+            .map_err(|err| miette::miette!(err.to_string()))
+            .context("fetching a mithril immutable window")?;
 
             if fetched.is_none() {
                 break Advance::Cancelled;

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -179,10 +179,14 @@ fn resume_file(highest: Option<u64>, cursor_slot: Option<u64>) -> Option<u64> {
 /// The resume file is deliberately re-fetched rather than skipped: an
 /// interrupted download may have left it truncated, and it has not been
 /// verified yet.
+///
+/// The window is added saturating: an operator's `--window` is unbounded above
+/// and the beacon clamps the end anyway, so a window wider than the chain is
+/// an ordinary "everything the aggregator has" rather than an overflow.
 fn next_window(resume: Option<u64>, window: u64, beacon: u64) -> Option<(Option<u64>, u64)> {
     match resume {
         Some(resume) if beacon <= resume => None,
-        Some(resume) => Some((Some(resume), beacon.min(resume + window))),
+        Some(resume) => Some((Some(resume), beacon.min(resume.saturating_add(window)))),
         None => Some((None, beacon.min(window))),
     }
 }
@@ -325,6 +329,21 @@ impl Driver<'_> {
     /// the domain: `import_blocks` skips the WAL by design, so a run that
     /// died mid-import left the state ahead of it, and the next domain open
     /// would refuse with `InconsistentState`.
+    ///
+    /// These stores are dropped rather than shut down, where [`Self::extend`]
+    /// takes the trouble — and the asymmetry is the write, not an oversight.
+    /// The one write here is the WAL reseed, whose only backend is redb, whose
+    /// `shutdown` is a no-op because a redb commit is already durable and its
+    /// drop cleans up without blocking. Everything the publish touches after
+    /// that it only reads, so fjall has no flush of ours to drain — which is
+    /// the whole reason `extend` shuts its domain down after a bulk import.
+    ///
+    /// Nothing in the publish observes [`Self::cancel`], either: a stele goes
+    /// out over minutes of store walking and uploading with no seam to check
+    /// a token at, so a signal arriving here is answered at the top of the
+    /// next loop. The window is wide by construction and the crash-safety the
+    /// module doc describes is what covers it — a SIGKILL through a publish
+    /// costs a store reopen and the in-flight epoch, and never a gap.
     fn publish_pending(&self) -> miette::Result<Step> {
         let stores = crate::common::open_data_stores(self.config)
             .into_diagnostic()
@@ -803,6 +822,10 @@ mod tests {
 
         // the last window clamps to the beacon
         assert_eq!(next_window(Some(990), 40, 1000), Some((Some(990), 1000)));
+
+        // a window wider than the chain clamps to the beacon rather than
+        // overflowing the addition
+        assert_eq!(next_window(Some(1), u64::MAX, 1000), Some((Some(1), 1000)));
 
         // nothing newer than what is on disk
         assert_eq!(next_window(Some(1000), 40, 1000), None);

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -620,9 +620,28 @@ impl Driver<'_> {
             .into_diagnostic()
             .context("reading the state cursor")?;
 
-        let point: Point = cursor
-            .map(|c| c.try_into().unwrap())
-            .unwrap_or(Point::Origin);
+        // A cursor with no hash is `ChainPoint::Slot`, which the pallas
+        // conversion refuses — and it refuses with `()`, so an `unwrap` here
+        // would panic saying nothing at all. The state reaches that shape when
+        // a crash lands between the epoch-start commit, which sets the cursor
+        // to the boundary slot alone, and the boundary block's own commit right
+        // after it. `export::plan` refuses the same state first, as an
+        // unanchored point, so the driver ordinarily fails there rather than
+        // here; this says the same thing `seed_wal` says, for the path that
+        // reaches it anyway.
+        let point: Point = match cursor {
+            None => Point::Origin,
+            Some(cursor) => {
+                let slot = cursor.slot();
+
+                cursor.try_into().map_err(|_| {
+                    miette::miette!(
+                        "state cursor at slot {slot} has no block hash, cannot walk the \
+                         immutable db from it"
+                    )
+                })?
+            }
+        };
 
         let mut iter = pallas::interop::hardano::storage::immutable::read_blocks_from_point(
             &self.immutable_dir,

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -433,9 +433,7 @@ impl Driver<'_> {
             .ok_or_else(|| miette::miette!("missing mithril config"))?;
 
         // After the publish and before the next epoch goes in, never between
-        // a boundary and its publish: pruning at tip T drops history below
-        // `T - max_history` only, and every later publish reads blocks at or
-        // above the T it was standing at when its predecessor was published.
+        // a boundary and its publish.
         if prune {
             let rounds = domain
                 .drain_housekeeping(None)
@@ -466,20 +464,13 @@ impl Driver<'_> {
                     break Advance::Boundary { cursor_slot };
                 }
                 Import::Cancelled => break Advance::Cancelled,
-                // Zero blocks imported is not a stall: on a sparse chain a
-                // whole window of chunks can legitimately be empty, and the
-                // replay simply needs those slot ranges walked. Keep
-                // fetching; the stall check below speaks in file numbers.
+                // Fetch another window rather than conclude anything: the
+                // stall check below is what decides whether more is coming.
                 Import::Exhausted => {}
             }
 
-            // Retried before it is fatal: the aggregator is the driver's most
-            // transient-prone external, and a beacon query it drops costs a
-            // whole restart — a restore, a window re-download and the
-            // in-flight epoch again — for a read that would have answered on
-            // the next attempt. A cancellation resolves to `Ok(None)` rather
-            // than an error, so a shutdown is never something the retry waits
-            // out.
+            // A cancellation resolves to `Ok(None)` rather than an error, so
+            // a shutdown is never something the retry waits out.
             let Some(beacon) = crate::common::retry_transient(
                 "listing mithril snapshots",
                 &|| self.cancel.is_cancelled(),
@@ -529,11 +520,8 @@ impl Driver<'_> {
                 ..Default::default()
             };
 
-            // Safe to simply run again: the window is named by explicit
-            // `download_start`/`download_end` arguments, so a retry plans the
-            // identical download and rewrites the same files — the same thing
-            // a restart would do, minus the store restore and the epoch's
-            // re-replay that made these failures expensive.
+            // Safe to run again: the explicit `download_start`/`download_end`
+            // make a retry plan the identical download over the same files.
             let fetched = crate::common::retry_transient(
                 "fetching a mithril immutable window",
                 &|| self.cancel.is_cancelled(),
@@ -557,11 +545,8 @@ impl Driver<'_> {
                 break Advance::Cancelled;
             }
 
-            // The one stall that is a hard error, and it is measured in file
-            // numbers, never blocks: a fetch that left the highest file
-            // where it was returned nothing new — a misconfigured range or
-            // a download failure — and every later round would only repeat
-            // it.
+            // The one stall that is a hard error: every later round would
+            // only repeat a fetch that returned nothing new.
             let after = crate::bootstrap::mithril::highest_existing_immutable(&self.immutable_dir);
 
             if !fetch_advanced(highest, after) {
@@ -657,10 +642,8 @@ impl Driver<'_> {
         }
 
         // A yield of nothing is not a verdict: the walk exhausts silently at
-        // the retained edge, empty chunks contribute no blocks, and a chunk
-        // read error truncates the iterator the same way. Whether anything
-        // more is coming is the fetch loop's question, answered in file
-        // numbers, never in block counts.
+        // the retained edge, and a chunk read error truncates the iterator the
+        // same way.
         Ok(Import::Exhausted)
     }
 

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -27,6 +27,8 @@ use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::feedback::Feedback;
 
+#[cfg(feature = "mithril")]
+mod backfill;
 mod digest;
 mod inspect;
 mod publish;
@@ -36,6 +38,11 @@ mod verify;
 pub enum Command {
     /// writes a stele to a local directory or an OCI repository
     Publish(publish::Args),
+
+    /// replays mithril history one epoch at a time, publishing a stele at
+    /// each boundary into an OCI repository
+    #[cfg(feature = "mithril")]
+    Backfill(backfill::Args),
 
     /// computes a stele's inscription and identity without writing one
     Digest(digest::Args),
@@ -61,6 +68,8 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         // that waits on a store walk and a network, and the other three are
         // over in the time it takes to print what they found.
         Command::Publish(x) => publish::run(config, x, feedback),
+        #[cfg(feature = "mithril")]
+        Command::Backfill(x) => backfill::run(config, x, feedback),
         Command::Digest(x) => digest::run(config, x),
         Command::Verify(x) => verify::run(config, x),
         Command::Inspect(x) => inspect::run(config, x),

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -312,7 +312,15 @@ pub(super) fn to_repository(
 ///   both sequences, so "the publisher has been down for a day" and "the
 ///   publisher has been down for a month" do not read the same.
 fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
-    let standing = registry::standing(registry, plan)
+    // The one network read a publish makes before it commits to anything, and
+    // the second of the two externals the preprod backfill saw drop calls. It
+    // is a read of the repository's latest manifest, so running it again is
+    // free of consequence, and the bounded retry keeps a dropped connection
+    // from costing a publisher the whole publish it was about to make.
+    let standing =
+        crate::common::retry_transient("reading the repository's latest stele", &|| false, || {
+            registry::standing(registry, plan)
+        })
         .into_diagnostic()
         .context("reading the repository's latest stele")?;
 

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -314,6 +314,11 @@ pub(super) fn to_repository(
 fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
     // A read of the latest manifest and the one network call a publish makes
     // before it commits to anything, so running it again is free of consequence.
+    //
+    // `&|| false` for every caller, `snapshot backfill`'s driver included: the
+    // publish that follows this read observes no cancellation for as long as it
+    // runs, so a predicate threaded in here would cut a shutdown's wait by the
+    // backoff and leave the minutes on either side of it untouched.
     let standing =
         crate::common::retry_transient("reading the repository's latest stele", &|| false, || {
             registry::standing(registry, plan)

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -89,11 +89,48 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     super::report_plan(&plan)?;
 
     match (&args.repo, &args.output_dir) {
-        (Some(repo), _) => to_repository(config, args, repo, &plan, &stores, feedback),
+        (Some(repo), _) => {
+            let publish = RepositoryPublish {
+                repo,
+                insecure: args.insecure,
+                scratch_dir: args.scratch_dir.as_deref(),
+                rebuild: args.rebuild,
+                dry_run: args.dry_run,
+                require_new: args.require_new,
+            };
+
+            to_repository(config, &publish, &plan, &stores, feedback)
+        }
         (None, Some(dir)) => to_directory(args, dir, &plan, &stores, feedback),
         // The required `destination` group already refuses this.
         (None, None) => unreachable!("one of --output-dir and --repo is required"),
     }
+}
+
+/// The repository arm's settings, freed of the CLI that spelled them.
+///
+/// Factored so `snapshot backfill` publishes through exactly the code path
+/// `snapshot publish --repo` does — same standing check, same preflight, same
+/// chained predecessor, same report — rather than a second telling of it that
+/// would drift.
+pub(super) struct RepositoryPublish<'a> {
+    /// The repository to publish into.
+    pub repo: &'a Repository,
+
+    /// Talk plaintext HTTP rather than HTTPS.
+    pub insecure: bool,
+
+    /// Where to stage layers; `None` takes `<storage.path>/scratch`.
+    pub scratch_dir: Option<&'a std::path::Path>,
+
+    /// Build every layer instead of carrying forward published ones.
+    pub rebuild: bool,
+
+    /// Report what would be written and stop.
+    pub dry_run: bool,
+
+    /// Fail when the repository is already at this node's sequence.
+    pub require_new: bool,
 }
 
 fn to_directory(
@@ -145,14 +182,15 @@ fn to_directory(
 /// The report is what a publisher wants to check rather than trust: how much of
 /// this stele was inherited rather than built, and how much of it moved. Both
 /// are numbers the code counted, not an inference from a duration.
-fn to_repository(
+pub(super) fn to_repository(
     config: &RootConfig,
-    args: &Args,
-    repo: &Repository,
+    publish: &RepositoryPublish,
     plan: &export::Plan,
     stores: &crate::common::Stores,
     feedback: &Feedback,
 ) -> miette::Result<()> {
+    let repo = publish.repo;
+
     // A publisher's credentials come from `STELAE_REGISTRY_USER` /
     // `STELAE_REGISTRY_PASSWORD`, which override anything configured. The
     // configured user is still the fallback: it is read-only, so authenticating
@@ -160,9 +198,9 @@ fn to_repository(
     // is the honest place for "these credentials cannot publish" to be said.
     let auth = crate::common::stele_registry_auth(&config.stelae)?;
 
-    let scratch = crate::common::stele_scratch_dir(&config.storage, args.scratch_dir.as_deref());
+    let scratch = crate::common::stele_scratch_dir(&config.storage, publish.scratch_dir);
 
-    let registry = registry::open(repo, args.insecure, auth, scratch)
+    let registry = registry::open(repo, publish.insecure, auth, scratch)
         .into_diagnostic()
         .context("opening the repository")?;
 
@@ -172,11 +210,11 @@ fn to_repository(
     // along with everything else.
     let publishing = registry::Publishing::new(&registry)
         .recording_in(&config.storage.path)
-        .rebuilding(args.rebuild);
+        .rebuilding(publish.rebuild);
 
     // Before anything is built, and before the dry run too: a publisher asking
     // what a publish would do wants the same answer the publish gives.
-    if !standing(&registry, plan, args)? {
+    if !standing(&registry, plan, publish.require_new)? {
         return Ok(());
     }
 
@@ -190,7 +228,7 @@ fn to_repository(
         .into_diagnostic()
         .context("sizing the staging directory")?;
 
-    if args.dry_run {
+    if publish.dry_run {
         // `None` here and `None` at the `publish` below are one decision: a dry
         // run describes the publish that follows it, so the two calls are
         // handed the same digest records or the number is about something else.
@@ -273,7 +311,7 @@ fn to_repository(
 ///   to invent. What is new is that the message names the distance alongside
 ///   both sequences, so "the publisher has been down for a day" and "the
 ///   publisher has been down for a month" do not read the same.
-fn standing(registry: &Registry, plan: &export::Plan, args: &Args) -> miette::Result<bool> {
+fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
     let standing = registry::standing(registry, plan)
         .into_diagnostic()
         .context("reading the repository's latest stele")?;
@@ -294,7 +332,7 @@ fn standing(registry: &Registry, plan: &export::Plan, args: &Args) -> miette::Re
                 plan.sequence,
             );
 
-            if args.require_new {
+            if require_new {
                 return Err(miette::miette!("{message}"));
             }
 

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -312,11 +312,8 @@ pub(super) fn to_repository(
 ///   both sequences, so "the publisher has been down for a day" and "the
 ///   publisher has been down for a month" do not read the same.
 fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
-    // The one network read a publish makes before it commits to anything, and
-    // the second of the two externals the preprod backfill saw drop calls. It
-    // is a read of the repository's latest manifest, so running it again is
-    // free of consequence, and the bounded retry keeps a dropped connection
-    // from costing a publisher the whole publish it was about to make.
+    // A read of the latest manifest and the one network call a publish makes
+    // before it commits to anything, so running it again is free of consequence.
     let standing =
         crate::common::retry_transient("reading the repository's latest stele", &|| false, || {
             registry::standing(registry, plan)


### PR DESCRIPTION
Plan: `plans/dolos-snapshot-backfill-driver.md` (Trellis `code-change-request`,
`decisions/0026-stelae-layer-compatibility.md`).

## What this is

`dolos snapshot backfill` — the publisher driver: one restart-safe loop that
acquires mithril immutable files in bounded windows, replays them to the next
epoch boundary under `stop_epoch`, publishes a stele into an OCI repository
in-process, prunes behind itself, and exits clean when the aggregator has
nothing further. A premature rerun finds the repository up to date and exits
zero without writing.

It is a composition, not a new mechanism: the mithril fetch, the import
lifecycle and the `snapshot publish --repo` path are used as they are. The one
refactor is on the publish side — `to_repository` now takes a
`RepositoryPublish` struct instead of the CLI `Args`, so the driver publishes
through exactly the code path `snapshot publish --repo` does rather than a
second telling of it that would drift. `snapshot publish`'s own behaviour is
unchanged by that refactor.

The rest is `pub(crate)` relaxation (`bootstrap::mithril`,
`common::wait_for_exit_signal`) plus two additions that had nowhere else to
live: `mithril::latest_immutable_file`, the aggregator beacon query the window
planner sizes against, and `common::setup_domain_with_stop_epoch`, which forces
`chain.stop_epoch` on a hand-built domain the way `doctor rebuild-state`
already does.

## Why the bar for this one is unusual

The driver is not new code. It ran the **preprod G1 backfill in production for
300+ published epochs**, plus SIGTERM and SIGKILL kill-tests and
crash-mid-publish resume checks, on branch `feat/snapshot-backfill-driver`. It
has to land on `main` because the mainnet backfill publishes permanent
artifacts and builds from merged, reviewed code only.

So the ask here is review and gates, not design. The design notes that matter
live in the module doc at the top of `src/bin/dolos/snapshot/backfill.rs`; the
three worth reading before the code are:

- **Publish-on-entry ordering.** Each iteration *opens* by publishing the
  sequence the cursor already stands at, then extends the replay by one epoch.
  Publishing on entry rather than right after the boundary import is what makes
  every crash window resumable — a rerun that finds the boundary reached but
  unpublished publishes it before moving on, instead of replaying past it and
  leaving a gap no later stele could close.
- **Sparse chunks and stall detection.** Preprod's early history has immutable
  chunks with zero blocks in 21600 slots. pallas `get_tip` reads only the
  second-highest chunk and answers `None` for the whole db when that chunk is
  empty — with full unimported chunks sitting right there — and its point
  iterator ends silently rather than erroring. So the driver never asks a block
  count whether more is coming: the stall check is file-number-based
  (`fetch_advanced`), and a zero-block window is an ordinary round.
- **Cold-start window derivation.** On an ephemeral disk the download dir comes
  back empty with a store restored from the registry. Resuming from file zero
  would re-download the whole chain, so an empty dir with a cursor derives the
  start from the cursor's own chunk file, a margin early (`resume_file`).

## The one behaviour change beyond the validated branch content

Second commit, reviewable on its own: **bounded retry-with-backoff around the
two transient-prone externals**, before the existing fatal path.

The preprod G1 run measured why. Between 06:39Z and 08:53Z on 2026-08-23 the
container exited with code 1 four times (restarts #4–#7). Each time the
supervisor relaunched it and it resumed correctly — epochs kept advancing, 240
to 248 — but effective throughput dropped ~40%, because every incident pays a
store restore, a window re-download and the in-flight epoch's re-replay. A live
tail on the registry Worker across restart #7 recorded zero 5xx and zero
exceptions, so the registry path is exonerated and the residual suspect is
transient aggregator failures, which the driver treated as fatal by design. The
checkpoint architecture absorbed this correctly; the finding was about cost.

`common::retry_transient` wraps three call sites:

- `mithril::latest_immutable_file` (the beacon query) — `backfill.rs`
- `mithril::fetch_snapshot` (the window download) — `backfill.rs`
- `registry::standing` (the repository's latest manifest) — `publish.rs`

Four attempts, waits of 5s / 10s / 20s, ceiling 35 seconds. The last attempt's
error is returned untouched, so every diagnostic the callers had before is the
diagnostic they still raise — the retry moves *where* the fatal path is
reached, never what it says.

Three things a reviewer should push on:

1. **It does not classify errors as transient or persistent.** The
   classification that would need does not exist at these seams — an
   aggregator's failures arrive as opaque strings — and guessing it wrong
   reinstates exactly the fatal exits this removes. What bounds the patience is
   the attempt count, not a judgement about the error. The cost: a genuinely
   persistent failure (a misconfigured aggregator, credentials that cannot read
   the repository) now takes 35 extra seconds to fail. It still fails.
2. **Retrying `fetch_snapshot` is safe because the window is explicit.** The
   driver names `download_start` and `download_end`, so a retry plans the
   identical download and rewrites the same files — what a restart would do,
   minus the restore and the re-replay.
3. **`snapshot publish` is affected too**, and deliberately: the standing call
   is the one network read a publish makes before committing to anything, it is
   a read of a manifest, and a publisher who loses a connection there should not
   lose the publish. This is the only place the two commits' behaviour differs
   from the branch that ran on preprod, and the plan scopes it in explicitly.

## Verification

Rebased onto `main` at `7c476f1c` (the fjall-archive-default merge). The rebase
was clean — the risk the plan flagged was a conflict inside `crates/`, meaning
something else had moved the publish surfaces; nothing had, and the driver
touches `src/bin/dolos/**` only.

```
cargo +nightly fmt --all -- --check                                    clean
cargo clippy -p dolos --all-targets --all-features -- -D warnings      clean
cargo test -p dolos                                                    all green
```

`src/bin/dolos` unit tests: 116 passed, 1 ignored — the 6 `snapshot::backfill`
tests (target selection, cold-start resume derivation, window planning, stall
detection, cleanup threshold, cleanup file selection) and 5 new
`common::retry_transient` tests (a success is not retried, a transient failure
is absorbed, patience is bounded and the final error is the one raised, a
shutdown ends the run on the failure in hand, a shutdown cuts a backoff short).

### Preprod smoke procedure

Genesis → epoch 12 against a local `serverless-registry` under `wrangler dev`.
This is the procedure; the recorded run of it went to epoch 16 and is written
up in the plan's parent experiment (16 stelae + `latest`, contiguous history,
Byron→Shelley transition, crash-mid-publish resume, SIGTERM → graceful store
shutdown with no redb repair on reopen, retained dump cut at epoch 10 and
inherited by 11+, and the `UpToDate` no-op).

1. **Registry.** From `solution/stelae/registry/vendor` (stock
   `cloudflare/serverless-registry`, pinned `20cd5909`):

   ```sh
   pnpm install
   npx wrangler dev --port 8787
   ```

   Its dev credentials are the Basic pair the Worker is configured with.

2. **Instance config.** A preprod `dolos.toml` — the publisher's
   (`solution/stelae/publisher/container/dolos.toml`) is the reference:
   `[mithril]` pointing at
   `https://aggregator.release-preprod.api.mithril.network/aggregator` with the
   preprod genesis key, `[chain] magic = 1, is_testnet = true`, pruned stores
   (`sync.max_history = 1296000`, three epochs — it must stay comfortably above
   one epoch, because the publish after a pruned restore rebuilds the previously
   clamped epoch window from the local archive with no coverage check), and
   `snapshot.state_epochs = [10]` to exercise the retained-dump cut and its
   inheritance inside the 12 epochs.

3. **Run it.**

   ```sh
   export DOLOS_STELAE_REGISTRY_USER=…
   export DOLOS_STELAE_REGISTRY_PASSWORD=…

   dolos -c dolos.toml snapshot backfill \
     --repo oci://127.0.0.1:8787/cardano/preprod-smoke \
     --insecure \
     --until-epoch 12 \
     --skip-validation
   ```

   `--insecure` because the registry is on loopback; `--skip-validation` skips
   the mithril digest and merkle checks (the certificate chain is still
   verified) and is for local smoke tests only. `--until-epoch 12` stops the
   loop after publishing sequence 12.

4. **Check.** 12 stelae plus `latest`; contiguous `follows:` chain across the
   Byron→Shelley transition; the epoch-10 dump present and inherited by 11 and
   12. Then confirm the no-op — rerunning the same command exits zero, writes
   nothing, and reports the repository up to date:

   ```sh
   dolos -c dolos.toml snapshot publish \
     --repo oci://127.0.0.1:8787/cardano/preprod-smoke --insecure --dry-run
   ```

5. **Resume, if exercising it.** SIGTERM mid-replay: the driver's own handler
   stops at the next chunk, exits non-zero on its interrupted path with the
   stores consistent, and the same command rerun resumes from the last
   published stele. SIGKILL is the uncatchable floor and resumes the same way,
   paying a store reopen.

## Notes for the reviewer

- The subcommand is behind the `mithril` feature, which is a default feature —
  it is in the default build and the default test run.
- `docs/content/configuration/schema.mdx` gains two accuracy edits, not new
  documentation: `snapshot backfill` creates `mithril/` under `storage.path`
  (alongside `scratch/`), and it reads the same `[stelae]` section `publish`
  does.
- The changelog entry comes from git-cliff via the conventional commit
  subjects; the plan wants this riding before the v1.7 tag with the new
  subcommand mentioned in the release notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `snapshot backfill` to replay Mithril history and publish snapshots to an OCI repository epoch by epoch.
  * Added options for scratch and download directories, download windows, stopping at a selected epoch, insecure repositories, and validation skipping.
  * Backfill supports restart-safe progress, cancellation, cleanup, and automatic handling of available snapshot files.

* **Bug Fixes**
  * Improved transient operation handling with bounded retries, exponential backoff, and clean interruption behavior.
  * Replaced a potential crash during snapshot processing with a clear diagnostic error.

* **Documentation**
  * Expanded storage documentation for snapshot verification, backfill directories, cleanup, and Mithril history processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->