### PR TITLE
fix(snapshot): size backfill's immutable chunks from the chain's own k

### DIFF
--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -12,13 +12,18 @@
 //! files are present. When none are — a cold container start, whose disk
 //! keeps nothing and whose store was just restored from the registry — the
 //! start is derived from the cursor's chunk file instead, a margin early,
-//! so a restart costs one window rather than the chain so far.
+//! so a restart costs one window rather than the chain so far. The chunk
+//! file's size is read from the chain's own shelley genesis rather than
+//! assumed: a mainnet-sized chunk applied to preview divides by five times
+//! too much and resumes 4096 files early, which is the whole chain over
+//! again in the direction nothing was guarding.
 //!
 //! The reader never opens the highest downloaded file — pallas pops it as
 //! "not really immutable" — so at the aggregator tip the replay stands at
-//! most one chunk (~21600 slots, about six hours) behind the mithril beacon.
-//! That lag is steady state, not loss: the next run picks the chunk up once
-//! the beacon moves past it.
+//! most one chunk (`10k` slots — about six hours on mainnet and preprod,
+//! rather over an hour on preview) behind the mithril beacon. That lag is
+//! steady state, not loss: the next run picks the chunk up once the beacon
+//! moves past it.
 //!
 //! Each iteration *opens* by publishing the sequence the cursor already stands
 //! at, then extends the replay by one epoch. Publishing on entry rather than
