### PR TITLE
perf(stelae): move a publish's layer round trips concurrently

### DIFF
--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -137,6 +137,7 @@ use std::{
     cell::{Cell, RefCell},
     collections::BTreeMap,
     io::Write as _,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -163,7 +164,7 @@ use stelae::{
 /// [`Auth`] rides along for the same reason: a host resolving its own
 /// credentials should not have to name the protocol crate to say what it
 /// resolved them to.
-pub use stelae::oci::{Auth, Registry, Repository, SCHEME};
+pub use stelae::oci::{Auth, Registry, Repository, DEFAULT_CONCURRENCY, SCHEME};
 
 use crate::{
     export::{self, history_for, same_network, Plan, Predecessor, Standing},
@@ -290,14 +291,19 @@ where
 /// `scratch_dir` is where layers are staged, in both directions. The transport
 /// creates it when the first layer needs it, so it need not exist yet.
 ///
+/// `tuning` is the publish path's concurrency and the one check an operator may
+/// want back; [`Tuning::default`] is what every caller that is not publishing
+/// wants.
+///
 /// **Never call any of this from inside an async context.** The transport owns
-/// a current-thread runtime and enters it with `block_on`; `stelae::oci`'s
-/// module documentation states the rule and the reason.
+/// a runtime and enters it with `block_on`; `stelae::oci`'s module
+/// documentation states the rule and the reason.
 pub fn open(
     repository: &Repository,
     insecure: bool,
     auth: Auth,
     scratch_dir: PathBuf,
+    tuning: Tuning,
 ) -> Result<Registry, Error> {
     Ok(Registry::open(
         repository,
@@ -305,8 +311,30 @@ pub fn open(
             insecure,
             scratch_dir: Some(scratch_dir),
             auth,
+            concurrency: tuning.concurrency.map_or(DEFAULT_CONCURRENCY, Into::into),
+            verify_adopted: tuning.verify_adopted,
         },
     )?)
+}
+
+/// What an operator may set about *how* a publish moves, as against where it
+/// goes.
+///
+/// Separated from [`open`]'s other arguments because it is the only one of them
+/// a caller can leave alone: a repository, a credential and a staging directory
+/// are facts a publish cannot be run without, and these two are a default and
+/// an escape hatch. A restore or an inspection passes [`Tuning::default`] and
+/// means it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Tuning {
+    /// How many layer round trips run at once; `None` is
+    /// [`DEFAULT_CONCURRENCY`].
+    pub concurrency: Option<NonZeroUsize>,
+
+    /// Re-prove that the registry still holds each blob carried forward out of
+    /// the predecessor's manifest. See [`stelae::oci::Options::verify_adopted`]
+    /// for why this is off.
+    pub verify_adopted: bool,
 }
 
 /// Where a publish is going, and what the host running it knows about itself.
@@ -813,15 +841,26 @@ pub fn inspect(registry: &Registry, point: Point) -> Result<Inspected, Error> {
 /// once. What it does have at once is a state kind's pass, which keeps that
 /// kind's shard sinks open across a single walk of its namespace — see
 /// [`crate::export`] for why sixteen passes over `utxos` is the alternative —
-/// plus whatever epoch layer is in flight beside it. Summing *every* state
+/// plus whatever epoch layers are in flight beside it. Summing *every* state
 /// layer rather than the widest kind's is deliberately conservative: the peak
 /// it prices is the pre-split one, an upper bound on any per-kind pass.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// "Epoch layers beside it" is a handful and not one, because the transport
+/// uploads concurrently: a layer's staging file lives until its own round trip
+/// lands, so as many finished layers as the transport has permits can sit on
+/// disk at once alongside the pass. How many that is comes from
+/// [`stelae::oci::Registry::concurrency`] — asked of the transport rather than
+/// assumed here — and *which* ones is the largest that many, since the peak is
+/// the worst arrangement and nothing orders the uploads.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StagingPeak {
     /// Every state layer, summed — the conservative reading above.
     pub state_bytes: u64,
-    /// The largest single non-state layer, which is staged alongside them.
-    pub largest_other_bytes: u64,
+    /// The non-state layers that can be staged at once, largest first: as many
+    /// as the transport uploads concurrently, or all of them where the stele
+    /// has fewer than that. Empty on a stele that is all state, and on a
+    /// [`StagingPeak::default`] nothing was measured into.
+    pub concurrent_other_bytes: Vec<u64>,
     /// Layers the predecessor's manifest stated no size for. Non-zero makes
     /// every number here a floor rather than an estimate.
     pub unsized_layers: usize,
@@ -829,8 +868,22 @@ pub struct StagingPeak {
 
 impl StagingPeak {
     /// Compressed bytes the scratch volume has to hold at once.
+    ///
+    /// Saturating throughout, because these are a manifest's numbers and a
+    /// manifest is not this node's document: a wrapped sum would be a *small*
+    /// need, which is the one direction a refusal must never be wrong in.
     pub fn bytes(&self) -> u64 {
-        self.state_bytes.saturating_add(self.largest_other_bytes)
+        self.concurrent_other_bytes
+            .iter()
+            .fold(self.state_bytes, |total, bytes| {
+                total.saturating_add(*bytes)
+            })
+    }
+
+    /// The largest non-state layer, which is the first of the ones staged at
+    /// once.
+    pub fn largest_other_bytes(&self) -> u64 {
+        self.concurrent_other_bytes.first().copied().unwrap_or(0)
     }
 }
 
@@ -859,13 +912,13 @@ pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
     let blobs = previous.blob_index()?;
 
     let mut peak = StagingPeak::default();
+    let mut others = Vec::new();
 
     for descriptor in &inscription.layers {
         match previous.compressed_size(&blobs, descriptor)? {
             None => peak.unsized_layers += 1,
             // Every state layer adds — the conservative sum-all-state rule the
-            // type documents. Everything else is one layer at a time beside
-            // them, so only the biggest counts.
+            // type documents.
             //
             // Saturating because these are a manifest's numbers and a manifest
             // is not this node's document: a wrapped sum would be a *small*
@@ -874,9 +927,17 @@ pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
             Some(bytes) if crate::is_state_kind(&descriptor.kind) => {
                 peak.state_bytes = peak.state_bytes.saturating_add(bytes)
             }
-            Some(bytes) => peak.largest_other_bytes = peak.largest_other_bytes.max(bytes),
+            Some(bytes) => others.push(bytes),
         }
     }
+
+    // The largest as many as the transport stages at once, and no more: a stele
+    // with fewer non-state layers than the transport has permits cannot put
+    // more of them on disk than it has.
+    others.sort_unstable_by(|a, b| b.cmp(a));
+    others.truncate(registry.concurrency());
+
+    peak.concurrent_other_bytes = others;
 
     Ok(Some(peak))
 }
@@ -1794,7 +1855,7 @@ mod tests {
         // their sum and not on either alone.
         let err = check(Some(StagingPeak {
             state_bytes: u64::MAX / 2,
-            largest_other_bytes: u64::MAX / 2,
+            concurrent_other_bytes: vec![u64::MAX / 4, u64::MAX / 4],
             unsized_layers: 0,
         }))
         .unwrap_err();

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -313,6 +313,12 @@ pub fn open(
             auth,
             concurrency: tuning.concurrency.map_or(DEFAULT_CONCURRENCY, Into::into),
             verify_adopted: tuning.verify_adopted,
+            // Not an operator's knob and deliberately not one: the number that
+            // absorbs a registry's transient `5xx` is the transport's own
+            // measurement, and an outage longer than it is answered a level up,
+            // where `snapshot backfill` re-runs the whole publish rather than
+            // dying into a pod restart.
+            attempts: stelae::oci::DEFAULT_ATTEMPTS,
         },
     )?)
 }

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -919,11 +919,6 @@ pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
             None => peak.unsized_layers += 1,
             // Every state layer adds — the conservative sum-all-state rule the
             // type documents.
-            //
-            // Saturating because these are a manifest's numbers and a manifest
-            // is not this node's document: a wrapped sum would be a *small*
-            // need, which is the one direction a refusal must never be wrong
-            // in.
             Some(bytes) if crate::is_state_kind(&descriptor.kind) => {
                 peak.state_bytes = peak.state_bytes.saturating_add(bytes)
             }

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -857,10 +857,10 @@ fn a_publisher_can_ask_where_it_stands() {
 /// in `registry`'s own unit tests, which need no registry to decide it.
 ///
 /// The peak is deliberately not the stele's size. A publish holds all sixteen
-/// shard sinks open across one walk of the store plus whatever epoch layer is
-/// in flight beside them, and never the whole document, so an operator sizing
-/// a scratch volume off the repository's total would size it for a run that
-/// never happens.
+/// shard sinks open across one walk of the store plus as many finished layers
+/// as the transport is uploading at once beside them, and never the whole
+/// document, so an operator sizing a scratch volume off the repository's total
+/// would size it for a run that never happens.
 #[test]
 #[ignore]
 fn a_publish_sizes_its_staging_off_the_stele_before_it() {
@@ -899,7 +899,7 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
     let inspected = registry::inspect(&repository, registry::Point::Latest).unwrap();
 
     let mut state_bytes = 0;
-    let mut largest_other_bytes = 0;
+    let mut others = Vec::new();
 
     for (descriptor, size) in inspected
         .inscription
@@ -912,35 +912,77 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
         if is_state_kind(&descriptor.kind) {
             state_bytes += size;
         } else {
-            largest_other_bytes = std::cmp::max(largest_other_bytes, size);
+            others.push(size);
         }
     }
 
-    assert_eq!(peak.state_bytes, state_bytes, "every state layer summed");
-    assert_eq!(
-        peak.largest_other_bytes, largest_other_bytes,
-        "and the largest single layer beside them"
-    );
-    assert_eq!(peak.bytes(), state_bytes + largest_other_bytes);
+    others.sort_unstable_by(|a, b| b.cmp(a));
 
-    // Epoch 0's other two layers are in the stele and not in the peak, which is
-    // the whole difference between what a repository holds and what a publish
-    // holds at once.
+    assert_eq!(peak.state_bytes, state_bytes, "every state layer summed");
+
+    // As many non-state layers as the transport uploads at once, because each
+    // holds its staging file until its own round trip lands — capped by how
+    // many the stele has. Read off the transport, not off a literal that would
+    // drift from the default.
+    let concurrency = stelae::oci::Registry::concurrency(&repository);
+    let staged = others.len().min(concurrency);
+
+    assert_eq!(
+        peak.concurrent_other_bytes,
+        others[..staged],
+        "the largest {staged} of the {} layers beside the state pass",
+        others.len(),
+    );
+
+    assert_eq!(
+        peak.largest_other_bytes(),
+        others[0],
+        "and the first of them is the largest",
+    );
+
+    assert_eq!(
+        peak.bytes(),
+        state_bytes + others[..staged].iter().sum::<u64>(),
+    );
+
+    // Never more than the repository holds: the publish stages a subset of the
+    // stele, which is the whole difference between what a repository holds and
+    // what a publish holds at once. Equality here is this fixture's stele
+    // having fewer epoch layers than the transport has permits — a mainnet
+    // stele has hundreds — so the claim is stated as the bound it is.
     assert!(
-        peak.bytes() < inspected.total_compressed,
-        "peak {} is not below the stele's {} compressed bytes",
+        peak.bytes() <= inspected.total_compressed,
+        "peak {} is above the stele's {} compressed bytes",
         peak.bytes(),
         inspected.total_compressed,
     );
+
+    // And a transport that uploads one at a time stages exactly one of them
+    // beside the pass, which is the arrangement this check was first written
+    // for and the floor the concurrent one is measured against.
+    let serial = fixture.repository_tuned(
+        "dolos/staging",
+        registry_fixture::credentials(),
+        registry::Tuning {
+            concurrency: std::num::NonZeroUsize::new(1),
+            verify_adopted: false,
+        },
+    );
+
+    let alone = registry::staging_peak(&serial).unwrap().unwrap();
+
+    assert_eq!(alone.bytes(), state_bytes + others[0]);
+    assert!(alone.bytes() < inspected.total_compressed);
 
     // And the volume the fixture stages on holds it, so the publish that
     // follows is not refused.
     registry::preflight(&repository).unwrap();
 
     eprintln!(
-        "staging peak: {} bytes ({state_bytes} across sixteen shards, {largest_other_bytes} for \
-         the largest other layer), against {} compressed bytes in the repository",
+        "staging peak: {} bytes ({state_bytes} across sixteen shards, {:?} for the {staged} \
+         largest layers beside them), against {} compressed bytes in the repository",
         peak.bytes(),
+        peak.concurrent_other_bytes,
         inspected.total_compressed,
     );
 }

--- a/crates/snapshot/tests/registry_fixture/mod.rs
+++ b/crates/snapshot/tests/registry_fixture/mod.rs
@@ -207,11 +207,24 @@ impl Fixture {
 
     /// The same, with whatever credentials a caller wants to try.
     pub fn repository_as(&self, name: &str, auth: Auth) -> Registry {
+        self.repository_tuned(name, auth, registry::Tuning::default())
+    }
+
+    /// The same again, with the publish path's concurrency named — for a test
+    /// whose subject is how many round trips the transport runs at once.
+    pub fn repository_tuned(&self, name: &str, auth: Auth, tuning: registry::Tuning) -> Registry {
         let repository = format!("oci://127.0.0.1:{}/{name}", self.port)
             .parse()
             .expect("the fixture named a usable repository");
 
-        registry::open(&repository, true, auth, self.scratch.path().to_path_buf()).unwrap()
+        registry::open(
+            &repository,
+            true,
+            auth,
+            self.scratch.path().to_path_buf(),
+            tuning,
+        )
+        .unwrap()
     }
 
     /// Where the transports this fixture opens stage their layers.

--- a/crates/snapshot/tests/watcher/mod.rs
+++ b/crates/snapshot/tests/watcher/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! What makes this worth having rather than a `Vec` per test: the assertions
 //! below are about the stream's *shape* — every layer opens once and closes
-//! once, the positions are exactly `0..total`, nothing is reported after the
-//! last layer closes — and those hold for a publish and a restore alike. A
+//! once, the positions are exactly `0..total`, the driver reports nothing after
+//! the last layer closes — and those hold for a publish and a restore alike. A
 //! suite that only checked the numbers it happened to care about would let a
 //! second emitter added later report a layer twice without anything noticing.
 //!
@@ -52,9 +52,18 @@ struct Stream {
     records: u64,
     blobs: Vec<Blob>,
     bytes: u64,
-    /// Anything reported after the last layer closed — which is nothing, and
-    /// checking it is how a byte delta escaping into the gap between layers
-    /// gets caught.
+    /// Anything the *driver* reported after the last layer closed — which is
+    /// nothing, and checking it is how a record delta escaping into the gap
+    /// between layers gets caught.
+    ///
+    /// The driver's events only, because the transport's are no longer in step
+    /// with them and are not meant to be: a publish uploads a layer's blob
+    /// concurrently with the driver building the next one, so a blob announced
+    /// or a byte moved after the last layer closed is the publish still
+    /// finishing rather than an emitter that has lost its place. What holds for
+    /// those is that they have all arrived by the time the operation returns,
+    /// and the totals below — cross-checked against `Transfer` — are what says
+    /// so.
     trailing: usize,
     /// Layers of each kind open right now, and the most that were ever open at
     /// once. A driver that holds several open across one walk of a store — the
@@ -133,21 +142,9 @@ impl Progress for Watcher {
                 stream.records += moved;
             }
 
-            Event::Blob { moved, bytes } => {
-                if stream.settled() {
-                    stream.trailing += 1;
-                }
+            Event::Blob { moved, bytes } => stream.blobs.push(Blob { moved, bytes }),
 
-                stream.blobs.push(Blob { moved, bytes });
-            }
-
-            Event::Bytes(moved) => {
-                if stream.settled() {
-                    stream.trailing += 1;
-                }
-
-                stream.bytes += moved;
-            }
+            Event::Bytes(moved) => stream.bytes += moved,
         }
     }
 }
