### PR TITLE
fix(cli): let a fatal driver failure reach the exit status

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -337,11 +337,11 @@ impl WalError {
 
 #[derive(Debug, Error)]
 pub enum ServeError {
-    #[error("failed to bind listener")]
-    BindError(std::io::Error),
+    #[error("failed to bind listener: {0}")]
+    BindError(#[source] std::io::Error),
 
-    #[error("failed to shutdown")]
-    ShutdownError(std::io::Error),
+    #[error("failed to shutdown: {0}")]
+    ShutdownError(#[source] std::io::Error),
 
     #[error(transparent)]
     Internal(#[from] Box<dyn std::error::Error + Send + Sync>),

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -516,25 +516,49 @@ pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationTo
     pipeline.teardown();
 }
 
+/// Drain the serving drivers, cancelling the rest once any one of them fails.
+///
+/// Polls the whole set rather than awaiting the handles in order: a driver
+/// only completes on its own failure or on cancellation, so awaiting them one
+/// at a time parked on the first healthy driver forever and left a failing
+/// driver's error sitting unobserved in its `JoinHandle`.
+///
+/// The first failure is returned, not just logged. Both callers surface it as
+/// the command's exit status, which is what a supervisor reads: a driver that
+/// cannot bind has to exit non-zero, or `Restart=on-failure` and
+/// `restartPolicy: OnFailure` see a clean shutdown and leave the node down.
+/// A task that panicked counts as a failure too — that path used to reach an
+/// `.unwrap()` and abort the process, and must not quietly become a success.
+///
+/// Draining continues past the first failure on purpose. Cancellation is what
+/// lets the healthy drivers wind down, and this is the only thing awaiting
+/// them; returning early would drop them mid-teardown.
 pub async fn monitor_drivers(
     mut drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>>,
     exit: CancellationToken,
-) {
+) -> Result<(), ServeError> {
+    let mut first_failure = None;
+
     while let Some(result) = drivers.next().await {
-        match result {
-            Ok(Ok(())) => {}
+        let failure = match result {
+            Ok(Ok(())) => continue,
             Ok(Err(e)) => {
                 error!("driver error: {}", e);
-                warn!("cancelling remaining drivers");
-                exit.cancel();
+                e
             }
             Err(e) => {
                 error!("driver task failed: {}", e);
-                warn!("cancelling remaining drivers");
-                exit.cancel();
+                ServeError::Internal(Box::new(e))
             }
-        }
+        };
+
+        warn!("cancelling remaining drivers");
+        exit.cancel();
+
+        first_failure.get_or_insert(failure);
     }
+
+    first_failure.map_or(Ok(()), Err)
 }
 
 pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
@@ -817,16 +841,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn monitor_drivers_observes_later_failures_before_waiting_for_earlier_drivers() {
+    async fn monitor_drivers_observes_a_failure_a_healthy_driver_would_hide() {
         let exit = CancellationToken::new();
         let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
 
-        let exit_for_slow_driver = exit.clone();
-        drivers.push(tokio::spawn(async move {
-            exit_for_slow_driver.cancelled().await;
-            Ok(())
-        }));
-
+        // Pushed first on purpose. `FuturesUnordered` links at the head, so
+        // the ordered drain this replaced reached the *last* push first; the
+        // failure that went unobserved is the one pushed here, exactly as
+        // `serve::load_drivers` pushes the Ouroboros driver first.
         drivers.push(tokio::spawn(async {
             Err(ServeError::BindError(io::Error::new(
                 io::ErrorKind::AddrInUse,
@@ -834,7 +856,13 @@ mod tests {
             )))
         }));
 
-        tokio::time::timeout(
+        let exit_for_healthy_driver = exit.clone();
+        drivers.push(tokio::spawn(async move {
+            exit_for_healthy_driver.cancelled().await;
+            Ok(())
+        }));
+
+        let result = tokio::time::timeout(
             Duration::from_secs(1),
             monitor_drivers(drivers, exit.clone()),
         )
@@ -842,5 +870,52 @@ mod tests {
         .expect("driver monitor should observe the bind failure promptly");
 
         assert!(exit.is_cancelled());
+
+        assert!(
+            matches!(result, Err(ServeError::BindError(_))),
+            "the bind failure has to reach the caller, not just the log",
+        );
+    }
+
+    #[tokio::test]
+    async fn monitor_drivers_propagates_a_panicking_driver() {
+        let exit = CancellationToken::new();
+        let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
+
+        drivers.push(tokio::spawn(async { panic!("driver panicked") }));
+
+        let result = monitor_drivers(drivers, exit.clone()).await;
+
+        assert!(exit.is_cancelled());
+
+        assert!(
+            result.is_err(),
+            "a panicking driver used to abort the process; it must not report success",
+        );
+    }
+
+    #[tokio::test]
+    async fn monitor_drivers_reports_a_clean_shutdown_as_success() {
+        let exit = CancellationToken::new();
+        let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
+
+        for _ in 0..3 {
+            let exit_for_driver = exit.clone();
+            drivers.push(tokio::spawn(async move {
+                exit_for_driver.cancelled().await;
+                Ok(())
+            }));
+        }
+
+        exit.cancel();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            monitor_drivers(drivers, exit.clone()),
+        )
+        .await
+        .expect("cancelled drivers should finish promptly");
+
+        assert!(result.is_ok(), "a signalled shutdown is not a failure");
     }
 }

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -516,23 +516,12 @@ pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationTo
     pipeline.teardown();
 }
 
-/// Drain the serving drivers, cancelling the rest once any one of them fails.
+/// Drains the serving drivers, cancelling the rest once any one of them fails.
 ///
-/// Polls the whole set rather than awaiting the handles in order: a driver
-/// only completes on its own failure or on cancellation, so awaiting them one
-/// at a time parked on the first healthy driver forever and left a failing
-/// driver's error sitting unobserved in its `JoinHandle`.
-///
-/// The first failure is returned, not just logged. Both callers surface it as
-/// the command's exit status, which is what a supervisor reads: a driver that
-/// cannot bind has to exit non-zero, or `Restart=on-failure` and
-/// `restartPolicy: OnFailure` see a clean shutdown and leave the node down.
-/// A task that panicked counts as a failure too — that path used to reach an
-/// `.unwrap()` and abort the process, and must not quietly become a success.
-///
-/// Draining continues past the first failure on purpose. Cancellation is what
-/// lets the healthy drivers wind down, and this is the only thing awaiting
-/// them; returning early would drop them mid-teardown.
+/// Returns the first failure instead of only logging it: the exit status is
+/// what a supervisor reads. Draining continues past that failure because
+/// cancellation is what winds the healthy drivers down and nothing else
+/// awaits them.
 pub async fn monitor_drivers(
     mut drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>>,
     exit: CancellationToken,
@@ -543,11 +532,11 @@ pub async fn monitor_drivers(
         let failure = match result {
             Ok(Ok(())) => continue,
             Ok(Err(e)) => {
-                error!("driver error: {}", e);
+                error!(error = %e, "driver failed");
                 e
             }
             Err(e) => {
-                error!("driver task failed: {}", e);
+                error!(error = %e, "driver task failed");
                 ServeError::Internal(Box::new(e))
             }
         };
@@ -845,10 +834,8 @@ mod tests {
         let exit = CancellationToken::new();
         let drivers: FuturesUnordered<JoinHandle<Result<(), ServeError>>> = FuturesUnordered::new();
 
-        // Pushed first on purpose. `FuturesUnordered` links at the head, so
-        // the ordered drain this replaced reached the *last* push first; the
-        // failure that went unobserved is the one pushed here, exactly as
-        // `serve::load_drivers` pushes the Ouroboros driver first.
+        // `FuturesUnordered` links at the head, so the ordered drain this
+        // replaced reached the last push first.
         drivers.push(tokio::spawn(async {
             Err(ServeError::BindError(io::Error::new(
                 io::ErrorKind::AddrInUse,
@@ -890,7 +877,7 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "a panicking driver used to abort the process; it must not report success",
+            "a panicking driver must not report success",
         );
     }
 

--- a/src/bin/dolos/daemon.rs
+++ b/src/bin/dolos/daemon.rs
@@ -47,11 +47,11 @@ pub async fn run(config: RootConfig, _args: &Args) -> miette::Result<()> {
         exit.clone(),
     );
 
-    crate::common::monitor_drivers(drivers, exit.clone()).await;
+    let outcome = crate::common::monitor_drivers(drivers, exit.clone()).await;
 
     sync.await.unwrap();
 
     warn!("shutdown complete");
 
-    Ok(())
+    outcome.into_diagnostic().context("serving clients")
 }

--- a/src/bin/dolos/serve.rs
+++ b/src/bin/dolos/serve.rs
@@ -1,6 +1,7 @@
 use dolos_core::config::RootConfig;
 use futures_util::stream::FuturesUnordered;
 use log::warn;
+use miette::{Context as _, IntoDiagnostic as _};
 
 #[derive(Debug, clap::Args)]
 pub struct Args {}
@@ -24,9 +25,9 @@ pub async fn run(config: RootConfig, _args: &Args) -> miette::Result<()> {
         exit.clone(),
     );
 
-    crate::common::monitor_drivers(drivers, exit.clone()).await;
+    let outcome = crate::common::monitor_drivers(drivers, exit.clone()).await;
 
     warn!("shutdown complete");
 
-    Ok(())
+    outcome.into_diagnostic().context("serving clients")
 }


### PR DESCRIPTION
Follow-up to #999, which I merged as-is. Two issues from the review of that PR, fixed here.

### 1. The regression test guarded nothing

`FuturesUnordered::push` links at the head, so the `for result in drivers` drain that #999 replaced reached the **last**-pushed handle **first**. The test added there pushed the never-completing driver first and the `BindError` driver second — precisely the order the pre-fix code already handled correctly, so it passed against the old implementation.

The two pushes are swapped, which also lines the test up with the real failure: `serve::load_drivers` pushes the Ouroboros driver *first*, and it is because ordered iteration awaited it *last* that its bind error went unobserved.

### 2. A fatal driver failure still exited 0

`monitor_drivers` logged and cancelled but returned `()`, so `serve::run` and `daemon::run` returned `Ok(())` and the process exited 0 after a driver died. For #293's own scenario, `dolos daemon` cancelled sync, tore down cleanly, and reported success — systemd `Restart=on-failure` and k8s `restartPolicy: OnFailure` see a clean exit and leave the node down. That traded a partial outage (gRPC/minibf still serving) for a silent total one.

The `Err(e)` arm also replaced the old `.unwrap()`, so a driver task that panicked went from aborting the process with exit 101 to exiting 0.

`monitor_drivers` now returns `Result<(), ServeError>`, holding the first failure and still draining the rest — cancellation is what lets the healthy drivers wind down, and this is the only thing awaiting them, so returning early would drop them mid-teardown. A `JoinError` becomes `ServeError::Internal`. Both call sites keep their existing teardown (`daemon` still awaits `sync`) and return the outcome, so the command's exit status is non-zero.

### 3. How the failure is reported

`error!("driver error: {}", e)` baked the value into the message string. This binary configures an OTLP exporter, so that gives the backend a distinct message per error and nothing queryable; the repo already leans the other way (42 structured-field call sites against 15 interpolations). Both sites now use `error!(error = %e, ..)`.

Rendering that field exposed a second gap: `ServeError::BindError` declares neither `{0}` nor `#[source]`, so it drops its `io::Error` from both `Display` and `source()`. A stale socket reported `failed to bind listener` — no `AddrInUse`, no path — which is exactly the diagnostic this PR is trying to deliver. `BindError` and `ShutdownError` now carry the cause, following `WalError::Internal` in the same file. That is the only change outside `src/bin/dolos/`; happy to split it out if it should not ride along.

### Tests

- `monitor_drivers_observes_a_failure_a_healthy_driver_would_hide` — the corrected push order; hangs against the pre-#999 drain, and now also asserts the `BindError` reaches the caller.
- `monitor_drivers_propagates_a_panicking_driver` — pins that a panicking task does not report success.
- `monitor_drivers_reports_a_clean_shutdown_as_success` — pins that a signalled shutdown stays `Ok`.

Note this still does not close #293 as filed ("unable to recover after forceful shutdown"): the failure is now loud, immediate and non-zero, but dolos still cannot start against a stale socket. The pidfile/unlink work is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
