### PR TITLE
perf(snapshot): produce a publish's layers from a pool of workers

### DIFF
--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -55,7 +55,12 @@
 //! records, but obtaining them means a Mithril aggregator and a certificate
 //! check, which is publisher plumbing. No restore, no signatures.
 
-use std::{collections::BTreeMap, num::NonZeroUsize, ops::Range};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    num::NonZeroUsize,
+    ops::Range,
+    sync::{atomic::AtomicBool, Mutex},
+};
 
 use dolos_cardano::{
     eras::ChainSummary, indexes::archive_dimensions, pallas::ledger::traverse::MultiEraBlock,
@@ -188,6 +193,69 @@ impl Default for IndexBand {
     }
 }
 
+/// How many layer producers one publish runs at once.
+///
+/// ## Why production is pooled at all
+///
+/// A publish's layers are independent by `(kind, scope)`: each is filled by its
+/// own store traversal, framed and compressed in isolation, and only joined at
+/// the seal. Driven one at a time on the caller's thread, the wall clock of a
+/// publish is the *sum* of every traversal — measured on the live backfill at
+/// one thread's worth of CPU against an idle link, with the per-layer cost flat
+/// against layer size. So the producers run on a pool of threads and the
+/// serial sum becomes a maximum: the index pass runs beside the state walks,
+/// which run beside each other.
+///
+/// ## What the pool must not change
+///
+/// Nothing about the bytes. Every layer is still filled by exactly one
+/// traversal, in the order that traversal promises, so its `diffId` is the one
+/// a serial walk computes; and the inscription lists layers by its own frozen
+/// rule rather than by completion order. Two runs at different worker counts —
+/// including one — produce the same document, which is what lets a
+/// reproduction pool differently than the publish it checks. The export golden
+/// and the cross-backend determinism test hold across every value of this.
+///
+/// ## Why the count is what it is
+///
+/// One worker is reserved for the index bands, which run in band order on that
+/// worker alone: a band holds [`IndexBand`]'s whole budget open at once, so two
+/// concurrent bands would be two copies of a budget that was sized as a
+/// ceiling, not as a share. Every other producer holds at most one state
+/// kind's shard sinks — sixteen, ~200 MiB by [`IndexBand::SINK_BYTES`] — so the
+/// pool's worst case beside the band's gigabyte is
+/// `(workers - 1) × 16 × 12 MiB`. The default of four keeps that under
+/// 600 MiB: a publish-wide resident peak around 1.6 GiB where the serial walk
+/// peaked at 1 GiB, on publishers measured well clear of either. An operator
+/// with less to spend narrows it with `--producers`, and `1` is the strictly
+/// serial walk this module always did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Producers(NonZeroUsize);
+
+impl Producers {
+    /// The pool a publish takes unless an operator resizes it.
+    pub const DEFAULT: Self = match NonZeroUsize::new(4) {
+        Some(workers) => Self(workers),
+        None => panic!("the default producer pool holds at least one worker"),
+    };
+
+    /// A pool of `workers` producers. Zero is not representable, which is the
+    /// refusal: a publish with no producer would write nothing.
+    pub fn new(workers: NonZeroUsize) -> Self {
+        Self(workers)
+    }
+
+    pub fn workers(&self) -> usize {
+        self.0.get()
+    }
+}
+
+impl Default for Producers {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 /// What a publish covers: where the node stands, and which epochs its layers
 /// describe.
 ///
@@ -212,14 +280,19 @@ pub struct Plan {
     pub retained: RetainedEpochs,
     /// How many `indexes` layers one traversal of the index store fills.
     ///
-    /// Execution rather than geometry, and the one field here that is: it
-    /// changes neither which layers this publish writes nor a byte of what is
-    /// in them, only how many passes over the index store it takes to fill
-    /// them. It rides on the plan because every driver that walks these stores
-    /// — [`export`], [`reproduce`], [`verify_reproduction`] — pays the same
-    /// cost and should take the same band without each call site spelling it.
-    /// See [`IndexBand`].
+    /// Execution rather than geometry: it changes neither which layers this
+    /// publish writes nor a byte of what is in them, only how many passes over
+    /// the index store it takes to fill them. It rides on the plan because
+    /// every driver that walks these stores — [`export`], [`reproduce`],
+    /// [`verify_reproduction`] — pays the same cost and should take the same
+    /// band without each call site spelling it. See [`IndexBand`].
     pub band: IndexBand,
+    /// How many layer producers run at once.
+    ///
+    /// Execution rather than geometry, exactly as `band` is, and riding on the
+    /// plan for the same reason: every driver that walks these stores pays the
+    /// same serial cost without it. See [`Producers`].
+    pub producers: Producers,
 }
 
 impl Plan {
@@ -263,6 +336,7 @@ impl Plan {
             epochs,
             retained,
             band: IndexBand::DEFAULT,
+            producers: Producers::DEFAULT,
         })
     }
 