@@ -271,7 +268,7 @@ impl Watcher {
 
         assert_eq!(
             stream.trailing, 0,
-            "records or bytes were reported after the last layer closed"
+            "records were reported after the last layer closed"
         );
 
         let open: Vec<(&String, &usize)> =

--- a/crates/snapshot/tests/watcher/mod.rs
+++ b/crates/snapshot/tests/watcher/mod.rs
@@ -52,6 +52,14 @@ struct Stream {
     records: u64,
     blobs: Vec<Blob>,
     bytes: u64,
+    /// Round trips the transport made again after the registry failed one.
+    ///
+    /// Recorded because it is the one thing that unpicks the byte cross-check
+    /// below: a re-sent blob crosses the wire twice and is counted once, so a
+    /// run that retried moved more bytes than it uploaded. Against these
+    /// fixtures it is always zero, and a suite that asserts that is a suite
+    /// that would notice a retry loop firing where nothing failed.
+    retries: usize,
     /// Anything the *driver* reported after the last layer closed — which is
     /// nothing, and checking it is how a record delta escaping into the gap
     /// between layers gets caught.
@@ -145,6 +153,8 @@ impl Progress for Watcher {
             Event::Blob { moved, bytes } => stream.blobs.push(Blob { moved, bytes }),
 
             Event::Bytes(moved) => stream.bytes += moved,
+
+            Event::Retry { .. } => stream.retries += 1,
         }
     }
 }
@@ -192,6 +202,11 @@ impl Watcher {
     /// Compressed bytes the transport said crossed the wire.
     pub fn bytes(&self) -> u64 {
         self.0.lock().unwrap().bytes
+    }
+
+    /// Round trips the registry failed and the transport made again.
+    pub fn retries(&self) -> usize {
+        self.0.lock().unwrap().retries
     }
 
     /// Blobs the transport handled, by whether anything moved for them.

--- a/crates/stelae/Cargo.toml
+++ b/crates/stelae/Cargo.toml
@@ -92,11 +92,12 @@ reqwest = { version = "0.13", optional = true, default-features = false, feature
 # One runtime, owned by the transport and entered with `block_on` at each call,
 # so the protocol stays synchronous. See `oci.rs`.
 #
-# `sync` is named here and not at the workspace root because it is this crate's
-# need and nobody else's: the publish path bounds its concurrent layer round
-# trips with a `Semaphore`, and the permit is what also bounds how many staged
-# layers can exist at once.
-tokio = { workspace = true, optional = true, features = ["sync"] }
+# `sync` and `time` are named here and not at the workspace root because they
+# are this crate's need and nobody else's: the publish path bounds its
+# concurrent layer round trips with a `Semaphore`, and the permit is what also
+# bounds how many staged layers can exist at once, while a round trip the
+# registry answered with a `5xx` waits out a backoff before it is made again.
+tokio = { workspace = true, optional = true, features = ["sync", "time"] }
 # `push_blob_stream` takes a `Stream`, which is how a layer is uploaded from
 # its staging file without ever being held.
 futures-util = { workspace = true, optional = true }

--- a/crates/stelae/Cargo.toml
+++ b/crates/stelae/Cargo.toml
@@ -89,9 +89,14 @@ oci-client = { version = "0.17", optional = true, default-features = false }
 reqwest = { version = "0.13", optional = true, default-features = false, features = [
     "rustls-no-provider",
 ] }
-# One current-thread runtime, owned by the transport and entered with
-# `block_on` at each call, so the protocol stays synchronous. See `oci.rs`.
-tokio = { workspace = true, optional = true }
+# One runtime, owned by the transport and entered with `block_on` at each call,
+# so the protocol stays synchronous. See `oci.rs`.
+#
+# `sync` is named here and not at the workspace root because it is this crate's
+# need and nobody else's: the publish path bounds its concurrent layer round
+# trips with a `Semaphore`, and the permit is what also bounds how many staged
+# layers can exist at once.
+tokio = { workspace = true, optional = true, features = ["sync"] }
 # `push_blob_stream` takes a `Stream`, which is how a layer is uploaded from
 # its staging file without ever being held.
 futures-util = { workspace = true, optional = true }

--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -280,6 +280,24 @@ pub enum Error {
         blob: String,
     },
 
+    /// A seal asked again of a transport whose layers did not all land.
+    ///
+    /// The publish path moves its layers concurrently and joins them at the
+    /// seal, so a layer's failure is reported *there* — once, as itself, with
+    /// whatever the registry or the network actually said. This is what every
+    /// seal after that one answers, and it is a refusal rather than a retry
+    /// because the failure is not one the transport can undo: a layer's staging
+    /// went with the round trip that lost it, and the bytes only exist in the
+    /// store the publisher built them from.
+    ///
+    /// So the recovery is a new publish, not another seal. Carrying the string
+    /// rather than the error keeps the original readable across the many later
+    /// calls that report it, which is the whole reason this variant exists
+    /// instead of a second copy of the cause.
+    #[cfg(feature = "oci")]
+    #[error("this publish cannot be sealed: a layer never reached the repository ({0})")]
+    LayerNotWritten(String),
+
     /// A repository name an operator gave that cannot address a repository.
     ///
     /// Raised while *reading* a name, never while using one, so a caller can

--- a/crates/stelae/src/lib.rs
+++ b/crates/stelae/src/lib.rs
@@ -290,6 +290,11 @@ pub enum Error {
     /// went with the round trip that lost it, and the bytes only exist in the
     /// store the publisher built them from.
     ///
+    /// The retry that *could* have undone it already happened, inside the round
+    /// trip and while the staging was still in hand — see
+    /// [`oci::Options::attempts`]. So a failure that gets this far is one the
+    /// registry repeated.
+    ///
     /// So the recovery is a new publish, not another seal. Carrying the string
     /// rather than the error keeps the original readable across the many later
     /// calls that report it, which is the whole reason this variant exists

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -55,9 +55,8 @@
 //! `oci-client` is async and this crate is not: `export` and `restore` are
 //! synchronous iterator code driving fallible store iterators, and threading a
 //! runtime through them would change every profile's shape for the benefit of
-//! one transport. So the transport owns **one current-thread runtime** and
-//! enters it with `block_on` at each call — the idiom `dolos bootstrap mithril`
-//! already uses.
+//! one transport. So the transport owns **one runtime** and enters it with
+//! `block_on` at each call — the idiom `dolos bootstrap mithril` already uses.
 //!
 //! **A [`Registry`] must never be used from inside an async context, and must
 //! never be dropped inside one.** `Runtime::block_on` panics when called from a
@@ -65,6 +64,44 @@
 //! caller today is a synchronous CLI path, which is what makes this safe; a
 //! caller that is not is a design question, and the answer is not a second
 //! runtime.
+//!
+//! ## Why the publish path is concurrent, and where it joins again
+//!
+//! A publish is not one transfer; it is a few hundred small ones. A stele's
+//! layers are cut at record-type and epoch granularity, so a mainnet publish
+//! moves tens of new blobs of half a megabyte each and carries hundreds of
+//! older ones forward — and every one of those, new or carried, costs at least
+//! one round trip to a registry that may be an ocean away. Run in sequence, the
+//! path spends nearly all of its wall clock waiting on a socket with the CPU
+//! and the link both idle, and the carried-forward half makes it *worse every
+//! epoch*: the stele gains layers, so the publish gains round trips, so the
+//! cycle time grows linearly with the history behind it.
+//!
+//! Nothing about that is a bandwidth problem, so the answer is not bigger
+//! layers — the cut geometry is the profile's, and it is deliberate. The answer
+//! is to stop doing one round trip at a time. Every layer's round trips are
+//! independent of every other layer's: a blob is addressed by its own content,
+//! and no blob's upload observes another's. So they are **deferred onto the
+//! runtime and run concurrently**, bounded by [`Options::concurrency`], and the
+//! caller's thread goes back to reading the store rather than waiting on a
+//! `PATCH`.
+//!
+//! What is *not* independent is the manifest, and that is the whole of the
+//! safety argument this concurrency has to preserve:
+//!
+//! > **A manifest must never name a blob the registry has not committed.**
+//!
+//! So [`SteleWriter::seal`] is the join. Every deferred round trip is awaited
+//! there — before the manifest is built, before the config blob goes up, before
+//! either tag is written — and the first failure among them fails the seal, in
+//! the state a failed seal has always left behind: layers unspent, nothing
+//! tagged, and the caller free to seal again. A publish that dies mid-flight
+//! leaves untagged blobs the registry reclaims, exactly as a serial one did.
+//!
+//! The bound is a permit taken *before* the staged layer is handed over rather
+//! than inside the task, so it is also what keeps the scratch directory from
+//! filling: at most [`Options::concurrency`] staged layers exist at once,
+//! whatever order the sinks finish in.
 //!
 //! ## TLS, and the second rule it comes with
 //!
@@ -270,8 +307,23 @@ pub struct Transfer {
     pub bytes_reused: u64,
 }
 
+/// How many of a publish's layer round trips run at once.
+///
+/// Eight, and the number is a floor on the registry's side of the trade rather
+/// than a ceiling on this one's: the round trips are latency, not bandwidth, so
+/// the transport would happily run more, and what stops it is that a stele's
+/// blobs go to *one* repository behind one origin. A publisher that opens
+/// thirty-two upload sessions at once against a registry sized for a container
+/// image is a publisher that finds the registry's limits rather than its own.
+///
+/// Eight moves the mainnet publish path off its serial floor by most of an
+/// order of magnitude while staying inside what a modest origin answers without
+/// complaint. [`Options::concurrency`] is there for an operator who has
+/// measured their own.
+pub const DEFAULT_CONCURRENCY: usize = 8;
+
 /// How to reach a registry.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Options {
     /// Talk to the registry over plaintext HTTP rather than HTTPS.
     ///
@@ -293,6 +345,49 @@ pub struct Options {
     /// credentials — see the module documentation for why that is a boundary
     /// rather than an omission.
     pub auth: Auth,
+
+    /// How many layer round trips a publish runs at once.
+    ///
+    /// Defaults to [`DEFAULT_CONCURRENCY`]. `1` restores the strictly serial
+    /// path — an escape hatch for a registry that answers concurrency badly,
+    /// not a mode anything should want — and `0` is read as `1` rather than
+    /// refused, because a transport that could move nothing is not a
+    /// configuration anybody means.
+    ///
+    /// It bounds the staging directory as well as the wire: see the module
+    /// documentation.
+    pub concurrency: usize,
+
+    /// Re-prove that the registry still holds a blob being adopted out of a
+    /// manifest this transport pulled.
+    ///
+    /// Off, and that is the plain reading of the distribution specification
+    /// rather than an optimism: a blob referenced by a manifest under a live
+    /// tag is not garbage, and a registry that reclaims one has broken the
+    /// contract that makes *the stele the manifest came from* restorable —
+    /// which the `HEAD` would not have saved either. Paying a round trip per
+    /// carried layer to re-establish that is what made the publish path's cost
+    /// grow with the history behind it, for a check whose failure means the
+    /// repository is already unusable.
+    ///
+    /// On, [`Registry::adopt_layer`] proves each blob before the manifest names
+    /// it, concurrently with everything else the publish is doing — so the
+    /// check costs latency it can hide rather than latency it serializes. For
+    /// an operator publishing into a registry whose retention they do not
+    /// trust.
+    pub verify_adopted: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            insecure: false,
+            scratch_dir: None,
+            auth: Auth::default(),
+            concurrency: DEFAULT_CONCURRENCY,
+            verify_adopted: false,
+        }
+    }
 }
 
 /// A repository an operator named, as `oci://HOST/PATH`.
@@ -436,7 +531,25 @@ struct Shared {
     name: Repository,
     auth: RegistryAuth,
     scratch_dir: Option<PathBuf>,
-    state: Mutex<PushState>,
+    /// Behind its own [`Arc`] rather than inside this one, because a deferred
+    /// layer round trip has to reach it and must **not** reach the runtime: the
+    /// task would then hold the thing that is driving it, and the last handle
+    /// dropping inside a worker thread would drop a runtime from inside itself,
+    /// which panics. Every deferred task below is built out of cheap clones —
+    /// the client, the reference, this handle, the observer — and never out of
+    /// a `Shared`.
+    state: Arc<Mutex<PushState>>,
+    /// How many layer round trips may be outstanding at once, and with them how
+    /// many staged layers may exist at once. A permit is taken on the caller's
+    /// thread before the staging file is handed over and released when the
+    /// round trip is done. See [`Options::concurrency`].
+    permits: Arc<tokio::sync::Semaphore>,
+    /// The deferred layer round trips, waiting to be joined by
+    /// [`SteleWriter::seal`].
+    ///
+    /// Not in [`PushState`], for the reason `state` is not in `Shared`: the
+    /// tasks reach the state and must never reach the handles that own them.
+    inflight: Mutex<Vec<tokio::task::JoinHandle<Result<(), Error>>>>,
     /// Who is watching this connection, in either direction.
     ///
     /// Beside the push state rather than inside it, because a [`Stele`] shares
@@ -445,6 +558,12 @@ struct Shared {
     /// property a restore depends on — the reader is created inside the driver
     /// and there is no other moment to wire it.
     observer: Mutex<Observer>,
+    /// [`Options::verify_adopted`], as it was given.
+    verify_adopted: bool,
+    /// [`Options::concurrency`], as it was resolved — the permit count, kept
+    /// beside the semaphore because the semaphore's own count is whatever is
+    /// free at the moment it is asked.
+    concurrency: usize,
 }
 
 #[derive(Default)]
@@ -452,6 +571,36 @@ struct PushState {
     /// Layers finished since the last [`SteleWriter::seal`], in finish order.
     pending: Vec<WrittenLayer>,
     transfer: Transfer,
+    /// The first deferred round trip that failed, rendered.
+    ///
+    /// Sticky, and that is the point. A failed [`Shared::join_layers`] empties
+    /// the handles it awaited, so without this a second seal would find nothing
+    /// in flight, agree that every layer was up, and publish a manifest naming
+    /// a blob that never landed — the one document this transport must never
+    /// write. See [`Error::LayerNotWritten`].
+    failed: Option<String>,
+}
+
+/// One layer's share of [`Options::concurrency`], held for as long as its round
+/// trips are outstanding.
+///
+/// Named because it is passed hand to hand — taken on the caller's thread by
+/// whoever is about to defer, moved into the task, and dropped when the task
+/// ends — and a bare `OwnedSemaphorePermit` in three signatures says nothing
+/// about which of those it is.
+type Permit = tokio::sync::OwnedSemaphorePermit;
+
+/// The push state, for a deferred task that holds the state and not the
+/// transport.
+///
+/// A poisoned lock means a push panicked while holding it. The counters are
+/// plain integers and the pending list is append-only, so what is behind the
+/// lock is still coherent; refusing to look at it would turn one failed push
+/// into a transport nobody can use.
+fn lock(state: &Mutex<PushState>) -> std::sync::MutexGuard<'_, PushState> {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 impl Registry {
@@ -464,9 +613,9 @@ impl Registry {
     /// parses it into a [`Repository`] and hands that over; nothing outside
     /// this module needs to know where the host ends.
     ///
-    /// Builds the current-thread runtime the whole transport runs on, and
-    /// stores the credentials [`Options::auth`] carries so they never have to
-    /// be threaded through a profile's call stack.
+    /// Builds the runtime the whole transport runs on, and stores the
+    /// credentials [`Options::auth`] carries so they never have to be threaded
+    /// through a profile's call stack.
     ///
     /// # Panics
     ///
@@ -498,7 +647,17 @@ impl Registry {
 
         let auth = options.auth.to_registry_auth();
 
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        // One worker per permit, and the two numbers are one decision. A
+        // deferred upload reads its staged layer with a *blocking* file read —
+        // see `blob_stream`, where that is deliberate — so a worker driving one
+        // upload is unavailable to another for the length of a read. Sizing the
+        // pool to the bound is what keeps that from turning a concurrency of
+        // eight into a concurrency of one on a slow volume.
+        let concurrency = options.concurrency.max(1);
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(concurrency)
+            .thread_name("stelae-oci")
             .enable_all()
             .build()?;
 
@@ -516,8 +675,12 @@ impl Registry {
                 name: repository.clone(),
                 auth,
                 scratch_dir: options.scratch_dir,
-                state: Mutex::new(PushState::default()),
+                state: Arc::new(Mutex::new(PushState::default())),
+                permits: Arc::new(tokio::sync::Semaphore::new(concurrency)),
+                inflight: Mutex::new(Vec::new()),
                 observer: Mutex::new(Observer::silent()),
+                verify_adopted: options.verify_adopted,
+                concurrency,
             }),
         })
     }
@@ -545,14 +708,41 @@ impl Registry {
         &self.shared.name
     }
 
