### PR TITLE
fix(ci): keep the Windows job off `getrusage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -91,9 +93,18 @@ jobs:
   # Windows is the slowest job and skips e2e, so on a PR it adds latency without
   # coverage anyone acts on. A Windows-only break lands on main and is caught by
   # the merge run instead of blocking the PR.
+  #
+  # The cost of that trade is that a fix *for* a Windows break cannot be proven
+  # before it merges, which is how the `getrusage` break stayed red across five
+  # merges. The two extra arms are the way out: label a PR `ci:windows` to opt
+  # it into this job, or dispatch the workflow against a branch. Neither changes
+  # what an unlabelled PR runs.
   test-windows:
     name: Test (windows-latest)
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main'
+      || github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'ci:windows')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,11 +123,6 @@ serial_test = "3"
 dolos-redb3 = { path = "crates/redb3" }
 stelae = { path = "crates/stelae" }
 
-# `nix` is a POSIX binding and has no Windows build. The e2e tests that SIGTERM
-# a child are already `#![cfg(not(windows))]`, and the `getrusage` measurements
-# in tests/index_roundtrip.rs are `#[cfg(unix)]` for the same reason; gating the
-# dependency here keeps the two from drifting apart, and spares the Windows job
-# a crate it can only ever compile to nothing.
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.30.1", features = ["signal", "resource"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ divan = "0.1.21"
 comfy-table = "7.1.1"
 csv = "1"
 csv-diff = "0.1"
-nix = { version = "0.30.1", features = ["signal", "resource"] }
 serde = { workspace = true }
 tempfile = "3.20.0"
 toml = "0.8.13"
@@ -123,6 +122,14 @@ stats_alloc = "0.1"
 serial_test = "3"
 dolos-redb3 = { path = "crates/redb3" }
 stelae = { path = "crates/stelae" }
+
+# `nix` is a POSIX binding and has no Windows build. The e2e tests that SIGTERM
+# a child are already `#![cfg(not(windows))]`, and the `getrusage` measurements
+# in tests/index_roundtrip.rs are `#[cfg(unix)]` for the same reason; gating the
+# dependency here keeps the two from drifting apart, and spares the Windows job
+# a crate it can only ever compile to nothing.
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.30.1", features = ["signal", "resource"] }
 
 [build-dependencies]
 vergen-gitcl = "9.1.0"

--- a/tests/index_roundtrip.rs
+++ b/tests/index_roundtrip.rs
@@ -1093,6 +1093,12 @@ fn measure_one_epoch_iteration_cost() {
 /// The unit is not portable: macOS reports bytes and Linux kilobytes. Both are
 /// spelled out rather than papered over, because a figure that is a thousand
 /// times wrong is worse than no figure.
+///
+/// `getrusage` is POSIX and has no Windows counterpart, so this and everything
+/// downstream of it is unix-only. The gate has to match the one on `nix` in
+/// `Cargo.toml` exactly — a config where one applies and the other does not is
+/// the compile error this replaces.
+#[cfg(unix)]
 fn max_rss_bytes() -> u64 {
     let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)
         .expect("getrusage failed");
@@ -1105,6 +1111,7 @@ fn max_rss_bytes() -> u64 {
     }
 }
 
+#[cfg(unix)]
 fn mib(bytes: u64) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
