### PR TITLE
fix(sync): surface an unreachable or silent upstream peer

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -945,6 +945,8 @@ pub struct MinibfConfig {
     pub url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     max_scan_items: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_tip_age_sec: Option<u64>,
 }
 
 impl MinibfConfig {
@@ -955,6 +957,7 @@ impl MinibfConfig {
             token_registry_url: None,
             url: None,
             max_scan_items: None,
+            max_tip_age_sec: None,
         }
     }
 
@@ -974,6 +977,22 @@ impl MinibfConfig {
 
     pub fn max_scan_items(&self) -> u64 {
         self.max_scan_items.unwrap_or(default_max_scan_items())
+    }
+
+    pub fn with_max_tip_age_sec(mut self, max_tip_age_sec: u64) -> Self {
+        self.max_tip_age_sec = Some(max_tip_age_sec);
+        self
+    }
+
+    /// Age, in seconds, past which the node's tip is considered too stale to
+    /// serve and `/health` starts answering `503`.
+    ///
+    /// Unset by default: a node that has fallen behind still reports healthy,
+    /// because a node catching up from a bootstrap is hours behind by design.
+    /// `/health` always reports `tip_age_seconds` regardless, so staleness is
+    /// observable whether or not an operator opts into the gate.
+    pub fn max_tip_age_sec(&self) -> Option<u64> {
+        self.max_tip_age_sec
     }
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -989,8 +989,8 @@ impl MinibfConfig {
     ///
     /// Unset by default: a node that has fallen behind still reports healthy,
     /// because a node catching up from a bootstrap is hours behind by design.
-    /// `/health` always reports `tip_age_seconds` regardless, so staleness is
-    /// observable whether or not an operator opts into the gate.
+    /// `/health/tip` reports `tip_age_seconds` whenever the tip is readable, so
+    /// staleness is observable whether or not an operator opts into the gate.
     pub fn max_tip_age_sec(&self) -> Option<u64> {
         self.max_tip_age_sec
     }

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -369,9 +369,10 @@ where
     let permissive_cors = facade.config.permissive_cors();
     let app = Router::new()
         .route("/", get(routes::root::<D>))
-        .route("/health", get(routes::health::naked))
+        .route("/health", get(routes::health::naked::<D>))
         .route("/metrics", get(routes::metrics::metrics::<D>))
         .route("/health/clock", get(routes::health::clock))
+        .route("/health/tip", get(routes::health::tip::<D>))
         .route("/genesis", get(routes::genesis::naked::<D>))
         .route("/network", get(routes::network::naked::<D>))
         .route("/network/eras", get(routes::network::eras::<D>))

--- a/crates/minibf/src/routes/health.rs
+++ b/crates/minibf/src/routes/health.rs
@@ -1,15 +1,107 @@
-use axum::{http::StatusCode, Json};
+use axum::{extract::State, http::StatusCode, Json};
+use dolos_core::Domain;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::Facade;
+
+/// Blockfrost's `/health` body, and deliberately nothing more.
+///
+/// The conformance suite compares this response with `toStrictEqual`, so an
+/// extra field here is a conformance failure. The staleness detail a caller
+/// needs lives on [`TipResponse`] instead; what `/health` carries is the
+/// verdict, which is the part a load balancer reads.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RootResponse {
     pub is_healthy: bool,
 }
 
-pub async fn naked() -> Result<Json<RootResponse>, StatusCode> {
-    // TODO: Relate this value to sync status. If not in tip, then unhealthy.
-    Ok(Json(RootResponse { is_healthy: true }))
+/// `/health/tip` — how current the node's own chain is.
+///
+/// A sibling of `/health/clock`, which already establishes that this server
+/// answers time-correctness questions about itself.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TipResponse {
+    /// Slot of the node's own tip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tip_slot: Option<u64>,
+
+    /// Wall-clock seconds between the tip's slot and now.
+    ///
+    /// The whole point of the endpoint: it lets a caller tell a current node
+    /// from one that has been serving the same block for hours, without
+    /// holding a second opinion about where the chain actually is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tip_age_seconds: Option<u64>,
+
+    /// The configured threshold, echoed so a caller can see what verdict it is
+    /// being given against. `None` when the operator set none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tip_age_seconds: Option<u64>,
+
+    /// Whether `tip_age_seconds` is past `max_tip_age_seconds`. Absent when no
+    /// threshold is configured, or when the tip could not be measured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_stale: Option<bool>,
+}
+
+/// Age of the node's tip in wall-clock seconds, or `None` when the tip or the
+/// era summary cannot be read.
+///
+/// Staleness reporting is strictly additive to liveness, so a failure to
+/// measure it must not turn a reachable node into an unhealthy one: every
+/// error here degrades to "unknown age" rather than propagating.
+fn tip_age_seconds<D: Domain>(domain: &Facade<D>) -> Option<(u64, u64)> {
+    let tip_slot = domain.get_tip_slot().ok()?;
+    let summary = domain.get_chain_summary().ok()?;
+
+    let tip_time = summary.slot_time(tip_slot);
+
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+
+    Some((tip_slot, now.saturating_sub(tip_time)))
+}
+
+/// Whether the node's tip is past the configured staleness threshold.
+///
+/// `None` means "no verdict": either the operator configured no threshold, or
+/// the tip could not be measured. A node that has fallen behind is only
+/// *unhealthy* if someone said how far behind is too far — a node catching up
+/// from a bootstrap is hours behind by design, so defaulting to a threshold
+/// would pull every such node out of its load balancer mid-sync.
+fn is_stale<D: Domain>(domain: &Facade<D>, tip_age: Option<u64>) -> Option<bool> {
+    match (domain.config.max_tip_age_sec(), tip_age) {
+        (Some(max), Some(age)) => Some(age > max),
+        _ => None,
+    }
+}
+
+pub async fn naked<D: Domain>(State(domain): State<Facade<D>>) -> (StatusCode, Json<RootResponse>) {
+    let tip_age = tip_age_seconds(&domain).map(|(_, age)| age);
+
+    let stale = is_stale(&domain, tip_age).unwrap_or(false);
+
+    let status = if stale {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        StatusCode::OK
+    };
+
+    (status, Json(RootResponse { is_healthy: !stale }))
+}
+
+pub async fn tip<D: Domain>(State(domain): State<Facade<D>>) -> Json<TipResponse> {
+    let (tip_slot, tip_age) = match tip_age_seconds(&domain) {
+        Some((slot, age)) => (Some(slot), Some(age)),
+        None => (None, None),
+    };
+
+    Json(TipResponse {
+        tip_slot,
+        tip_age_seconds: tip_age,
+        max_tip_age_seconds: domain.config.max_tip_age_sec(),
+        is_stale: is_stale(&domain, tip_age),
+    })
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,4 +121,107 @@ impl Default for ClockResponse {
 
 pub async fn clock() -> Result<Json<ClockResponse>, StatusCode> {
     Ok(Json(ClockResponse::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{TestApp, TestFault};
+
+    async fn get_json<T: serde::de::DeserializeOwned>(
+        app: &TestApp,
+        path: &str,
+    ) -> (StatusCode, T) {
+        let (status, bytes) = app.get_bytes(path).await;
+        let parsed = serde_json::from_slice(&bytes).unwrap_or_else(|err| {
+            panic!(
+                "failed to parse {path} response ({err}): {}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+
+        (status, parsed)
+    }
+
+    /// The synthetic chain sits at a slot whose wall-clock time is years in the
+    /// past, so it is stale by any threshold an operator would set — which is
+    /// what makes it a usable fixture for the staleness cases below.
+    #[tokio::test]
+    async fn health_stays_blockfrost_exact() {
+        let app = TestApp::new();
+        let (status, bytes) = app.get_bytes("/health").await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        // The conformance suite compares this body with `toStrictEqual`, so the
+        // shape is load-bearing: one extra field fails the `health` fixture.
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("valid json");
+        assert_eq!(body, serde_json::json!({ "is_healthy": true }));
+    }
+
+    #[tokio::test]
+    async fn health_fails_once_the_tip_is_older_than_the_threshold() {
+        let app = TestApp::new_with_minibf_config(|cfg| cfg.with_max_tip_age_sec(60));
+        let (status, body) = get_json::<RootResponse>(&app, "/health").await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!body.is_healthy);
+    }
+
+    #[tokio::test]
+    async fn health_passes_when_the_tip_is_within_the_threshold() {
+        let app = TestApp::new_with_minibf_config(|cfg| cfg.with_max_tip_age_sec(u64::MAX));
+        let (status, body) = get_json::<RootResponse>(&app, "/health").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.is_healthy);
+    }
+
+    #[tokio::test]
+    async fn tip_reports_age_without_a_threshold() {
+        let app = TestApp::new();
+        let (status, body) = get_json::<TipResponse>(&app, "/health/tip").await;
+
+        assert_eq!(status, StatusCode::OK);
+
+        // No threshold configured: the endpoint measures but does not judge.
+        assert_eq!(body.is_stale, None);
+        assert_eq!(body.max_tip_age_seconds, None);
+
+        assert!(body.tip_slot.is_some(), "tip slot should be reported");
+        assert!(
+            body.tip_age_seconds.is_some_and(|age| age > 0),
+            "a tip in the past should report a non-zero age, got {:?}",
+            body.tip_age_seconds
+        );
+    }
+
+    #[tokio::test]
+    async fn tip_judges_against_a_configured_threshold() {
+        let app = TestApp::new_with_minibf_config(|cfg| cfg.with_max_tip_age_sec(60));
+        let (status, body) = get_json::<TipResponse>(&app, "/health/tip").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.is_stale, Some(true));
+        assert_eq!(body.max_tip_age_seconds, Some(60));
+        assert!(body.tip_age_seconds.is_some_and(|age| age > 60));
+    }
+
+    /// Staleness reporting is additive to liveness: a node whose tip cannot be
+    /// read is unmeasurable, not unhealthy, so `/health` keeps its original
+    /// meaning rather than inventing a failure.
+    #[tokio::test]
+    async fn an_unreadable_tip_is_unmeasurable_not_unhealthy() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+
+        let (status, body) = get_json::<RootResponse>(&app, "/health").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.is_healthy);
+
+        let (status, body) = get_json::<TipResponse>(&app, "/health/tip").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.tip_slot, None);
+        assert_eq!(body.tip_age_seconds, None);
+        assert_eq!(body.is_stale, None);
+    }
 }

--- a/crates/minibf/src/routes/health.rs
+++ b/crates/minibf/src/routes/health.rs
@@ -153,8 +153,8 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
 
-        // The conformance suite compares this body with `toStrictEqual`, so the
-        // shape is load-bearing: one extra field fails the `health` fixture.
+        // Parsed as raw JSON, not into `RootResponse`, which would accept an
+        // extra field silently and let the conformance regression through.
         let body: serde_json::Value = serde_json::from_slice(&bytes).expect("valid json");
         assert_eq!(body, serde_json::json!({ "is_healthy": true }));
     }
@@ -184,7 +184,6 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
 
-        // No threshold configured: the endpoint measures but does not judge.
         assert_eq!(body.is_stale, None);
         assert_eq!(body.max_tip_age_seconds, None);
 

--- a/crates/minibf/src/test_support.rs
+++ b/crates/minibf/src/test_support.rs
@@ -121,6 +121,18 @@ impl TestApp {
         Self::from_domain(domain, vectors, fault)
     }
 
+    /// Same as [`TestApp::new`], with the minibf config adjusted before the
+    /// router is built — for routes whose behaviour is config-driven.
+    pub fn new_with_minibf_config(tweak: impl FnOnce(MinibfConfig) -> MinibfConfig) -> Self {
+        let cfg = SyntheticBlockConfig {
+            block_count: 5,
+            txs_per_block: 3,
+            ..Default::default()
+        };
+        let (domain, vectors) = TestDomainBuilder::new_with_synthetic(cfg).finish();
+        Self::from_domain_with_config(domain, vectors, None, tweak)
+    }
+
     pub fn new_with_cfg_and_setup(
         cfg: SyntheticBlockConfig,
         setup: impl FnOnce(&ToyDomain, &SyntheticVectors),
@@ -131,12 +143,23 @@ impl TestApp {
     }
 
     fn from_domain(domain: ToyDomain, vectors: SyntheticVectors, fault: Option<TestFault>) -> Self {
+        Self::from_domain_with_config(domain, vectors, fault, |cfg| cfg)
+    }
+
+    fn from_domain_with_config(
+        domain: ToyDomain,
+        vectors: SyntheticVectors,
+        fault: Option<TestFault>,
+        tweak: impl FnOnce(MinibfConfig) -> MinibfConfig,
+    ) -> Self {
         let domain = match fault {
             Some(fault) => dolos_testing::faults::FaultyToyDomain::new(domain, fault),
             None => dolos_testing::faults::FaultyToyDomain::new(domain, TestFault::None),
         };
 
-        let cfg = MinibfConfig::new("[::]:0".parse().expect("invalid listen address"));
+        let cfg = tweak(MinibfConfig::new(
+            "[::]:0".parse().expect("invalid listen address"),
+        ));
 
         let facade = Facade {
             inner: domain.clone(),

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -73,12 +73,14 @@ The `serve.minibf` section controls the options for the MiniBF endpoint that can
 | token_registry_url | string  | "https://token-registry.io"     |
 | url                | string  | "https://minibf.local"          |
 | max_scan_items     | integer | 3000                             |
+| max_tip_age_sec    | integer | 300                              |
 
 - `listen_address`: the local address (`IP:PORT`) to listen for incoming connections (`[::]` represents any IP address).
 - `permissive_cors`: allow cross-origin requests from any origin.
 - `token_registry_url`: optional token registry base URL used for off-chain asset metadata. 
 - `url`: optional public URL used in the `/` root response.
 - `max_scan_items`: caps page-based scans for heavy endpoints (defaults to 3000 if unset).
+- `max_tip_age_sec`: opts into the health gate described under "Health and staleness" below — past this many seconds of tip age, `/health` answers `503`. Unset by default, in which case `/health` keeps reporting healthy however far behind the node has fallen.
 
 This is an example of the `serve.minibf` fragment with a `dolos.toml` configuration file.
 
@@ -89,6 +91,7 @@ permissive_cors = true
 token_registry_url = "https://token-registry.io"
 url = "https://minibf.local"
 max_scan_items = 3000
+max_tip_age_sec = 300
 ```
 
 Check the [Configuration Schema](../configuration/schema) for detailed info on how to set this up.

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -102,6 +102,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/`                                        | Service info (version, revision)                         |
 | `/health`                                  | Health check                                             |
 | `/health/clock`                            | Clock health                                             |
+| `/health/tip`                              | Tip age and staleness verdict                            |
 | `/metrics`                                 | Prometheus metrics                                       |
 | `/accounts/{stake_address}`                | Get account information for a stake address              |
 | `/accounts/{stake_address}/addresses`      | Get addresses for a stake address                        |
@@ -167,3 +168,41 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/txs/{tx_hash}/stakes`                    | Get stakes for a specific transaction                    |
 | `/txs/{tx_hash}/utxos`                     | Get UTXOs for a specific transaction                     |
 | `/txs/{tx_hash}/withdrawals`               | Get withdrawals for a specific transaction               |
+
+## Health and staleness
+
+`/health` answers the Blockfrost question — is this node fit to serve? — and
+nothing else:
+
+```json
+{ "is_healthy": true }
+```
+
+`/health/tip` answers the more useful one: how current is it?
+
+```json
+{
+  "tip_slot": 84916321,
+  "tip_age_seconds": 34,
+  "max_tip_age_seconds": 300,
+  "is_stale": false
+}
+```
+
+`tip_age_seconds` is the wall-clock gap between the node's tip and now. It is
+the field that distinguishes a node tracking the chain from one that has been
+serving the same block for hours — a distinction a caller otherwise cannot make
+without a second, independent opinion about where the chain actually is.
+
+By default dolos measures but does not judge: `is_stale` and
+`max_tip_age_seconds` are omitted, and `/health` keeps answering `200` however
+far behind the node has fallen, since a node catching up from a bootstrap is
+hours behind by design. Set `serve.minibf.max_tip_age_sec` to opt into a gate:
+past that many seconds `/health` answers `503` with `is_healthy: false`, which
+is what lets a load balancer or supervisor take a stale node out of rotation,
+while `/health/tip` reports `is_stale: true` alongside the age that earned the
+verdict.
+
+`tip_slot` and `tip_age_seconds` are omitted when the tip cannot be read at
+all — an unmeasurable node is reported as unmeasurable rather than as unhealthy,
+so `/health` keeps its original meaning.

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -317,12 +317,14 @@ The `serve.minibf` section controls the options for the HTTP endpoint that hosts
 | token_registry_url | string  | "https://token-registry.io"     |
 | url                | string  | "https://minibf.local"          |
 | max_scan_items     | integer | 3000                             |
+| max_tip_age_sec    | integer | 300                              |
 
 - `listen_address`: the local address (`IP:PORT`) to listen for incoming connections (`[::]` represents any IP address).
 - `permissive_cors`: allow cross-origin requests from any origin (defaults to `true`).
 - `token_registry_url`: optional token registry base URL used for off-chain asset metadata.
 - `url`: optional public URL used in the `/` root response.
 - `max_scan_items`: caps page-based scans for heavy endpoints (defaults to 3000 if unset).
+- `max_tip_age_sec`: how far behind the wall clock the node's tip may fall before `/health` starts answering `503`. Unset by default, in which case `/health` keeps reporting healthy no matter how stale the node is — a node catching up from a bootstrap is hours behind by design, so a default threshold would pull it out of a load balancer mid-sync. Regardless of this setting, `/health/tip` always reports `tip_slot` and `tip_age_seconds`, so staleness is observable without opting into the gate.
 
 ## `serve.minikupo` section
 

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -324,7 +324,7 @@ The `serve.minibf` section controls the options for the HTTP endpoint that hosts
 - `token_registry_url`: optional token registry base URL used for off-chain asset metadata.
 - `url`: optional public URL used in the `/` root response.
 - `max_scan_items`: caps page-based scans for heavy endpoints (defaults to 3000 if unset).
-- `max_tip_age_sec`: how far behind the wall clock the node's tip may fall before `/health` starts answering `503`. Unset by default, in which case `/health` keeps reporting healthy no matter how stale the node is — a node catching up from a bootstrap is hours behind by design, so a default threshold would pull it out of a load balancer mid-sync. Regardless of this setting, `/health/tip` always reports `tip_slot` and `tip_age_seconds`, so staleness is observable without opting into the gate.
+- `max_tip_age_sec`: how far behind the wall clock the node's tip may fall before `/health` starts answering `503`. Unset by default, in which case `/health` keeps reporting healthy no matter how stale the node is — a node catching up from a bootstrap is hours behind by design, so a default threshold would pull it out of a load balancer mid-sync. Regardless of this setting, `/health/tip` reports `tip_slot` and `tip_age_seconds` whenever the tip is readable — they are omitted when it is not — so staleness is observable without opting into the gate.
 
 ## `serve.minikupo` section
 

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -1,10 +1,22 @@
+use std::time::{Duration, Instant};
+
 use dolos_core::SyncExt;
 use gasket::{framework::*, messaging::Message};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{adapters::DomainAdapter, prelude::*};
 
 pub type UpstreamPort = gasket::messaging::InputPort<PullEvent>;
+
+/// How long the pipeline may go without hearing anything from upstream before
+/// each housekeeping tick starts warning about it.
+///
+/// Well past any plausible inter-block gap on a Cardano network, where the mean
+/// is ~20s. The point is to separate "behind but advancing" — a node catching
+/// up floods this stage with events — from "not receiving anything at all",
+/// which is the shape of an unreachable or silent peer and looks identical to a
+/// healthy node from the outside.
+const UPSTREAM_SILENCE_THRESHOLD: Duration = Duration::from_secs(300);
 
 pub enum WorkUnit {
     PullEvent(PullEvent),
@@ -30,6 +42,13 @@ pub struct Stage {
 
     housekeeping_interval: std::time::Duration,
 
+    /// The peer this pipeline pulls from, named in the silence warning so an
+    /// operator can tell a misconfigured address from a peer that went quiet.
+    /// `None` for the emulator pipeline, which has no upstream to lose.
+    peer_address: Option<String>,
+
+    last_upstream_event: Instant,
+
     pub upstream: UpstreamPort,
 
     #[metric]
@@ -40,13 +59,39 @@ pub struct Stage {
 }
 
 impl Stage {
-    pub fn new(domain: DomainAdapter, housekeeping_interval: std::time::Duration) -> Self {
+    pub fn new(
+        domain: DomainAdapter,
+        housekeeping_interval: std::time::Duration,
+        peer_address: Option<String>,
+    ) -> Self {
         Self {
             domain,
             housekeeping_interval,
+            peer_address,
+            last_upstream_event: Instant::now(),
             upstream: Default::default(),
             block_count: Default::default(),
             wal_count: Default::default(),
+        }
+    }
+
+    /// Warn, on every tick, while nothing has arrived from upstream for longer
+    /// than [`UPSTREAM_SILENCE_THRESHOLD`]. Repeating it is deliberate: a single
+    /// line at the moment the peer went quiet scrolls out of a log that then
+    /// looks entirely healthy.
+    fn warn_if_upstream_silent(&self) {
+        let Some(peer_address) = self.peer_address.as_ref() else {
+            return;
+        };
+
+        let silence = self.last_upstream_event.elapsed();
+
+        if silence >= UPSTREAM_SILENCE_THRESHOLD {
+            warn!(
+                peer_address,
+                silence_sec = silence.as_secs(),
+                "nothing received from upstream peer; the chain we serve is not advancing"
+            );
         }
     }
 
@@ -94,11 +139,16 @@ impl gasket::framework::Worker<Stage> for Worker {
 
     async fn execute(&mut self, unit: &WorkUnit, stage: &mut Stage) -> Result<(), WorkerError> {
         match unit {
-            WorkUnit::PullEvent(evt) => match evt {
-                PullEvent::RollForward(x) => stage.on_roll_forward(x.clone())?,
-                PullEvent::Rollback(x) => stage.on_rollback(x)?,
-            },
+            WorkUnit::PullEvent(evt) => {
+                stage.last_upstream_event = Instant::now();
+
+                match evt {
+                    PullEvent::RollForward(x) => stage.on_roll_forward(x.clone())?,
+                    PullEvent::Rollback(x) => stage.on_rollback(x)?,
+                }
+            }
             WorkUnit::Housekeeping => {
+                stage.warn_if_upstream_silent();
                 stage.domain.housekeeping().or_panic()?;
             }
         }

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -76,9 +76,9 @@ impl Stage {
     }
 
     /// Warn, on every tick, while nothing has arrived from upstream for longer
-    /// than [`UPSTREAM_SILENCE_THRESHOLD`]. Repeating it is deliberate: a single
-    /// line at the moment the peer went quiet scrolls out of a log that then
-    /// looks entirely healthy.
+    /// than [`UPSTREAM_SILENCE_THRESHOLD`]. Repeating it is deliberate: a
+    /// single line at the moment the peer went quiet scrolls out of a log
+    /// that then looks entirely healthy.
     fn warn_if_upstream_silent(&self) {
         let Some(peer_address) = self.peer_address.as_ref() else {
             return;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -58,7 +58,11 @@ pub fn sync(
 ) -> Result<Vec<gasket::runtime::Tether>, Error> {
     let mut pull = pull::Stage::new(config, upstream, network_magic, domain.wal().clone());
 
-    let mut apply = apply::Stage::new(domain.clone(), HOUSEKEEPING_INTERVAL);
+    let mut apply = apply::Stage::new(
+        domain.clone(),
+        HOUSEKEEPING_INTERVAL,
+        Some(upstream.peer_address.clone()),
+    );
 
     let submit = submit::Stage::new(
         upstream.peer_address.clone(),
@@ -94,7 +98,7 @@ pub fn devnet(
         emulator_cfg.block_production_interval,
     );
 
-    let mut apply = apply::Stage::new(domain.clone(), HOUSEKEEPING_INTERVAL);
+    let mut apply = apply::Stage::new(domain.clone(), HOUSEKEEPING_INTERVAL, None);
 
     let (to_apply, from_pull) = gasket::messaging::tokio::mpsc_channel(50);
     emulator.downstream.connect(to_apply);

--- a/src/sync/pull.rs
+++ b/src/sync/pull.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use dolos_cardano::consensus::{ChainFragment, RollbackResult};
 use dolos_core::config::{PeerConfig, SyncConfig, SyncLimit};
@@ -26,6 +27,17 @@ fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, WorkerError
 // ============================================================================
 // Pull stage
 // ============================================================================
+
+/// Ceiling on a single attempt to open a chainsync session with the upstream
+/// peer, covering both the TCP connect and the N2N handshake.
+///
+/// Neither has a deadline of its own, so an address that resolves but never
+/// answers leaves the stage parked in `bootstrap` forever — no error, no log
+/// line, and no signal to the supervising daemon, which sees a stage that is
+/// merely still starting up. The node then serves whatever it had on disk
+/// indefinitely. Bounding the attempt turns that silence into a retry we can
+/// warn about.
+const PEER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub type DownstreamPort = gasket::messaging::OutputPort<PullEvent>;
 
@@ -221,9 +233,31 @@ impl gasket::framework::Worker<Stage> for Worker {
 
         debug!("connecting to peer");
 
-        let mut peer_session = PeerClient::connect(&stage.peer_address, stage.network_magic)
-            .await
-            .or_retry()?;
+        let connect = PeerClient::connect(&stage.peer_address, stage.network_magic);
+
+        let mut peer_session = match tokio::time::timeout(PEER_CONNECT_TIMEOUT, connect).await {
+            Ok(Ok(session)) => session,
+            Ok(Err(err)) => {
+                warn!(
+                    address = stage.peer_address,
+                    magic = stage.network_magic,
+                    %err,
+                    "could not reach upstream peer, will retry"
+                );
+
+                return Err(WorkerError::Retry);
+            }
+            Err(_) => {
+                warn!(
+                    address = stage.peer_address,
+                    magic = stage.network_magic,
+                    timeout_sec = PEER_CONNECT_TIMEOUT.as_secs(),
+                    "upstream peer did not answer within the connect timeout, will retry"
+                );
+
+                return Err(WorkerError::Retry);
+            }
+        };
 
         info!(
             address = stage.peer_address,


### PR DESCRIPTION
Plan: `plans/dolos-daemon-silent-upstream-stall.md` (sub-plan of `dolos-v1-7-blockfrost-conformance`).

## The defect

A daemon whose `peer_address` is unreachable serves stale data indefinitely and says nothing about it. Found standing up the preview conformance instance against `preview-node.world.dev.cardano.org:30002` — the address `dolos init` still offers for preview, unreachable as of 2026-08-24. The node bound its ports, answered `/blocks/latest` with a well-formed response, stayed 8 hours behind the chain, and `grep -ic "error\|refused\|timeout"` over the whole log returned 0.

This corrupts measurement, not just uptime: the 2026-01 Blockfrost conformance run on preview was taken against a node ~8h behind tip, and those 25 failures were carried as a baseline for seven months.

## Root cause

`PeerClient::connect` bounds neither the TCP connect nor the N2N handshake, and that relay black-holes packets rather than refusing them — `nc -z` against it hangs too. So the pull stage parked in `bootstrap` forever.

Gasket's supervisor only notices a stage that has **ended**; `TetherState::Alive(StagePhase::Bootstrap)` reads as a healthy boot, so `Daemon::should_stop` never fired. The 20-retry bootstrap policy that would have surfaced this was already in place and simply never reached — this PR adds no new failure policy, it lets the existing one run.

## Changes

- **`src/sync/pull.rs`** — bound a connect attempt at 30s; warn with the peer address on both the timeout and the error path.
- **`src/sync/apply.rs`** — warn from the housekeeping tick while nothing has arrived from upstream for 5 minutes, naming the peer and the elapsed silence. It repeats each tick on purpose: one line at the moment a peer goes quiet scrolls out of a log that then reads as entirely healthy. The apply stage is the resilient place for it — it keeps ticking even when the pull stage is stuck in bootstrap or has ended. Measuring *inbound events* rather than tip age is what separates "behind but advancing" (a bootstrap catch-up floods this stage) from "not receiving anything at all".
- **`crates/minibf`** — new `/health/tip` reporting `tip_slot`, `tip_age_seconds`, `max_tip_age_seconds`, `is_stale`.
- **`crates/core/src/config.rs`** — new `serve.minibf.max_tip_age_sec`.
- **docs** — `apis/minibf.mdx` and `configuration/schema.mdx`.

### Two deliberate design calls

**`/health` keeps Blockfrost's exact `{"is_healthy": true}` body.** The conformance suite compares it with `toStrictEqual` (`suite/src/index.ts:423`), so an extra field there is a conformance failure on this plan's own parent objective. Staleness detail goes on a sibling endpoint instead; `/health/clock` is the precedent. A regression test pins the exact body.

**Staleness is only a verdict where an operator asked for one.** `max_tip_age_sec` is unset by default, and while unset `/health` answers `200` however far behind the node is — a node catching up from a bootstrap is hours behind by design, so a default threshold would pull every such node out of its load balancer mid-sync. Set it, and `/health` answers `503` past the threshold. A tip that cannot be read at all is reported as unmeasurable, never as unhealthy.

## Verification

`cargo test --workspace` green. `cargo clippy --all-targets -- -D warnings` clean on `dolos`, `dolos-minibf`, `dolos-core`. `cargo fmt --all` applied.

Six new tests in `crates/minibf/src/routes/health.rs` cover the exact-body regression, both threshold directions, the tip report with and without a threshold, and the unreadable-tip degradation.

End-to-end against a black-holed peer (`192.0.2.1:3001`), preview magic:

```
12:05:25  WARN stage{stage="pull"}:bootstrap: upstream peer did not answer within the connect
          timeout, will retry address="192.0.2.1:3001" magic=2 timeout_sec=30
12:05:59  WARN stage{stage="pull"}:bootstrap: upstream peer did not answer within the connect
          timeout, will retry address="192.0.2.1:3001" magic=2 timeout_sec=30
12:13:57  WARN stage{stage="apply"}:execute: nothing received from upstream peer; the chain we
          serve is not advancing peer_address="192.0.2.1:3001" silence_sec=300
12:14:57  WARN stage{stage="apply"}:execute: nothing received from upstream peer; the chain we
          serve is not advancing peer_address="192.0.2.1:3001" silence_sec=360
```

With `max_tip_age_sec = 300` and a real tip on disk:

```
$ curl -s -o /dev/null -w "%{http_code}" /health   → 503
$ curl -s /health       → {"is_healthy":false}
$ curl -s /health/tip   → {"tip_slot":5980,"tip_age_seconds":120997745,
                           "max_tip_age_seconds":300,"is_stale":true}
```

## Pre-existing, not touched

`cargo clippy --workspace --all-targets -- -D warnings` fails identically on `origin/main` at the repo's toolchain (1.93) — 4 `doc_list_item_without_indentation` in `dolos-snapshot`'s `publish` test, plus `filter_next` and two `cloned_ref_to_slice_refs` in `dolos-cardano`. Unrelated to this branch.

## Left for the plan owner

The plan's "Adjacent, worth deciding together" raises two items this PR deliberately does not decide: refreshing the dead `preview` preset in `init.rs`, and a sweep for the sibling "fails quietly" pattern (`FlatFileStore::new` doing `create_dir_all` on an unmounted `blocks_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXJLTar7Rb8LB7e3J5W5iQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/health/tip` to report tip slot, age, configured threshold, and staleness.
  * Added optional tip-age monitoring that returns HTTP 503 from `/health` when configured limits are exceeded.
  * Added warnings when no upstream synchronization event is received for over five minutes.
  * Added timeouts and retry handling for upstream connection and handshake attempts.

* **Documentation**
  * Documented the new health endpoint and tip-age configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->