+    /// [`Options::concurrency`], as it was resolved.
+    ///
+    /// Asked by a caller sizing the volume this transport stages on, for the
+    /// reason [`Registry::scratch_dir`] is asked for the directory: the number
+    /// that bounds how many layers are staged at once is the transport's, and a
+    /// caller re-deriving it from its own configuration is a second copy of a
+    /// number that has to stay in step.
+    pub fn concurrency(&self) -> usize {
+        self.shared.concurrency
+    }
+
     /// What has been pushed through this transport since it was opened, or
     /// since the last [`Registry::take_transfer`].
+    ///
+    /// **What has *finished*.** Layer round trips are deferred and joined at
+    /// the seal, so a publish still in flight is a publish still counting, and
+    /// the moment these numbers are the whole story is after
+    /// [`SteleWriter::seal`] returns. Asked earlier they are a progress
+    /// reading; asked there they are the cost of the stele. A caller that wants
+    /// the second one does not have to do anything to get it — a publish ends
+    /// at a seal — and this does not block to manufacture it, because a
+    /// counter that waited for the network would be a strange thing for a
+    /// progress renderer to call.
     pub fn transfer(&self) -> Transfer {
         self.shared.locked().transfer
     }
 
     /// The same numbers, and reset — so a publisher pushing several steles
     /// through one transport reads each one's cost rather than a running total.
+    ///
+    /// Read it after the seal, for the reason [`Registry::transfer`] gives, and
+    /// with one more of its own: this one clears what it read, so a call made
+    /// while round trips are still in flight does not merely see a partial
+    /// figure, it takes the figure away from the seal that was going to
+    /// complete it.
     pub fn take_transfer(&self) -> Transfer {
         std::mem::take(&mut self.shared.locked().transfer)
     }
@@ -666,11 +856,24 @@ impl Registry {
     /// **The new stele attests a layer it did not reproduce.** That is the
     /// trade, and it is the caller's to make: nothing here can check that the
     /// descriptor describes those bytes, because checking would mean reading
-    /// them, which is the cost being avoided. What *is* checked is that the
-    /// blob is still there — one `HEAD`, before the manifest is written —
-    /// because a descriptor pointing at a blob the registry has reclaimed is a
-    /// stele nobody can restore, and it would be published looking perfectly
-    /// well-formed.
+    /// them, which is the cost being avoided.
+    ///
+    /// ## What is not checked, and why that is the default
+    ///
+    /// `source` is a stele this transport *pulled*: its manifest is live in
+    /// this repository under a tag, and it names this blob. A registry is not
+    /// permitted to reclaim a blob in that position, and one that does has
+    /// already broken the stele the descriptor came from — a `HEAD` here would
+    /// find the damage a publish too late and could not have prevented it.
+    ///
+    /// Re-establishing it per carried layer per publish is what made this path
+    /// cost a round trip for every layer of history behind the stele, and made
+    /// each publish slower than the one before it for a reason that had nothing
+    /// to do with what it was publishing. So it is not paid by default.
+    /// [`Options::verify_adopted`] restores the proof for an operator who wants
+    /// it, and pays for it concurrently rather than in sequence: the `HEAD`
+    /// still lands before the manifest names the blob, which is the only
+    /// ordering that was ever load-bearing.
     ///
     /// The caller names the layer by its `descriptor` — identity, out of an
     /// inscription — and the stele it came from. The blob digest and the
@@ -721,20 +924,21 @@ impl Registry {
             descriptor,
         };
 
-        let kind = adopted.descriptor.kind.clone();
-        let diff_id = adopted.descriptor.diff_id;
-
         // A manifest naming a blob the registry no longer has is a refusal and
         // not a miss: the stele that named it is published, and something has
         // reclaimed underneath it. See [`Registry::adopt_carried`] for the case
-        // where the same absence is merely a rebuild.
-        if !self.adopt_carried(adopted)? {
-            return Err(Error::BlobMissing {
-                kind,
-                diff_id: diff_id.to_string(),
-                blob: named,
-            });
+        // where the same absence is merely a rebuild — and `Options` for why
+        // this transport does not go looking for it by default.
+        if self.shared.verify_adopted {
+            let permit = self.shared.permit();
+
+            self.shared.prove_blob(&adopted, permit);
         }
+
+        let mut state = self.shared.locked();
+        state.transfer.layers_reused += 1;
+        state.transfer.bytes_reused += adopted.digests.compressed_size;
+        state.pending.push(adopted);
 
         Ok(())
     }
@@ -844,13 +1048,7 @@ fn scratch_in(dir: Option<&Path>) -> Result<File, Error> {
 
 impl Shared {
     fn locked(&self) -> std::sync::MutexGuard<'_, PushState> {
-        // A poisoned lock means a push panicked while holding it. The counters
-        // are plain integers and the pending list is append-only, so what is
-        // behind the lock is still coherent; refusing to look at it would turn
-        // one failed push into a transport nobody can use.
-        self.state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+        lock(&self.state)
     }
 
     /// A handle on whoever is watching, taken once per operation.
@@ -892,52 +1090,185 @@ impl Shared {
         )?)
     }
 
-    /// Upload a staged layer, unless the registry already has it.
+    /// Take a permit, on the caller's thread.
+    ///
+    /// This is the back pressure, and taking it *here* rather than inside the
+    /// task is what makes it back pressure at all: the caller does not get to
+    /// stage a ninth layer while eight are still moving, so the scratch
+    /// directory is bounded by the same number as the wire.
+    fn permit(&self) -> tokio::sync::OwnedSemaphorePermit {
+        // The semaphore is never closed — nothing here closes one — so the only
+        // error this call has is unreachable.
+        self.runtime
+            .block_on(Arc::clone(&self.permits).acquire_owned())
+            .expect("the transport's semaphore is never closed")
+    }
+
+    /// Run one layer's round trips off the caller's thread.
+    ///
+    /// The future is built by the caller out of clones and owns everything it
+    /// touches, which is the invariant that keeps a task from holding the
+    /// runtime driving it — see [`Shared::state`].
+    fn defer(&self, task: impl std::future::Future<Output = Result<(), Error>> + Send + 'static) {
+        let handle = self.runtime.spawn(task);
+
+        self.inflight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(handle);
+    }
+
+    /// Wait for every deferred round trip, and report the first failure.
+    ///
+    /// **Every** one, including after a failure has already been seen: a task
+    /// left running is a task still writing to a registry the caller is about
+    /// to be told nothing was written to, and — on the error path — one that
+    /// would be cancelled by the runtime shutting down under it. The first
+    /// error is the one reported because the others are usually the same
+    /// network saying the same thing twice.
+    ///
+    /// A panicking task is re-raised on this thread rather than folded into an
+    /// error: a panic in an upload is a bug in this module, and turning it into
+    /// a returned `Err` would file it under "the registry refused".
+    ///
+    /// **A failure here is remembered.** The first call reports the cause
+    /// itself; every call after it reports [`Error::LayerNotWritten`], because
+    /// the handles are gone and a join that found nothing outstanding would
+    /// otherwise read as "everything landed".
+    fn join_layers(&self) -> Result<(), Error> {
+        let handles: Vec<_> = std::mem::take(
+            &mut *self
+                .inflight
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        );
+
+        let (first, panicked) = self.runtime.block_on(async {
+            let mut first: Option<Error> = None;
+            let mut panicked: Option<Box<dyn std::any::Any + Send>> = None;
+
+            for handle in handles {
+                match handle.await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => first = first.or(Some(error)),
+                    Err(join) if join.is_panic() => panicked = panicked.or(Some(join.into_panic())),
+                    // Nothing here cancels a task, so this arm is the runtime
+                    // shutting down mid-join, which cannot happen while this
+                    // call holds it.
+                    Err(_) => {}
+                }
+            }
+
+            (first, panicked)
+        });
+
+        if let Some(payload) = panicked {
+            std::panic::resume_unwind(payload);
+        }
+
+        let mut state = self.locked();
+
+        if let Some(error) = first {
+            state.failed.get_or_insert_with(|| error.to_string());
+
+            return Err(error);
+        }
+
+        match &state.failed {
+            Some(why) => Err(Error::LayerNotWritten(why.clone())),
+            None => Ok(()),
+        }
+    }
+
+    /// Upload a staged layer, unless the registry already has it — later.
     ///
     /// The existence check *is* the blob-skip — the whole delta-transfer claim
     /// reduces to this one `HEAD` per layer — and both outcomes are counted.
