### PR TITLE
docs(minibf): reconcile the endpoint coverage table with the router

### DIFF
--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -109,6 +109,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}/delegations`    | Get delegations for a stake address                      |
 | `/accounts/{stake_address}/registrations`  | Get registrations for a stake address                    |
 | `/accounts/{stake_address}/rewards`        | Get rewards for a stake address                          |
+| `/accounts/{stake_address}/transactions`   | Get transactions for a stake address                     |
 | `/accounts/{stake_address}/utxos`          | Get UTXOs for a stake address                            |
 | `/accounts/{stake_address}/withdrawals`    | Get withdrawals for a stake address                      |
 | `/addresses/{address}`                     | Get general information for a specific address           |
@@ -117,6 +118,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/addresses/{address}/txs`                 | Alias of `/addresses/{address}/transactions`             |
 | `/addresses/{address}/utxos`               | Get UTXOs for a specific address                         |
 | `/addresses/{address}/utxos/{asset}`       | Get UTXOs for a specific address and asset               |
+| `/assets/policy/{policy_id}`               | Get assets minted under a specific policy                |
 | `/assets/{subject}`                        | Get asset information                                    |
 | `/assets/{subject}/addresses`              | Get addresses holding a specific asset                   |
 | `/assets/{subject}/transactions`           | Get transactions involving a specific asset              |
@@ -130,10 +132,14 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/blocks/{hash_or_number}/previous`        | Get previous block                                       |
 | `/blocks/{hash_or_number}/txs`             | Get transactions for a specific block                    |
 | `/blocks/{hash_or_number}/txs/cbor`        | Get transactions with CBOR data for a specific block     |
+| `/epochs/latest`                           | Get latest epoch information                             |
 | `/epochs/latest/parameters`                | Get latest epoch parameters                              |
+| `/epochs/{epoch}`                          | Get information for a specific epoch                     |
 | `/epochs/{epoch}/blocks`                   | Get blocks in a specific epoch                           |
 | `/epochs/{epoch}/blocks/{pool_id}`         | Get blocks minted by a specific pool in a specific epoch |
+| `/epochs/{epoch}/next`                     | Get the epochs following a specific epoch                |
 | `/epochs/{epoch}/parameters`               | Get epoch parameters                                     |
+| `/epochs/{epoch}/previous`                 | Get the epochs preceding a specific epoch                |
 | `/epochs/{epoch}/stakes`                   | Get epoch stake distribution                             |
 | `/epochs/{epoch}/stakes/{pool_id}`         | Get epoch stake distribution for a specific pool         |
 | `/genesis`                                 | Get genesis information                                  |
@@ -142,11 +148,16 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/metadata/txs/labels/{label}/cbor`        | Get CBOR metadata for transactions with a specific label |
 | `/network`                                 | Get network information                                  |
 | `/network/eras`                            | Get network eras information                             |
+| `/pools`                                   | Get list of registered pools                             |
 | `/pools/extended`                          | Get extended pool information                            |
+| `/pools/retired`                           | Get list of retired pools                                |
+| `/pools/retiring`                          | Get list of retiring pools                               |
 | `/pools/{id}`                              | Get information for a specific pool                      |
 | `/pools/{id}/delegators`                   | Get delegators for a specific pool                       |
 | `/pools/{id}/history`                      | Get history for a specific pool                          |
 | `/pools/{id}/metadata`                     | Get metadata for a specific pool                         |
+| `/pools/{id}/relays`                       | Get relays for a specific pool                           |
+| `/pools/{id}/updates`                      | Get certificate updates for a specific pool              |
 | `/scripts/{script_hash}`                   | Get script information                                   |
 | `/scripts/{script_hash}/json`              | Get script JSON                                          |
 | `/scripts/{script_hash}/cbor`              | Get script CBOR                                          |


### PR DESCRIPTION
Plan: `plans/dolos-minibf-docs-endpoint-coverage.md` (Brain/txpipe domain), sub-plan of `dolos-v1-7-blockfrost-conformance`.

## What changed

The `## Coverage` table in `docs/content/apis/minibf.mdx` is the published claim of which Blockfrost endpoints dolos serves — it carries no support/partial marking, so membership in it *is* the claim. It had drifted: the table listed **68** endpoints while `build_router_with_facade` (`crates/minibf/src/lib.rs`) registers **79**.

The drift was strictly one-directional — every documented endpoint is served — but eleven served endpoints were undocumented:

```
/accounts/{stake_address}/transactions
/assets/policy/{policy_id}
/epochs/latest
/epochs/{epoch}
/epochs/{epoch}/next
/epochs/{epoch}/previous
/pools
/pools/retired
/pools/retiring
/pools/{id}/relays
/pools/{id}/updates
```

`/pools`, `/pools/retired` and `/epochs/{epoch}` are whole families. This matters beyond cosmetics: the v1.7 Blockfrost conformance gate derives its endpoint allowlist from this table, so anything missing from it would go untested.

This PR adds those eleven rows, each in the table's established resource-ordered position, using the doc's own brace notation and parameter names. Descriptions were written against the actual handlers (`routes::pools::by_id_updates` returns certificate updates; `routes::epochs::by_number_next` returns a list). The diff is purely additive — no existing row is renamed, renumbered, or reworded.

Deliberately out of scope: the doc's parameter names differ from upstream Blockfrost's in four places (`{subject}`/`{epoch}`/`{id}`/`{tx_hash}` vs `{asset}`/`{number}`/`{pool_id}`/`{hash}`). Aligning them is a separate concern with its own reader-compatibility question.

## Verification

Two-way diff between the table and the `Router::new()` route set, at this commit:

```
$ sed -n '360,700p' crates/minibf/src/lib.rs | tr '\n' ' ' \
    | grep -o '\.route(\s*"[^"]*"' | sed -E 's/.*"(.*)"/\1/' | sort > routes.txt   # 79
$ sed -n '/## Coverage/,$p' docs/content/apis/minibf.mdx \
    | grep -oE '^\| `[^`]+`' | sed -E 's/^\| `(.*)`/\1/' | sort > doc.txt          # 79
$ comm -23 routes.txt doc.txt   # served but undocumented → empty
$ comm -13 routes.txt doc.txt   # documented but unserved  → empty
```

Both directions empty; no duplicate rows. Docs-only change, no Rust touched, so the Rust CI jobs are unaffected.

## Note for the reviewer

The plan leaves one question open for its owner, deliberately not decided here: whether `minibf.mdx` should gain an explicit **"Not supported"** section, as its sibling `minikupo.mdx` has. Families present in the vendored `crates/minibf/openapi.yaml` but neither routed nor documented — `/mempool*`, `/governance/proposals*`, `/governance/dreps` (list), `/assets` (list), `/assets/{asset}/history`, `/accounts/{stake_address}/history`, `/pools/{pool_id}/blocks` — are currently silently unclaimed; a migrating Blockfrost user discovers them by hitting a 404.

Separately: the table is hand-maintained and will drift again on the next endpoint added. The durable fix is a test or CI check asserting this two-way diff is empty — larger than this plan, and worth weighing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw3f9EqhmFanA9t6e2j9ap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded MiniBF API endpoint coverage to include:
    * Account transaction lookups
    * Policy asset lookups
    * Epoch details and navigation
    * Additional pool listing and detail endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->