@@ -57,6 +62,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use dolos_core::config::RootConfig;
+use dolos_core::Genesis;
 use dolos_core::{Domain as _, DomainError, ImportExt as _, StateStore as _, WalStore as _};
 use dolos_snapshot::{
     export,
@@ -66,7 +72,7 @@ use indicatif::ProgressBar;
 use itertools::Itertools as _;
 use miette::{bail, Context as _, IntoDiagnostic as _};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::feedback::Feedback;
 use dolos::adapters::DomainAdapter;
@@ -82,13 +88,18 @@ const IMPORT_CHUNK: usize = 100;
 /// the immutable reader without the cursor's own chunk.
 const IMMUTABLE_FILE_MARGIN: u64 = 2;
 
-/// Slots per immutable chunk file — a node packaging convention, not a
-/// protocol invariant. Used to pick files safe to delete and, on a cold
-/// start whose download dir is empty, to derive where downloading resumes;
-/// never to plan how far a replay goes. Both uses carry
-/// [`IMMUTABLE_FILE_MARGIN`], and a derivation that still lands past the
-/// cursor's chunk is caught by the stalled-window check rather than trusted.
-const SLOTS_PER_IMMUTABLE_FILE: u64 = 21_600;
+/// Immutable chunk files a node packs per slot of the security parameter:
+/// a chunk holds `10k` slots. A packaging convention, not a protocol
+/// invariant — stated as the multiplier so the derivation below reads as
+/// the rule rather than as one chain's answer to it.
+const SLOTS_PER_SECURITY_PARAM: u64 = 10;
+
+/// Slots per immutable chunk file when the shelley genesis names no
+/// `securityParam`: mainnet's `10k`, which is what every dolos before this
+/// one used on every chain. Guessing *small* is the expensive direction —
+/// it resumes a cold start far behind its own cursor — so an unknown `k`
+/// keeps the old value rather than inventing a smaller one.
+const FALLBACK_SLOTS_PER_IMMUTABLE_FILE: u64 = 21_600;
 
 /// Where the mithril window lands when the operator names nowhere: beside the
 /// stores, so the bytes stay on the data mount.
@@ -177,6 +188,25 @@ enum Import {
     Cancelled,
 }
 
+/// Slots per immutable chunk file on this chain: `10k`, read from the
+/// shelley genesis the run already loads.
+///
+/// Used to pick files safe to delete and, on a cold start whose download dir
+/// is empty, to derive where downloading resumes; never to plan how far a
+/// replay goes. Both uses carry [`IMMUTABLE_FILE_MARGIN`]. The derivation is
+/// no more trusted than the literal it replaces — landing past the cursor's
+/// chunk is still caught by the stalled-window check, and landing far behind
+/// it by [`resume_lag`] — but it is at least asked of the chain being
+/// replayed: mainnet and preprod answer 21600, preview 4320.
+fn slots_per_immutable_file(genesis: &Genesis) -> u64 {
+    genesis
+        .shelley
+        .security_param
+        .map_or(FALLBACK_SLOTS_PER_IMMUTABLE_FILE, |k| {
+            u64::from(k) * SLOTS_PER_SECURITY_PARAM
+        })
+}
+
 /// The epoch the next replay stops at: one past the cursor's, or 1 from a
 /// fresh store.
 fn target_epoch(cursor_epoch: Option<u64>) -> u64 {
@@ -191,11 +221,40 @@ fn target_epoch(cursor_epoch: Option<u64>) -> u64 {
 /// restored from the registry onto a disk that keeps nothing, and resuming
 /// from file zero would re-download the whole chain, so the start is derived
 /// from the cursor's own chunk file instead, a margin early.
-fn resume_file(highest: Option<u64>, cursor_slot: Option<u64>) -> Option<u64> {
+fn resume_file(
+    highest: Option<u64>,
+    cursor_slot: Option<u64>,
+    slots_per_immutable_file: u64,
+) -> Option<u64> {
     highest.or_else(|| {
         cursor_slot
-            .map(|slot| (slot / SLOTS_PER_IMMUTABLE_FILE).saturating_sub(IMMUTABLE_FILE_MARGIN))
+            .map(|slot| (slot / slots_per_immutable_file).saturating_sub(IMMUTABLE_FILE_MARGIN))
     })
+}
+
+/// Immutable files a resume start sits behind the cursor's own chunk, past
+/// the [`IMMUTABLE_FILE_MARGIN`] the derivation deliberately backs up by, or
+/// `None` when it sits within the margin.
+///
+/// Early is the cheap direction in the small — a re-downloaded file's blocks
+/// at or before the cursor are skipped on import — and that cheapness is what
+/// left it unguarded. It stops being cheap in the large: a chunk size taken
+/// from the wrong chain resumed a preview cold start 4096 files behind its
+/// own cursor and spent 89 minutes re-downloading them before it could replay
+/// anything, with nothing in the log naming the cost. This is that number, so
+/// the next packaging assumption that drifts gets reported rather than paid
+/// for in silence.
+fn resume_lag(
+    resume: Option<u64>,
+    cursor_slot: Option<u64>,
+    slots_per_immutable_file: u64,
+) -> Option<u64> {
+    let expected = (cursor_slot? / slots_per_immutable_file).saturating_sub(IMMUTABLE_FILE_MARGIN);
+
+    match expected.saturating_sub(resume.unwrap_or(0)) {
+        0 => None,
+        lag => Some(lag),
+    }
 }
 
 /// The next download round, as `(download_start, download_end)`, or `None`
@@ -230,8 +289,8 @@ fn fetch_advanced(before: Option<u64>, after: Option<u64>) -> bool {
 
 /// Immutable files strictly below this number sit wholly behind the cursor,
 /// margin included, and are safe to delete.
-fn consumed_below(cursor_slot: u64) -> u64 {
-    (cursor_slot / SLOTS_PER_IMMUTABLE_FILE).saturating_sub(IMMUTABLE_FILE_MARGIN)
+fn consumed_below(cursor_slot: u64, slots_per_immutable_file: u64) -> u64 {
+    (cursor_slot / slots_per_immutable_file).saturating_sub(IMMUTABLE_FILE_MARGIN)
 }
 
 /// What the immutable directory holds, for a diagnostic.
@@ -261,8 +320,12 @@ fn dir_contents(immutable_dir: &Path) -> String {
 }
 
 /// Delete the numbered immutable files the replay has consumed.
-fn cleanup_consumed(immutable_dir: &Path, cursor_slot: u64) -> miette::Result<()> {
-    let threshold = consumed_below(cursor_slot);
+fn cleanup_consumed(
+    immutable_dir: &Path,
+    cursor_slot: u64,
+    slots_per_immutable_file: u64,
+) -> miette::Result<()> {
+    let threshold = consumed_below(cursor_slot, slots_per_immutable_file);
 
     if threshold == 0 {
         return Ok(());
@@ -345,6 +408,10 @@ struct Driver<'a> {
     cancel: CancellationToken,
     download_dir: PathBuf,
     immutable_dir: PathBuf,
+    /// `10k` for the chain being replayed, settled once from the shelley
+    /// genesis at startup: it cannot change under a running backfill, and
+    /// deriving it per round would only reread the same files.
+    slots_per_immutable_file: u64,
 }
 
 impl Driver<'_> {
@@ -569,7 +636,23 @@ impl Driver<'_> {
                 .context("reading the state cursor")?
                 .map(|cursor| cursor.slot());
 
-            let resume = resume_file(highest, cursor_slot);
+            let resume = resume_file(highest, cursor_slot, self.slots_per_immutable_file);
+
+            // Not fatal, and deliberately not a fallback either: the round
+            // still runs, it just stops running silently. Anything inside a
+            // window is the margin doing its job.
+            if let Some(lag) = resume_lag(resume, cursor_slot, self.slots_per_immutable_file)
+                .filter(|lag| *lag > self.args.window)
+            {
+                warn!(
+                    lag,
+                    ?resume,
+                    slots_per_immutable_file = self.slots_per_immutable_file,
+                    "the download resumes more than a window behind the cursor's own \
+                     immutable file; every file between is re-downloaded before the \
+                     replay can advance"
+                );
+            }
 
             let Some((start, end)) = next_window(resume, self.args.window, beacon) else {
                 break Advance::MithrilExhausted;
@@ -773,6 +856,16 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         bail!("missing mithril config");
     }
 
+    // Loaded here rather than at first use so a run whose genesis is missing
+    // fails before it downloads anything.
+    let genesis = crate::common::open_genesis_files(&config.genesis)?;
+    let slots_per_immutable_file = slots_per_immutable_file(&genesis);
+
+    info!(
+        slots_per_immutable_file,
+        "derived the immutable chunk size from the shelley genesis"
+    );
+
     let download_dir = args
         .download_dir
         .clone()
@@ -792,6 +885,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         cancel: spawn_exit_watcher()?,
         immutable_dir: download_dir.join("immutable"),
         download_dir,
+        slots_per_immutable_file,
     };
 
     loop {
@@ -808,7 +902,11 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 
         match driver.extend(target, prune)? {
             Advance::Boundary { cursor_slot } => {
-                cleanup_consumed(&driver.immutable_dir, cursor_slot)?;
+                cleanup_consumed(
+                    &driver.immutable_dir,
+                    cursor_slot,
+                    driver.slots_per_immutable_file,
+                )?;
             }
             Advance::MithrilExhausted => {
                 println!("the repository is up to date with mithril; nothing left to backfill");
@@ -823,6 +921,15 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 mod tests {
     use super::*;
 
+    /// Mainnet's `10k`, and the value every network used before the chunk
+    /// size was derived. Spelled out so the tests below assert against a
+    /// number rather than against the constant they are checking.
+    const MAINNET_SLOTS_PER_FILE: u64 = 21_600;
+
+    /// The preview publisher's restore cursor on 2026-08-25 — the restart
+    /// that cost 89 minutes and ~2900 re-downloaded files.
+    const PREVIEW_RESTORE_CURSOR: u64 = 22_118_504;
+
     #[test]
     fn the_first_target_is_epoch_one_and_every_later_one_follows_the_cursor() {
         assert_eq!(target_epoch(None), 1);
@@ -831,35 +938,112 @@ mod tests {
     }
 
     #[test]
+    fn the_chunk_size_is_each_networks_own_ten_k() {
+        use dolos_cardano::include;
+
+        // the four networks dolos ships a genesis for. Preview is the reason
+        // this is derived at all: its `k` is 432, so its chunks are a fifth
+        // of mainnet's and the literal divided by five times too much.
+        assert_eq!(
+            slots_per_immutable_file(&include::mainnet::load()),
+            MAINNET_SLOTS_PER_FILE,
+        );
+        assert_eq!(
+            slots_per_immutable_file(&include::preprod::load()),
+            MAINNET_SLOTS_PER_FILE,
+        );
+        assert_eq!(slots_per_immutable_file(&include::preview::load()), 4_320);
+        assert_eq!(
+            slots_per_immutable_file(&include::devnet::load()),
+            MAINNET_SLOTS_PER_FILE,
+        );
+    }
+
+    #[test]
+    fn a_genesis_without_a_security_param_keeps_the_old_value() {
+        // guessing small is the expensive direction — the one this change
+        // exists to remove — so an unknown `k` falls back rather than guesses
+        let mut genesis = dolos_cardano::include::preview::load();
+        genesis.shelley.security_param = None;
+
+        assert_eq!(slots_per_immutable_file(&genesis), MAINNET_SLOTS_PER_FILE);
+    }
+
+    #[test]
+    fn a_cold_start_resumes_from_the_cursors_own_file_on_every_network() {
+        use dolos_cardano::include;
+
+        let resume = |genesis| {
+            resume_file(
+                None,
+                Some(PREVIEW_RESTORE_CURSOR),
+                slots_per_immutable_file(&genesis),
+            )
+        };
+
+        // the regression bar: 21600-slot chunks put this cursor in file 1024,
+        // a margin early is 1022, and that is what these three resumed from
+        // before the derivation existed. A change here means it is wrong.
+        assert_eq!(resume(include::mainnet::load()), Some(1022));
+        assert_eq!(resume(include::preprod::load()), Some(1022));
+        assert_eq!(resume(include::devnet::load()), Some(1022));
+
+        // and the fix: preview's 4320-slot chunks put the same cursor in file
+        // 5120, so the resume moves 4096 files forward, onto the window it
+        // actually needs
+        assert_eq!(resume(include::preview::load()), Some(5118));
+    }
+
+    #[test]
     fn an_empty_download_dir_resumes_from_the_cursors_own_file() {
+        let resume = |highest, cursor| resume_file(highest, cursor, MAINNET_SLOTS_PER_FILE);
+
         // empty dir with a cursor: the cursor's chunk file, a margin early
         assert_eq!(
-            resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE * 6000)),
-            Some(5998),
+            resume(None, Some(MAINNET_SLOTS_PER_FILE * 6000)),
+            Some(5998)
         );
 
         // mid-file slots land in the same file before the margin applies
         assert_eq!(
-            resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE * 6000 + 5)),
+            resume(None, Some(MAINNET_SLOTS_PER_FILE * 6000 + 5)),
             Some(5998),
         );
 
         // the margin floors at the first file
-        assert_eq!(resume_file(None, Some(SLOTS_PER_IMMUTABLE_FILE)), Some(0));
-        assert_eq!(resume_file(None, Some(0)), Some(0));
+        assert_eq!(resume(None, Some(MAINNET_SLOTS_PER_FILE)), Some(0));
+        assert_eq!(resume(None, Some(0)), Some(0));
 
         // empty dir, fresh store: the beginning
-        assert_eq!(resume_file(None, None), None);
-        assert_eq!(
-            next_window(resume_file(None, None), 40, 1000),
-            Some((None, 40))
-        );
+        assert_eq!(resume(None, None), None);
+        assert_eq!(next_window(resume(None, None), 40, 1000), Some((None, 40)));
 
         // files on disk stay authoritative, wherever the cursor is
         assert_eq!(
-            resume_file(Some(120), Some(SLOTS_PER_IMMUTABLE_FILE * 6000)),
+            resume(Some(120), Some(MAINNET_SLOTS_PER_FILE * 6000)),
             Some(120),
         );
+    }
+
+    #[test]
+    fn a_resume_far_behind_the_cursors_own_file_is_measured() {
+        let lag = |resume, cursor| resume_lag(resume, cursor, 4_320);
+
+        // the derivation's own answer sits exactly on the margin: no lag
+        let derived = resume_file(None, Some(PREVIEW_RESTORE_CURSOR), 4_320);
+        assert_eq!(lag(derived, Some(PREVIEW_RESTORE_CURSOR)), None);
+
+        // what the mainnet literal did to preview, in files
+        assert_eq!(lag(Some(1022), Some(PREVIEW_RESTORE_CURSOR)), Some(4_096));
+
+        // a stale download dir costs the same way, and is reported the same
+        assert_eq!(lag(Some(5), Some(PREVIEW_RESTORE_CURSOR)), Some(5_113));
+        assert_eq!(lag(None, Some(PREVIEW_RESTORE_CURSOR)), Some(5_118));
+
+        // ahead of the cursor is the stalled-window check's business, not
+        // this one's, and no cursor is nothing to measure against
+        assert_eq!(lag(Some(9_000), Some(PREVIEW_RESTORE_CURSOR)), None);
+        assert_eq!(lag(Some(0), None), None);
     }
 
     #[test]
@@ -902,10 +1086,16 @@ mod tests {
 
     #[test]
     fn cleanup_keeps_a_margin_behind_the_cursor() {
-        assert_eq!(consumed_below(0), 0);
-        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 2), 0);
-        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 3), 1);
-        assert_eq!(consumed_below(SLOTS_PER_IMMUTABLE_FILE * 10 + 5), 8);
+        let consumed = |slot| consumed_below(slot, MAINNET_SLOTS_PER_FILE);
+
+        assert_eq!(consumed(0), 0);
+        assert_eq!(consumed(MAINNET_SLOTS_PER_FILE * 2), 0);
+        assert_eq!(consumed(MAINNET_SLOTS_PER_FILE * 3), 1);
+        assert_eq!(consumed(MAINNET_SLOTS_PER_FILE * 10 + 5), 8);
+
+        // and the smaller chunks delete on their own scale, not mainnet's:
+        // the same slot is far more files in on preview
+        assert_eq!(consumed_below(MAINNET_SLOTS_PER_FILE * 3, 4_320), 13);
     }
 
     #[test]
@@ -921,7 +1111,12 @@ mod tests {
         std::fs::write(dir.path().join("lock"), []).unwrap();
 
         // threshold 3: files 0..=2 consumed, 3..=5 and non-numeric names stay
-        cleanup_consumed(dir.path(), SLOTS_PER_IMMUTABLE_FILE * 5).unwrap();
+        cleanup_consumed(
+            dir.path(),
+            MAINNET_SLOTS_PER_FILE * 5,
+            MAINNET_SLOTS_PER_FILE,
+        )
+        .unwrap();
 
         let mut remaining: Vec<String> = std::fs::read_dir(dir.path())
             .unwrap()

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -14,9 +14,8 @@
 //! start is derived from the cursor's chunk file instead, a margin early,
 //! so a restart costs one window rather than the chain so far. The chunk
 //! file's size is read from the chain's own shelley genesis rather than
-//! assumed: a mainnet-sized chunk applied to preview divides by five times
-//! too much and resumes 4096 files early, which is the whole chain over
-//! again in the direction nothing was guarding.
+//! assumed: mainnet's chunk applied to preview is five times too wide and
+//! resumes thousands of files early.
 //!
 //! The reader never opens the highest downloaded file — pallas pops it as
 //! "not really immutable" — so at the aggregator tip the replay stands at
@@ -90,15 +89,12 @@ const IMMUTABLE_FILE_MARGIN: u64 = 2;
 
 /// Slots an immutable chunk file holds per unit of the security parameter:
 /// a chunk is `10k` slots wide. A packaging convention, not a protocol
-/// invariant — stated as the multiplier so the derivation below reads as
-/// the rule rather than as one chain's answer to it.
+/// invariant.
 const SLOTS_PER_SECURITY_PARAM: u64 = 10;
 
 /// Slots per immutable chunk file when the shelley genesis names no
-/// `securityParam`: mainnet's `10k`, which is what every dolos before this
-/// one used on every chain. Guessing *small* is the expensive direction —
-/// it resumes a cold start far behind its own cursor — so an unknown `k`
-/// keeps the old value rather than inventing a smaller one.
+/// `securityParam`: mainnet's `10k`. Guessing small resumes a cold start far
+/// behind its own cursor, so an unknown `k` keeps the old value.
 const FALLBACK_SLOTS_PER_IMMUTABLE_FILE: u64 = 21_600;
 
 /// Where the mithril window lands when the operator names nowhere: beside the
@@ -193,11 +189,7 @@ enum Import {
 ///
 /// Used to pick files safe to delete and, on a cold start whose download dir
 /// is empty, to derive where downloading resumes; never to plan how far a
-/// replay goes. Both uses carry [`IMMUTABLE_FILE_MARGIN`]. The derivation is
-/// no more trusted than the literal it replaces — landing past the cursor's
-/// chunk is still caught by the stalled-window check, and landing far behind
-/// it by [`resume_lag`] — but it is at least asked of the chain being
-/// replayed: mainnet and preprod answer 21600, preview 4320.
+/// replay goes. Both uses carry [`IMMUTABLE_FILE_MARGIN`].
 fn slots_per_immutable_file(genesis: &Genesis) -> u64 {
     genesis
         .shelley
@@ -233,17 +225,11 @@ fn resume_file(
 }
 
 /// Immutable files a resume start sits behind the cursor's own chunk, past
-/// the [`IMMUTABLE_FILE_MARGIN`] the derivation deliberately backs up by, or
-/// `None` when it sits within the margin.
+/// the [`IMMUTABLE_FILE_MARGIN`], or `None` when it sits within the margin.
 ///
-/// Early is the cheap direction in the small — a re-downloaded file's blocks
-/// at or before the cursor are skipped on import — and that cheapness is what
-/// left it unguarded. It stops being cheap in the large: a chunk size taken
-/// from the wrong chain resumed a preview cold start 4096 files behind its
-/// own cursor and spent 89 minutes re-downloading them before it could replay
-/// anything, with nothing in the log naming the cost. This is that number, so
-/// the next packaging assumption that drifts gets reported rather than paid
-/// for in silence.
+/// Early is the cheap direction only in the small: a resume many files behind
+/// the cursor re-downloads every file between before the replay can advance,
+/// so it is measured rather than left silent.
 fn resume_lag(
     resume: Option<u64>,
     cursor_slot: Option<u64>,
@@ -408,9 +394,8 @@ struct Driver<'a> {
     cancel: CancellationToken,
     download_dir: PathBuf,
     immutable_dir: PathBuf,
-    /// `10k` for the chain being replayed, settled once from the shelley
-    /// genesis at startup: it cannot change under a running backfill, and
-    /// deriving it per round would only reread the same files.
+    /// Settled once at startup: it cannot change under a running backfill,
+    /// and deriving it per round would only reread the same genesis.
     slots_per_immutable_file: u64,
 }
 
@@ -638,9 +623,8 @@ impl Driver<'_> {
 
             let resume = resume_file(highest, cursor_slot, self.slots_per_immutable_file);
 
-            // Not fatal, and deliberately not a fallback either: the round
-            // still runs, it just stops running silently. Anything inside a
-            // window is the margin doing its job.
+            // Deliberately not a fallback: the round still runs, it just
+            // stops running silently. Inside a window is the margin working.
             if let Some(lag) = resume_lag(resume, cursor_slot, self.slots_per_immutable_file)
                 .filter(|lag| *lag > self.args.window)
             {
@@ -921,13 +905,11 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 mod tests {
     use super::*;
 
-    /// Mainnet's `10k`, and the value every network used before the chunk
-    /// size was derived. Spelled out so the tests below assert against a
-    /// number rather than against the constant they are checking.
+    /// Mainnet's `10k`, spelled out so the tests assert against a number
+    /// rather than against the constant they are checking.
     const MAINNET_SLOTS_PER_FILE: u64 = 21_600;
 
-    /// The preview publisher's restore cursor on 2026-08-25 — the restart
-    /// that cost 89 minutes and ~2900 re-downloaded files.
+    /// The preview publisher's restore cursor on 2026-08-25.
     const PREVIEW_RESTORE_CURSOR: u64 = 22_118_504;
 
     #[test]
@@ -941,9 +923,8 @@ mod tests {
     fn the_chunk_size_is_each_networks_own_ten_k() {
         use dolos_cardano::include;
 
-        // the four networks dolos ships a genesis for. Preview is the reason
-        // this is derived at all: its `k` is 432, so its chunks are a fifth
-        // of mainnet's and the literal divided by five times too much.
+        // preview is the reason this is derived: its `k` is 432, so its
+        // chunks are a fifth of mainnet's
         assert_eq!(
             slots_per_immutable_file(&include::mainnet::load()),
             MAINNET_SLOTS_PER_FILE,
@@ -961,8 +942,7 @@ mod tests {
 
     #[test]
     fn a_genesis_without_a_security_param_keeps_the_old_value() {
-        // guessing small is the expensive direction — the one this change
-        // exists to remove — so an unknown `k` falls back rather than guesses
+        // guessing small is the expensive direction, so an unknown `k` falls back
         let mut genesis = dolos_cardano::include::preview::load();
         genesis.shelley.security_param = None;
 
@@ -982,15 +962,12 @@ mod tests {
         };
 
         // the regression bar: 21600-slot chunks put this cursor in file 1024,
-        // a margin early is 1022, and that is what these three resumed from
-        // before the derivation existed. A change here means it is wrong.
+        // a margin early is 1022 — unchanged from before the derivation
         assert_eq!(resume(include::mainnet::load()), Some(1022));
         assert_eq!(resume(include::preprod::load()), Some(1022));
         assert_eq!(resume(include::devnet::load()), Some(1022));
 
-        // and the fix: preview's 4320-slot chunks put the same cursor in file
-        // 5120, so the resume moves 4096 files forward, onto the window it
-        // actually needs
+        // preview's 4320-slot chunks put the same cursor in file 5120
         assert_eq!(resume(include::preview::load()), Some(5118));
     }
 

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -88,8 +88,8 @@ const IMPORT_CHUNK: usize = 100;
 /// the immutable reader without the cursor's own chunk.
 const IMMUTABLE_FILE_MARGIN: u64 = 2;
 
-/// Immutable chunk files a node packs per slot of the security parameter:
-/// a chunk holds `10k` slots. A packaging convention, not a protocol
+/// Slots an immutable chunk file holds per unit of the security parameter:
+/// a chunk is `10k` slots wide. A packaging convention, not a protocol
 /// invariant — stated as the multiplier so the derivation below reads as
 /// the rule rather than as one chain's answer to it.
 const SLOTS_PER_SECURITY_PARAM: u64 = 10;


### PR DESCRIPTION
Plan: [`plans/dolos-backfill-cold-start-window-derivation.md`](https://github.com/txpipe/brain/blob/main/plans/dolos-backfill-cold-start-window-derivation.md) (Trellis domain, private)

## Why

`dolos snapshot backfill` restores its stores from the registry onto an empty
disk and then has to decide where to resume downloading immutable files. With
no files on disk it derived that point from the cursor:

```rust
cursor_slot.map(|slot| (slot / SLOTS_PER_IMMUTABLE_FILE).saturating_sub(IMMUTABLE_FILE_MARGIN))
```

`SLOTS_PER_IMMUTABLE_FILE` was `21_600` — `10k` for `k = 2160`, **mainnet's**
security parameter, applied to every chain. Preview's `k` is 432, so its
immutable files hold 4320 slots and the derivation divided by five times too
much:

| network | `k` | `10k` slots/file | derived resume | true resume |
|---|---|---|---|---|
| mainnet | 2160 | 21600 | 1022 | 1022 |
| preprod | 2160 | 21600 | 1022 | 1022 |
| devnet | 2160 | 21600 | 1022 | 1022 |
| **preview** | **432** | **4320** | **1022** | **5118** |

(for the preview publisher's actual restore cursor, slot 22118504)

So a cold start on preview resumed **4096 files early** and re-downloaded them
before it could replay anything. Measured on the live preview publisher on
2026-08-25: restarted at 13:55Z, it downloaded ~2900 immutable files in 40-file
windows at roughly one window per 50 s and did not resume replay until
**15:24Z — 89 minutes**, against the one window the module documents.

The constant's own comment anticipated the wrong direction. It noted the value
is "a node packaging convention, not a protocol invariant", and that "a
derivation that still lands past the cursor's chunk is caught by the
stalled-window check rather than trusted" — landing *late* was guarded.
Landing early was unguarded on the reasoning that "early is the cheap
direction", which holds for the two files of `IMMUTABLE_FILE_MARGIN` and does
not hold for 4096.

Mainnet and preprod both carry `k = 2160`, which is why the mainnet backfill
has restarted repeatedly at one-window cost while preview's single restart cost
an hour and a half.

## What changed

All in `src/bin/dolos/snapshot/backfill.rs`.

**The chunk size is derived, not assumed.** `slots_per_immutable_file(&genesis)`
reads `10k` from `genesis.shelley.security_param` — the shelley genesis the run
already loads — replacing the mainnet literal. `run()` settles it once at
startup (it cannot change under a running backfill) and the `Driver` carries it
to both of the convention's uses: `resume_file` and `consumed_below`. Loading
genesis in `run()` also means a backfill whose genesis is missing now fails
before it downloads anything.

**The fallback keeps today's behaviour.** A genesis with no `securityParam`
gets `FALLBACK_SLOTS_PER_IMMUTABLE_FILE = 21_600`, unchanged from before.
Guessing *small* is the expensive direction — it is the whole bug — so an
unknown `k` does not guess.

**The margin semantics are unchanged.** `IMMUTABLE_FILE_MARGIN` still backs up
two files, because landing late still leaves the immutable reader without the
cursor's own chunk. They are now two correctly-sized files.

**The cheap direction is guarded too.** `resume_lag` measures how many files a
resume start sits behind the cursor's own chunk past that margin, and
`advance_domain` warns when it exceeds one `--window`. Not fatal and
deliberately not a fallback: the round still runs, it just stops running
silently. This catches both a packaging assumption that drifts again and a
stale download dir far behind a restored cursor — the same invisible cost from
the other direction.

**Out of scope, per the plan:** the stalled-window check and the replay planner
are untouched. The constant is documented as "never to plan how far a replay
goes", and that is still true.

## Verification

`cargo test -p dolos` — 10 tests in `snapshot::backfill`, 4 of them new, all
passing:

- `the_chunk_size_is_each_networks_own_ten_k` — asserts against the **real
  shipped genesis** of all four networks (`dolos_cardano::include::{mainnet,
  preprod, preview, devnet}::load()`), not against fixtures: 21600, 21600,
  4320, 21600.
- `a_cold_start_resumes_from_the_cursors_own_file_on_every_network` — the
  regression bar. For cursor slot 22118504, mainnet/preprod/devnet resume from
  file **1022**, byte-identical to today; preview resumes from **5118**.
- `a_genesis_without_a_security_param_keeps_the_old_value` — the fallback.
- `a_resume_far_behind_the_cursors_own_file_is_measured` — `resume_lag` returns
  `None` on the derivation's own answer, `Some(4096)` for what the mainnet
  literal did to preview, and reports a stale download dir the same way.

The existing `resume_file` / `consumed_below` / `cleanup_consumed` tests were
rewritten against an explicit mainnet chunk size rather than the removed
constant, so they still assert the same numbers.

CI on this branch is green: `cargo clippy`, `cargo fmt` (nightly), `cargo
deny`, `Test (ubuntu-latest)`, `Test (macos-14)`, `Test (all features)`, and
all three registry round trips. Windows and E2E are skipped on PRs by repo
policy.

One pre-existing finding, not touched here: `crates/snapshot/src/restore.rs:981`
warns `unused_mut` on `main` (`let mut cursor = Cursor::new(...)`).

**Still owed, after merge:** the live check the plan names — restart the
preview publisher from a restored cursor and confirm it resumes replay inside
one download window instead of climbing to it. The before number is recorded:
89 minutes and ~2900 files from a restore at sequence 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BSgkfr2YNNrJZdihZXz5S



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot backfill recovery and resumption across different networks.
  * Adjusted snapshot processing windows to match each network, with a safe fallback when configuration is unavailable.
  * Corrected lag reporting, consumed-file calculations, and cleanup behavior.
  * Added warnings when resuming significantly behind the available download window.
  * Improved cold-start resume positions and cleanup scaling for more reliable recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->