-    fn put_layer(&self, layer: &WrittenLayer, staged: File) -> Result<(), Error> {
+    ///
+    /// The layer is added to the pending list here, on the caller's thread and
+    /// in finish order, so [`Registry::carried`] answers for it the moment its
+    /// sink returns and the manifest is built out of the order the inscription
+    /// was. What is deferred is the two round trips, and their failure, which
+    /// [`Shared::join_layers`] collects at the seal.
+    fn put_layer(&self, layer: &WrittenLayer, staged: File, permit: Permit) {
         let digest = layer.digests.blob_digest;
         let size = layer.digests.compressed_size;
         let observer = self.observer();
 
-        if self.blob_exists(&digest)? {
-            // Announced even though nothing moves: "the registry already had
-            // this one" is the blob-skip working, and a watcher that only heard
-            // about uploads would read the whole point of a content-addressed
-            // registry as a stall.
+        self.locked().pending.push(layer.clone());
+
+        let client = self.client.clone();
+        let repository = self.repository.clone();
+        let state = Arc::clone(&self.state);
+
+        self.defer(async move {
+            let _permit = permit;
+            let named = digest.to_string();
+
+            if client.blob_exists(&repository, &named).await? {
+                // Announced even though nothing moves: "the registry already
+                // had this one" is the blob-skip working, and a watcher that
+                // only heard about uploads would read the whole point of a
+                // content-addressed registry as a stall.
+                observer.emit(Event::Blob {
+                    moved: false,
+                    bytes: size,
+                });
+
+                let mut state = lock(&state);
+                state.transfer.layers_skipped += 1;
+                state.transfer.bytes_skipped += size;
+
+                return Ok(());
+            }
+
+            // Before the upload rather than after it, so a watcher knows how
+            // big the transfer it is about to see is while it is still
+            // happening.
             observer.emit(Event::Blob {
-                moved: false,
+                moved: true,
                 bytes: size,
             });
 
-            let mut state = self.locked();
-            state.transfer.layers_skipped += 1;
-            state.transfer.bytes_skipped += size;
-            state.pending.push(layer.clone());
+            client
+                .push_blob_stream(&repository, blob_stream(staged, observer), &named)
+                .await?;
 
-            return Ok(());
-        }
+            let mut state = lock(&state);
+            state.transfer.layers_uploaded += 1;
+            state.transfer.bytes_uploaded += size;
 
-        // Before the upload rather than after it, so a watcher knows how big
-        // the transfer it is about to see is while it is still happening.
-        observer.emit(Event::Blob {
-            moved: true,
-            bytes: size,
+            Ok(())
         });
+    }
 
-        self.runtime.block_on(self.client.push_blob_stream(
-            &self.repository,
-            blob_stream(staged, observer),
-            &digest.to_string(),
-        ))?;
+    /// Prove — later — that the registry still holds a blob being carried
+    /// forward.
+    ///
+    /// [`Options::verify_adopted`] only. Deferred for the reason an upload is,
+    /// and joined at the same point: what the check has to beat is the manifest
+    /// naming the blob, not the descriptor being handed back.
+    fn prove_blob(&self, layer: &WrittenLayer, permit: Permit) {
+        let kind = layer.descriptor.kind.clone();
+        let diff_id = layer.descriptor.diff_id;
+        let blob = layer.digests.blob_digest;
 
-        let mut state = self.locked();
-        state.transfer.layers_uploaded += 1;
-        state.transfer.bytes_uploaded += size;
-        state.pending.push(layer.clone());
+        let client = self.client.clone();
+        let repository = self.repository.clone();
 
-        Ok(())
+        self.defer(async move {
+            let _permit = permit;
+            let named = blob.to_string();
+
+            match client.blob_exists(&repository, &named).await? {
+                true => Ok(()),
+                false => Err(Error::BlobMissing {
+                    kind,
+                    diff_id: diff_id.to_string(),
+                    blob: named,
+                }),
+            }
+        });
     }
 
     /// Upload a small blob a caller already holds — the inscription, and
@@ -1044,9 +1375,11 @@ impl SteleWriter for Registry {
     /// The override the default's documentation asks for: this transport pairs
     /// every layer the inscription describes against a layer it wrote, and a
     /// descriptor with nothing beside it fails the seal. Nothing is uploaded
-    /// and nothing is checked — the blob went up when the first descriptor's
-    /// sink finished, in this same publish, so there is no state of the
-    /// registry under which it is there for one name and absent for the other.
+    /// and nothing is checked — the blob was handed to the upload pool when the
+    /// first descriptor's sink finished, in this same publish, and the seal
+    /// joins that upload before it names either descriptor. So there is no
+    /// state of the registry under which it is there for one name and absent
+    /// for the other.
     ///
     /// Counted as **skipped** rather than reused, by the distinction
     /// [`Transfer::layers_reused`] draws: these bytes were built out of a
@@ -1087,17 +1420,22 @@ impl SteleWriter for Registry {
     ///
     /// The order is the whole of the safety argument:
     ///
-    /// 1. every layer blob is already up — that happened in
-    ///    [`RecordSink::finish`], one blob at a time;
+    /// 1. **every layer blob is up.** The round trips were deferred by
+    ///    [`RecordSink::finish`] and [`Registry::adopt_layer`] and ran
+    ///    concurrently; this is where they are joined, and the first failure
+    ///    among them is this call's failure;
     /// 2. the inscription goes up as the config blob;
     /// 3. the manifest is tagged with the immutable tag the profile renders for
     ///    this sequence;
     /// 4. and **only then** the moving tag moves.
     ///
-    /// Step 4 is last so that a reader following `latest` never resolves to a
-    /// stele whose blobs are still uploading. A push that dies in the middle
-    /// leaves untagged blobs the registry will reclaim, and a `latest` that
-    /// still points at the previous stele — which is a stele, and restores.
+    /// Step 1 is the serialization point the concurrency is arranged around:
+    /// the manifest is built *after* it, so no document this transport writes
+    /// can name a blob the registry has not committed. Step 4 is last so that a
+    /// reader following `latest` never resolves to a stele whose blobs are
+    /// still uploading. A push that dies in the middle leaves untagged blobs
+    /// the registry will reclaim, and a `latest` that still points at the
+    /// previous stele — which is a stele, and restores.
     ///
     /// **A seal that succeeds consumes the layers finished since the last
     /// one.** One transport can therefore publish several steles in turn —
@@ -1110,6 +1448,15 @@ impl SteleWriter for Registry {
     /// 500 leaves a transport the caller can seal again — the blobs are
     /// already up, and re-exporting a stele to recover from a transient error
     /// is not a price this owes anyone.
+    ///
+    /// **A seal that fails at step 1 is the exception, and it is permanent.** A
+    /// layer that did not reach the repository cannot be sent again from here:
+    /// its staging went with the round trip that lost it, and the bytes are
+    /// only in the store the publisher built them from. So the failure is
+    /// remembered, every later seal answers [`Error::LayerNotWritten`], and the
+    /// recovery is another publish rather than another seal. Retrying the seal
+    /// is what would produce the one document this transport must never
+    /// write — see [`Shared::join_layers`].
     fn seal(&self, profile: &dyn Profile, inscription: &Inscription) -> Result<Digest, Error> {
         // Both tags before either push. Validating the moving tag after the
         // sequence manifest is already public would make a bad tag something
@@ -1117,6 +1464,15 @@ impl SteleWriter for Registry {
         let sequence_tag = checked_tag_for_sequence(profile, inscription.sequence)?;
         let moving_tag = profile.moving_tag().to_owned();
         validate_tag(&moving_tag)?;
+
+        // The join, and it is before the manifest is even built rather than
+        // merely before it is pushed: a document assembled out of a pending
+        // list whose blobs are still in flight is a document that must not
+        // exist, not one that must not be sent. Fallible, like every other step
+        // here, and — like every other step here — it runs before the layers
+        // are spent, so a transport whose upload the network broke can be
+        // sealed again once the caller has decided what to do about it.
+        self.shared.join_layers()?;
 
         // Scoped so the guard is gone before anything touches the network.
         let (body, config) = {
@@ -1188,7 +1544,19 @@ impl RecordSink for RegistrySink {
         self.sequence.count()
     }
 
-    /// Close the layer and upload it — unless the registry has it already.
+    /// Close the layer and hand it to the upload pool.
+    ///
+    /// The descriptor comes back as soon as the last record is framed: it is a
+    /// fact about bytes this sink already has, and nothing the registry says
+    /// can change it. The upload — and the `HEAD` that may make it
+    /// unnecessary — runs concurrently with whatever the caller does next, and
+    /// is joined by [`SteleWriter::seal`] before the manifest can name it.
+    ///
+    /// So an error here is a failure to *close the layer*; a failure to move it
+    /// surfaces at the seal. That is a change in when a registry's refusal is
+    /// reported and not in what it costs: a publish that cannot upload is a
+    /// publish that does not seal, in either arrangement, having tagged
+    /// nothing.
     fn finish(self) -> Result<WrittenLayer, Error> {
         let Self {
             sequence,
@@ -1197,6 +1565,14 @@ impl RecordSink for RegistrySink {
             media_type,
             scope,
         } = self;
+
+        // Before the layer is closed, so the bound on outstanding round trips
+        // is also the bound on staged layers: a caller with sixteen sinks open
+        // waits here rather than filling the scratch directory. Taken before
+        // the fallible steps below for the same reason it is released by the
+        // task — a permit's lifetime is the layer's, and a layer that never
+        // closes has none.
+        let permit = shared.permit();
 
         let count = sequence.count();
         let (mut staged, digests) = sequence.into_inner().finish()?;
@@ -1216,7 +1592,7 @@ impl RecordSink for RegistrySink {
             digests,
         };
 
-        shared.put_layer(&written, staged)?;
+        shared.put_layer(&written, staged, permit);
 
         Ok(written)
     }
@@ -1571,9 +1947,10 @@ pub fn read_manifest(
 
 /// A staged layer, as a stream of chunks.
 ///
-/// Reads from the staging file synchronously, which is safe precisely because
-/// the runtime under it is this transport's own and has nothing else to do: the
-/// read is not waiting on anything the runtime is responsible for driving.
+/// Reads from the staging file synchronously. The runtime under it is this
+/// transport's own — the read is not waiting on anything it is responsible for
+/// driving — and it is sized so that a read blocking a worker cannot starve the
+/// other uploads: one worker per permit, decided in [`Registry::open`].
 ///
 /// One chunk is allocated at a time and handed over, so what the upload holds
 /// is [`UPLOAD_CHUNK`] and not the layer.

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -103,6 +103,46 @@
 //! filling: at most [`Options::concurrency`] staged layers exist at once,
 //! whatever order the sinks finish in.
 //!
+//! ## A round trip nobody answered is made again
+//!
+//! Concurrency raised the number of round trips in flight; it did nothing about
+//! the ones that fail for no reason and would have worked a second later. Over
+//! eleven hours of the mainnet backfill the registry answered a create-session
+//! `POST` with a bare `500` eight times, each lasting the milliseconds it took
+//! to ask again — and each one cost the whole epoch, because a publish that
+//! could not seal took the driver down with it, and the driver's recovery is to
+//! restore its stores and replay the epoch it lost.
+//!
+//! That is the most expensive recovery in the system, bought for the cheapest
+//! failure there is. So a round trip is **attempted [`Options::attempts`]
+//! times**, with a doubling wait between them, and the failure the caller keeps
+//! is the last attempt's:
+//!
+//! - **a `5xx`** — the registry answered, and what it said was about itself
+//!   rather than about the request. Asking again is the whole remedy;
+//! - **no answer at all** — a connection refused, a request that timed out, a
+//!   socket that went away mid-body.
+//!
+//! Nothing else. A `4xx` is the registry saying something true about *this*
+//! request — the credential, the digest, the name — and repeating it four times
+//! only makes the diagnosis take longer to arrive. `429` is excluded on purpose
+//! and not by omission: a registry rationing this publisher is a fact its
+//! operator has to see, and a client that absorbed it would report the ration
+//! as slowness.
+//!
+//! This is safe to do at every seam because every one of them is idempotent by
+//! construction. A blob is addressed by the digest of its own content, so an
+//! upload that half-happened and an upload that fully happened both converge on
+//! the same blob when it is sent again; a `HEAD` and a manifest `GET` are
+//! reads; and the manifest `PUT` writes bytes that are a pure function of the
+//! stele. The one thing a retry needs and the serial path did not is the
+//! staging file back at its first byte, which is why it is rewound per attempt
+//! rather than consumed once.
+//!
+//! Every retry is announced through [`Event::Retry`], because a transport that
+//! silently absorbed the failure class would have hidden the measurement that
+//! motivated absorbing it.
+//!
 //! ## TLS, and the second rule it comes with
 //!
 //! The client speaks TLS through rustls, built with **no crypto provider wired
@@ -159,6 +199,7 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures_util::Stream;
@@ -322,6 +363,27 @@ pub struct Transfer {
 /// measured their own.
 pub const DEFAULT_CONCURRENCY: usize = 8;
 
+/// How many times one of a publish's round trips is made before the failure is
+/// the caller's.
+///
+/// Four, and the number is read off the failure it absorbs rather than chosen:
+/// the registry's transient `500`s arrive alone and clear in the time it takes
+/// to ask again, so the first retry is the one that does the work and the rest
+/// are there for the case where it is a second longer than that. Bounded for
+/// the same reason [`crate::Error::LayerNotWritten`] exists — a registry that
+/// is *actually* refusing has to keep refusing, out loud, while whoever
+/// launched the publish is still watching.
+pub const DEFAULT_ATTEMPTS: u32 = 4;
+
+/// How long the transport waits after the first failed attempt; each later wait
+/// doubles it.
+///
+/// Three waits of 500ms, 1s and 2s put the ceiling at three and a half seconds
+/// of patience per round trip — under the cost of one lost epoch by four orders
+/// of magnitude, and small enough that a publish absorbing a handful of them a
+/// night does not show up as a slower publish.
+const RETRY_DELAY: Duration = Duration::from_millis(500);
+
 /// How to reach a registry.
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -376,6 +438,18 @@ pub struct Options {
     /// an operator publishing into a registry whose retention they do not
     /// trust.
     pub verify_adopted: bool,
+
+    /// How many times a round trip is made before its failure is the caller's.
+    ///
+    /// Defaults to [`DEFAULT_ATTEMPTS`]. `0` and `1` both mean one attempt and
+    /// no retry — `0` is read as `1` rather than refused, for the reason
+    /// [`Options::concurrency`] reads it that way: a transport that would make
+    /// no attempt at all is not a configuration anybody means.
+    ///
+    /// Only the failures the module documentation lists are retried; a
+    /// registry's refusal of *this* request is never one of them, so raising
+    /// this does not slow down a publish that was going to fail anyway.
+    pub attempts: u32,
 }
 
 impl Default for Options {
@@ -386,6 +460,7 @@ impl Default for Options {
             auth: Auth::default(),
             concurrency: DEFAULT_CONCURRENCY,
             verify_adopted: false,
+            attempts: DEFAULT_ATTEMPTS,
         }
     }
 }
@@ -564,6 +639,8 @@ struct Shared {
     /// beside the semaphore because the semaphore's own count is whatever is
     /// free at the moment it is asked.
     concurrency: usize,
+    /// [`Options::attempts`], as it was resolved.
+    attempts: u32,
 }
 
 #[derive(Default)]
@@ -681,6 +758,7 @@ impl Registry {
                 observer: Mutex::new(Observer::silent()),
                 verify_adopted: options.verify_adopted,
                 concurrency,
+                attempts: options.attempts.max(1),
             }),
         })
     }
@@ -770,11 +848,13 @@ impl Registry {
 
         let reference = self.shared.tagged(tag);
 
-        let (manifest, _digest) = self.shared.runtime.block_on(
-            self.shared
-                .client
-                .pull_image_manifest(&reference, &self.shared.auth),
-        )?;
+        let (manifest, _digest) = self.shared.retrying(|| {
+            Ok(self.shared.runtime.block_on(
+                self.shared
+                    .client
+                    .pull_image_manifest(&reference, &self.shared.auth),
+            )?)
+        })?;
 
         check_envelope(&manifest)?;
 
@@ -1017,6 +1097,175 @@ fn is_absent(error: &oci_client::errors::OciDistributionError) -> bool {
     }
 }
 
+/// Whether a failure is one that asking again can fix.
+///
+/// The counterpart of [`is_absent`], and narrow for the same reason that one
+/// is: a classification that guesses wide turns a registry's considered refusal
+/// into four of them spread over three and a half seconds, and the caller reads
+/// the last copy. Two shapes qualify.
+///
+/// **A `5xx`.** The registry answered, and what it said was about itself. This
+/// is the measured class — the create-session `POST` that returns
+/// `500 INTERNAL_ERROR` and succeeds on the next ask.
+///
+/// **No answer at all.** A connection refused, a request that timed out, a
+/// socket closed mid-body. `oci-client` reports these through `reqwest`
+/// untouched, and [`oci_client::Client::blob_exists`] reports a `5xx` that way
+/// too — it asks `reqwest` for the status rather than mapping it — so both
+/// shapes have to be read out of the same variant.
+///
+/// Everything else propagates on the first attempt:
+///
+/// - **a `4xx`** is the registry saying something true about *this* request.
+///   The credential is wrong, the digest does not match what arrived, the
+///   repository is not there. Repetition does not change any of those, it only
+///   delays the report;
+/// - **`429` in particular**, and that is a decision rather than an oversight.
+///   A registry rationing this publisher is a fact its operator needs, and a
+///   client that waited it out would deliver the ration as unexplained
+///   slowness;
+/// - **anything local** — a staging file that would not read, a manifest that
+///   would not parse. Nothing on the far side is involved and nothing about
+///   waiting helps.
+fn is_transient(error: &Error) -> bool {
+    use oci_client::errors::OciDistributionError as E;
+
+    let Error::Registry(error) = error else {
+        return false;
+    };
+
+    match error {
+        E::ServerError { code, .. } => (500..600).contains(code),
+        E::RequestError(source) => match source.status() {
+            Some(status) => status.is_server_error(),
+            None => source.is_timeout() || source.is_connect() || source.is_request(),
+        },
+        _ => false,
+    }
+}
+
+/// What a bounded retry keeps between attempts: how many are left, and how long
+/// the next wait is.
+///
+/// A value rather than a loop because there are two loops — one on the caller's
+/// thread around a `block_on`, one inside a deferred task around an `await` —
+/// and the decision they share is this and not the sleeping. Splitting it here
+/// is what keeps the policy in one place while each loop waits the way its own
+/// thread has to.
+struct Backoff {
+    attempted: u32,
+    attempts: u32,
+    delay: Duration,
+}
+
+impl Backoff {
+    fn new(attempts: u32, delay: Duration) -> Self {
+        Self {
+            attempted: 0,
+            attempts: attempts.max(1),
+            delay,
+        }
+    }
+
+    /// How long to wait before making the round trip again, or `None` if this
+    /// failure is the caller's.
+    ///
+    /// Announces the retry it is about to allow, before the wait rather than
+    /// after it, so a watcher hears about a registry misbehaving while it is
+    /// still misbehaving.
+    fn wait_after(&mut self, error: &Error, observer: &Observer) -> Option<Duration> {
+        self.attempted += 1;
+
+        let remaining = self.attempts - self.attempted;
+
+        if remaining == 0 || !is_transient(error) {
+            return None;
+        }
+
+        observer.emit(Event::Retry {
+            attempt: self.attempted,
+            remaining,
+            reason: &error.to_string(),
+        });
+
+        let waiting = self.delay;
+        self.delay = self.delay.saturating_mul(2);
+
+        Some(waiting)
+    }
+}
+
+/// Run a round trip on the caller's thread, making it again while
+/// [`is_transient`] says it is worth it.
+///
+/// `op` does its own `block_on` and is run from a thread that is not the
+/// transport's runtime — the rule the module documentation states — so the wait
+/// is a plain thread sleep. `op` is called again from scratch, which is what
+/// puts any resetting a second attempt needs inside it rather than around it.
+fn retrying<T>(
+    attempts: u32,
+    observer: &Observer,
+    mut op: impl FnMut() -> Result<T, Error>,
+) -> Result<T, Error> {
+    let mut backoff = Backoff::new(attempts, RETRY_DELAY);
+
+    loop {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(error) => match backoff.wait_after(&error, observer) {
+                Some(waiting) => std::thread::sleep(waiting),
+                None => return Err(error),
+            },
+        }
+    }
+}
+
+/// [`retrying`], for a round trip already inside the runtime.
+///
+/// The deferred layer tasks, where the wait must yield the worker rather than
+/// hold it: a thread sleeping here is one of [`Options::concurrency`] threads,
+/// and parking it would stall an upload that has nothing wrong with it.
+///
+/// `op` returns a future that owns everything it touches, for the reason
+/// [`Shared::defer`] gives — and here for a second one: a future that borrowed
+/// the closure could not be built twice.
+async fn retrying_async<T, F, Fut>(
+    attempts: u32,
+    observer: &Observer,
+    mut op: F,
+) -> Result<T, Error>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, Error>>,
+{
+    let mut backoff = Backoff::new(attempts, RETRY_DELAY);
+
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(error) => match backoff.wait_after(&error, observer) {
+                Some(waiting) => tokio::time::sleep(waiting).await,
+                None => return Err(error),
+            },
+        }
+    }
+}
+
+/// A staging file, back at its first byte and ready to be streamed.
+///
+/// A `dup` rather than the file itself, because a stream consumes what it is
+/// given and a second attempt has to read the same bytes again. The two
+/// descriptors share an offset, so the seek here is what rewinds *the* file
+/// however many handles are outstanding — which is sound because only one
+/// attempt of one layer ever reads it at a time.
+fn rewound(staged: &File) -> Result<File, Error> {
+    let mut again = staged.try_clone()?;
+
+    again.seek(SeekFrom::Start(0))?;
+
+    Ok(again)
+}
+
 /// A staged file, created where [`Options::scratch_dir`] said.
 ///
 /// Both calls that can fail against a *named* directory raise
@@ -1083,11 +1332,23 @@ impl Shared {
         scratch_in(self.scratch_dir.as_deref())
     }
 
+    /// [`retrying`], with this transport's own bound and observer.
+    ///
+    /// Every round trip made on a caller's thread goes through here, so the
+    /// policy is stated once and no seam is left out by having been written
+    /// before the policy existed.
+    fn retrying<T>(&self, op: impl FnMut() -> Result<T, Error>) -> Result<T, Error> {
+        retrying(self.attempts, &self.observer(), op)
+    }
+
     fn blob_exists(&self, digest: &Digest) -> Result<bool, Error> {
-        Ok(self.runtime.block_on(
-            self.client
-                .blob_exists(&self.repository, &digest.to_string()),
-        )?)
+        let named = digest.to_string();
+
+        self.retrying(|| {
+            Ok(self
+                .runtime
+                .block_on(self.client.blob_exists(&self.repository, &named))?)
+        })
     }
 
     /// Take a permit, on the caller's thread.
@@ -1135,6 +1396,12 @@ impl Shared {
     /// itself; every call after it reports [`Error::LayerNotWritten`], because
     /// the handles are gone and a join that found nothing outstanding would
     /// otherwise read as "everything landed".
+    ///
+    /// A failure that arrives here has already been retried — each round trip
+    /// was made [`Options::attempts`] times while its staged bytes were still
+    /// in hand, which is the only moment at which the transport can do anything
+    /// about it. So what reaches this point is a registry that means it, and
+    /// permanence is the right answer to it rather than a harsh one.
     fn join_layers(&self) -> Result<(), Error> {
         let handles: Vec<_> = std::mem::take(
             &mut *self
@@ -1194,6 +1461,7 @@ impl Shared {
         let digest = layer.digests.blob_digest;
         let size = layer.digests.compressed_size;
         let observer = self.observer();
+        let attempts = self.attempts;
 
         self.locked().pending.push(layer.clone());
 
@@ -1205,7 +1473,16 @@ impl Shared {
             let _permit = permit;
             let named = digest.to_string();
 
-            if client.blob_exists(&repository, &named).await? {
+            let present = retrying_async(attempts, &observer, || {
+                let client = client.clone();
+                let repository = repository.clone();
+                let named = named.clone();
+
+                async move { Ok(client.blob_exists(&repository, &named).await?) }
+            })
+            .await?;
+
+            if present {
                 // Announced even though nothing moves: "the registry already
                 // had this one" is the blob-skip working, and a watcher that
                 // only heard about uploads would read the whole point of a
@@ -1225,14 +1502,38 @@ impl Shared {
             // Before the upload rather than after it, so a watcher knows how
             // big the transfer it is about to see is while it is still
             // happening.
+            //
+            // Once, however many attempts the upload takes. What a lost attempt
+            // moved is bytes that crossed the wire and are not coming back, so
+            // the deltas can outrun this announcement — which is a fact about
+            // the link, and [`Event::Bytes`] says so where a renderer will read
+            // it.
             observer.emit(Event::Blob {
                 moved: true,
                 bytes: size,
             });
 
-            client
-                .push_blob_stream(&repository, blob_stream(staged, observer), &named)
-                .await?;
+            // The staged bytes are still in hand here, which is the whole
+            // reason this is the right place for the retry: past the join the
+            // layer's only copy is the store it was built from, and the
+            // recovery costs a publish. Rewound per attempt, because the stream
+            // consumes the handle it is given.
+            retrying_async(attempts, &observer, || {
+                let client = client.clone();
+                let repository = repository.clone();
+                let named = named.clone();
+                let observer = observer.clone();
+                let staged = rewound(&staged);
+
+                async move {
+                    client
+                        .push_blob_stream(&repository, blob_stream(staged?, observer), &named)
+                        .await?;
+
+                    Ok(())
+                }
+            })
+            .await?;
 
             let mut state = lock(&state);
             state.transfer.layers_uploaded += 1;
@@ -1255,12 +1556,26 @@ impl Shared {
 
         let client = self.client.clone();
         let repository = self.repository.clone();
+        let observer = self.observer();
+        let attempts = self.attempts;
 
         self.defer(async move {
             let _permit = permit;
             let named = blob.to_string();
 
-            match client.blob_exists(&repository, &named).await? {
+            // The retry is over the round trip and not over the verdict: a
+            // registry that answered "no" answered, and asking a second time is
+            // how a publisher talks itself into carrying a blob that is gone.
+            let present = retrying_async(attempts, &observer, || {
+                let client = client.clone();
+                let repository = repository.clone();
+                let named = named.clone();
+
+                async move { Ok(client.blob_exists(&repository, &named).await?) }
+            })
+            .await?;
+
+            match present {
                 true => Ok(()),
                 false => Err(Error::BlobMissing {
                     kind,
@@ -1278,13 +1593,22 @@ impl Shared {
             return Ok(());
         }
 
-        self.runtime.block_on(self.client.push_blob(
-            &self.repository,
-            bytes,
-            &digest.to_string(),
-        ))?;
+        let named = digest.to_string();
 
-        Ok(())
+        // Into `Bytes` once, so an attempt after the first re-sends the
+        // document rather than re-allocating it: this is the inscription, and
+        // the clone a retry costs should be a refcount.
+        let bytes = bytes::Bytes::from(bytes);
+
+        self.retrying(|| {
+            self.runtime.block_on(self.client.push_blob(
+                &self.repository,
+                bytes.clone(),
+                &named,
+            ))?;
+
+            Ok(())
+        })
     }
 
     /// Fetch a small blob into memory, bounded by the size its descriptor
@@ -1302,16 +1626,26 @@ impl Shared {
         // No observer: the config blob is the inscription, not a layer, and a
         // watcher summing byte deltas against a layer total would find them
         // disagreeing by however large the document is.
-        self.runtime.block_on(self.client.pull_blob(
-            reference,
-            descriptor,
-            Blocking::new(
-                &mut buffer,
-                descriptor.size,
-                &descriptor.digest,
-                Observer::silent(),
-            ),
-        ))?;
+        self.retrying(|| {
+            // Emptied rather than reused, so a second attempt writes the
+            // document and not the document twice. `Blocking` counts from zero
+            // per attempt for the same reason, which it gets by being built
+            // here.
+            buffer.clear();
+
+            self.runtime.block_on(self.client.pull_blob(
+                reference,
+                descriptor,
+                Blocking::new(
+                    &mut buffer,
+                    descriptor.size,
+                    &descriptor.digest,
+                    Observer::silent(),
+                ),
+            ))?;
+
+            Ok(())
+        })?;
 
         Ok(buffer)
     }
@@ -1337,11 +1671,27 @@ impl Shared {
             bytes: descriptor.size.max(0) as u64,
         });
 
-        self.runtime.block_on(self.client.pull_blob(
-            reference,
-            descriptor,
-            Blocking::new(&mut file, descriptor.size, &descriptor.digest, observer),
-        ))?;
+        self.retrying(|| {
+            // Back to empty before each attempt, for the reason a staged layer
+            // is rewound before each of its own: what a half-finished download
+            // left behind is not a prefix of what the next one writes, it is
+            // bytes in front of it.
+            file.set_len(0)?;
+            file.seek(SeekFrom::Start(0))?;
+
+            self.runtime.block_on(self.client.pull_blob(
+                reference,
+                descriptor,
+                Blocking::new(
+                    &mut file,
+                    descriptor.size,
+                    &descriptor.digest,
+                    observer.clone(),
+                ),
+            ))?;
+
+            Ok(())
+        })?;
 
         file.seek(SeekFrom::Start(0))?;
 
@@ -1457,6 +1807,11 @@ impl SteleWriter for Registry {
     /// recovery is another publish rather than another seal. Retrying the seal
     /// is what would produce the one document this transport must never
     /// write — see [`Shared::join_layers`].
+    ///
+    /// Which is why the retry that *can* help is not here but inside the round
+    /// trip, where the staging file has not been spent yet: by the time a
+    /// failure reaches this join it has already been asked
+    /// [`Options::attempts`] times.
     fn seal(&self, profile: &dyn Profile, inscription: &Inscription) -> Result<Digest, Error> {
         // Both tags before either push. Validating the moving tag after the
         // sequence manifest is already public would make a bad tag something
@@ -1507,13 +1862,15 @@ impl Shared {
     fn push_manifest(&self, tag: &str, body: Vec<u8>) -> Result<(), Error> {
         let reference = self.tagged(tag);
 
-        self.runtime.block_on(self.client.push_manifest_raw(
-            &reference,
-            body,
-            http::HeaderValue::from_static(OCI_IMAGE_MEDIA_TYPE),
-        ))?;
+        self.retrying(|| {
+            self.runtime.block_on(self.client.push_manifest_raw(
+                &reference,
+                body.clone(),
+                http::HeaderValue::from_static(OCI_IMAGE_MEDIA_TYPE),
+            ))?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -2110,6 +2467,196 @@ mod tests {
         assert!(is_absent(&server_error(404)));
         assert!(is_absent(&envelope(OciErrorCode::ManifestUnknown)));
         assert!(is_absent(&envelope(OciErrorCode::NameUnknown)));
+    }
+
+    /// A `reqwest` error carrying a status, which is how
+    /// [`oci_client::Client::blob_exists`] reports one.
+    ///
+    /// There is no constructor for one, so it is provoked: a response with the
+    /// status, asked to fail on it. Built on the transport's own runtime kind
+    /// rather than in an async test, because this module's rule is that its
+    /// types are used from synchronous code.
+    fn request_error(code: u16) -> OciDistributionError {
+        let response = http::Response::builder()
+            .status(code)
+            .body(Vec::new())
+            .unwrap();
+
+        let refused = reqwest::Response::from(response)
+            .error_for_status()
+            .expect_err("a status the builder was given was not an error");
+
+        OciDistributionError::RequestError(refused)
+    }
+
+    /// The two shapes worth asking again about, and the several that are not.
+    #[test]
+    fn a_transient_failure_is_the_registry_talking_about_itself() {
+        // The measured class: the create-session `POST` that answers 500 and
+        // works on the next ask.
+        assert!(is_transient(&Error::Registry(server_error(500))));
+        assert!(is_transient(&Error::Registry(server_error(502))));
+        assert!(is_transient(&Error::Registry(server_error(503))));
+
+        // And the same thing seen through `blob_exists`, which asks `reqwest`
+        // for the status instead of mapping it.
+        assert!(is_transient(&Error::Registry(request_error(500))));
+
+        // A refusal of *this* request is not. Repeating it only delays the
+        // report, and `429` is deliberately among them: a registry rationing
+        // this publisher is something its operator has to be told.
+        assert!(!is_transient(&Error::Registry(server_error(400))));
+        assert!(!is_transient(&Error::Registry(server_error(404))));
+        assert!(!is_transient(&Error::Registry(server_error(429))));
+        assert!(!is_transient(&Error::Registry(request_error(429))));
+        assert!(!is_transient(&Error::Registry(envelope(
+            OciErrorCode::DigestInvalid
+        ))));
+        assert!(!is_transient(&Error::Registry(
+            OciDistributionError::UnauthorizedError {
+                url: "https://registry.invalid/v2/".to_owned(),
+            }
+        )));
+
+        // Nor is anything that never involved the far side. A staging file that
+        // would not read reads the same the second time.
+        assert!(!is_transient(&Error::Io(std::io::Error::other("staging"))));
+        assert!(!is_transient(&Error::LayerNotWritten("earlier".to_owned())));
+    }
+
+    /// A recorder for what the retry loop announced.
+    #[derive(Default)]
+    struct Retries(Mutex<Vec<(u32, u32)>>);
+
+    impl crate::progress::Progress for Retries {
+        fn on(&self, event: Event<'_>) {
+            if let Event::Retry {
+                attempt, remaining, ..
+            } = event
+            {
+                self.0.lock().unwrap().push((attempt, remaining));
+            }
+        }
+    }
+
+    /// The loop with the waits taken out, so the bound can be exercised without
+    /// waiting out a real backoff.
+    fn retried<T>(
+        attempts: u32,
+        observer: &Observer,
+        mut op: impl FnMut() -> Result<T, Error>,
+    ) -> Result<T, Error> {
+        let mut backoff = Backoff::new(attempts, Duration::ZERO);
+
+        loop {
+            match op() {
+                Ok(value) => return Ok(value),
+                Err(error) => match backoff.wait_after(&error, observer) {
+                    Some(_) => continue,
+                    None => return Err(error),
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn a_call_that_succeeds_is_made_once() {
+        let mut calls = 0;
+
+        let value = retried(4, &Observer::silent(), || {
+            calls += 1;
+            Ok(7u8)
+        })
+        .unwrap();
+
+        assert_eq!(value, 7);
+        assert_eq!(calls, 1, "a success must not be retried");
+    }
+
+    /// The whole point: the registry's bad half-second costs a half-second and
+    /// not an epoch.
+    #[test]
+    fn a_transient_failure_is_absorbed() {
+        let watcher = Arc::new(Retries::default());
+        let observer = Observer::new(watcher.clone());
+
+        let mut calls = 0;
+
+        let value = retried(4, &observer, || {
+            calls += 1;
+
+            match calls < 3 {
+                true => Err(Error::Registry(server_error(500))),
+                false => Ok(calls),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(value, 3);
+        assert_eq!(calls, 3);
+
+        // And it said so both times, counting the failures up and the patience
+        // down, so a watcher can tell a hiccup from a transport about to give
+        // up.
+        assert_eq!(*watcher.0.lock().unwrap(), vec![(1, 3), (2, 2)]);
+    }
+
+    /// Bounded, so a registry that is wrong rather than flaky still fails —
+    /// and fails as itself, with what it actually said.
+    #[test]
+    fn patience_runs_out_and_the_last_failure_is_the_one_reported() {
+        let watcher = Arc::new(Retries::default());
+        let observer = Observer::new(watcher.clone());
+
+        let mut calls = 0;
+
+        let refused = retried(4, &observer, || {
+            calls += 1;
+            Err::<(), _>(Error::Registry(server_error(500)))
+        })
+        .expect_err("a registry that never answered was treated as having answered");
+
+        assert_eq!(calls, 4, "the bound is attempts, not retries");
+        assert!(matches!(refused, Error::Registry(_)));
+
+        // Three retries for four attempts, and nothing announced for the last
+        // failure — there was no next attempt to announce.
+        assert_eq!(*watcher.0.lock().unwrap(), vec![(1, 3), (2, 2), (3, 1)]);
+    }
+
+    /// A refusal of this request is reported the first time it is made.
+    #[test]
+    fn a_refusal_of_this_request_is_not_retried() {
+        let watcher = Arc::new(Retries::default());
+        let observer = Observer::new(watcher.clone());
+
+        let mut calls = 0;
+
+        let refused = retried(4, &observer, || {
+            calls += 1;
+            Err::<(), _>(Error::Registry(envelope(OciErrorCode::DigestInvalid)))
+        })
+        .expect_err("a digest the registry rejected was retried");
+
+        assert_eq!(calls, 1, "a refusal must cost one round trip");
+        assert!(matches!(refused, Error::Registry(_)));
+        assert!(watcher.0.lock().unwrap().is_empty());
+    }
+
+    /// `0` attempts is one attempt, for the reason `0` concurrency is one
+    /// permit: a transport that would make no attempt at all is not a
+    /// configuration anybody means.
+    #[test]
+    fn no_attempts_at_all_is_still_one_attempt() {
+        let mut calls = 0;
+
+        let refused = retried(0, &Observer::silent(), || {
+            calls += 1;
+            Err::<(), _>(Error::Registry(server_error(500)))
+        });
+
+        assert_eq!(calls, 1);
+        assert!(refused.is_err());
     }
 
     fn repository(raw: &str) -> Result<Repository, Error> {

--- a/crates/stelae/src/progress.rs
+++ b/crates/stelae/src/progress.rs
@@ -31,6 +31,13 @@
 //!   driver reports nothing for the entire duration of a download, which on the
 //!   restore side is the entire operation.
 //!
+//! The two halves are not in step, and on the publish side they are
+//! deliberately not: the transport moves a layer's blob concurrently with the
+//! driver building the next one, so a blob's bytes arrive after the driver has
+//! already closed the layer they belong to. Everything is reported before the
+//! operation returns — that is what the seal's join buys — and nothing about
+//! the order in between is promised.
+//!
 //! The transports answer through [`SteleWriter::observe`] and
 //! [`SteleReader::observe`], which have default no-op bodies: reporting is
 //! something a transport *may* do, not a tax every implementation pays.
@@ -180,11 +187,25 @@ pub enum Event<'a> {
     /// both directions — from the digest pipeline on the way up, from the
     /// manifest on the way down — so a watcher can size the transfer it is
     /// about to see. `moved` is false when nothing will cross the wire because
-    /// the far side already holds it, and no [`Event::Bytes`] follows.
+    /// the far side already holds it, and no [`Event::Bytes`] follows for it.
+    ///
+    /// **Several of these can be outstanding at once, and one is not finished
+    /// when the next arrives.** A publish runs its layer round trips
+    /// concurrently, so what this announces is one more blob the transfer has
+    /// taken on rather than the blob the transfer is now on. A renderer that
+    /// reset a per-blob bar here would show eight uploads fighting over one
+    /// bar; the shape that reads correctly is a running total, and the totals
+    /// are exact because every announced blob is accounted for before the
+    /// operation that announced it returns.
     Blob { moved: bool, bytes: u64 },
 
-    /// Compressed bytes that crossed the wire since the last one of these,
-    /// for the blob the most recent [`Event::Blob`] announced.
+    /// Compressed bytes that crossed the wire since the last one of these.
+    ///
+    /// Across every blob the transport currently has in flight, and not for the
+    /// blob the most recent [`Event::Blob`] announced — see there. A publish
+    /// that is uploading eight layers at once reports one stream of deltas,
+    /// because the thing an operator is watching is the link and not one of the
+    /// eight.
     Bytes(u64),
 }
 

--- a/crates/stelae/src/progress.rs
+++ b/crates/stelae/src/progress.rs
@@ -206,7 +206,35 @@ pub enum Event<'a> {
     /// that is uploading eight layers at once reports one stream of deltas,
     /// because the thing an operator is watching is the link and not one of the
     /// eight.
+    ///
+    /// **These can total more than the blobs announced.** A round trip the
+    /// registry failed is made again from the blob's first byte, and the bytes
+    /// the lost attempt moved were still moved — see [`Event::Retry`]. So a
+    /// renderer keeping a running total holds the total to at least the
+    /// position rather than assuming the announcements bound it; what it is
+    /// reporting is the link, and the link carried them.
     Bytes(u64),
+
+    /// A round trip that failed in a way the transport answered by making it
+    /// again.
+    ///
+    /// Emitted before the wait, once per attempt that was thrown away, and it
+    /// is the only trace a retry leaves: a transport that quietly absorbed a
+    /// registry's `5xx` would turn "this registry is unwell" into "publishes
+    /// got slower", which is the diagnosis nobody can act on. A publisher's
+    /// business is to make progress anyway; an operator's is to know it had
+    /// to.
+    ///
+    /// `attempt` is the one that just failed, counting from one; `remaining` is
+    /// how many are left after it, so a watcher can tell a hiccup from a
+    /// transport about to give up. `reason` is the failure as it rendered
+    /// itself, because what an operator reads is the binary's business and not
+    /// this crate's.
+    Retry {
+        attempt: u32,
+        remaining: u32,
+        reason: &'a str,
+    },
 }
 
 #[cfg(test)]

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -103,6 +103,7 @@ use stelae::{
         build_manifest, manifest_bytes, read_manifest, Auth, Options, Registry, DIFF_ID_ANNOTATION,
         KIND_ANNOTATION, SCOPE_ANNOTATION,
     },
+    progress::{Event, Observer, Progress},
     Compression, Digest, Error, HistoryEntry, Inscription, LayerDigests, LayerSpec, Profile,
     RecordSink, SteleReader, SteleWriter, WrittenLayer,
 };
@@ -2129,6 +2130,13 @@ fn a_publish_dropped_mid_flight_leaves_the_previous_stele_standing() {
 ///    transport must never write, and it is exactly the document a concurrent
 ///    publish makes reachable — so the refusal is remembered rather than
 ///    recomputed.
+/// 3. **The failure was retried first, and said so.** A connection nobody
+///    answers is the transient class, so the round trip is made again before it
+///    is anybody's failure — and the retry is announced, because a transport
+///    that absorbed a registry's bad minute in silence would have hidden the
+///    measurement that motivated absorbing it. Two attempts here rather than
+///    the default four, so the test proves the loop runs without waiting out
+///    the whole of its patience.
 #[test]
 fn a_deferred_upload_that_fails_fails_every_seal() {
     let _serial = exclusive();
@@ -2147,10 +2155,14 @@ fn a_deferred_upload_that_fails_fails_every_seal() {
         Options {
             insecure: true,
             concurrency: 4,
+            attempts: 2,
             ..Default::default()
         },
     )
     .unwrap();
+
+    let retries = std::sync::Arc::new(Retries::default());
+    registry.observe(Observer::new(retries.clone()));
 
     let (header, scope) = notes_scope(1);
     let notes: Vec<CanonicalCbor> = (1..=3).map(note_record).collect();
@@ -2204,6 +2216,37 @@ fn a_deferred_upload_that_fails_fails_every_seal() {
     assert!(!why.is_empty(), "the refusal names no cause");
 
     println!("and every seal after it: {again}");
+
+    // One round trip was deferred — the existence check for the one layer — and
+    // it was made twice. The second seal had nothing outstanding to retry, so
+    // this also says the sticky refusal is answered without touching the
+    // network again.
+    assert_eq!(
+        retries.seen(),
+        vec![(1, 1)],
+        "a refused connection was not retried before the layer was declared lost",
+    );
+}
+
+/// What a transport said about the round trips it made again.
+#[derive(Default)]
+struct Retries(Mutex<Vec<(u32, u32)>>);
+
+impl Progress for Retries {
+    fn on(&self, event: Event<'_>) {
+        if let Event::Retry {
+            attempt, remaining, ..
+        } = event
+        {
+            self.0.lock().unwrap().push((attempt, remaining));
+        }
+    }
+}
+
+impl Retries {
+    fn seen(&self) -> Vec<(u32, u32)> {
+        self.0.lock().unwrap().clone()
+    }
 }
 
 /// The annotation map is a `BTreeMap`, so the canonical JSON above is not

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1997,7 +1997,14 @@ fn a_verified_carry_refuses_a_blob_the_repository_does_not_hold() {
 /// blobs happened to land in.
 ///
 /// Two repositories in one registry rather than two registries, so the
-/// comparison is not also comparing two servers.
+/// comparison is not also comparing two servers — with the one consequence
+/// that the *counters* cannot be compared to each other. `zot` addresses
+/// blobs across the whole registry rather than per repository, as
+/// [`a_verified_carry_refuses_a_blob_the_repository_does_not_hold`] documents
+/// at more length, so on that registry the second publish skips what the first
+/// one uploaded. What is asserted instead is the property that holds on either
+/// kind and is the one worth having: every layer and every byte the stele
+/// describes is accounted for, whichever way the registry answered.
 #[test]
 #[ignore = "spawns a registry"]
 fn concurrency_changes_the_cost_of_a_publish_and_not_the_stele() {
@@ -2027,11 +2034,29 @@ fn concurrency_changes_the_cost_of_a_publish_and_not_the_stele() {
         "the manifests differ",
     );
 
+    // The serial publish is the first into this registry, so nothing can have
+    // been there before it: two layers, both uploaded.
+    let counted = serial.transfer();
+
+    assert_eq!(counted.layers_uploaded, one.layers.len() as u64);
+    assert_eq!(counted.layers_skipped, 0);
+
+    // And the concurrent one accounts for exactly the same layers and the same
+    // bytes, however the registry split them between "uploaded" and "the far
+    // side already had it".
+    let against = concurrent.transfer();
+
     assert_eq!(
-        serial.transfer(),
-        concurrent.transfer(),
-        "the transfers differ",
+        against.layers_uploaded + against.layers_skipped,
+        counted.layers_uploaded + counted.layers_skipped,
+        "a layer went unaccounted for",
     );
+    assert_eq!(
+        against.bytes_uploaded + against.bytes_skipped,
+        counted.bytes_uploaded + counted.bytes_skipped,
+        "the bytes do not add up",
+    );
+    assert_eq!(against.layers_reused, 0, "nothing was carried forward");
 
     // And it reads back, which is the property the manifest exists to serve.
     let inscription = from_concurrent.read_inscription().unwrap();

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -100,8 +100,8 @@ use stelae::{
     frame::{encode, CanonicalCbor, Limits},
     inscription::LayerDescriptor,
     oci::{
-        build_manifest, manifest_bytes, read_manifest, Auth, Options, Registry, Transfer,
-        DIFF_ID_ANNOTATION, KIND_ANNOTATION, SCOPE_ANNOTATION,
+        build_manifest, manifest_bytes, read_manifest, Auth, Options, Registry, DIFF_ID_ANNOTATION,
+        KIND_ANNOTATION, SCOPE_ANNOTATION,
     },
     Compression, Digest, Error, HistoryEntry, Inscription, LayerDigests, LayerSpec, Profile,
     RecordSink, SteleReader, SteleWriter, WrittenLayer,
@@ -839,6 +839,20 @@ impl Fixture {
         self.registry_staging_in(repository, None)
     }
 
+    /// The same transport, with the publish path's concurrency named.
+    ///
+    /// Only the tests whose subject is the concurrency itself set it; every
+    /// other test in this file runs at the default, which is the arrangement
+    /// the deployment uses.
+    fn registry_at(&self, repository: &str, concurrency: usize) -> Registry {
+        self.options(repository, |options| options.concurrency = concurrency)
+    }
+
+    /// The same transport, re-proving every layer it carries forward.
+    fn verifying(&self, repository: &str) -> Registry {
+        self.options(repository, |options| options.verify_adopted = true)
+    }
+
     /// Every transport in this file is built here, so that whether the fixture
     /// is speaking TLS — and which credentials it presents — is decided in
     /// exactly one place. A test that assembled its own [`Options`] to set a
@@ -890,20 +904,44 @@ impl Fixture {
     }
 
     fn registry_as(&self, repository: &str, scratch_dir: Option<PathBuf>, auth: Auth) -> Registry {
+        self.open(repository, scratch_dir, auth, |_| {})
+    }
+
+    /// The fixture's own transport, with one thing about it changed.
+    ///
+    /// The knob the tests below reach for. Spelled as an edit rather than as
+    /// another argument so that a test naming the concurrency does not also
+    /// have to restate the credentials and the scheme this fixture decided.
+    fn options(&self, repository: &str, set: impl FnOnce(&mut Options)) -> Registry {
+        self.open(repository, None, self.credentials(), set)
+    }
+
+    fn open(
+        &self,
+        repository: &str,
+        scratch_dir: Option<PathBuf>,
+        auth: Auth,
+        set: impl FnOnce(&mut Options),
+    ) -> Registry {
         let repository = match &self.server {
             Server::Container { .. } => repository.to_owned(),
             Server::Remote { namespace, .. } => format!("{namespace}/{repository}"),
         };
 
+        let mut options = Options {
+            insecure: !self.tls,
+            scratch_dir,
+            auth,
+            ..Default::default()
+        };
+
+        set(&mut options);
+
         Registry::open(
             &format!("oci://{}/{repository}", self.address())
                 .parse()
                 .expect("the fixture named a usable repository"),
-            Options {
-                insecure: !self.tls,
-                scratch_dir,
-                auth,
-            },
+            options,
         )
         .unwrap()
     }
@@ -971,33 +1009,39 @@ impl Drop for Fixture {
 /// what goes in the index layer, which is how the delta test makes two steles
 /// that share a blob and differ in one.
 fn write_stele<W: SteleWriter>(stele: &W, chapter: u64) -> Inscription {
+    write_stele_fallibly(stele, chapter).unwrap()
+}
+
+/// The same publish, with every refusal handed back rather than unwrapped.
+///
+/// For the tests whose subject *is* a refusal. Split out rather than made the
+/// only spelling because the twenty callers that expect a stele would each
+/// grow an `.unwrap()` that says nothing, and the one that does not would stop
+/// standing out.
+fn write_stele_fallibly<W: SteleWriter>(stele: &W, chapter: u64) -> Result<Inscription, Error> {
     let (notes_header, notes_scope) = notes_scope(3);
     let (index_header, index_scope) = index_scope(chapter);
 
     let notes: Vec<CanonicalCbor> = (1..=3).map(note_record).collect();
 
-    let written_notes = stele
-        .write_layer(
-            &ToyProfile,
-            &LayerSpec::new("notes", notes_header, notes_scope),
-            COMPRESSION_LEVEL,
-            &notes,
-        )
-        .unwrap();
+    let written_notes = stele.write_layer(
+        &ToyProfile,
+        &LayerSpec::new("notes", notes_header, notes_scope),
+        COMPRESSION_LEVEL,
+        &notes,
+    )?;
 
-    let mut sink = stele
-        .layer_sink(
-            &ToyProfile,
-            &LayerSpec::new("index", index_header, index_scope),
-            COMPRESSION_LEVEL,
-        )
-        .unwrap();
+    let mut sink = stele.layer_sink(
+        &ToyProfile,
+        &LayerSpec::new("index", index_header, index_scope),
+        COMPRESSION_LEVEL,
+    )?;
 
     for id in 1..=chapter {
-        sink.write_record(&note_record(id)).unwrap();
+        sink.write_record(&note_record(id))?;
     }
 
-    let written_index = sink.finish().unwrap();
+    let written_index = sink.finish()?;
 
     let mut inscription = Inscription::new(
         &ToyProfile,
@@ -1012,9 +1056,9 @@ fn write_stele<W: SteleWriter>(stele: &W, chapter: u64) -> Inscription {
 
     inscription.layers = vec![written_notes.descriptor, written_index.descriptor];
 
-    stele.seal(&ToyProfile, &inscription).unwrap();
+    stele.seal(&ToyProfile, &inscription)?;
 
-    inscription
+    Ok(inscription)
 }
 
 /// Every record of every layer, read back through the streaming reader.
@@ -1843,40 +1887,28 @@ fn the_read_only_pair_pulls_and_cannot_push() {
     assert_eq!(inscription, published);
     records_of(&stele, &inscription);
 
-    let (header, scope) = notes_scope(4);
-    let refused = reading
-        .layer_sink(
-            &ToyProfile,
-            &LayerSpec::new("notes", header, scope),
-            COMPRESSION_LEVEL,
-        )
-        .and_then(|mut sink| {
-            sink.write_record(&note_record(1))?;
-            sink.finish().map(|_| ())
-        })
-        .expect_err("a pull-only pair was allowed to upload a layer");
+    // Through the seal, because that is where an upload's refusal is now
+    // reported: `finish` closes the layer and hands the round trips to the
+    // pool, so the credential is not asked about them until they are joined.
+    // The claim is unchanged — this pair cannot put a stele in this
+    // repository — and the seal is the honest place to make it, since a
+    // publish that seals is a publish that happened.
+    let refused = write_stele_fallibly(&reading, 4)
+        .expect_err("a pull-only pair was allowed to publish a stele");
 
     println!("write through the pull-only pair: {refused}");
 }
 
-/// A layer cannot be carried forward into a repository that does not hold its
-/// blob.
+/// Carrying a layer forward costs nothing and asks nothing.
 ///
-/// The guard exists because the failure it prevents is invisible: a manifest
-/// pointing at a reclaimed blob is a perfectly well-formed stele that nobody
-/// can restore.
-///
-/// **Provoked with a second registry, not a second repository**, and the
-/// difference is a real one this test found. `zot` answers `HEAD` *and* `GET`
-/// for a blob under a repository it was never pushed to — its storage is
-/// content-addressed across the whole registry — while `distribution` 2.8 and
-/// 3.0 answer 404. So a sibling repository is not reliably a place a blob is
-/// absent from, and on `zot` it would not even be the wrong answer: a registry
-/// that will serve the blob is a registry where the manifest works. Only a
-/// separate server is absent everywhere.
+/// The default, and the reason the publish path stopped getting slower with
+/// every epoch behind it: `source` is a stele this transport pulled, its
+/// manifest is live under a tag, and a registry may not reclaim a blob in that
+/// position. So the layer is carried on the manifest's word — no round trip,
+/// no bytes — and only the counters move.
 #[test]
 #[ignore = "spawns a registry"]
-fn a_layer_whose_blob_is_not_there_cannot_be_carried_forward() {
+fn a_layer_is_carried_forward_on_the_manifest_that_names_it() {
     let _serial = exclusive();
 
     let fixture = Fixture::spawn();
@@ -1885,18 +1917,6 @@ fn a_layer_whose_blob_is_not_there_cannot_be_carried_forward() {
     let published = write_stele(&source, 3);
     let stele = source.latest(&ToyProfile).unwrap().unwrap();
 
-    let somewhere_else = Fixture::spawn();
-    let elsewhere = somewhere_else.registry("stelae/source");
-
-    let err = elsewhere
-        .adopt_layer(&stele, published.layers[0].clone())
-        .unwrap_err();
-
-    assert!(matches!(err, Error::BlobMissing { .. }), "{err:?}");
-    assert_eq!(elsewhere.transfer(), Transfer::default(), "nothing counted");
-
-    // The same call against the repository that does hold it is the whole
-    // operation: no bytes move, and the layer is counted as carried forward.
     // Reset first, so what is read back is this call's cost and not the two
     // layers `write_stele` pushed through the same transport.
     source.take_transfer();
@@ -1910,6 +1930,255 @@ fn a_layer_whose_blob_is_not_there_cannot_be_carried_forward() {
     assert_eq!(transfer.layers_reused, 1);
     assert_eq!(transfer.layers_uploaded, 0);
     assert!(transfer.bytes_reused > 0);
+}
+
+/// An operator who does not trust the repository's retention gets the check
+/// back, and it still lands before the manifest does.
+///
+/// This is the guarantee `verify_adopted` exists for, and the failure it
+/// prevents is invisible without it: a manifest pointing at a reclaimed blob is
+/// a perfectly well-formed stele that nobody can restore. What has moved is
+/// *when* the refusal is reported — the `HEAD` runs concurrently with the rest
+/// of the publish and is joined at the seal — and what has not moved is that
+/// the refusal comes before anything is tagged.
+///
+/// **Provoked with a second registry, not a second repository**, and the
+/// difference is a real one this test found. `zot` answers `HEAD` *and* `GET`
+/// for a blob under a repository it was never pushed to — its storage is
+/// content-addressed across the whole registry — while `distribution` 2.8 and
+/// 3.0 answer 404. So a sibling repository is not reliably a place a blob is
+/// absent from, and on `zot` it would not even be the wrong answer: a registry
+/// that will serve the blob is a registry where the manifest works. Only a
+/// separate server is absent everywhere.
+#[test]
+#[ignore = "spawns a registry"]
+fn a_verified_carry_refuses_a_blob_the_repository_does_not_hold() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    let source = fixture.registry("stelae/source");
+    let published = write_stele(&source, 3);
+    let stele = source.latest(&ToyProfile).unwrap().unwrap();
+
+    let somewhere_else = Fixture::spawn();
+    let elsewhere = somewhere_else.verifying("stelae/source");
+
+    // The descriptor is handed back: nothing has been asked yet, and what the
+    // caller holds is a fact about bytes rather than a promise about a
+    // registry.
+    elsewhere
+        .adopt_layer(&stele, published.layers[0].clone())
+        .unwrap();
+
+    // The seal is where the promise is collected, and it is refused.
+    let mut inscription = published.clone();
+    inscription.layers = vec![published.layers[0].clone()];
+
+    let err = elsewhere.seal(&ToyProfile, &inscription).unwrap_err();
+
+    assert!(matches!(err, Error::BlobMissing { .. }), "{err:?}");
+
+    // And nothing was published: the moving tag in a repository that never had
+    // a stele still resolves to nothing.
+    assert!(
+        elsewhere.latest(&ToyProfile).unwrap().is_none(),
+        "a refused seal tagged a manifest anyway",
+    );
+}
+
+/// Concurrency changes what a publish costs and nothing about what it
+/// produces.
+///
+/// The claim the whole change rests on. The same records, published through the
+/// serial path and through eight-way concurrency, must give the same
+/// inscription — the same identity — the same manifest bytes, and the same
+/// transfer counters, because none of those is a function of the order the
+/// blobs happened to land in.
+///
+/// Two repositories in one registry rather than two registries, so the
+/// comparison is not also comparing two servers.
+#[test]
+#[ignore = "spawns a registry"]
+fn concurrency_changes_the_cost_of_a_publish_and_not_the_stele() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    let serial = fixture.registry_at("stelae/serial", 1);
+    let concurrent = fixture.registry_at("stelae/concurrent", 8);
+
+    let one = write_stele(&serial, 5);
+    let other = write_stele(&concurrent, 5);
+
+    assert_eq!(one, other, "the inscriptions differ");
+    assert_eq!(
+        one.digest().unwrap(),
+        other.digest().unwrap(),
+        "the identities differ",
+    );
+
+    let from_serial = serial.pull_latest(&ToyProfile).unwrap();
+    let from_concurrent = concurrent.pull_latest(&ToyProfile).unwrap();
+
+    assert_eq!(
+        manifest_bytes(from_serial.manifest()).unwrap(),
+        manifest_bytes(from_concurrent.manifest()).unwrap(),
+        "the manifests differ",
+    );
+
+    assert_eq!(
+        serial.transfer(),
+        concurrent.transfer(),
+        "the transfers differ",
+    );
+
+    // And it reads back, which is the property the manifest exists to serve.
+    let inscription = from_concurrent.read_inscription().unwrap();
+
+    assert_eq!(inscription, one);
+    records_of(&from_concurrent, &inscription);
+}
+
+/// A publish abandoned while its layers are still in flight leaves the stele
+/// before it standing.
+///
+/// The concurrent path's version of the ordering argument, and the reason the
+/// join is at the seal rather than anywhere later: layers go up in parallel,
+/// but nothing is tagged until all of them are up, so a publisher that dies in
+/// the middle — here, a transport dropped without a seal — leaves untagged
+/// blobs the registry reclaims and a moving tag still pointing at a stele that
+/// restores.
+#[test]
+#[ignore = "spawns a registry"]
+fn a_publish_dropped_mid_flight_leaves_the_previous_stele_standing() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    let standing = write_stele(&fixture.registry("stelae/abandoned"), 3);
+
+    {
+        let abandoning = fixture.registry_at("stelae/abandoned", 8);
+
+        let (header, scope) = notes_scope(4);
+        let mut sink = abandoning
+            .layer_sink(
+                &ToyProfile,
+                &LayerSpec::new("notes", header, scope),
+                COMPRESSION_LEVEL,
+            )
+            .unwrap();
+
+        for id in 1..=64 {
+            sink.write_record(&note_record(id)).unwrap();
+        }
+
+        sink.finish().unwrap();
+
+        // And dropped here, with the upload deferred and no seal to join it.
+    }
+
+    let reopened = fixture.registry("stelae/abandoned");
+    let stele = reopened.pull_latest(&ToyProfile).unwrap();
+
+    assert_eq!(stele.read_inscription().unwrap(), standing);
+}
+
+/// A deferred upload's failure is the seal's failure, and it stays the seal's
+/// failure.
+///
+/// No registry: the transport is pointed at a port nothing is listening on, so
+/// every round trip it defers is refused. That is enough to hold the two
+/// properties that matter about the deferral, and it holds them under plain
+/// `cargo test` rather than only where a container can be spawned.
+///
+/// 1. **`finish` succeeds.** Closing a layer is a fact about bytes the sink
+///    already has; a transport that could not reach the registry still hands
+///    back the descriptor, because the caller's next act is to read more of its
+///    store and not to wait on a socket.
+/// 2. **`seal` fails, and every seal after it fails too.** The join empties the
+///    handles it awaited, so a transport that forgot would find nothing
+///    outstanding the second time, agree that every layer was up, and publish a
+///    manifest naming a blob that never landed. That is the one document this
+///    transport must never write, and it is exactly the document a concurrent
+///    publish makes reachable — so the refusal is remembered rather than
+///    recomputed.
+#[test]
+fn a_deferred_upload_that_fails_fails_every_seal() {
+    let _serial = exclusive();
+
+    install_crypto_provider();
+
+    // Bound and dropped: the kernel just told us a port nobody has, and
+    // refusing a connection is faster and more portable than any other way of
+    // failing one.
+    let closed = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = closed.local_addr().unwrap();
+    drop(closed);
+
+    let registry = Registry::open(
+        &format!("oci://{address}/stelae/nowhere").parse().unwrap(),
+        Options {
+            insecure: true,
+            concurrency: 4,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let (header, scope) = notes_scope(1);
+    let notes: Vec<CanonicalCbor> = (1..=3).map(note_record).collect();
+
+    let written = registry
+        .write_layer(
+            &ToyProfile,
+            &LayerSpec::new("notes", header, scope),
+            COMPRESSION_LEVEL,
+            &notes,
+        )
+        .expect("closing a layer waited on the registry");
+
+    let mut inscription = Inscription::new(
+        &ToyProfile,
+        1,
+        json!({"chapter": 1}),
+        json!({"noteWidth": 40}),
+        Compression {
+            algo: "zstd".to_owned(),
+            level: COMPRESSION_LEVEL as i64,
+        },
+    );
+
+    inscription.layers = vec![written.descriptor];
+
+    let refused = registry
+        .seal(&ToyProfile, &inscription)
+        .expect_err("sealed against a port nothing is listening on");
+
+    println!("the seal collected the deferred failure: {refused}");
+
+    // And it is remembered: nothing is outstanding any more, so a transport
+    // that only asked what was in flight would seal this stele over a blob that
+    // never landed.
+    let again = registry
+        .seal(&ToyProfile, &inscription)
+        .expect_err("the second seal published a manifest over a blob that never landed");
+
+    assert!(
+        matches!(again, Error::LayerNotWritten(_)),
+        "the second seal did not remember the first: {again:?}",
+    );
+
+    // Carrying the cause, so the operator reading the second refusal is not
+    // told less than the one who read the first.
+    let Error::LayerNotWritten(why) = &again else {
+        unreachable!()
+    };
+
+    assert!(!why.is_empty(), "the refusal names no cause");
+
+    println!("and every seal after it: {again}");
 }
 
 /// The annotation map is a `BTreeMap`, so the canonical JSON above is not

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -2193,6 +2193,16 @@ fn a_deferred_upload_that_fails_fails_every_seal() {
         .seal(&ToyProfile, &inscription)
         .expect_err("sealed against a port nothing is listening on");
 
+    // The *cause*, not the sticky refusal — and asserting which way round that
+    // is, is the point. `LayerNotWritten` is what every seal *after* this one
+    // answers; a first seal that reported it would have thrown away what the
+    // network actually said, leaving an operator to debug a connection failure
+    // from a message about a layer.
+    assert!(
+        matches!(refused, Error::Registry(_)),
+        "the first seal reported the refusal instead of its cause: {refused:?}",
+    );
+
     println!("the seal collected the deferred failure: {refused}");
 
     // And it is remembered: nothing is outstanding any more, so a transport

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -238,7 +238,7 @@ fn restore_repo(
 
     let scratch = crate::common::stele_scratch_dir(&config.storage, scratch_dir);
 
-    let registry = registry::open(repo, insecure, auth, scratch)
+    let registry = registry::open(repo, insecure, auth, scratch, registry::Tuning::default())
         .into_diagnostic()
         .context("opening the repository")?;
 
@@ -524,8 +524,12 @@ mod progress_tests {
         assert_eq!(progress.layers_position(), PER_RESTORE as u64);
         assert_eq!(progress.layers_length(), Some(PER_RESTORE as u64));
 
-        assert_eq!(progress.blob_position(), 8_192);
-        assert_eq!(progress.blob_length(), Some(8_192));
+        // A running total over every blob the restore pulled, rather than the
+        // last one's size — see `SteleProgress`.
+        let pulled = (PER_RESTORE as u64 - 1) * 8_192;
+
+        assert_eq!(progress.blob_position(), pulled);
+        assert_eq!(progress.blob_length(), Some(pulled));
 
         assert_eq!(
             progress.records_position(),

--- a/src/bin/dolos/feedback.rs
+++ b/src/bin/dolos/feedback.rs
@@ -263,13 +263,22 @@ impl Progress for SteleProgress {
             // up front on the publish side — a layer's compressed size exists
             // only once it has been compressed — so a cumulative bar would show
             // a length that grew as it filled.
+            // A running total rather than a bar per blob. A publish moves
+            // several layers at once, so "the blob in flight" is not a single
+            // thing and a bar reset here would be eight uploads overwriting
+            // each other; what an operator is watching is the link. The total
+            // grows as the transfer takes blobs on, which is what makes the
+            // rate and the estimate honest without the transport having to know
+            // the whole stele's weight up front.
             Event::Blob { moved, bytes } => {
-                self.blob.set_position(0);
-                self.blob.set_length(bytes);
+                self.blob.inc_length(bytes);
 
-                match moved {
-                    true => self.blob.set_message(""),
-                    false => self.blob.set_message("already in the registry"),
+                // Counted as done the moment it is announced: nothing will
+                // cross the wire for it, and a bar whose total grew by bytes
+                // that are never coming would stall a little further from the
+                // end with every blob the far side already held.
+                if !moved {
+                    self.blob.inc(bytes);
                 }
             }
 
@@ -343,26 +352,41 @@ mod tests {
         assert_eq!(progress.layers.length(), Some(4));
     }
 
+    /// The byte bar totals the run, and a blob nothing moves for is counted
+    /// done rather than pending.
+    ///
+    /// The interleaving is the point of the first half: two blobs are announced
+    /// before either finishes, exactly as a concurrent publish announces them,
+    /// and the deltas that follow belong to whichever of the two produced them.
+    /// A bar that reset per blob would answer 40 here.
     #[test]
-    fn a_blob_bar_is_per_blob_and_a_skip_moves_nothing() {
+    fn the_byte_bar_totals_the_run_across_blobs_in_flight() {
         let progress = hidden("publishing");
 
         progress.on(Event::Blob {
             moved: true,
             bytes: 300,
         });
+        progress.on(Event::Blob {
+            moved: true,
+            bytes: 100,
+        });
+
         progress.on(Event::Bytes(120));
         progress.on(Event::Bytes(180));
+        progress.on(Event::Bytes(100));
 
-        assert_eq!(progress.blob.position(), 300);
-        assert_eq!(progress.blob.length(), Some(300));
+        assert_eq!(progress.blob.position(), 400);
+        assert_eq!(progress.blob.length(), Some(400));
 
+        // And a blob the far side already holds lands on both sides at once, so
+        // the bar stays where it was rather than falling behind by its size.
         progress.on(Event::Blob {
             moved: false,
             bytes: 50,
         });
 
-        assert_eq!(progress.blob.position(), 0);
-        assert_eq!(progress.blob.length(), Some(50));
+        assert_eq!(progress.blob.position(), 450);
+        assert_eq!(progress.blob.length(), Some(450));
     }
 }

--- a/src/bin/dolos/feedback.rs
+++ b/src/bin/dolos/feedback.rs
@@ -259,10 +259,6 @@ impl Progress for SteleProgress {
 
             Event::Records(moved) => self.records.inc(moved),
 
-            // Per blob, not per run: the total a run will move is not knowable
-            // up front on the publish side — a layer's compressed size exists
-            // only once it has been compressed — so a cumulative bar would show
-            // a length that grew as it filled.
             // A running total rather than a bar per blob. A publish moves
             // several layers at once, so "the blob in flight" is not a single
             // thing and a bar reset here would be eight uploads overwriting

--- a/src/bin/dolos/feedback.rs
+++ b/src/bin/dolos/feedback.rs
@@ -278,7 +278,37 @@ impl Progress for SteleProgress {
                 }
             }
 
-            Event::Bytes(moved) => self.blob.inc(moved),
+            // The total is held to at least the position rather than trusted
+            // to bound it. A round trip the registry failed is made again from
+            // the blob's first byte, and what the lost attempt moved is bytes
+            // that crossed the wire — so the deltas can outrun the
+            // announcements by however far the failure got. Taking the total up
+            // to meet them is what the bar means: the link carried that much.
+            Event::Bytes(moved) => {
+                self.blob.inc(moved);
+
+                let position = self.blob.position();
+
+                if self.blob.length().is_some_and(|total| total < position) {
+                    self.blob.set_length(position);
+                }
+            }
+
+            // Said out loud rather than absorbed. The whole point of retrying
+            // is that the run survives a registry's bad minute, and the whole
+            // risk of retrying is that nobody finds out it had one — a `500`
+            // per hour is a fact about the registry, and it reaches an operator
+            // through the run log or not at all.
+            Event::Retry {
+                attempt,
+                remaining,
+                reason,
+            } => tracing::warn!(
+                attempt,
+                remaining,
+                reason,
+                "the registry failed a round trip; making it again",
+            ),
         }
     }
 }
@@ -384,5 +414,35 @@ mod tests {
 
         assert_eq!(progress.blob.position(), 450);
         assert_eq!(progress.blob.length(), Some(450));
+    }
+
+    /// A blob the registry failed part way through is sent again from its first
+    /// byte, so the deltas outrun the announcement — and the total goes up to
+    /// meet them rather than the bar sitting past its own end.
+    ///
+    /// The arithmetic is the point: 120 bytes of a 300-byte blob went out
+    /// before the round trip died, the retry sent all 300, and 420 bytes really
+    /// did cross the wire for a blob that was announced once.
+    #[test]
+    fn a_retried_blob_takes_the_total_up_to_what_the_link_carried() {
+        let progress = hidden("publishing");
+
+        progress.on(Event::Blob {
+            moved: true,
+            bytes: 300,
+        });
+
+        progress.on(Event::Bytes(120));
+
+        progress.on(Event::Retry {
+            attempt: 1,
+            remaining: 3,
+            reason: "the registry said 500",
+        });
+
+        progress.on(Event::Bytes(300));
+
+        assert_eq!(progress.blob.position(), 420);
+        assert_eq!(progress.blob.length(), Some(420));
     }
 }

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -47,7 +47,10 @@ use std::sync::Arc;
 use clap::Parser;
 use dolos_core::config::RootConfig;
 use dolos_core::{Domain as _, DomainError, ImportExt as _, StateStore as _, WalStore as _};
-use dolos_snapshot::{export, registry::Repository};
+use dolos_snapshot::{
+    export,
+    registry::{self, Repository},
+};
 use indicatif::ProgressBar;
 use itertools::Itertools as _;
 use miette::{bail, Context as _, IntoDiagnostic as _};
@@ -100,6 +103,17 @@ pub struct Args {
     /// `<storage.path>/scratch`
     #[arg(long, value_name = "DIR")]
     scratch_dir: Option<PathBuf>,
+
+    /// how many layer round trips to run at once against the repository; see
+    /// `dolos snapshot publish --concurrency`. Defaults to 8
+    #[arg(long, value_name = "N")]
+    concurrency: Option<std::num::NonZeroUsize>,
+
+    /// check that the repository still holds every layer carried forward from
+    /// the previous stele; see `dolos snapshot publish --verify-carried`. One
+    /// round trip per carried layer, every epoch
+    #[arg(long, action)]
+    verify_carried: bool,
 
     /// directory the mithril immutable files are downloaded into; defaults to
     /// `<storage.path>/mithril`
@@ -403,6 +417,10 @@ impl Driver<'_> {
             rebuild: false,
             dry_run: false,
             require_new: false,
+            tuning: registry::Tuning {
+                concurrency: self.args.concurrency,
+                verify_adopted: self.args.verify_carried,
+            },
         };
 
         super::publish::to_repository(self.config, &publish, &plan, &stores, self.feedback)?;

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -32,10 +32,21 @@
 //! architecture absorbs a transient failure correctly and expensively: the
 //! preprod G1 run took four such exits in two hours and kept publishing, at
 //! ~40% of its throughput, each incident paying a restore, a window
-//! re-download and the in-flight epoch's re-replay. The patience is bounded
-//! at [`common::retry_transient`](crate::common::retry_transient)'s four
-//! attempts, so an aggregator that is wrong rather than flaky still fails,
-//! and fails while an operator is watching.
+//! re-download and the in-flight epoch's re-replay. The mainnet run measured
+//! the same shape on the other external — eight transient registry `500`s in
+//! eleven hours, each costing an epoch, ~7% of the night's wall clock spent
+//! redoing work over a failure class that lasts milliseconds. The patience is
+//! bounded at [`common::retry_transient`](crate::common::retry_transient)'s
+//! four attempts, so an aggregator that is wrong rather than flaky still
+//! fails, and fails while an operator is watching.
+//!
+//! The publish is retried *in place*, and that is the cheap recovery rather
+//! than a second copy of the expensive one. The transport's own answer to a
+//! layer it could not move is that the recovery is another publish — so this
+//! loop performs one, from stores that are intact and consistent at that point
+//! and a resumption record that carries forward every layer the failed attempt
+//! already got up. What the alternative buys is the same publish, after a pod
+//! restart, a registry restore and a full epoch re-replay.
 //!
 //! This module is orchestration only: it composes the mithril fetch, the
 //! import lifecycle, and the publish path `snapshot publish --repo` uses, and
@@ -352,12 +363,15 @@ impl Driver<'_> {
     /// that it only reads, so fjall has no flush of ours to drain — which is
     /// the whole reason `extend` shuts its domain down after a bulk import.
     ///
-    /// Nothing in the publish observes [`Self::cancel`], either: a stele goes
-    /// out over minutes of store walking and uploading with no seam to check
-    /// a token at, so a signal arriving here is answered at the top of the
+    /// Nothing *inside* the publish observes [`Self::cancel`]: a stele goes out
+    /// over minutes of store walking and uploading with no seam to check a
+    /// token at, so a signal arriving mid-publish is answered at the top of the
     /// next loop. The window is wide by construction and the crash-safety the
     /// module doc describes is what covers it — a SIGKILL through a publish
-    /// costs a store reopen and the in-flight epoch, and never a gap.
+    /// costs a store reopen and the in-flight epoch, and never a gap. The one
+    /// seam that does exist is *between* attempts, which is where the retry
+    /// below polls it: a shutdown during a backoff ends the run on the failure
+    /// in hand rather than after the remaining patience.
     fn publish_pending(&self) -> miette::Result<Step> {
         let stores = crate::common::open_data_stores(self.config)
             .into_diagnostic()
@@ -423,7 +437,24 @@ impl Driver<'_> {
             },
         };
 
-        super::publish::to_repository(self.config, &publish, &plan, &stores, self.feedback)?;
+        // Retried here rather than allowed to end the process, because the
+        // process ending is the most expensive recovery this driver has and a
+        // transient `500` is the cheapest failure it sees. Nothing about the
+        // publish is spent by an attempt that failed: `to_repository` opens its
+        // own transport, the stores it reads are untouched, and the resumption
+        // record beside them means the layers that did land are carried forward
+        // instead of rebuilt. So the second attempt is a fraction of the first,
+        // where a restart would pay for the epoch twice.
+        //
+        // The shutdown token is observed between attempts — the only seam in
+        // the whole publish where it can be, per this method's own note — so a
+        // SIGTERM arriving during a backoff ends the run on the failure in hand
+        // rather than after the remaining patience.
+        crate::common::retry_transient(
+            "publishing the pending sequence",
+            &|| self.cancel.is_cancelled(),
+            || super::publish::to_repository(self.config, &publish, &plan, &stores, self.feedback),
+        )?;
 
         if self
             .args

--- a/src/bin/dolos/snapshot/inspect.rs
+++ b/src/bin/dolos/snapshot/inspect.rs
@@ -57,9 +57,15 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     // and this directory is never created here.
     let scratch = crate::common::stele_scratch_dir(&config.storage, None);
 
-    let registry = registry::open(&args.repo, args.insecure, auth, scratch)
-        .into_diagnostic()
-        .context("opening the repository")?;
+    let registry = registry::open(
+        &args.repo,
+        args.insecure,
+        auth,
+        scratch,
+        registry::Tuning::default(),
+    )
+    .into_diagnostic()
+    .context("opening the repository")?;
 
     let inspected = registry::inspect(&registry, args.point)
         .into_diagnostic()

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -63,6 +63,20 @@ pub struct Args {
     #[arg(long, value_name = "EPOCHS")]
     index_band: Option<std::num::NonZeroUsize>,
 
+    /// how many layer round trips to run at once against the repository; a
+    /// publish is a few hundred small transfers and its wall clock is their
+    /// latency, not their bytes. Defaults to 8; `1` is the strictly serial
+    /// path, for a registry that answers concurrency badly
+    #[arg(long, value_name = "N", conflicts_with = "output_dir")]
+    concurrency: Option<std::num::NonZeroUsize>,
+
+    /// check that the repository still holds every layer carried forward from
+    /// the previous stele, instead of trusting the manifest that names them.
+    /// One round trip per carried layer, so the cost grows with the history
+    /// behind the stele; for a repository whose blob retention you do not trust
+    #[arg(long, action, conflicts_with = "output_dir")]
+    verify_carried: bool,
+
     /// report what would be written and exit
     #[arg(long, action)]
     dry_run: bool,
@@ -105,6 +119,10 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
                 rebuild: args.rebuild,
                 dry_run: args.dry_run,
                 require_new: args.require_new,
+                tuning: registry::Tuning {
+                    concurrency: args.concurrency,
+                    verify_adopted: args.verify_carried,
+                },
             };
 
             to_repository(config, &publish, &plan, &stores, feedback)
@@ -139,6 +157,9 @@ pub(super) struct RepositoryPublish<'a> {
 
     /// Fail when the repository is already at this node's sequence.
     pub require_new: bool,
+
+    /// How the publish moves: concurrency, and the carried-layer check.
+    pub tuning: registry::Tuning,
 }
 
 fn to_directory(
@@ -208,7 +229,7 @@ pub(super) fn to_repository(
 
     let scratch = crate::common::stele_scratch_dir(&config.storage, publish.scratch_dir);
 
-    let registry = registry::open(repo, publish.insecure, auth, scratch)
+    let registry = registry::open(repo, publish.insecure, auth, scratch, publish.tuning)
         .into_diagnostic()
         .context("opening the repository")?;
 
@@ -455,11 +476,13 @@ mod tests {
         assert_eq!(progress.layers_length(), Some(PER_PUBLISH as u64));
         assert_eq!(progress.records_position(), 53_000);
 
-        // The last blob was one the registry already held, so the byte bar sits
-        // at zero over its stated size rather than carrying the previous
-        // layer's total forward.
-        assert_eq!(progress.blob_position(), 0);
-        assert_eq!(progress.blob_length(), Some(512));
+        // Everything the publish took on is accounted for: the three layers
+        // that were uploaded, byte for byte, and the ones the registry already
+        // held, counted done the moment they were announced.
+        let skipped = (PER_PUBLISH as u64 - 3) * 512;
+
+        assert_eq!(progress.blob_position(), 3 * 4_096 + skipped);
+        assert_eq!(progress.blob_length(), Some(3 * 4_096 + skipped));
 
         assert_eq!(moved, 3 * 4_096);
 

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -88,9 +88,15 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     // than moving a node's own data.
     let scratch = crate::common::stele_scratch_dir(&config.storage, None);
 
-    let registry = registry::open(&args.repo, args.insecure, auth, scratch)
-        .into_diagnostic()
-        .context("opening the repository")?;
+    let registry = registry::open(
+        &args.repo,
+        args.insecure,
+        auth,
+        scratch,
+        registry::Tuning::default(),
+    )
+    .into_diagnostic()
+    .context("opening the repository")?;
 
     let verified = registry::verify(&registry, args.point)
         .into_diagnostic()


### PR DESCRIPTION
Plan: [`plans/dolos-stelae-publish-path-concurrency.md`](https://github.com/txpipe/brain/blob/main/plans/dolos-stelae-publish-path-concurrency.md) (Trellis domain, private)

## Why

The mainnet backfill produced the first clean measurement of the
`dolos snapshot backfill` publish path, and it contradicts the CPU-ceiling
framing the substrate was chosen for:

- A Byron epoch replays in **~10 s** on 8 vCPU. The rest of the ~6–7 min cycle
  is the **publish**, during which CPU and bandwidth both sit idle (~1 Mbps
  effective on a 15 Gbps node).
- One publish moves ~79 new layers ≈ 41 MiB — average layer ~0.5 MiB — as a
  strictly serial sequence of OCI round trips: a `HEAD` per layer of the full
  manifest, plus a create-session `POST`, chunked `PATCH`es and a commit `PUT`
  per new layer. Hundreds of sequential HTTPS round trips per epoch.
- Cycle time grows **linearly with history**: ~285 s at epoch 5 → ~428 s at
  epoch 53, a stable **+3 s/epoch** — the stele gains ~3 layers per epoch and
  every publish paid a round trip per layer of history behind it. Extrapolated
  over mainnet's remaining ~590 epochs that is **≈9 days of publish time
  alone**, crossing the backfill's abort line from the latency term rather
  than the compute term.

Nothing about that is a bandwidth problem, so the answer is not bigger layers
— the cut geometry is signed ground (decision 0025) and untouched here.

## What changed

**Concurrent layer round trips** (`crates/stelae/src/oci.rs`). A layer's round
trips are independent of every other layer's — a blob is addressed by its own
content, and no blob's upload observes another's — so they are deferred onto
the transport's runtime and run concurrently, bounded by
`Options::concurrency` (default **8**, `1` restores the serial path). The
runtime becomes multi-threaded with one worker per permit, because
`blob_stream` reads its staging file with a blocking read and a worker driving
one upload must not starve the others.

`RecordSink::finish` now closes the layer and hands the round trips to the
pool: the descriptor is a fact about bytes the sink already has, so the caller
goes back to reading its store instead of waiting on a socket.

**The manifest is the join.** `SteleWriter::seal` awaits every deferred round
trip *before the manifest is built* — not merely before it is pushed — so no
document this transport writes can name a blob the registry has not committed.
The rest of the seal's order is unchanged: config blob, sequence tag, then the
moving tag.

**A carried-forward layer costs no round trip.** `Registry::adopt_layer` takes
its blob on the word of the manifest it came from: that manifest is live in
this repository under a tag, and a registry may not reclaim a blob in that
position — one that does has already broken the stele the descriptor came
from, which the `HEAD` would not have saved either. This was the
history-proportional term. `Options::verify_adopted` /
`--verify-carried` restores the proof for an operator who does not trust their
repository's retention, and pays for it concurrently rather than in sequence.

**An upload's failure is permanent.** The join empties the handles it awaited,
so a transport that forgot would find nothing outstanding on a second seal,
agree that every layer was up, and publish a manifest naming a blob that never
landed — the one document this transport must never write, and exactly the
document concurrency makes reachable. It is remembered instead:
`Error::LayerNotWritten`, and the recovery is another publish rather than
another seal.

**Two consequences of the above, handled here rather than left to be found:**

- The byte progress bar becomes a **running total over the run** rather than a
  bar per blob. Several blobs are now in flight at once, so "the blob in
  flight" is not a single thing and a per-blob bar would show eight uploads
  overwriting each other. `Event::Blob` / `Event::Bytes` are re-documented to
  say so. A blob the far side already holds is counted done the moment it is
  announced, so the bar does not stall further from the end with every skip.
- The **staging preflight** sizes as many finished layers as the transport
  uploads at once beside the state pass — largest first, capped by how many
  the stele has — because a finished layer holds its staging file until its
  own round trip lands. `StagingPeak::concurrent_other_bytes` replaces
  `largest_other_bytes`.

**Operator surface.** `dolos snapshot publish` and `dolos snapshot backfill`
gain `--concurrency N` and `--verify-carried`. `registry::Tuning` carries them
through `registry::open`; every non-publishing caller passes
`Tuning::default()`.

Out of scope, per the plan: layer geometry, and any registry Worker change.

## Verification

- `cargo test --workspace --all-targets --all-features` — green with the three
  crates CI excludes (`dolos-minibf`, `dolos-minikupo`, `dolos-trp`); see
  Findings.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly fmt --all --check` — clean.
- The `#[ignore]`d registry suites for `stelae` and `dolos-snapshot`, run
  locally against **`registry:2`** and **`zot:v2.1.20`** — the two ends of
  CI's matrix — and in CI against all three: **40 tests per registry, all
  passing**, including the crash-mid-publish resume tests and the
  killed-registry-restore test.

New tests:

- `concurrency_changes_the_cost_of_a_publish_and_not_the_stele` — the same
  records published serially and eight-way give the same inscription, the same
  identity, the same manifest bytes and the same transfer counters.
- `a_publish_dropped_mid_flight_leaves_the_previous_stele_standing` — a
  transport dropped with layers in flight and no seal leaves `latest` pointing
  at a stele that restores.
- `a_verified_carry_refuses_a_blob_the_repository_does_not_hold` — with
  `verify_adopted`, the refusal still lands before anything is tagged
  (replaces the old `adopt_layer`-time refusal).
- `a_layer_is_carried_forward_on_the_manifest_that_names_it` — the default
  path spends no round trip.
- `a_deferred_upload_that_fails_fails_every_seal` — **not** `#[ignore]`d: it
  points the transport at a closed port, so the deferral and the sticky
  refusal are covered under plain `cargo test` rather than only where a
  container can be spawned.

## What this PR cannot verify

The plan's done criterion is read off the live mainnet run's curve — the
+3 s/epoch slope flattening and absolute publish time dropping severalfold
after the driver image bump. That is a post-merge, ops-side measurement
against `~/stelae-backfill/mainnet-backfill.log`; nothing in this repository
can stand in for it. The plan's own contingency applies if it regresses: pin
the previous image tag, one epoch of rework.

Registry Worker behaviour under eight concurrent upload sessions is likewise
unmeasured here — the container fixture is not the deployment. Per the plan,
a Worker-side limit surfacing (429s, `cpu_ms` pressure) is a founder
escalation, not something to work around here; the modest default and
`--concurrency 1` are the levers if it does.

## Findings (pre-existing, not caused by this change)

- `main`'s CI is red on **Test (windows-latest)**, since #1259. Untouched here.
- `cargo test --workspace --all-targets --all-features` without CI's
  exclusions fails 314 tests in `dolos-minibf` (`epoch_value.rs:236`, accounts
  routes). Reproduces on `main`; CI's all-features job excludes that crate, so
  it does not gate anything.
- `crates/snapshot/tests/publish.rs` carried four
  `clippy::doc_lazy_continuation` warnings under the repo's pinned 1.93 (CI's
  clippy job installs 1.91 and does not see them). The doc comment they were
  in is rewritten here, so they are gone incidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162zpAPq7FPY6FNHFbPZi1h



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable publish concurrency, including serial publishing.
  - Added verification for carried-forward layers.
  - Added snapshot backfill options for concurrency and layer verification.
  - Added configurable retry attempts and progress notifications for transient registry failures.

- **Bug Fixes**
  - Improved staging estimates for concurrent uploads.
  - Progress tracking now accurately aggregates transferred and retried bytes.
  - Added clearer errors when a layer cannot be published.
  - Improved cancellation handling during retry backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->