### PR TITLE
perf(stelae): send 4 MiB upload chunks instead of 1 MiB

### DIFF
--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -315,9 +315,24 @@ pub const SCOPE_ANNOTATION: &str = "store.stelae.layer.scope";
 /// How much of a staged layer is held in memory on the way up.
 ///
 /// One chunk at a time, allocated and handed to the client, which sends it as
-/// one `PATCH`. Well under `oci-client`'s own 4 MiB ceiling per chunk, so this
-/// number — and not the layer's size — is what bounds the upload.
-const UPLOAD_CHUNK: usize = 1024 * 1024;
+/// one `PATCH` — and a `PATCH` costs the registry about three seconds
+/// *whatever it carries*, flat across an eightfold change in chunk size,
+/// because what it is spent on is the upload state the worker round-trips
+/// through its object store rather than the bytes. So the chunk count is the
+/// publish's wall clock, and this constant is what sets it: mainnet's largest
+/// layer is 231 MB, which at 1 MiB was 221 round trips and eleven minutes of a
+/// fifteen-minute publish.
+///
+/// Concurrency is not the alternative. A `PATCH` answers with a `Location`
+/// carrying the session's state hash and the next one is refused unless it
+/// presents the current value, so a blob is one serial chain —
+/// [`Options::concurrency`] bounds layers in flight, never chunks within a
+/// layer.
+///
+/// 4 MiB and not more because `oci-client` re-splits whatever this stream hands
+/// it at its own `PUSH_CHUNK_MAX_SIZE`, which is 4 MiB and has no setter.
+/// Anything larger here would go out as 4 MiB anyway, having cost the memory.
+const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
 
 /// What a push moved, and what it did not have to.
 ///

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1292,10 +1292,16 @@ fn bulk_records() -> u64 {
 
 /// What either direction may hold at any one moment.
 ///
-/// Above the 1 MiB upload chunk because the HTTP client copies a body on its
-/// way to the socket and zstd buffers on either side of the codec. What matters
-/// is not the number but that it does not move when the layer does — the layer
-/// is fifty times it.
+/// The push peak is one upload chunk and a little change — 4 MiB and some
+/// tens of kilobytes, measured, and stable to a fraction of a percent across
+/// runs, because the client splits the chunk it is handed rather than copying
+/// it. The pull side sits far below that. 5 MiB is the larger of the two with
+/// room over it.
+///
+/// What matters is not the number but that it does not move when the layer
+/// does: the peak is bound by the chunk, and the layer here is ten times the
+/// budget. `STELAE_TEST_BULK_RECORDS` below asks the same question at a
+/// mainnet shard's scale and this constant does not follow it up.
 const TRANSPORT_BUDGET: usize = 5 * 1024 * 1024;
 
 /// A record whose body zstd cannot shrink.


### PR DESCRIPTION
## What binds a publish

Not bandwidth, and not an aggregate ceiling. A `PATCH` costs the registry
**about three seconds whatever it carries** — flat across an eightfold sweep of
chunk sizes, because what it buys is the upload state the worker round-trips
through its object store rather than the bytes.

At `UPLOAD_CHUNK = 1 MiB`, mainnet's 231 MB `blocks` layer is **221 strictly
serial round trips ≈ 674 s**, which together with the ~120 s layer-build burst
is the whole 888 s publish. The "~1.6 MB/s ceiling" reported after #1272 was
that constant wall clock divided by the publish's bytes; nothing was moving
1.6 MB/s of anything.

Concurrency cannot reach it. A `PATCH` answers with a `Location` carrying the
session's state hash, and the next one is refused unless it presents the current
value — so a blob is one serial chain, and `--concurrency` bounds *layers* in
flight, never chunks within a layer. That is why raising the publisher 16 → 32
moved nothing.

## The change

`UPLOAD_CHUNK: 1 MiB → 4 MiB`. One constant.

4 MiB and not more because `oci-client`'s `push_blob_stream` re-splits whatever
the stream hands it at `min(self.push_chunk_size, len)`, and `push_chunk_size`
is initialised to `PUSH_CHUNK_MAX_SIZE = 4 MiB` in every constructor with no
public setter and no `ClientConfig` field. Handing it 8 MiB yields two 4 MiB
`PATCH`es and no gain.

Measured effect on a 64 MiB blob: **0.27 → 0.80 MB/s**. Projected on a mainnet
publish:

| | before | after |
|---|---|---|
| `blocks` layer round trips | 221 | **56** |
| upload critical path | ~674 s | **~171 s** |
| publish window | ~888 s | **~290 s** |

Aggregate should not become the new constraint: ~508 total round trips at
`--concurrency 32` is ~16 deep ≈ 49 s, well under the 171 s chain.

## Costs, stated

- **Transport memory grows fourfold.** `blob_stream` allocates one
  `UPLOAD_CHUNK` per in-flight upload, so peak goes 32 MiB → 128 MiB at
  `--concurrency 32`. The publisher pod requests 12 Gi.
- **Progress resolution coarsens.** `Event::Bytes` is emitted per chunk, so a
  watcher's granularity goes 1 MiB → 4 MiB.
- **4 MiB is still below the registry's 5 MiB minimum chunk**, so the worker
  keeps taking its recombination branch. Crossing that boundary was measured
  worth ~2% — it removes ~60% of the backend's byte traffic and almost no time,
  because what tracks throughput is the request count, not the amplification.

## `TRANSPORT_BUDGET`

The constant holds at 5 MiB; its derivation did not. It claimed the value was
"above the 1 MiB upload chunk because the HTTP client copies a body on its way
to the socket". It does not copy. Push peak measures **4 243 426 – 4 251 794
bytes** across three runs — one chunk plus ~55 KiB, stable to 0.2%. The comment
now says the measured thing.

## Testing

`cargo +nightly fmt`, `cargo clippy -p stelae --all-targets --all-features`, and
`cargo test -p stelae --all-features` — green, including all **14
registry-backed `#[ignore]`d tests** that spawn a real OCI Distribution server,
`neither_direction_holds_a_layer` among them.

**Unrelated, found in passing:** `cargo test -p dolos-snapshot --test publish --
--ignored` fails `a_restarted_publish_carries_forward_the_layers_it_finished`
and `..._the_retained_dump_it_adopted` when the 14 registry tests run in
parallel. Reproduced identically on unmodified `main`, and green at
`--test-threads=1` on both. A fixture interaction that predates this branch;
not addressed here, and probably worth its own issue.

## Not in this PR

- **Monolithic `POST` + `PUT` for small layers** — 12× measured, and it covers
  79 of mainnet's 81 layers, but those layers are not the critical path. It is
  most of *preview's* win, and it needs the whole layer resident against the
  deliberate one-chunk staging.
- **Chunks above 4 MiB** — needs an upstream `oci-client` change exposing
  `push_chunk_size`, and is separately gated by the Workers request-body limit.
- **Sharding the `blocks` layer** — the only lever that lets concurrency reach
  the critical path, and the only one that survives Babbage/Conway
  densification, but layer geometry is settled ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved OCI upload efficiency by increasing the upload chunk size to 4 MiB.
  - Updated memory usage guidance with measured push and pull peaks.
  - Clarified how bulk data volume independently affects memory requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->