@@ -273,6 +347,16 @@ impl Plan {
     /// spelled, and it applies it to a plan the rules already built.
     pub fn with_band(mut self, band: IndexBand) -> Self {
         self.band = band;
+
+        self
+    }
+
+    /// Take a producer pool other than [`Producers::DEFAULT`].
+    ///
+    /// The same builder shape as [`with_band`](Plan::with_band), for the same
+    /// operator.
+    pub fn with_producers(mut self, producers: Producers) -> Self {
+        self.producers = producers;
 
         self
     }
@@ -370,7 +454,12 @@ pub fn plan<S: StateStore>(
 /// layers behind that a restart may carry forward on exactly the terms a
 /// predecessor's do. Nothing here decides where that is written down — that is
 /// the implementor's, as `adopt` already is.
-pub trait Predecessor {
+///
+/// `Sync`, because [`export`] drives its layer producers from a pool of
+/// threads and each producer asks these questions for its own layers. An
+/// implementor that keeps state — an adoption counter, a resumption record —
+/// keeps it behind its own synchronization.
+pub trait Predecessor: Sync {
     /// The history the new inscription carries: every prior publication,
     /// contiguous and ascending, ending at `sequence - 1`.
     ///
@@ -428,12 +517,14 @@ pub trait Predecessor {
     /// Note that `descriptor`'s layer is in the transport and will be in the
     /// manifest, whether it was built here or adopted.
     ///
-    /// Called once per epoch layer, as it lands and before the next one starts,
-    /// so an implementor writing it down leaves a record that means "this layer
-    /// is up" rather than "this layer was attempted" — the same boundary
-    /// [`crate::restore::Checkpoint`] records on its side. The state shards are
-    /// deliberately never offered: they describe a moving tip, and a restart
-    /// must rebuild them.
+    /// Called once per epoch layer, the moment it lands, so an implementor
+    /// writing it down leaves a record that means "this layer is up" rather
+    /// than "this layer was attempted" — the same boundary
+    /// [`crate::restore::Checkpoint`] records on its side. Layers land from
+    /// concurrent producers, so calls interleave; the record is keyed by kind
+    /// and scope, never by arrival order. The state shards are deliberately
+    /// never offered: they describe a moving tip, and a restart must rebuild
+    /// them.
     ///
     /// A failure here **fails the publish**. Recording is not a courtesy: a
     /// record that silently stopped being written would cost the hours it
@@ -790,7 +881,11 @@ impl Standing {
 ///
 /// Layers are listed in [`crate::KINDS`] order, and within a kind in ascending
 /// epoch or shard order. That order is part of the canonical document, so it is
-/// frozen by a golden rather than left to the loop that happens to write them.
+/// frozen by a golden rather than left to the pool that happens to write them:
+/// production is split into jobs that run concurrently under
+/// [`Plan::producers`], and each job's descriptors are reassembled by the
+/// position its layers hold in the document, whatever order the jobs finish
+/// in. See [`Producers`] for what the pool changes and what it must not.
 ///
 /// `digest_records` is optional and has no source in this slice — a stele
 /// without a `digests` layer is valid, since ADR-004 makes every layer
@@ -820,7 +915,7 @@ pub fn export<W, A, S, I>(
     observer: &Observer,
 ) -> Result<Inscription, Error>
 where
-    W: SteleWriter,
+    W: SteleWriter + Sync,
     A: ArchiveStore,
     S: StateStore,
     I: IndexStore,
@@ -840,59 +935,70 @@ where
         + state_layers(plan, previous)?
         + usize::from(digest_records.is_some());
 
-    let mut cursor = Cursor::new(observer, total);
+    let cursor = Cursor::new(observer, total);
+    let cursor = &cursor;
 
-    let mut layers = Vec::new();
+    // One job per independent slice of the document, queued in the order the
+    // inscription lists layers. The queue order is what [`produce`] reassembles
+    // descriptors by, so the pool can run these however it likes without the
+    // document noticing.
+    let mut jobs: Vec<Job<'_>> = Vec::new();
 
     for window in &plan.epochs {
-        landed(
-            write_blocks(stele, plan, archive, window, previous, &mut cursor)?,
-            previous,
-            &mut layers,
-        )?;
+        jobs.push(Job::light(move || {
+            let descriptor = write_blocks(stele, plan, archive, window, previous, cursor)?;
+            previous.landed(&descriptor)?;
+
+            Ok(vec![descriptor])
+        }));
     }
 
     // Banded rather than one window at a time: an index layer costs a pass over
-    // the whole store, so this loop is where a first publish's O(N²) lives.
-    // See [`IndexBand`], and [`write_indexes`] for why no `landed` call sits
-    // here as it does in the loops around it.
+    // the whole store, so these jobs are where a first publish's O(N²) lives.
+    // They run on the band lane — in band order, one at a time, beside the
+    // light jobs rather than after them. See [`IndexBand`] and [`Producers`],
+    // and [`write_indexes`] for why no `landed` call sits here as it does in
+    // the jobs around it.
     for band in plan.epochs.chunks(plan.band.epochs()) {
-        layers.extend(write_indexes(
-            stele,
-            plan,
-            indexes,
-            band,
-            previous,
-            &mut cursor,
-        )?);
+        jobs.push(Job::band(move || {
+            write_indexes(stele, plan, indexes, band, previous, cursor)
+        }));
     }
 
-    // Kind-major, like the two loops above: the inscription lists layers in
-    // `KINDS` order and within a kind by ascending epoch.
+    // Kind-major, like the jobs above: the inscription lists layers in `KINDS`
+    // order and within a kind by ascending epoch.
     for (kind, ns) in LOG_KINDS {
         for window in &plan.epochs {
-            if let Some(descriptor) = write_logs(
-                stele,
-                plan,
-                archive,
-                window,
-                kind,
-                ns,
-                previous,
-                &mut cursor,
-            )? {
-                landed(descriptor, previous, &mut layers)?;
-            }
+            jobs.push(Job::light(move || {
+                match write_logs(stele, plan, archive, window, kind, ns, previous, cursor)? {
+                    Some(descriptor) => {
+                        previous.landed(&descriptor)?;
+
+                        Ok(vec![descriptor])
+                    }
+                    None => Ok(Vec::new()),
+                }
+            }));
         }
     }
 
-    // The tip shards are not offered to the predecessor; the dumps among them
-    // are. See [`Predecessor::landed`].
-    layers.extend(write_state(stele, plan, state, previous, &mut cursor)?);
+    // One job per state kind: each walks its own namespace once, so the
+    // seventeen walks that ran in sequence overlap instead. The tip shards are
+    // not offered to the predecessor; the dumps among them are. See
+    // [`Predecessor::landed`].
+    for (kind, ns, shards) in STATE_KINDS {
+        jobs.push(Job::light(move || {
+            write_state_kind(stele, plan, state, kind, ns, shards, previous, cursor)
+        }));
+    }
 
     if let Some(records) = digest_records {
-        layers.push(write_digests(stele, plan, records, &mut cursor)?);
+        jobs.push(Job::light(move || {
+            Ok(vec![write_digests(stele, plan, records, cursor)?])
+        }));
     }
+
+    let layers = produce(jobs, plan.producers)?;
 
     debug_assert_eq!(
         cursor.opened(),
@@ -1188,21 +1294,185 @@ fn sink<W: SteleWriter>(stele: &W, spec: &LayerSpec) -> Result<W::Sink, Error> {
     Ok(stele.layer_sink(&DolosProfile, spec, COMPRESSION_LEVEL)?)
 }
 
-/// One epoch layer is in the transport: tell the predecessor before counting
-/// it.
-///
-/// In that order, and one layer at a time, because the two together are what
-/// make the note honest — a record written after the loop would describe a
-/// publish that finished, which is the one case it is no use in.
-fn landed(
-    descriptor: LayerDescriptor,
-    previous: &dyn Predecessor,
-    layers: &mut Vec<LayerDescriptor>,
-) -> Result<(), Error> {
-    previous.landed(&descriptor)?;
-    layers.push(descriptor);
+/// What one production job returns: the descriptors for its slice of the
+/// document, in the order that slice lists them.
+type JobRun<'run> = Box<dyn FnOnce() -> Result<Vec<LayerDescriptor>, Error> + Send + 'run>;
 
-    Ok(())
+/// One independent slice of a publish's production: a traversal, the sinks it
+/// fills, and the `landed` notes for the layers it lands.
+///
+/// Jobs borrow the stores and the transport for the length of one [`produce`]
+/// call, which is why the lifetime is a run and not `'static`: the pool is
+/// scoped threads, not tasks.
+struct Job<'run> {
+    lane: Lane,
+    run: JobRun<'run>,
+}
+
+/// Which worker a job may run on. See [`Producers`] for why the bands have a
+/// lane of their own.
+enum Lane {
+    /// The index bands: one at a time, in band order, on the reserved worker —
+    /// each holds the whole of [`IndexBand`]'s budget open, so two at once
+    /// would be two copies of a ceiling.
+    Band,
+    /// Everything else: at most one state kind's shard sinks apiece, safe to
+    /// run as many at once as the pool has workers.
+    Light,
+}
+
+impl<'run> Job<'run> {
+    fn light(run: impl FnOnce() -> Result<Vec<LayerDescriptor>, Error> + Send + 'run) -> Self {
+        Self {
+            lane: Lane::Light,
+            run: Box::new(run),
+        }
+    }
+
+    fn band(run: impl FnOnce() -> Result<Vec<LayerDescriptor>, Error> + Send + 'run) -> Self {
+        Self {
+            lane: Lane::Band,
+            run: Box::new(run),
+        }
+    }
+}
+
+/// The shared side of one [`produce`] call: the queue the light workers pull
+/// from, the slots the results land in, and the first failure.
+struct Pool<'run> {
+    lights: Mutex<VecDeque<(usize, JobRun<'run>)>>,
+    slots: Mutex<Vec<Option<Vec<LayerDescriptor>>>>,
+    failed: AtomicBool,
+    error: Mutex<Option<Error>>,
+}
+
+/// A poisoned lock here means a job panicked, and the panic is already
+/// propagating through the thread scope; what is behind the lock is plain data
+/// that was never mutated mid-panic, so the other workers drain out through it
+/// rather than turning one panic into many.
+fn unpoisoned<T>(lock: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+impl<'run> Pool<'run> {
+    fn failed(&self) -> bool {
+        self.failed.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// File one job's outcome. The first error is the export's error; a job
+    /// that fails after it is the same walk failing again, and a job that
+    /// succeeds after it is work the seal will never name — either way the
+    /// flag stops the queues.
+    fn finish(&self, position: usize, outcome: Result<Vec<LayerDescriptor>, Error>) {
+        match outcome {
+            Ok(descriptors) => {
+                unpoisoned(&self.slots)[position] = Some(descriptors);
+            }
+            Err(error) => {
+                self.failed
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                unpoisoned(&self.error).get_or_insert(error);
+            }
+        }
+    }
+
+    /// Run light jobs until the queue is empty or the export has failed.
+    fn drain(&self) {
+        loop {
+            if self.failed() {
+                return;
+            }
+
+            let Some((position, run)) = unpoisoned(&self.lights).pop_front() else {
+                return;
+            };
+
+            self.finish(position, run());
+        }
+    }
+}
+
+/// Run every job and hand back the document's layers, in document order.
+///
+/// A pool of [`Producers::workers`] threads: one reserved for the band lane,
+/// which runs the index bands in order and then helps with the light queue;
+/// the rest on the light queue from the start. One worker is the strictly
+/// serial walk — every job inline, in document order, no threads at all —
+/// which is both the escape hatch and the baseline the concurrent path is
+/// tested against.
+///
+/// The first failure stops both queues and is the error the caller gets. Jobs
+/// already running finish first — a store iterator cannot be cancelled
+/// mid-record, and a sink dropped without [`RecordSink::finish`] cleans up
+/// after itself — so a failed export returns once the pool is quiet, with
+/// nothing staged left behind.
+fn produce(jobs: Vec<Job<'_>>, producers: Producers) -> Result<Vec<LayerDescriptor>, Error> {
+    if producers.workers() == 1 {
+        let mut layers = Vec::new();
+
+        for job in jobs {
+            layers.extend((job.run)()?);
+        }
+
+        return Ok(layers);
+    }
+
+    let mut bands = VecDeque::new();
+    let mut lights = VecDeque::new();
+    let mut slots = Vec::with_capacity(jobs.len());
+
+    for (position, job) in jobs.into_iter().enumerate() {
+        slots.push(None);
+
+        match job.lane {
+            Lane::Band => bands.push_back((position, job.run)),
+            Lane::Light => lights.push_back((position, job.run)),
+        }
+    }
+
+    let pool = Pool {
+        lights: Mutex::new(lights),
+        slots: Mutex::new(slots),
+        failed: AtomicBool::new(false),
+        error: Mutex::new(None),
+    };
+
+    std::thread::scope(|scope| {
+        let pool = &pool;
+
+        std::thread::Builder::new()
+            .name("stele-produce-bands".to_owned())
+            .spawn_scoped(scope, move || {
+                for (position, run) in bands {
+                    if pool.failed() {
+                        return;
+                    }
+
+                    pool.finish(position, run());
+                }
+
+                pool.drain();
+            })
+            .expect("spawning the band producer");
+
+        for worker in 1..producers.workers() {
+            std::thread::Builder::new()
+                .name(format!("stele-produce-{worker}"))
+                .spawn_scoped(scope, move || pool.drain())
+                .expect("spawning a layer producer");
+        }
+    });
+
+    if let Some(error) = unpoisoned(&pool.error).take() {
+        return Err(error);
+    }
+
+    let slots = std::mem::take(&mut *unpoisoned(&pool.slots));
+
+    Ok(slots
+        .into_iter()
+        .flat_map(|slot| slot.expect("a job neither failed the export nor filled its slot"))
+        .collect())
 }
 
 /// The layer spec for one epoch window, and what the predecessor says about it.
@@ -1232,7 +1502,7 @@ fn write_blocks<W: SteleWriter, A: ArchiveStore>(
     archive: &A,
     window: &EpochWindow,
     previous: &dyn Predecessor,
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let scope = window.scope(plan.network.magic());
 
@@ -1293,7 +1563,7 @@ fn write_logs<W: SteleWriter, A: ArchiveStore>(
     kind: &'static str,
     ns: Namespace,
     previous: &dyn Predecessor,
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<Option<LayerDescriptor>, Error> {
     let scope = window.scope(plan.network.magic());
 
@@ -1514,7 +1784,7 @@ fn write_indexes<W: SteleWriter, I: IndexStore>(
     store: &I,
     band: &[EpochWindow],
     previous: &dyn Predecessor,
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<Vec<LayerDescriptor>, Error> {
     let mut descriptors: Vec<Option<LayerDescriptor>> = Vec::with_capacity(band.len());
     let mut building = Vec::with_capacity(band.len());
@@ -1642,16 +1912,17 @@ fn route_index<K: RecordSink>(
     Ok(())
 }
 
-/// The state tip: seventeen kinds, walked one namespace at a time.
+/// One state kind: its namespace, walked once into its shard layers.
 ///
-/// Kinds go in [`STATE_KINDS`] order — the inscription's order — and within a
-/// kind every shard is written ascending. Per kind, that kind's shard sinks
-/// stay open while its namespace is walked once and each record is routed by
-/// [`crate::shard_of`]; the alternative — sixteen passes over `utxos`, or one
-/// pass buffering into sixteen buckets — is either sixteen full scans of a
-/// mainnet-sized set or the whole of it in memory. The I/O adds up to what the
-/// pre-split single walk cost, because that walk was already seventeen
-/// sequential per-namespace iterations under one loop.
+/// [`export`] queues one of these per [`STATE_KINDS`] entry, in table order —
+/// the inscription's order — and within a kind every shard is written
+/// ascending. The kind's shard sinks stay open while its namespace is walked
+/// once and each record is routed by [`crate::shard_of`]; the alternative —
+/// sixteen passes over `utxos`, or one pass buffering into sixteen buckets —
+/// is either sixteen full scans of a mainnet-sized set or the whole of it in
+/// memory. Each kind reads its own namespace and nothing else's, which is what
+/// lets the kinds run as concurrent jobs where they used to be sequential
+/// iterations under one loop.
 ///
 /// Every shard of every kind is written, including an empty one, so the layer
 /// set a reader sees is fixed by [`STATE_KINDS`] and never a function of what
@@ -1693,115 +1964,111 @@ fn route_index<K: RecordSink>(
 /// from the predecessor, or — where the predecessor has no such layer — warned
 /// about and left out, which is a publish that carries less history rather
 /// than a failure. Producing a missing one is a backfill run's job.
-fn write_state<W: SteleWriter, S: StateStore>(
+#[allow(clippy::too_many_arguments)]
+fn write_state_kind<W: SteleWriter, S: StateStore>(
     stele: &W,
     plan: &Plan,
     store: &S,
+    kind: &'static str,
+    ns: Namespace,
+    shards: u8,
     previous: &dyn Predecessor,
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<Vec<LayerDescriptor>, Error> {
-    // The tip, plus one full set per due dump. An adopt-miss makes this an
-    // overestimate, which is the direction a capacity hint is free to be wrong
-    // in.
-    let mut layers =
-        Vec::with_capacity(state_layer_count() * (1 + plan.retained.due(plan.sequence).count()));
+    // Ascending epoch, then the tip: the order the inscription lists a
+    // kind's layers in, fixed here rather than left to the loops below.
+    let mut dumps = Vec::new();
 
-    for (kind, ns, shards) in STATE_KINDS {
-        // Ascending epoch, then the tip: the order the inscription lists a
-        // kind's layers in, fixed here rather than left to the loops below.
-        let mut dumps = Vec::new();
-
-        for epoch in plan.adoptable_dumps() {
-            dumps.extend(adopt_dump(plan, kind, shards, epoch, previous, cursor)?);
-        }
-
-        let mut sinks = Vec::with_capacity(shards as usize);
-        let mut orders = Vec::with_capacity(shards as usize);
-        let mut positions = Vec::with_capacity(shards as usize);
-
-        // Announced before the tip's, because that is where they sit in the
-        // document; they are closed after it, because that is when the bytes
-        // they name exist.
-        let cut: Vec<LayerSpec> = match plan.cuts_a_dump() {
-            true => (0..shards)
-                .map(|shard| plan.dump_scope(plan.sequence, shard).layer_spec(kind))
-                .collect::<Result<_, Error>>()?,
-            false => Vec::new(),
-        };
-
-        let cut_positions: Vec<usize> = cut
-            .iter()
-            .map(|spec| cursor.open(kind, &spec.scope))
-            .collect();
-
-        for shard in 0..shards {
-            let spec = plan.state_scope(shard).layer_spec(kind)?;
-
-            positions.push(cursor.open(kind, &spec.scope));
-            sinks.push(sink(stele, &spec)?);
-            orders.push(state::OrderCheck::for_shard(shard, shards));
-        }
-
-        let mut records = cursor.records();
-
-        if ns == UTXOS {
-            for entry in store.iter_utxos()? {
-                let (txo, value) = entry?;
-
-                route(
-                    &mut sinks,
-                    &mut orders,
-                    ns,
-                    shards,
-                    state::utxo(&txo, &value)?,
-                )?;
-                records.tick();
-            }
-        } else {
-            // `full_range` is the store's own name for everything, and it ends
-            // *exclusively* at `[0xff; 32]` — so an entity keyed with
-            // thirty-two `0xff` bytes is invisible to it. That is a limit of a
-            // fixed-width key type rather than something export could route
-            // around: there is no representable exclusive bound above the
-            // maximum key. It is stated rather than silently inherited, because
-            // a state entity that no publisher can export is worth someone
-            // knowing about.
-            for entry in store.iter_entities(ns, EntityKey::full_range())? {
-                let (key, value) = entry?;
-
-                route(
-                    &mut sinks,
-                    &mut orders,
-                    ns,
-                    shards,
-                    state::entity(&key, &value),
-                )?;
-                records.tick();
-            }
-        }
-
-        records.flush();
-
-        let mut tip = Vec::with_capacity(shards as usize);
-
-        for (sink, at) in sinks.into_iter().zip(positions) {
-            let written = sink.finish()?;
-            cursor.close(at, kind, Outcome::Transferred);
-
-            tip.push(written);
-        }
-
-        for ((spec, at), written) in cut.iter().zip(cut_positions).zip(&tip) {
-            let again = stele.carry_again(written, spec.scope.clone())?;
-            cursor.close(at, kind, Outcome::Transferred);
-
-            previous.landed(&again.descriptor)?;
-            dumps.push(again.descriptor);
-        }
-
-        layers.append(&mut dumps);
-        layers.extend(tip.into_iter().map(|written| written.descriptor));
+    for epoch in plan.adoptable_dumps() {
+        dumps.extend(adopt_dump(plan, kind, shards, epoch, previous, cursor)?);
     }
+
+    let mut sinks = Vec::with_capacity(shards as usize);
+    let mut orders = Vec::with_capacity(shards as usize);
+    let mut positions = Vec::with_capacity(shards as usize);
+
+    // Announced before the tip's, because that is where they sit in the
+    // document; they are closed after it, because that is when the bytes
+    // they name exist.
+    let cut: Vec<LayerSpec> = match plan.cuts_a_dump() {
+        true => (0..shards)
+            .map(|shard| plan.dump_scope(plan.sequence, shard).layer_spec(kind))
+            .collect::<Result<_, Error>>()?,
+        false => Vec::new(),
+    };
+
+    let cut_positions: Vec<usize> = cut
+        .iter()
+        .map(|spec| cursor.open(kind, &spec.scope))
+        .collect();
+
+    for shard in 0..shards {
+        let spec = plan.state_scope(shard).layer_spec(kind)?;
+
+        positions.push(cursor.open(kind, &spec.scope));
+        sinks.push(sink(stele, &spec)?);
+        orders.push(state::OrderCheck::for_shard(shard, shards));
+    }
+
+    let mut records = cursor.records();
+
+    if ns == UTXOS {
+        for entry in store.iter_utxos()? {
+            let (txo, value) = entry?;
+
+            route(
+                &mut sinks,
+                &mut orders,
+                ns,
+                shards,
+                state::utxo(&txo, &value)?,
+            )?;
+            records.tick();
+        }
+    } else {
+        // `full_range` is the store's own name for everything, and it ends
+        // *exclusively* at `[0xff; 32]` — so an entity keyed with
+        // thirty-two `0xff` bytes is invisible to it. That is a limit of a
+        // fixed-width key type rather than something export could route
+        // around: there is no representable exclusive bound above the
+        // maximum key. It is stated rather than silently inherited, because
+        // a state entity that no publisher can export is worth someone
+        // knowing about.
+        for entry in store.iter_entities(ns, EntityKey::full_range())? {
+            let (key, value) = entry?;
+
+            route(
+                &mut sinks,
+                &mut orders,
+                ns,
+                shards,
+                state::entity(&key, &value),
+            )?;
+            records.tick();
+        }
+    }
+
+    records.flush();
+
+    let mut tip = Vec::with_capacity(shards as usize);
+
+    for (sink, at) in sinks.into_iter().zip(positions) {
+        let written = sink.finish()?;
+        cursor.close(at, kind, Outcome::Transferred);
+
+        tip.push(written);
+    }
+
+    for ((spec, at), written) in cut.iter().zip(cut_positions).zip(&tip) {
+        let again = stele.carry_again(written, spec.scope.clone())?;
+        cursor.close(at, kind, Outcome::Transferred);
+
+        previous.landed(&again.descriptor)?;
+        dumps.push(again.descriptor);
+    }
+
+    let mut layers = dumps;
+    layers.extend(tip.into_iter().map(|written| written.descriptor));
 
     Ok(layers)
 }
@@ -1826,7 +2093,7 @@ fn adopt_dump(
     shards: u8,
     epoch: u64,
     previous: &dyn Predecessor,
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<Vec<LayerDescriptor>, Error> {
     let mut adopted = Vec::with_capacity(shards as usize);
 
@@ -1892,7 +2159,7 @@ fn write_digests<W: SteleWriter>(
     stele: &W,
     plan: &Plan,
     records: &[digests::ImmutableDigests],
-    cursor: &mut Cursor<'_>,
+    cursor: &Cursor<'_>,
 ) -> Result<LayerDescriptor, Error> {
     let mut order = digests::OrderCheck::default();
 
@@ -2152,6 +2419,7 @@ mod chain_tests {
             epochs: vec![],
             retained: RetainedEpochs::default(),
             band: IndexBand::DEFAULT,
+            producers: Producers::DEFAULT,
         }
     }
 

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -134,11 +134,14 @@
 //! same goes for where the layers are staged on the way through.
 
 use std::{
-    cell::{Cell, RefCell},
     collections::BTreeMap,
     io::Write as _,
     num::NonZeroUsize,
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    },
 };
 
 use dolos_core::{ArchiveStore, IndexStore, StateStore};
@@ -1062,7 +1065,7 @@ pub fn publish_into<W, A, S, I>(
     observer: &Observer,
 ) -> Result<Published, Error>
 where
-    W: SteleWriter,
+    W: SteleWriter + Sync,
     A: ArchiveStore,
     S: StateStore,
     I: IndexStore,
@@ -1092,7 +1095,7 @@ where
     previous.forget_record()?;
 
     let identity = inscription.digest()?;
-    let layers_reused = previous.adopted.get();
+    let layers_reused = previous.adopted.load(Ordering::Relaxed);
 
     Ok(Published {
         layers_built: inscription.layers.len() - layers_reused,
@@ -1193,7 +1196,9 @@ struct Chained<'a> {
     inheritable: BTreeMap<(String, String), LayerDescriptor>,
     resumable: BTreeMap<(String, String), WrittenLayer>,
     record: Option<Recording>,
-    adopted: Cell<usize>,
+    /// Atomic, like the record's lock below: [`export::export`] asks a
+    /// predecessor about layers from a pool of producer threads.
+    adopted: AtomicUsize,
 }
 
 /// The resumption record this publish is writing, open.
@@ -1202,10 +1207,15 @@ struct Chained<'a> {
 /// than the whole of what *this attempt* put up: an attempt that adopts twenty
 /// layers and adds one, then dies, has to leave twenty-one behind or the third
 /// attempt pays for the difference.
+///
+/// The lock is held across the file write as well as the map insert: each
+/// write rewrites the whole record, so two producers landing layers at once
+/// must serialize on the file or the later write would drop the earlier
+/// layer.
 struct Recording {
     path: PathBuf,
     origin: Origin,
-    layers: RefCell<BTreeMap<(String, String), WrittenLayer>>,
+    layers: Mutex<BTreeMap<(String, String), WrittenLayer>>,
 }
 
 impl<'a> Chained<'a> {
@@ -1273,7 +1283,7 @@ impl<'a> Chained<'a> {
         let record = storage_path.map(|storage_path| Recording {
             path: record_path_in(storage_path),
             origin,
-            layers: RefCell::new(resumable.clone()),
+            layers: Mutex::new(resumable.clone()),
         });
 
         Ok(Self {
@@ -1284,7 +1294,7 @@ impl<'a> Chained<'a> {
             inheritable,
             resumable,
             record,
-            adopted: Cell::new(0),
+            adopted: AtomicUsize::new(0),
         })
     }
 
@@ -1329,7 +1339,7 @@ impl Predecessor for Chained<'_> {
         // happened.
         if let (Some(source), Some(descriptor)) = (self.source, self.inheritable.get(&key)) {
             self.registry.adopt_layer(source, descriptor.clone())?;
-            self.adopted.set(self.adopted.get() + 1);
+            self.adopted.fetch_add(1, Ordering::Relaxed);
 
             return Ok(Some(descriptor.clone()));
         }
@@ -1348,7 +1358,7 @@ impl Predecessor for Chained<'_> {
             return Ok(None);
         }
 
-        self.adopted.set(self.adopted.get() + 1);
+        self.adopted.fetch_add(1, Ordering::Relaxed);
 
         Ok(Some(recorded.descriptor.clone()))
     }
@@ -1384,7 +1394,11 @@ impl Predecessor for Chained<'_> {
             digests: written.digests,
         };
 
-        let mut layers = record.layers.borrow_mut();
+        // Held across the save below, not just the insert — see [`Recording`].
+        let mut layers = record
+            .layers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         layers.insert(scope_key(&descriptor.kind, &descriptor.scope)?, written);
 

--- a/crates/snapshot/src/reporting.rs
+++ b/crates/snapshot/src/reporting.rs
@@ -27,9 +27,15 @@ const RECORD_CADENCE: u64 = 4096;
 /// driver may hold several open at once — the export's state pass keeps all
 /// sixteen shard sinks open across one walk of the store — and a single cursor
 /// would report the last one opened as the one that finished.
+///
+/// The position counter is atomic because the export drives its layer
+/// producers from a pool of threads, and every producer announces through the
+/// one cursor. Positions are display order, nothing else: the inscription
+/// lists layers by its own rule, so two runs that announce in different
+/// interleavings still publish the same document.
 pub(crate) struct Cursor<'a> {
     observer: &'a Observer,
-    next: usize,
+    next: std::sync::atomic::AtomicUsize,
     total: usize,
 }
 
@@ -37,15 +43,14 @@ impl<'a> Cursor<'a> {
     pub(crate) fn new(observer: &'a Observer, total: usize) -> Self {
         Self {
             observer,
-            next: 0,
+            next: std::sync::atomic::AtomicUsize::new(0),
             total,
         }
     }
 
     /// Announce a layer and take its position in the run.
-    pub(crate) fn open(&mut self, kind: &str, scope: &serde_json::Value) -> usize {
-        let index = self.next;
-        self.next += 1;
+    pub(crate) fn open(&self, kind: &str, scope: &serde_json::Value) -> usize {
+        let index = self.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         self.observer.emit(Event::LayerStarted {
             index,
@@ -78,7 +83,7 @@ impl<'a> Cursor<'a> {
     /// Layers announced so far — what a caller cross-checks its own total
     /// against once the run is over.
     pub(crate) fn opened(&self) -> usize {
-        self.next
+        self.next.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -144,7 +149,7 @@ mod tests {
     fn positions_survive_layers_held_open_together() {
         let recorder = Arc::new(Recorder::default());
         let observer = Observer::new(recorder.clone());
-        let mut cursor = Cursor::new(&observer, 2);
+        let cursor = Cursor::new(&observer, 2);
 
         let scope = serde_json::json!({});
         let first = cursor.open("state", &scope);

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -978,7 +978,7 @@ where
         observer,
     };
 
-    let mut cursor = Cursor::new(observer, plan.layers().count());
+    let cursor = Cursor::new(observer, plan.layers().count());
     let mut summary = Summary::default();
 
     indexes.initialize_schema()?;

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -703,6 +703,157 @@ fn same_inscription_from_both_backends(at: Option<(u64, RetainedEpochs)>) {
     }
 }
 
+/// The pool changes nothing about the document — the property
+/// [`export::Producers`] promises and every operator flag repeats.
+///
+/// One backend, one seeding, three walks: strictly serial (one producer, no
+/// threads at all), the default pool, and a pool wider than the job list is
+/// deep. Each runs over a plan that cuts a retained dump — so the tee through
+/// `carry_again` is in the mix — and with the band narrowed to one epoch, so
+/// more than one band job actually queues on the band lane. Byte-identical
+/// inscriptions and blobs, or the pool moved something it promised only to
+/// reschedule.
+#[test]
+fn a_pooled_production_is_byte_identical_to_the_serial_walk() {
+    let domain: ToyDomain = harness();
+    let retained = RetainedEpochs::new(vec![1]).unwrap();
+
+    let pool_of = |producers: usize| {
+        plan_at_boundary(&domain, 1, retained.clone())
+            .with_band(export::IndexBand::new(
+                std::num::NonZeroUsize::new(1).unwrap(),
+            ))
+            .with_producers(export::Producers::new(
+                std::num::NonZeroUsize::new(producers).unwrap(),
+            ))
+    };
+
+    let serial_root = tempfile::tempdir().unwrap();
+    let pooled_root = tempfile::tempdir().unwrap();
+    let wide_root = tempfile::tempdir().unwrap();
+
+    let serial = export_plan(serial_root.path(), &domain, &pool_of(1));
+    let pooled = export_plan(pooled_root.path(), &domain, &pool_of(4));
+    let wide = export_plan(wide_root.path(), &domain, &pool_of(32));
+
+    // Compared layer by layer first, so a divergence names the kind and the
+    // scope it happened in rather than only moving the final digest.
+    for (left, right) in serial.layers.iter().zip(&pooled.layers) {
+        assert_eq!(
+            (&left.kind, &left.scope, left.records, left.diff_id),
+            (&right.kind, &right.scope, right.records, right.diff_id),
+            "layer {:?} {} diverged between the serial and pooled walks",
+            left.kind,
+            left.scope,
+        );
+    }
+
+    assert_eq!(serial, pooled);
+    assert_eq!(serial, wide);
+    assert_eq!(serial.digest().unwrap(), pooled.digest().unwrap());
+
+    // Same document on disk, and the same blobs behind it.
+    assert_eq!(
+        std::fs::read(serial_root.path().join("inscription.json")).unwrap(),
+        std::fs::read(pooled_root.path().join("inscription.json")).unwrap(),
+    );
+
+    let left = SteleDir::open(serial_root.path())
+        .unwrap()
+        .blob_index()
+        .unwrap();
+    let right = SteleDir::open(pooled_root.path())
+        .unwrap()
+        .blob_index()
+        .unwrap();
+
+    for descriptor in &serial.layers {
+        assert_eq!(
+            left.blob_for(&descriptor.diff_id),
+            right.blob_for(&descriptor.diff_id),
+            "layer {:?} {}",
+            descriptor.kind,
+            descriptor.scope,
+        );
+    }
+}
+
+/// A transport that refuses to open a sink for one kind, for the test below.
+///
+/// The directory twin of `tests/publish.rs`'s `Interrupted`: everything else
+/// goes straight through, and `carry_again`'s default body is right here
+/// because a directory's is the default.
+struct DyingAt<'a> {
+    inner: &'a SteleDir,
+    kind: &'static str,
+}
+
+impl stelae::SteleWriter for DyingAt<'_> {
+    type Sink = <SteleDir as stelae::SteleWriter>::Sink;
+
+    fn layer_sink(
+        &self,
+        profile: &dyn stelae::Profile,
+        spec: &stelae::LayerSpec,
+        level: i32,
+    ) -> Result<Self::Sink, stelae::Error> {
+        if spec.kind == self.kind {
+            return Err(stelae::Error::Io(std::io::Error::other(
+                "the machine went away",
+            )));
+        }
+
+        self.inner.layer_sink(profile, spec, level)
+    }
+
+    fn seal(
+        &self,
+        profile: &dyn stelae::Profile,
+        inscription: &stelae::Inscription,
+    ) -> Result<stelae::Digest, stelae::Error> {
+        self.inner.seal(profile, inscription)
+    }
+}
+
+/// A failing job fails the pooled export with its own error.
+///
+/// The pool's error path: the first failure stops the queues, the jobs already
+/// running finish, and what the caller gets is the failure itself rather than
+/// a document with a hole in it. The serial walk's version of this property is
+/// exercised by every error test above; this one runs the pool.
+#[test]
+fn a_failing_producer_fails_the_pooled_export() {
+    let domain: ToyDomain = harness();
+
+    let root = tempfile::tempdir().unwrap();
+    let stele = SteleDir::create(root.path()).unwrap();
+    let dying = DyingAt {
+        inner: &stele,
+        kind: BLOCKS,
+    };
+
+    let plan = plan_for(&domain).with_producers(export::Producers::new(
+        std::num::NonZeroUsize::new(4).unwrap(),
+    ));
+
+    let err = export::export(
+        &dying,
+        &plan,
+        domain.archive(),
+        domain.state(),
+        domain.indexes(),
+        None,
+        &export::First,
+        &Observer::silent(),
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(err, dolos_snapshot::Error::Stelae(stelae::Error::Io(_))),
+        "{err:?}"
+    );
+}
+
 /// The dumps a stele carries, by the epoch their scope names.
 fn dumps_in(
     inscription: &stelae::inscription::Inscription,

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -229,7 +229,7 @@ mod registry_node {
 
         /// The same publish, through a writer of the caller's — the interrupted
         /// transport the resume suite kills at a layer it chose.
-        pub fn publish_through<W: stelae::SteleWriter>(
+        pub fn publish_through<W: stelae::SteleWriter + Sync>(
             &self,
             stele: &W,
             publishing: Publishing<'_>,

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -396,7 +396,7 @@ fn a_restarted_publish_carries_forward_the_retained_dump_it_adopted() {
                 epoch: None,
             },
             publishing(&dying, &storage),
-            &following,
+            &serial(&following),
         )
         .unwrap_err();
 
@@ -477,6 +477,93 @@ fn a_restarted_publish_carries_forward_the_retained_dump_it_adopted() {
         "the record bought nothing: {} reused against {}",
         resumed.layers_reused,
         uninterrupted.layers_reused,
+    );
+
+    assert_eq!(
+        registry::PublishRecord::load(&record_path(&storage)).unwrap(),
+        None,
+        "a resumed publish that sealed left its record behind",
+    );
+}
+
+/// The kill-during-parallel-production case: a publish dies inside one
+/// producer while the others are still landing layers, and the restart still
+/// converges on the uninterrupted manifest, byte for byte.
+///
+/// The serial version of this property is the test above; what a pool adds is
+/// that the record is written from concurrent producers and the killed
+/// attempt's surviving layers are whichever jobs happened to finish. So the
+/// assertions here are the invariants that must hold *whatever* landed —
+/// identical stele, identical manifest, no layer dropped and none duplicated,
+/// record consumed — and none of the exact arithmetic, which is racy by
+/// design and already pinned serially.
+#[test]
+#[ignore]
+fn a_publish_killed_during_parallel_production_resumes_cleanly() {
+    let fixture = Fixture::spawn();
+    let node = Node::build();
+    let storage = tempfile::tempdir().unwrap();
+
+    let pooled = |plan: export::Plan| {
+        plan.with_producers(export::Producers::new(
+            std::num::NonZeroUsize::new(4).unwrap(),
+        ))
+    };
+
+    let cutting = pooled(plan_at_epoch_end(&node.domain, 1, retaining_epoch_1()));
+    let following = pooled(plan_at_boundary(&node.domain, 2, retaining_epoch_1()));
+
+    let first = fixture.repository("dolos/parallel-kill");
+    node.publish_as(publishing(&first, &storage), &cutting)
+        .unwrap();
+
+    // Die at the first tip shard of the first state kind, exactly as the
+    // serial test does — except here the sink is asked for from a producer
+    // thread, with the other producers mid-flight.
+    let (first_kind, _, _) = STATE_KINDS[0];
+
+    let dying = fixture.repository("dolos/parallel-kill");
+
+    let killed = node
+        .publish_through(
+            &Interrupted {
+                inner: &dying,
+                kind: first_kind,
+                epoch: None,
+            },
+            publishing(&dying, &storage),
+            &following,
+        )
+        .unwrap_err();
+
+    assert!(
+        matches!(killed, Error::Stelae(stelae::Error::Io(_))),
+        "{killed:?}"
+    );
+
+    // The restart, against the same repository and the same storage.
+    let resumed_into = fixture.repository("dolos/parallel-kill");
+
+    let resumed = node
+        .publish_as(publishing(&resumed_into, &storage), &following)
+        .unwrap();
+
+    // Held against an uninterrupted pooled run rather than literals, exactly
+    // as the serial resume test is: "the interruption changed nothing".
+    let clean = fixture.repository("dolos/parallel-kill-clean");
+
+    node.publish(&clean, &cutting, false);
+    let uninterrupted = node.publish(&clean, &following, false);
+
+    assert_eq!(resumed.identity, uninterrupted.identity);
+    assert_eq!(resumed.inscription, uninterrupted.inscription);
+    assert_eq!(manifest_of(&resumed_into), manifest_of(&clean));
+
+    // Whatever subset of layers the killed attempt landed, the resume accounts
+    // for every layer exactly once.
+    assert_eq!(
+        resumed.layers_built + resumed.layers_reused,
+        uninterrupted.layers_built + uninterrupted.layers_reused,
     );
 
     assert_eq!(
@@ -1032,7 +1119,7 @@ fn a_restarted_publish_carries_forward_the_layers_it_finished() {
                 epoch: Some(1),
             },
             publishing(&dying, &storage),
-            &node.second,
+            &serial(&node.second),
         )
         .unwrap_err();
 
@@ -1148,7 +1235,7 @@ fn a_rebuild_and_another_repository_both_ignore_the_record() {
                 epoch: Some(1),
             },
             publishing(repository, &storage),
-            &node.second,
+            &serial(&node.second),
         )
         .unwrap_err();
 
@@ -1211,6 +1298,19 @@ fn a_rebuild_and_another_repository_both_ignore_the_record() {
         1,
         "a rebuild still chains",
     );
+}
+
+/// The same plan on the strictly serial walk.
+///
+/// For the interruption tests whose assertions name *which* layers landed
+/// ahead of the kill: that prefix is only deterministic when one producer
+/// drives the walk in document order, which is exactly what these tests pin.
+/// The pooled counterpart — whatever subset landed, the resume converges —
+/// is `a_publish_killed_during_parallel_production_resumes_cleanly`.
+fn serial(plan: &export::Plan) -> export::Plan {
+    plan.clone().with_producers(export::Producers::new(
+        std::num::NonZeroUsize::new(1).unwrap(),
+    ))
 }
 
 /// A publish into `repository`, recording beside the stores at `storage`.

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -65,6 +65,12 @@
 //! caller that is not is a design question, and the answer is not a second
 //! runtime.
 //!
+//! Several synchronous caller threads at once are fine, and the publish path
+//! uses them: a profile driver may open and finish sinks from a pool of its
+//! own producer threads. Everything those calls share — the push state, the
+//! in-flight list, the permits — is behind its own lock, and `block_on` from
+//! many non-runtime threads is exactly what a runtime is for.
+//!
 //! ## Why the publish path is concurrent, and where it joins again
 //!
 //! A publish is not one transfer; it is a few hundred small ones. A stele's

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -68,6 +68,13 @@ pub struct Args {
     #[arg(long, value_name = "EPOCHS")]
     index_band: Option<std::num::NonZeroUsize>,
 
+    /// how many layer producers run at once: the store traversals that fill,
+    /// frame and compress layers, one of them reserved for the index bands.
+    /// Changes nothing about the digest it computes. Defaults to 4; `1` is the
+    /// strictly serial walk
+    #[arg(long, value_name = "N")]
+    producers: Option<std::num::NonZeroUsize>,
+
     /// canonical inscription of the stele this one follows, as
     /// `inspect --json` or a published `inscription.json` holds it; without it
     /// the reproduction carries no history, which is a different digest
@@ -96,6 +103,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
     let plan = super::restrict(plan, args.epochs);
     let plan = super::banded(plan, args.index_band);
+    let plan = super::produced(plan, args.producers);
 
     super::report_plan(&plan)?;
 

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -23,7 +23,7 @@
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
 use dolos_snapshot::{
-    export::{IndexBand, Plan},
+    export::{IndexBand, Plan, Producers},
     RetainedEpochs,
 };
 use miette::{Context as _, IntoDiagnostic as _};
@@ -194,6 +194,20 @@ pub fn restrict(plan: Plan, range: Option<EpochRange>) -> Plan {
 pub fn banded(plan: Plan, band: Option<std::num::NonZeroUsize>) -> Plan {
     match band {
         Some(band) => plan.with_band(IndexBand::new(band)),
+        None => plan,
+    }
+}
+
+/// Apply an operator's producer pool to a plan, or leave the sized default.
+///
+/// Shared for the reason [`banded`] is: the same three commands pay the same
+/// store walks, so the knob that pools them is spelled once. Like the band,
+/// this changes nothing about the document — layers are reassembled by their
+/// position in it, never by completion order — so a reproduction is free to
+/// pool differently than the publish it checks.
+pub fn produced(plan: Plan, producers: Option<std::num::NonZeroUsize>) -> Plan {
+    match producers {
+        Some(producers) => plan.with_producers(Producers::new(producers)),
         None => plan,
     }
 }

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -63,6 +63,13 @@ pub struct Args {
     #[arg(long, value_name = "EPOCHS")]
     index_band: Option<std::num::NonZeroUsize>,
 
+    /// how many layer producers run at once: the store traversals that fill,
+    /// frame and compress layers, one of them reserved for the index bands.
+    /// Changes nothing about the stele it produces. Defaults to 4; `1` is the
+    /// strictly serial walk
+    #[arg(long, value_name = "N")]
+    producers: Option<std::num::NonZeroUsize>,
+
     /// how many layer round trips to run at once against the repository; a
     /// publish is a few hundred small transfers and its wall clock is their
     /// latency, not their bytes. Defaults to 8; `1` is the strictly serial
@@ -107,6 +114,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 
     let plan = super::restrict(plan, args.epochs);
     let plan = super::banded(plan, args.index_band);
+    let plan = super::produced(plan, args.producers);
 
     super::report_plan(&plan)?;
 

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -73,6 +73,13 @@ pub struct Args {
     #[arg(long, value_name = "EPOCHS", requires = "reproduce")]
     index_band: Option<std::num::NonZeroUsize>,
 
+    /// how many layer producers run at once: the store traversals that fill,
+    /// frame and compress layers, one of them reserved for the index bands.
+    /// Changes nothing about the reproduction. Defaults to 4; `1` is the
+    /// strictly serial walk
+    #[arg(long, value_name = "N", requires = "reproduce")]
+    producers: Option<std::num::NonZeroUsize>,
+
     /// epochs the reproduction builds layers for, e.g. `500..520`, `500..=520`
     /// or `500`; defaults to every epoch below the cursor, and must match what
     /// the stele was published with
@@ -146,6 +153,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
 
     let plan = super::restrict(plan, args.epochs);
     let plan = super::banded(plan, args.index_band);
+    let plan = super::produced(plan, args.producers);
 
     super::report_plan(&plan)?;
 


### PR DESCRIPTION
## What

A publish's wall clock is bounded by serial record production, not by the wire. PR #1260 made the layer round trips concurrent and the live backfill has now measured that lever's ceiling: doubling `--concurrency` buys ~11% (confounded), per-layer cost is flat against layer size (preview's layers are 12x smaller than mainnet's and only 1.5x faster), pod CPU sits at one thread's worth against an idle link, and mainnet's publish grew 10.1 → 18.1 min between sequences 287 and 316 with the built-layer count flat — the growth is index-store traversal, which cannot seek and re-walks the whole store per band.

This PR makes production concurrent:

- **`export` splits into jobs, independent by `(kind, scope)`**: one per epoch's `blocks` layer, one per log `(kind, window)`, one per state kind (its own namespace walk into its shard sinks), one per index band, one for `digests`.
- **A bounded pool of OS threads runs them** (`Producers`, default 4, riding on `Plan` like the band): one worker is reserved for the index bands, which run in band order — each holds the whole of `IndexBand`'s 1 GiB budget, so two at once would be two copies of a ceiling — and then helps with the rest. The index pass now runs beside the state walks instead of before them, and the fourteen state-kind walks overlap instead of queueing.
- **`--producers` sizes the pool** on `snapshot publish`, `snapshot digest` and `snapshot verify --reproduce`; `--producers 1` is the strictly serial walk, byte for byte. The backfill driver picks the default up through `Plan`.

## What does not change

- **The bytes.** Every layer is still filled by exactly one traversal in store order, so its `diffId` is the serial walk's; the inscription lists layers by document position, never completion order. Pinned by a new serial-vs-pooled byte-identity test (which also narrows the band to force several band jobs, and cuts a retained dump so the `carry_again` tee is in the mix), by the existing goldens, and by the cross-backend determinism test — all running on the default pool now.
- **The seal-as-join invariant.** `SteleWriter::seal` remains the single join; the manifest still never names a blob the registry has not committed. A first job failure stops the queues and fails the export once the pool is quiet, with nothing staged left behind (sinks dropped without `finish` clean up after themselves).
- **The `--concurrency` default and the layer geometry** (decision 0025), both out of scope by the plan.

## Thread-safety changes this rides on

- `Cursor` (progress positions) takes `&self` on an atomic counter; positions are display order only.
- `Predecessor` gains a `Sync` supertrait; the registry driver's `Chained` moves its adoption counter to an atomic and the resumption record behind a `Mutex` held across the record-file rewrite, so concurrent producers cannot drop each other's layers from it.
- The `stelae` OCI transport needed **no code change**: sinks already own their state, the permit is taken on the caller's thread, and everything shared is behind locks — the module doc now states the multi-threaded-caller contract explicitly.

## Verification

- `cargo test -p stelae --all-features`: green (32 + 21 + doc tests).
- `cargo test -p dolos-snapshot --features oci`: green, including the new `a_pooled_production_is_byte_identical_to_the_serial_walk` and `a_failing_producer_fails_the_pooled_export`.
- Docker registry suite `--test publish -- --ignored`: **14/14 green**, including the new `a_publish_killed_during_parallel_production_resumes_cleanly` (kill inside one producer while others land layers → resume converges on the uninterrupted manifest byte for byte, record consumed). The three pre-existing interruption tests assert *which* layers landed ahead of the kill — a prefix only the serial walk guarantees — and now run pinned to `--producers 1`, which is the semantics they were written to pin.
- `cargo clippy --features oci --all-targets`: no new warnings (4 pre-existing `doc_lazy_continuation` in `tests/publish.rs:205-208`, untouched text).
- nightly `cargo fmt`: clean.

The live check — per-epoch publish time before/after at comparable history, read from the backfill run log — happens on rollout per the plan's measurement section. Worth noting for expectations: the floor after this change is a single full index-store pass per publish (the store cannot seek to a slot), so the curve should drop severalfold and flatten substantially, but the one-pass term still grows slowly with store size; cutting *that* needs a slot-seekable index, which is a store-schema question out of this PR's scope.

Plan: `plans/dolos-stelae-publish-record-production.md` (Brain/txpipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLQJKLMHrqZMCDnsMi2668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot creation, publishing, and verification now support configurable parallel layer production.
  * Added the `--producers` option, with four workers by default and `--producers 1` for serial processing.
  * Parallel processing preserves canonical output ordering and supports consistent progress reporting.

* **Bug Fixes**
  * Improved error handling and recovery when snapshot production is interrupted.

* **Tests**
  * Added coverage for deterministic results across worker counts, producer failures, and interrupted publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->