### PR TITLE
fix(cardano): gate the roll crawl on transaction validity

### DIFF
--- a/crates/cardano/src/roll/dreps.rs
+++ b/crates/cardano/src/roll/dreps.rs
@@ -148,13 +148,20 @@ impl BlockVisitor for DRepStateVisitor {
             return Ok(());
         };
 
+        // The crawl still calls `visit_tx` for phase-2-invalid transactions
+        // (fees and collateral are priced there), but nothing below is a fee:
+        // votes, the dormancy release and the expiry refreshes are all CERTS
+        // and GOV effects, which run only under `IsValid True`.
+        if !tx.is_valid() {
+            return Ok(());
+        }
+
         // Dormancy release (research §3.3.1): the first proposal after a
         // dormant stretch folds the counter into every non-long-expired
         // DRep's stored expiry and resets it. In the Haskell CERTS rule this
         // runs in the terminal case *before* the certificates, so certs and
-        // votes of the same tx already see the reset counter. Phase-2-invalid
-        // transactions contribute nothing.
-        if tx.is_valid() && self.dormancy.dormant_epochs > 0 && !tx.gov_proposals().is_empty() {
+        // votes of the same tx already see the reset counter.
+        if self.dormancy.dormant_epochs > 0 && !tx.gov_proposals().is_empty() {
             for key in self.dormancy.release_targets() {
                 deltas.add_for_entity(DRepDormancyRelease::new(
                     key,
@@ -184,16 +191,14 @@ impl BlockVisitor for DRepStateVisitor {
 
             // Voting refresh (research §3.3.2): a registered DRep that votes
             // gets its expiry pushed out, exactly like an `UpdateDRepCert`
-            // heartbeat. Valid txs only.
-            if tx.is_valid() {
-                if let Some(expiry) = self.refresh_expiry() {
-                    deltas.add_for_entity(DRepExpiryUpdate::new(
-                        drep,
-                        expiry,
-                        self.current_epoch,
-                        true,
-                    ));
-                }
+            // heartbeat.
+            if let Some(expiry) = self.refresh_expiry() {
+                deltas.add_for_entity(DRepExpiryUpdate::new(
+                    drep,
+                    expiry,
+                    self.current_epoch,
+                    true,
+                ));
             }
         }
 
@@ -204,24 +209,23 @@ impl BlockVisitor for DRepStateVisitor {
         &mut self,
         deltas: &mut WorkDeltas,
         block: &MultiEraBlock,
-        tx: &MultiEraTx,
+        _: &MultiEraTx,
         order: &TxOrder,
         cert: &MultiEraCert,
     ) -> Result<(), ChainError> {
-        // Committee certificates target the governance singleton. Valid txs
-        // only — CERT state effects never apply for phase-2-invalid txs.
-        if tx.is_valid() {
-            if let Some(auth) = pallas_extras::cert_as_committee_auth(cert) {
-                deltas.add_for_entity(crate::CommitteeAuth::new(auth.cold, auth.hot, block.slot()));
-            }
+        // Committee certificates target the governance singleton. The crawl
+        // gates the whole certificate fan-out on `tx.is_valid()`, so CERT
+        // state effects never apply for a phase-2-invalid transaction.
+        if let Some(auth) = pallas_extras::cert_as_committee_auth(cert) {
+            deltas.add_for_entity(crate::CommitteeAuth::new(auth.cold, auth.hot, block.slot()));
+        }
 
-            if let Some(resign) = pallas_extras::cert_as_committee_resign(cert) {
-                deltas.add_for_entity(crate::CommitteeResign::new(
-                    resign.cold,
-                    resign.anchor,
-                    block.slot(),
-                ));
-            }
+        if let Some(resign) = pallas_extras::cert_as_committee_resign(cert) {
+            deltas.add_for_entity(crate::CommitteeResign::new(
+                resign.cold,
+                resign.anchor,
+                block.slot(),
+            ));
         }
 
         let Some(drep) = cert_drep(cert) else {
@@ -241,26 +245,24 @@ impl BlockVisitor for DRepStateVisitor {
 
                     deltas.add_for_entity(DRepAnchorUpdate::new(drep.clone(), anchor.clone()));
 
-                    if tx.is_valid() {
-                        if let Some(expiry) = self.registration_expiry() {
-                            deltas.add_for_entity(DRepExpiryUpdate::new(
-                                drep.clone(),
-                                expiry,
-                                self.current_epoch,
-                                false,
-                            ));
-                        }
+                    if let Some(expiry) = self.registration_expiry() {
+                        deltas.add_for_entity(DRepExpiryUpdate::new(
+                            drep.clone(),
+                            expiry,
+                            self.current_epoch,
+                            false,
+                        ));
+                    }
 
-                        // While a dormant stretch is open, a registration
-                        // creates a row the batch-start snapshot doesn't
-                        // have — remember it so a release later in the
-                        // batch still reaches it (Haskell folds over the
-                        // live DRep map, which includes it).
-                        if self.dormancy.dormant_epochs > 0 {
-                            self.dormancy
-                                .batch_registrations
-                                .push(drep_to_entity_key(&drep));
-                        }
+                    // While a dormant stretch is open, a registration creates
+                    // a row the batch-start snapshot doesn't have — remember
+                    // it so a release later in the batch still reaches it
+                    // (Haskell folds over the live DRep map, which includes
+                    // it).
+                    if self.dormancy.dormant_epochs > 0 {
+                        self.dormancy
+                            .batch_registrations
+                            .push(drep_to_entity_key(&drep));
                     }
                 }
                 conway::Certificate::UnRegDRepCert(_, _) => {
@@ -273,15 +275,13 @@ impl BlockVisitor for DRepStateVisitor {
                 conway::Certificate::UpdateDRepCert(_, anchor) => {
                     deltas.add_for_entity(DRepAnchorUpdate::new(drep.clone(), anchor.clone()));
 
-                    if tx.is_valid() {
-                        if let Some(expiry) = self.refresh_expiry() {
-                            deltas.add_for_entity(DRepExpiryUpdate::new(
-                                drep.clone(),
-                                expiry,
-                                self.current_epoch,
-                                false,
-                            ));
-                        }
+                    if let Some(expiry) = self.refresh_expiry() {
+                        deltas.add_for_entity(DRepExpiryUpdate::new(
+                            drep.clone(),
+                            expiry,
+                            self.current_epoch,
+                            false,
+                        ));
                     }
                 }
                 _ => (),

--- a/crates/cardano/src/roll/mod.rs
+++ b/crates/cardano/src/roll/mod.rs
@@ -61,6 +61,11 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a transaction. IMPORTANT: the crawl calls this for *every*
+    /// transaction in the block, phase-2-invalid ones included, so that fees
+    /// and collateral can still be priced. An implementation that consumes
+    /// transaction-body content (certificates, mints, withdrawals, proposals,
+    /// votes) owes its own `tx.is_valid()` check.
     #[allow(unused_variables)]
     fn visit_tx(
         &mut self,
@@ -72,6 +77,9 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a consumed input. IMPORTANT: for a phase-2-invalid transaction
+    /// pallas resolves `consumes()` to the collateral inputs, which is exactly
+    /// what the ledger spends — this must not be gated on validity.
     #[allow(unused_variables)]
     fn visit_input(
         &mut self,
@@ -84,6 +92,9 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a produced output. IMPORTANT: for a phase-2-invalid transaction
+    /// pallas resolves `produces()` to the collateral-return output, which is
+    /// exactly what the ledger creates — this must not be gated on validity.
     #[allow(unused_variables)]
     fn visit_output(
         &mut self,
@@ -96,6 +107,8 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a mint. The crawl calls this only for valid transactions: the
+    /// Conway LEDGER rule applies no body effects for a phase-2 failure.
     #[allow(unused_variables)]
     fn visit_mint(
         &mut self,
@@ -107,6 +120,8 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a certificate. The crawl calls this only for valid transactions:
+    /// CERTS runs only under `IsValid True`.
     #[allow(unused_variables)]
     fn visit_cert(
         &mut self,
@@ -119,6 +134,8 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a withdrawal. The crawl calls this only for valid transactions:
+    /// the withdrawal drain runs only under `IsValid True`.
     #[allow(unused_variables)]
     fn visit_withdrawal(
         &mut self,
@@ -131,6 +148,11 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a protocol-parameter update. The crawl calls the transaction-
+    /// carried form (`tx: Some(_)`) only for valid transactions — UTXOS's
+    /// invalid branch returns the PPUP state untouched. The block-level form
+    /// (`tx: None`) is the Byron/Shelley header update, which has no
+    /// transaction and no validity.
     #[allow(unused_variables)]
     fn visit_update(
         &mut self,
@@ -155,6 +177,8 @@ pub trait BlockVisitor {
         Ok(())
     }
 
+    /// Visit a governance proposal. The crawl calls this only for valid
+    /// transactions: GOV runs only under `IsValid True`.
     #[allow(unused_variables)]
     fn visit_proposal(
         &mut self,
@@ -384,74 +408,83 @@ impl<'a> DeltaBuilder<'a> {
                     .visit_output(&mut deltas, block, tx, index as u32, &output)?;
             }
 
-            for mint in tx.mints() {
-                self.account_state
-                    .visit_mint(&mut deltas, block, tx, &mint)?;
-                self.asset_state.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.datum_state.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.drep_state.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.epoch_state.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.pool_state.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.tx_logs.visit_mint(&mut deltas, block, tx, &mint)?;
-                self.proposal_logs
-                    .visit_mint(&mut deltas, block, tx, &mint)?;
-            }
+            // The Conway LEDGER rule runs CERTS, GOV, the withdrawal drain and
+            // the PPUP/update registration only under `IsValid True`; a
+            // phase-2-invalid tx moves collateral and nothing else. Two
+            // carve-outs stay outside this guard: the input/output fan-outs,
+            // where pallas already resolves `consumes()`/`produces()` to the
+            // collateral pair, and `visit_tx`, which every visitor still sees
+            // so fees and collateral can be priced.
+            if tx.is_valid() {
+                for mint in tx.mints() {
+                    self.account_state
+                        .visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.asset_state.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.datum_state.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.drep_state.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.epoch_state.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.pool_state.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.tx_logs.visit_mint(&mut deltas, block, tx, &mint)?;
+                    self.proposal_logs
+                        .visit_mint(&mut deltas, block, tx, &mint)?;
+                }
 
-            for cert in tx.certs() {
-                self.account_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.asset_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.datum_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.drep_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.epoch_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.pool_state
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.tx_logs
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-                self.proposal_logs
-                    .visit_cert(&mut deltas, block, tx, &order, &cert)?;
-            }
+                for cert in tx.certs() {
+                    self.account_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.asset_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.datum_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.drep_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.epoch_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.pool_state
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.tx_logs
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                    self.proposal_logs
+                        .visit_cert(&mut deltas, block, tx, &order, &cert)?;
+                }
 
-            for (account, amount) in tx.withdrawals().collect::<Vec<_>>() {
-                self.account_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.asset_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.datum_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.drep_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.epoch_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.pool_state
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.tx_logs
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-                self.proposal_logs
-                    .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
-            }
+                for (account, amount) in tx.withdrawals().collect::<Vec<_>>() {
+                    self.account_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.asset_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.datum_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.drep_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.epoch_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.pool_state
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.tx_logs
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                    self.proposal_logs
+                        .visit_withdrawal(&mut deltas, block, tx, account, amount)?;
+                }
 
-            if let Some(update) = tx.update() {
-                self.account_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.asset_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.datum_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.drep_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.epoch_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.pool_state
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.tx_logs
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
-                self.proposal_logs
-                    .visit_update(&mut deltas, block, Some(tx), &update)?;
+                if let Some(update) = tx.update() {
+                    self.account_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.asset_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.datum_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.drep_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.epoch_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.pool_state
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.tx_logs
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                    self.proposal_logs
+                        .visit_update(&mut deltas, block, Some(tx), &update)?;
+                }
             }
 
             for datum in tx.plutus_data() {
@@ -472,23 +505,27 @@ impl<'a> DeltaBuilder<'a> {
                     .visit_datums(&mut deltas, block, tx, datum)?;
             }
 
-            for (idx, proposal) in tx.gov_proposals().iter().enumerate() {
-                self.account_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.asset_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.datum_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.drep_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.epoch_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.pool_state
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.tx_logs
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
-                self.proposal_logs
-                    .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+            // Same LEDGER gate as above: GOV never registers a proposal
+            // carried by a phase-2-invalid transaction.
+            if tx.is_valid() {
+                for (idx, proposal) in tx.gov_proposals().iter().enumerate() {
+                    self.account_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.asset_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.datum_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.drep_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.epoch_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.pool_state
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.tx_logs
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                    self.proposal_logs
+                        .visit_proposal(&mut deltas, block, tx, proposal, idx)?;
+                }
             }
 
             for redeemer in tx.redeemers() {
@@ -614,4 +651,248 @@ pub(crate) fn compute_delta<D: Domain>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use dolos_core::NsKey;
+    use pallas::codec::utils::{NonEmptySet, NonZeroInt, Set};
+    use pallas::crypto::hash::Hash;
+    use pallas::ledger::primitives::conway::{
+        Anchor, Certificate, GovAction, GovActionId, ProposalProcedure, TransactionBody, Vote,
+        Voter, VotingProcedure,
+    };
+    use pallas::ledger::primitives::{StakeCredential, UnitInterval};
+
+    use crate::model::{EpochStatsUpdate, PParamValue as Val};
+    use crate::{CardanoDelta, OwnedMultiEraBlock};
+
+    use super::*;
+
+    const SLOT: u64 = 1_000;
+    const EPOCH: Epoch = 42;
+    const EPOCH_START: u64 = 900;
+
+    /// A transaction body with no inputs and no outputs — `consumes()` and
+    /// `produces()` are empty under either validity, so the crawl needs no
+    /// resolved UTxOs — carrying one of every body element the LEDGER rule
+    /// gates: a stake registration, a DRep registration, a pool registration,
+    /// a withdrawal, a mint, a proposal and a vote.
+    fn loaded_tx_body() -> TransactionBody<'static> {
+        let mut mint = BTreeMap::new();
+        let mut assets = BTreeMap::new();
+        assets.insert(
+            pallas::ledger::primitives::Bytes::from(vec![0xaa, 0xbb]),
+            NonZeroInt::try_from(7i64).unwrap(),
+        );
+        mint.insert(Hash::<28>::from([0x33u8; 28]), assets);
+
+        let mut withdrawals = BTreeMap::new();
+        withdrawals.insert(
+            pallas::codec::utils::Bytes::from(vec![0xe0; 29]),
+            1_000_000u64,
+        );
+
+        let anchor = Anchor {
+            url: "https://example.com".to_string(),
+            content_hash: Hash::<32>::from([0x44u8; 32]),
+        };
+
+        let proposal = ProposalProcedure {
+            deposit: 100_000_000,
+            reward_account: pallas::codec::utils::Bytes::from(vec![0xe0; 29]),
+            gov_action: GovAction::Information,
+            anchor: anchor.clone(),
+        };
+
+        let mut votes = BTreeMap::new();
+        votes.insert(
+            GovActionId {
+                transaction_id: Hash::<32>::from([0x55u8; 32]),
+                action_index: 0,
+            },
+            VotingProcedure {
+                vote: Vote::Yes,
+                anchor: None,
+            },
+        );
+        let mut voting_procedures = BTreeMap::new();
+        voting_procedures.insert(Voter::DRepKey(Hash::<28>::from([0x66u8; 28])), votes);
+
+        let certs = vec![
+            Certificate::StakeRegistration(StakeCredential::AddrKeyhash(Hash::<28>::from(
+                [0x11u8; 28],
+            ))),
+            Certificate::RegDRepCert(
+                StakeCredential::AddrKeyhash(Hash::<28>::from([0x66u8; 28])),
+                500_000_000,
+                Some(anchor.clone()),
+            ),
+            // Operator differs from the block issuer, so a `pools` row for it
+            // is unambiguously the certificate's doing and not `visit_root`'s.
+            Certificate::PoolRegistration {
+                operator: Hash::<28>::from([0x77u8; 28]),
+                vrf_keyhash: Hash::<32>::from([0x88u8; 32]),
+                pledge: 1,
+                cost: 2,
+                margin: UnitInterval {
+                    numerator: 1,
+                    denominator: 2,
+                },
+                reward_account: pallas::codec::utils::Bytes::from(vec![0xe0; 29]),
+                pool_owners: Set::from(vec![]),
+                relays: vec![],
+                pool_metadata: None,
+            },
+        ];
+
+        TransactionBody {
+            inputs: Set::from(vec![]),
+            outputs: vec![],
+            fee: 170_000,
+            ttl: None,
+            certificates: Some(NonEmptySet::try_from(certs).unwrap()),
+            withdrawals: Some(withdrawals),
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: Some(mint),
+            script_data_hash: None,
+            collateral: None,
+            required_signers: None,
+            network_id: None,
+            collateral_return: None,
+            total_collateral: None,
+            reference_inputs: None,
+            voting_procedures: Some(voting_procedures),
+            proposal_procedures: Some(NonEmptySet::try_from(vec![proposal]).unwrap()),
+            treasury_value: None,
+            donation: None,
+        }
+    }
+
+    fn test_pparams() -> PParamsSet {
+        PParamsSet::default()
+            .with(Val::ProtocolVersion((10, 0)))
+            .with(Val::KeyDeposit(2_000_000))
+            .with(Val::PoolDeposit(500_000_000))
+            .with(Val::DrepDeposit(500_000_000))
+            .with(Val::DrepInactivityPeriod(20))
+            .with(Val::GovernanceActionValidityPeriod(6))
+    }
+
+    /// Crawl a one-transaction Conway block whose transaction is valid or
+    /// phase-2-invalid, and hand back the deltas it produced.
+    fn crawl_single_tx_block(valid: bool) -> WorkDeltas {
+        let (_, raw) =
+            dolos_testing::blocks::make_conway_block_with_tx(SLOT, loaded_tx_body(), None, valid);
+
+        let block = OwnedMultiEraBlock::decode(raw).unwrap();
+        let mut work = WorkBlock::new(block);
+
+        let genesis = Arc::new(crate::load_test_genesis("preview"));
+        let pparams = test_pparams();
+        let utxos = HashMap::new();
+
+        let mut builder = DeltaBuilder::new(
+            genesis,
+            10,
+            &pparams,
+            EPOCH,
+            EPOCH_START,
+            &mut work,
+            &utxos,
+            DormancyContext::default(),
+        );
+
+        builder.crawl().unwrap();
+
+        work.deltas
+    }
+
+    fn keys_in(deltas: &WorkDeltas, ns: &str) -> Vec<EntityKey> {
+        deltas
+            .entities
+            .keys()
+            .filter(|NsKey(namespace, _)| *namespace == ns)
+            .map(|NsKey(_, key)| key.clone())
+            .collect()
+    }
+
+    fn epoch_stats(deltas: &WorkDeltas) -> EpochStatsUpdate {
+        deltas
+            .entities
+            .iter()
+            .filter(|(NsKey(ns, _), _)| *ns == "epochs")
+            .flat_map(|(_, group)| group.iter())
+            .find_map(|delta| match delta {
+                CardanoDelta::EpochStatsUpdate(stats) => Some((**stats).clone()),
+                _ => None,
+            })
+            .expect("epoch stats delta")
+    }
+
+    /// The block issuer's operator hash, which `PoolStateVisitor::visit_root`
+    /// emits a `MintedBlocksInc` for on every block regardless of validity.
+    fn block_issuer_key() -> EntityKey {
+        let issuer =
+            dolos_testing::blocks::make_conway_block_with_tx(SLOT, loaded_tx_body(), None, true);
+        let block = OwnedMultiEraBlock::decode(issuer.1).unwrap();
+        let key = block.view().header().issuer_vkey().unwrap().to_vec();
+        let operator = pallas::crypto::hash::Hasher::<224>::hash(&key);
+        EntityKey::from(operator.as_slice())
+    }
+
+    #[test]
+    fn invalid_tx_contributes_no_entity_state() {
+        let deltas = crawl_single_tx_block(false);
+
+        for ns in ["accounts", "dreps", "proposals", "assets"] {
+            assert!(
+                keys_in(&deltas, ns).is_empty(),
+                "phase-2-invalid tx wrote to the `{ns}` namespace"
+            );
+        }
+
+        assert_eq!(
+            keys_in(&deltas, "pools"),
+            vec![block_issuer_key()],
+            "the only pools row must be the block issuer's minted-blocks counter"
+        );
+
+        let stats = epoch_stats(&deltas);
+        assert_eq!(stats.new_accounts, 0);
+        assert_eq!(stats.removed_accounts, 0);
+        assert_eq!(stats.drep_deposits, 0);
+        assert_eq!(stats.drep_refunds, 0);
+        assert_eq!(stats.proposal_deposits, 0);
+        assert_eq!(stats.withdrawals, 0);
+        assert_eq!(stats.reserve_mirs, 0);
+        assert_eq!(stats.treasury_mirs, 0);
+        assert!(stats.registered_pools.is_empty());
+
+        // The transaction is still counted and its collateral still priced.
+        assert_eq!(stats.tx_count, 1);
+    }
+
+    #[test]
+    fn valid_tx_contributes_entity_state() {
+        let deltas = crawl_single_tx_block(true);
+
+        for ns in ["accounts", "dreps", "proposals", "assets", "pools"] {
+            assert!(
+                !keys_in(&deltas, ns).is_empty(),
+                "valid tx wrote nothing to the `{ns}` namespace — the fixture is wrong"
+            );
+        }
+
+        let stats = epoch_stats(&deltas);
+        assert!(stats.new_accounts > 0);
+        assert!(stats.drep_deposits > 0);
+        assert!(stats.proposal_deposits > 0);
+        assert!(stats.withdrawals > 0);
+        assert!(!stats.registered_pools.is_empty());
+        assert_eq!(stats.tx_count, 1);
+    }
 }

--- a/crates/cardano/src/roll/mod.rs
+++ b/crates/cardano/src/roll/mod.rs
@@ -833,6 +833,12 @@ mod tests {
             .expect("epoch stats delta")
     }
 
+    /// The operator hash of the fixture's `PoolRegistration` certificate,
+    /// which `PoolRegistration::key` uses as the `pools` entity key.
+    fn cert_pool_key() -> EntityKey {
+        EntityKey::from([0x77u8; 28].as_slice())
+    }
+
     /// The block issuer's operator hash, which `PoolStateVisitor::visit_root`
     /// emits a `MintedBlocksInc` for on every block regardless of validity.
     fn block_issuer_key() -> EntityKey {
@@ -886,6 +892,13 @@ mod tests {
                 "valid tx wrote nothing to the `{ns}` namespace — the fixture is wrong"
             );
         }
+
+        // `visit_root` alone fills `pools` with the block issuer, so only the
+        // certificate's own operator key proves the cert path ran.
+        assert!(
+            keys_in(&deltas, "pools").contains(&cert_pool_key()),
+            "valid tx did not register the certificate's pool — the fixture is wrong"
+        );
 
         let stats = epoch_stats(&deltas);
         assert!(stats.new_accounts > 0);

--- a/crates/testing/src/blocks.rs
+++ b/crates/testing/src/blocks.rs
@@ -71,10 +71,18 @@ pub fn make_conway_block_with_prev(
     (chain_point, Arc::new(raw_bytes))
 }
 
+/// Hard-fork-combinator variant index for a Conway block. `pallas`'s
+/// `probe::block_era` reads this to pick the decoder, and its numbering is
+/// offset by one from `Era` (`Era::Byron` is 0, but the Byron variant is 1),
+/// so `Era::Conway as u16` would tag the block as Babbage — which decodes an
+/// empty body fine and only fails once the body carries a Conway-only field.
+const CONWAY_BLOCK_WRAPPER: u16 = 7;
+
 pub fn make_conway_block_with_tx(
     slot: BlockSlot,
     tx_body: pallas::ledger::primitives::conway::TransactionBody<'static>,
     auxiliary_data: Option<alonzo::AuxiliaryData>,
+    valid: bool,
 ) -> (ChainPoint, RawBlock) {
     let header_body = HeaderBody {
         block_number: 1,
@@ -123,12 +131,12 @@ pub fn make_conway_block_with_tx(
             }
             None => BTreeMap::new(),
         },
-        invalid_transactions: None,
+        invalid_transactions: if valid { None } else { Some(vec![0]) },
     };
 
     let hash = block.header.compute_hash();
 
-    let wrapper = (Era::Conway as u16, block);
+    let wrapper = (CONWAY_BLOCK_WRAPPER, block);
 
     let raw_bytes = pallas::codec::minicbor::to_vec(&wrapper).unwrap();
     let chain_point = ChainPoint::Specific(slot, hash);


### PR DESCRIPTION
Plan: `plans/dolos-invalid-tx-visitor-gating.md`

## The defect

Phase-2-invalid transactions move collateral and nothing else in the Cardano ledger. The Conway `LEDGER` rule runs `CERTS`, `GOV`, the withdrawal drain and the DRep expiry bookkeeping **only** under `IsValid True` (`Cardano/Ledger/Conway/Rules/Ledger.hs`, the `else` arm is a bare `pure (utxoState, certState)`). Pre-Conway, `UTXOS`'s invalid branch returns the `PPUP` state untouched, so an update proposal carried by an invalid transaction is never registered.

`DeltaBuilder::crawl` fanned every transaction's certs, mints, withdrawals, update and proposals out to all eight visitors with no validity check. The consequences are not cosmetic:

- **A DRep row is created for a registration that never happened** — `DRepActivity::apply` does `get_or_insert_with(DRepState::new)`, and the crawl emitted it for every DRep-bearing cert.
- **Real vote delegations can be destroyed** — an ungated `DRepUnRegistration` stamps `unregistered_at`, which the epoch-boundary sweep reads to drop delegators.
- **The deposits pot drifts** — `EpochStatsUpdate`'s account, pool, DRep, proposal, withdrawal and MIR counters all feed `Pots`, and so reserves, treasury and the reward calculation.
- **Asset supply moves for a mint that never happened.**
- Account and pool state followed the same pattern; governance was gated only in the two places phase 2 of the governance-gaps work happened to touch.

`MultiEraTx::consumes()`/`produces()` are already validity-aware (they resolve to the collateral pair), but `certs()`, `mints()`, `gov_proposals()`, `withdrawals()` and `update()` return the transaction body's content regardless.

## What changed

**`crates/cardano/src/roll/mod.rs`** — two `if tx.is_valid()` guards inside `DeltaBuilder::crawl`'s per-transaction loop: one over the mint / cert / withdrawal / update span, one over the proposal span. Nothing else moved or was reordered.

The gate lives in the crawl, not in the visitors: the rule is a property of the `LEDGER` transition, not of any one entity, and a single call site cannot be forgotten by a visitor added later — it had already been forgotten outright in four of the eight visitors.

Left deliberately ungated:

- the input and output fan-outs — pallas already resolves them to the collateral pair;
- `visit_tx` — `define_tx_fees`/`compute_collateral_value` branch on validity themselves, and this is where an invalid transaction's collateral is priced and counted;
- `visit_datums` refcounting, driven by the same collateral-aware fan-outs;
- the block-level `visit_update(…, None, …)` — the Byron/Shelley header update has no transaction and no validity.

**`BlockVisitor` trait doc comments** — record which side of the split each hook is on, so the invariant is discoverable from the trait rather than only from the crawl.

**`crates/cardano/src/roll/dreps.rs`** — `visit_tx` still runs for invalid transactions, so it keeps a gate, but one instead of three: an early return after the Conway binding, replacing the dormancy-release condition's `tx.is_valid() &&` and the inner wrapper around the expiry refresh. The `DRepActivity` emitted for a voter — ungated before — now falls under it. `visit_cert` is unreachable for invalid transactions after the crawl guard, so its three checks are dead and are removed.

`roll/proposals.rs` is unchanged: its `if !tx.is_valid()` is in `visit_tx`, which still runs for every transaction.

**No change to the archive or index side.** `CardanoIndexDeltaBuilder::index_block` keeps indexing every transaction's certs, withdrawals and inputs, and minibf keeps serving an invalid transaction's certificates alongside `valid_contract: false`. Entity state models the ledger; the index models the block.

## Tests

`crates/cardano/src/roll/mod.rs` gains two tests over a Conway block whose single transaction has no inputs and no outputs (so `consumes()`/`produces()` are empty under either validity and no resolved UTxOs are needed) and carries a stake registration, a `RegDRepCert`, a `PoolRegistration` whose operator differs from the block issuer, a withdrawal, a mint, an `Information` proposal and a DRep vote:

- `invalid_tx_contributes_no_entity_state` — nothing lands in the `accounts`, `dreps`, `proposals` or `assets` namespaces; the only `pools` key is the block issuer's `MintedBlocksInc` from `visit_root`; every gated `EpochStatsUpdate` counter is zero while `tx_count == 1`.
- `valid_tx_contributes_entity_state` — the same body with `valid = true` populates each of those namespaces and each of those counters. Without it the first test would pass on a malformed fixture.

Reverting either crawl guard fails `invalid_tx_contributes_no_entity_state`.

### A latent bug in the test-block builder

`make_conway_block_with_tx` gains the `valid: bool` parameter these tests need. It also had to be corrected: it tagged its blocks `Era::Conway as u16`, which is `6` — the hard-fork-combinator index for **Babbage**, since `Era::Byron` is `0` but the Byron wrapper variant is `1`. pallas's `probe::block_era` therefore picked the Babbage decoder. Nothing noticed because the helper had no callers in the workspace and an empty transaction body decodes identically either way; a body carrying a Conway-only field fails with `unexpected type tag … expected array`. Fixed here as `CONWAY_BLOCK_WRAPPER: u16 = 7` with a comment naming the off-by-one.

Two sibling call sites have the same off-by-one and are **not** touched by this PR, since they are out of its scope and their blocks carry no Conway-only fields today: `crates/testing/src/blocks.rs:66` (`make_conway_block_with_prev`, whose blocks have no transactions at all) and `src/bin/dolos/doctor/wal_integrity.rs:198`.

## Verification

Run against `origin/main` at `d1a2da1e`:

- `cargo test --workspace` — pass (exit 0; 1 400+ tests across every crate, including the 262 `dolos-cardano` unit tests).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

No existing test asserted the old behaviour, so nothing had to be adjusted.

## Migration note

**No already-synced instance is repaired by this change.** The gate only takes effect when the affected block is replayed, so existing instances — and any published stele restored from one — keep whatever an invalid transaction wrote to their entity state. Whether and when to re-cut the published snapshots is a separate decision.

The defect is observable only on blocks that carry a phase-2-invalid transaction with certificates, proposals, withdrawals or mints. That is rare, but the divergence it produces is unbounded in size once it happens: a single invalid `UnRegDRepCert` destroys real vote delegations, and a single invalid deposit drifts the pots for the rest of the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1ypWFNr3Rao9qNJycJ4aS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction processing so phase-2-invalid transactions no longer apply minting, withdrawal, certificate, governance, or update effects.
  * Valid transactions continue to update ledger state, expiry information, voting activity, and related statistics correctly.
  * Preserved transaction tracking and collateral-resolved input/output handling for invalid transactions.
  * Corrected Conway block decoding and validation behavior in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->