@@ -1121,6 +1128,7 @@ fn mib(bytes: u64) -> f64 {
 /// Run with:
 /// `cargo test --release --test index_roundtrip -- --ignored --nocapture
 /// measure_layer_sink_residency`
+#[cfg(unix)]
 #[test]
 #[ignore = "measurement, not an assertion"]
 fn measure_layer_sink_residency() {
@@ -1201,6 +1209,7 @@ fn measure_layer_sink_residency() {
 /// `cargo test --release --test index_roundtrip -- --ignored --nocapture
 /// measure_banded_publish_cost`, and `DOLOS_INDEX_COST_EPOCHS=32` for the
 /// deeper store [`measure_one_epoch_iteration_cost`] also reports.
+#[cfg(unix)]
 #[test]
 #[ignore = "measurement, not an assertion"]
 fn measure_banded_publish_cost() {
@@ -1266,6 +1275,7 @@ fn measure_banded_publish_cost() {
 
 /// Publish the seeded index store at `band`, into a directory that lives as
 /// long as the returned guard.
+#[cfg(unix)]
 fn publish_at_band<S: CoreIndexStore>(
     store: &S,
     epochs: u64,
@@ -1323,6 +1333,7 @@ fn publish_at_band<S: CoreIndexStore>(
 
 /// One era of [`EPOCH_LEN`]-slot epochs from slot zero — the geometry
 /// [`epoch_slots`] already seeds against, stated in the form a [`Plan`] reads.
+#[cfg(unix)]
 fn cost_summary() -> dolos_cardano::eras::ChainSummary {
     let mut chain = dolos_cardano::eras::ChainSummary::default();
 


### PR DESCRIPTION
## What's broken

The `Test (windows-latest)` job has failed on **every merge to main since 2026-08-23**. Five consecutive red runs, one cause:

```
error[E0433]: failed to resolve: could not find `sys` in `nix`
    --> tests\index_roundtrip.rs:1097:22
1097 |     let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)
     |                      ^^^ could not find `sys` in `nix`
```

`nix` is a POSIX binding that compiles to an empty crate on Windows, so the `dolos` test target never builds there. **No test in the workspace has run on Windows since 135cfc68 (2026-08-22)** — the job dies at compile time.

Introduced by 7e1d21ec (#1255), which added both `max_rss_bytes()` and the `nix` dev-dependency. That commit is the first red run (32645217496), and the last green Windows job is the merge immediately before it.

## The fix

`getrusage` is POSIX with no Windows counterpart, and the code that wants it is a self-contained cluster nothing else reaches:

| item | why it's gated |
|---|---|
| `max_rss_bytes` | calls `getrusage` |
| `mib` | only formats RSS figures |
| `measure_layer_sink_residency` | `#[ignore]` measurement, reads RSS |
| `measure_banded_publish_cost` | `#[ignore]` measurement, reads RSS |
| `publish_at_band`, `cost_summary` | reached only from `measure_banded_publish_cost` |

All six get `#[cfg(unix)]`, and `nix` moves to `[target.'cfg(unix)'.dev-dependencies]` so the code gate and the dependency gate can't drift — a config where one applies and the other doesn't is exactly the compile error this replaces.

`cost_epochs` / `cost_spec` are **not** gated: `measure_one_epoch_iteration_cost` also uses them and needs no RSS. The e2e tests that `SIGTERM` a child were already `#![cfg(not(windows))]` and are untouched.

### Nothing is lost on Windows

All 19 index-roundtrip conformance tests still build and run there. The two that drop out are `#[ignore]`-marked measurements CI never invokes on any platform, and they remain fully available on Linux and macOS (verified: `cargo test --test index_roundtrip -- --list` still reports 22 tests on macOS).

## Closing the hole that let this sit red

The job is pinned to `refs/heads/main`, which is a deliberate latency trade from 135cfc68 — but it means a fix *for* a Windows break can't be proven before it merges. That's how this stayed red across five merges.

Two arms added to the condition:

```yaml
if: >-
  github.ref == 'refs/heads/main'
  || github.event_name == 'workflow_dispatch'
  || contains(github.event.pull_request.labels.*.name, 'ci:windows')
```

Label a PR `ci:windows` to opt it in, or dispatch the workflow against a branch. **An unlabelled PR runs exactly what it ran before** — the main-only default is preserved.

Two supporting trigger changes:
- `workflow_dispatch:` added, so the dispatch arm can ever be true. (It only becomes usable once this is on main — GitHub reads dispatch triggers from the default branch.)
- `labeled` added to `pull_request` types, so applying the label re-evaluates the job instead of waiting for the next push.

> **One side effect worth knowing:** with `labeled` in the trigger types, adding *any* label to an open PR starts a fresh CI run. `cancel-in-progress` keeps that to one run rather than two, and all jobs still run on that event so no required check ends up skipped or cancelled mid-flight.

## Verification

- `cargo check --workspace --all-targets` on macOS — clean, no warnings
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test --test index_roundtrip -- --list` — 22 tests, both measurements intact
- Windows itself is verified by this PR's own `ci:windows` label — the point of the escape hatch
- Diff since the last green Windows run scanned for other Windows-hostile APIs (`std::os::unix`, `PermissionsExt`, `symlink`, `libc::`, hardcoded `/tmp`): the gated `getrusage` is the only real hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)