### PR TITLE
perf(stelae): push a layer that fits as one request

### DIFF
--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -322,6 +322,14 @@ pub fn open(
             // where `snapshot backfill` re-runs the whole publish rather than
             // dying into a pod restart.
             attempts: stelae::oci::DEFAULT_ATTEMPTS,
+            // Nor these, for a related reason: both are facts about the
+            // registry this publishes to and about the pod the publisher runs
+            // in, measured rather than chosen, and neither moves when an
+            // operator changes how fast a publish goes. `upload_memory` in
+            // particular is what keeps `--concurrency` from being a claim on
+            // memory — raising one does not raise the other.
+            monolithic_max: stelae::oci::DEFAULT_MONOLITHIC_MAX,
+            upload_memory: stelae::oci::DEFAULT_UPLOAD_MEMORY,
         },
     )?)
 }

--- a/crates/stelae/src/oci.rs
+++ b/crates/stelae/src/oci.rs
@@ -40,15 +40,28 @@
 //!
 //! ## Bounded by one layer, in both directions
 //!
-//! [`oci_client::Client::push_blob_stream`] needs the blob's digest *up front*,
-//! and a layer's digest is only known once its last record has been written. So
-//! a layer is staged into a temporary file exactly as a directory stages one,
-//! and then streamed up from it. A pulled layer is streamed to a temporary file
-//! and read back synchronously.
+//! Both push paths need the blob's digest *up front*, and a layer's digest is
+//! only known once its last record has been written. So a layer is staged into
+//! a temporary file exactly as a directory stages one, and then sent up from
+//! it. A pulled layer is streamed to a temporary file and read back
+//! synchronously.
 //!
-//! Neither direction ever holds a whole stele or a whole layer. The staging
-//! files are unlinked at creation, so an abandoned push or a failed pull leaves
-//! nothing behind and needs no cleanup path of its own.
+//! Neither direction ever holds a whole stele. The staging files are unlinked
+//! at creation, so an abandoned push or a failed pull leaves nothing behind and
+//! needs no cleanup path of its own.
+//!
+//! What the *upload* holds is decided by [`Options::monolithic_max`]. Above it,
+//! a layer is streamed and one [`UPLOAD_CHUNK`] is resident at a time. At or
+//! below it, the layer goes up as one request — a `POST` and a `PUT` carrying
+//! the whole body — and is resident in full while it does, because the client
+//! takes the body as bytes and there is no ordering in which it does not.
+//!
+//! That is bought deliberately: a `PATCH` costs the registry about three
+//! seconds whatever it carries, so a publish's wall clock is its request count,
+//! and 79 of mainnet's 81 layers fit under the threshold. What keeps the price
+//! bounded is [`Options::upload_memory`] — a budget in *bytes*, spent by the
+//! layers actually in flight rather than inferred from how many of them there
+//! are. See [`Shared::resident`].
 //!
 //! ## The async boundary, and the one rule it comes with
 //!
@@ -108,6 +121,13 @@
 //! than inside the task, so it is also what keeps the scratch directory from
 //! filling: at most [`Options::concurrency`] staged layers exist at once,
 //! whatever order the sinks finish in.
+//!
+//! It is not the bound on memory, and reading it as one is the mistake this
+//! paragraph exists to prevent. A layer count says nothing about bytes when the
+//! layers differ in size by three orders of magnitude — mainnet's median layer
+//! is 0.41 MB and its largest is 231 MB — and the single-request path spends
+//! bytes. So there is a second permit, taken in the task where the size is
+//! finally known, one per resident byte, against [`Options::upload_memory`].
 //!
 //! ## A round trip nobody answered is made again
 //!
@@ -200,7 +220,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{Seek, SeekFrom, Write},
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
@@ -312,16 +332,18 @@ pub const DIFF_ID_ANNOTATION: &str = "store.stelae.layer.diffId";
 /// epoch or shard a blob covers without fetching the config blob.
 pub const SCOPE_ANNOTATION: &str = "store.stelae.layer.scope";
 
-/// How much of a staged layer is held in memory on the way up.
+/// How much of a *streamed* layer is held in memory on the way up.
 ///
-/// One chunk at a time, allocated and handed to the client, which sends it as
-/// one `PATCH` — and a `PATCH` costs the registry about three seconds
-/// *whatever it carries*, flat across an eightfold change in chunk size,
-/// because what it is spent on is the upload state the worker round-trips
-/// through its object store rather than the bytes. So the chunk count is the
-/// publish's wall clock, and this constant is what sets it: mainnet's largest
-/// layer is 231 MB, which at 1 MiB was 221 round trips and eleven minutes of a
-/// fifteen-minute publish.
+/// The layers too large for [`DEFAULT_MONOLITHIC_MAX`], and nothing else: a
+/// layer that fits goes up as one request and is resident in full while it
+/// does. What is left here is one chunk at a time, allocated and handed to the
+/// client, which sends it as one `PATCH` — and a `PATCH` costs the registry
+/// about three seconds *whatever it carries*, flat across an eightfold change
+/// in chunk size, because what it is spent on is the upload state the worker
+/// round-trips through its object store rather than the bytes. So the chunk
+/// count is the publish's wall clock, and this constant is what sets it:
+/// mainnet's largest layer is 231 MB, which at 1 MiB was 221 round trips and
+/// eleven minutes of a fifteen-minute publish.
 ///
 /// Concurrency is not the alternative. A `PATCH` answers with a `Location`
 /// carrying the session's state hash and the next one is refused unless it
@@ -333,6 +355,41 @@ pub const SCOPE_ANNOTATION: &str = "store.stelae.layer.scope";
 /// it at its own `PUSH_CHUNK_MAX_SIZE`, which is 4 MiB and has no setter.
 /// Anything larger here would go out as 4 MiB anyway, having cost the memory.
 const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
+
+/// The largest layer this transport will push as one request.
+///
+/// A `POST` followed by a `PUT` carrying the whole body skips the chunked
+/// session entirely — no `PATCH` chain, no upload state round-tripped through
+/// the registry's object store, no recombination — and measured against the
+/// live registry it moves **3.29 MB/s against 0.27**. It also covers most of a
+/// publish: 79 of mainnet's 81 layers are under this number, and the median
+/// layer is 0.41 MB.
+///
+/// 100 MB because that is what this registry advertises as
+/// `OCI-Chunk-Max-Length`, decimal as the header is
+/// (`registry/vendor/src/chunk.ts`, `MAXIMUM_CHUNK_UPLOAD_SIZE`). It is a
+/// property of *that* registry and not of registries in general, which is why
+/// it is [`Options::monolithic_max`] rather than a literal in the push path —
+/// but it cannot be read from the wire: the header rides on the upload
+/// session's response and `oci-client` extracts only the `Location` from it
+/// (`client.rs`, `extract_location_header`), so nothing this crate calls ever
+/// sees it. A default a caller can override is the whole of the honesty
+/// available here.
+pub const DEFAULT_MONOLITHIC_MAX: u64 = 1000 * 1000 * 100;
+
+/// How many bytes of layer a publish may hold in memory at once.
+///
+/// One gibibyte, and it exists because a monolithic push turns
+/// [`Options::concurrency`] into a claim on *memory* and not just on the
+/// scratch directory. A layer count is the wrong unit for that: thirty-two
+/// permits against a 100 MB threshold is 3.2 GB worst case, on a publisher pod
+/// requesting 12 GiB and already sitting at seven.
+///
+/// So the resident bytes are bounded directly rather than inferred from a
+/// layer count — see [`Shared::resident`]. At the default threshold this is ten
+/// large layers in flight at once, whatever the concurrency is set to, while
+/// the median 0.41 MB layer costs a permit it will never wait for.
+pub const DEFAULT_UPLOAD_MEMORY: u64 = 1024 * 1024 * 1024;
 
 /// What a push moved, and what it did not have to.
 ///
@@ -438,7 +495,8 @@ pub struct Options {
     /// configuration anybody means.
     ///
     /// It bounds the staging directory as well as the wire: see the module
-    /// documentation.
+    /// documentation. It does not bound memory — [`Options::upload_memory`]
+    /// does, and in the unit that one is spent in.
     pub concurrency: usize,
 
     /// Re-prove that the registry still holds a blob being adopted out of a
@@ -471,6 +529,29 @@ pub struct Options {
     /// registry's refusal of *this* request is never one of them, so raising
     /// this does not slow down a publish that was going to fail anyway.
     pub attempts: u32,
+
+    /// The largest layer to push as one request rather than as a `PATCH` chain.
+    ///
+    /// Defaults to [`DEFAULT_MONOLITHIC_MAX`], which is what the registry this
+    /// was measured against advertises. A registry that accepts less is a
+    /// registry an operator has to say so about, because the advertisement is
+    /// not reachable from here — see the constant.
+    ///
+    /// Clamped down to [`Options::upload_memory`] when it is larger, so that a
+    /// layer at the threshold always fits the budget that admits it. `0` is
+    /// read as "never", not as "layers of no bytes": it streams everything,
+    /// which is the escape hatch for a registry that answers a monolithic
+    /// `PUT` badly.
+    pub monolithic_max: u64,
+
+    /// How many bytes of layer this transport may hold in memory at once.
+    ///
+    /// Defaults to [`DEFAULT_UPLOAD_MEMORY`]. It bounds the single-request path
+    /// and nothing else — a streamed layer holds one [`UPLOAD_CHUNK`] whatever
+    /// this says — and it is a budget rather than a limit on any one layer:
+    /// several small layers share it, and a layer larger than the whole budget
+    /// cannot exist because the threshold is clamped to it.
+    pub upload_memory: u64,
 }
 
 impl Default for Options {
@@ -482,6 +563,8 @@ impl Default for Options {
             concurrency: DEFAULT_CONCURRENCY,
             verify_adopted: false,
             attempts: DEFAULT_ATTEMPTS,
+            monolithic_max: DEFAULT_MONOLITHIC_MAX,
+            upload_memory: DEFAULT_UPLOAD_MEMORY,
         }
     }
 }
@@ -639,6 +722,9 @@ struct Shared {
     /// many staged layers may exist at once. A permit is taken on the caller's
     /// thread before the staging file is handed over and released when the
     /// round trip is done. See [`Options::concurrency`].
+    ///
+    /// Layers, not bytes: what this bounds is the scratch directory. Memory is
+    /// `resident`, below.
     permits: Arc<tokio::sync::Semaphore>,
     /// The deferred layer round trips, waiting to be joined by
     /// [`SteleWriter::seal`].
@@ -662,6 +748,29 @@ struct Shared {
     concurrency: usize,
     /// [`Options::attempts`], as it was resolved.
     attempts: u32,
+    /// The resident-byte budget, one permit per byte.
+    ///
+    /// A second bound beside `permits`, and a different unit on purpose. That
+    /// one counts layers and bounds the scratch directory; this one counts
+    /// bytes and bounds *memory*, which is what the single-request path spends
+    /// and what a layer count cannot express — the layers differ in size by
+    /// three orders of magnitude.
+    ///
+    /// Taken inside the deferred task rather than on the caller's thread,
+    /// because that is where a layer's size is known: the permit in
+    /// [`RecordSink::finish`] is taken before the layer is closed, and its
+    /// size does not exist yet. Held for the upload and released before the
+    /// backoff between attempts, so a publish waiting on a failing registry
+    /// holds no bytes at all.
+    ///
+    /// Cannot deadlock: `monolithic_max` is clamped to the budget, so any
+    /// single acquisition can be satisfied by an empty semaphore, and
+    /// `tokio`'s is fair — a large waiter is not overtaken by the small ones
+    /// behind it.
+    resident: Arc<tokio::sync::Semaphore>,
+    /// [`Options::monolithic_max`], as it was resolved against
+    /// [`Options::upload_memory`].
+    monolithic_max: u64,
 }
 
 #[derive(Default)]
@@ -730,8 +839,21 @@ impl Registry {
             ClientProtocol::Https
         };
 
+        // `use_monolithic_push` is what makes `push_blob` send a `POST` and
+        // then one `PUT` carrying the whole body instead of opening a chunked
+        // session. It reaches two paths: the layers under `monolithic_max`
+        // below, which is the point, and `Shared::put_bytes`, which was already
+        // calling `push_blob` for the inscription — a document of a few
+        // kilobytes that now costs one round trip fewer.
+        //
+        // The flag also removes `push_blob`'s fallback: without it a chunked
+        // push that trips a spec violation retries monolithically, and with it
+        // there is nothing to fall back *from*. That is the trade this whole
+        // change is, and the single-request path is the one measured against
+        // the registry this publishes to.
         let client = Client::new(ClientConfig {
             protocol,
+            use_monolithic_push: true,
             ..Default::default()
         });
 
@@ -752,6 +874,20 @@ impl Registry {
         // pool to the bound is what keeps that from turning a concurrency of
         // eight into a concurrency of one on a slow volume.
         let concurrency = options.concurrency.max(1);
+
+        // The budget first, then the threshold against it: a layer at the
+        // threshold has to be admissible on an empty semaphore, or the task
+        // holding a layer larger than the whole budget would wait forever.
+        let upload_memory = options
+            .upload_memory
+            .min(tokio::sync::Semaphore::MAX_PERMITS as u64);
+        // `u32` because that is what one `acquire_many` can ask for; no layer
+        // this format cuts comes near it, and a threshold that did would be
+        // asking for four gibibytes of one blob in memory.
+        let monolithic_max = options
+            .monolithic_max
+            .min(upload_memory)
+            .min(u32::MAX as u64);
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(concurrency)
@@ -780,6 +916,8 @@ impl Registry {
                 verify_adopted: options.verify_adopted,
                 concurrency,
                 attempts: options.attempts.max(1),
+                resident: Arc::new(tokio::sync::Semaphore::new(upload_memory as usize)),
+                monolithic_max,
             }),
         })
     }
@@ -1287,6 +1425,33 @@ fn rewound(staged: &File) -> Result<File, Error> {
     Ok(again)
 }
 
+/// A staged layer, whole, for the single-request path.
+///
+/// Read on the runtime's own worker thread and synchronously, for the reason
+/// [`blob_stream`] reads that way: the file is local, the runtime is this
+/// transport's own, and it is sized one worker per permit so a thread inside a
+/// read cannot starve another upload.
+///
+/// Read fresh per attempt rather than held across the backoff — the caller has
+/// already taken the resident-byte permit that admits it, and holding the bytes
+/// through a wait would multiply the budget by the retry window at exactly the
+/// moment the registry is failing.
+///
+/// `size` is the compressed size the digest pipeline reported as it wrote this
+/// file, and the read is exact rather than to the end. One allocation of
+/// exactly the layer, so what the resident-byte permit admitted is what the
+/// upload actually holds — `read_to_end` would probe past the end and can grow
+/// the buffer past the permit that paid for it. A file that does not hold
+/// `size` bytes is a bug in this process and fails here rather than as a digest
+/// the registry rejects.
+fn staged_bytes(mut staged: File, size: u64) -> Result<bytes::Bytes, Error> {
+    let mut body = vec![0u8; size as usize];
+
+    staged.read_exact(&mut body)?;
+
+    Ok(bytes::Bytes::from(body))
+}
+
 /// A staged file, created where [`Options::scratch_dir`] said.
 ///
 /// Both calls that can fail against a *named* directory raise
@@ -1378,6 +1543,10 @@ impl Shared {
     /// task is what makes it back pressure at all: the caller does not get to
     /// stage a ninth layer while eight are still moving, so the scratch
     /// directory is bounded by the same number as the wire.
+    ///
+    /// The resident-byte permit cannot be taken here — the layer is not closed
+    /// yet and has no size — which is why there are two of them and why they
+    /// are taken in different places. See [`Shared::resident`].
     fn permit(&self) -> tokio::sync::OwnedSemaphorePermit {
         // The semaphore is never closed — nothing here closes one — so the only
         // error this call has is unreachable.
@@ -1489,6 +1658,8 @@ impl Shared {
         let client = self.client.clone();
         let repository = self.repository.clone();
         let state = Arc::clone(&self.state);
+        let resident = Arc::clone(&self.resident);
+        let monolithic_max = self.monolithic_max;
 
         self.defer(async move {
             let _permit = permit;
@@ -1537,24 +1708,59 @@ impl Shared {
             // The staged bytes are still in hand here, which is the whole
             // reason this is the right place for the retry: past the join the
             // layer's only copy is the store it was built from, and the
-            // recovery costs a publish. Rewound per attempt, because the stream
-            // consumes the handle it is given.
-            retrying_async(attempts, &observer, || {
-                let client = client.clone();
-                let repository = repository.clone();
-                let named = named.clone();
-                let observer = observer.clone();
-                let staged = rewound(&staged);
+            // recovery costs a publish. Rewound per attempt, because both paths
+            // consume the handle they are given.
+            if monolithic_max > 0 && size <= monolithic_max {
+                retrying_async(attempts, &observer, || {
+                    let client = client.clone();
+                    let repository = repository.clone();
+                    let named = named.clone();
+                    let resident = Arc::clone(&resident);
+                    let staged = rewound(&staged);
 
-                async move {
-                    client
-                        .push_blob_stream(&repository, blob_stream(staged?, observer), &named)
-                        .await?;
+                    async move {
+                        // Taken per attempt and released with the attempt, so
+                        // the doubling wait between two of them holds no bytes:
+                        // a registry answering `500` is exactly when this
+                        // transport should be at its smallest.
+                        let _bytes = resident
+                            .acquire_many_owned(size as u32)
+                            .await
+                            .expect("the transport's semaphore is never closed");
 
-                    Ok(())
-                }
-            })
-            .await?;
+                        client
+                            .push_blob(&repository, staged_bytes(staged?, size)?, &named)
+                            .await?;
+
+                        Ok(())
+                    }
+                })
+                .await?;
+
+                // Once, at the end, because there is nothing finer to say: the
+                // request either landed or it did not. A layer that took two
+                // attempts reports what it *is* rather than what crossed the
+                // wire, which is the opposite of the streamed path's answer and
+                // the honest one for a transfer with no intermediate states.
+                observer.emit(Event::Bytes(size));
+            } else {
+                retrying_async(attempts, &observer, || {
+                    let client = client.clone();
+                    let repository = repository.clone();
+                    let named = named.clone();
+                    let observer = observer.clone();
+                    let staged = rewound(&staged);
+
+                    async move {
+                        client
+                            .push_blob_stream(&repository, blob_stream(staged?, observer), &named)
+                            .await?;
+
+                        Ok(())
+                    }
+                })
+                .await?;
+            }
 
             let mut state = lock(&state);
             state.transfer.layers_uploaded += 1;
@@ -1609,6 +1815,14 @@ impl Shared {
 
     /// Upload a small blob a caller already holds — the inscription, and
     /// nothing else.
+    ///
+    /// Goes up in one request like a small layer does, and for the same reason:
+    /// `use_monolithic_push` is set on the client, so `push_blob` sends a
+    /// `POST` and a `PUT` rather than opening a chunked session for a
+    /// document of a few kilobytes. No resident-byte permit — the
+    /// inscription is bounded by [`MANIFEST_SIZE_LIMIT`]'s order of
+    /// magnitude and by being one document, not by a budget shared with the
+    /// layers.
     fn put_bytes(&self, digest: &Digest, bytes: Vec<u8>) -> Result<(), Error> {
         if self.blob_exists(digest)? {
             return Ok(());
@@ -1898,9 +2112,9 @@ impl Shared {
 /// A layer being written into a registry, one record at a time.
 ///
 /// Staged into a temporary file for a reason that is not a limitation of this
-/// implementation: `push_blob_stream` takes the digest up front, and a layer's
+/// implementation: both push paths take the digest up front, and a layer's
 /// digest is the digest of its own compressed bytes. There is no ordering of
-/// the operations in which a streaming upload learns the name first.
+/// the operations in which an upload learns the name first.
 ///
 /// The staging file is unlinked at creation, so a sink dropped without
 /// [`RecordSink::finish`] — an export that fails halfway with sixteen shards
@@ -2325,16 +2539,21 @@ pub fn read_manifest(
 
 /// A staged layer, as a stream of chunks.
 ///
+/// The path for the layers [`Options::monolithic_max`] excludes — on mainnet,
+/// `blocks` and one `state-accounts` shard. Everything smaller goes up whole
+/// through [`staged_bytes`], in one request rather than a `PATCH` chain.
+///
 /// Reads from the staging file synchronously. The runtime under it is this
 /// transport's own — the read is not waiting on anything it is responsible for
 /// driving — and it is sized so that a read blocking a worker cannot starve the
 /// other uploads: one worker per permit, decided in [`Registry::open`].
 ///
-/// One chunk is allocated at a time and handed over, so what the upload holds
-/// is [`UPLOAD_CHUNK`] and not the layer.
+/// One chunk is allocated at a time and handed over, so what a *streamed*
+/// upload holds is [`UPLOAD_CHUNK`] and not the layer.
 /// Each chunk is reported as it is handed over, which is the only resolution
 /// this loop has: a `PATCH` either went out or it did not, and the client does
-/// not say how much of one has reached the wire.
+/// not say how much of one has reached the wire. A single-request layer has no
+/// such resolution to report and announces itself once, at the end.
 fn blob_stream(
     file: File,
     observer: Observer,

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1525,10 +1525,6 @@ fn neither_direction_holds_a_layer() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// One request, or a chain of them
-// ---------------------------------------------------------------------------
-
 /// Every [`Event::Bytes`] the transport emitted, in order.
 ///
 /// The only in-process view of *how many requests* an upload took. The
@@ -1588,10 +1584,14 @@ fn a_layer_under_the_threshold_goes_up_in_one_request() {
 
     let fixture = Fixture::spawn();
 
-    // Between the two layers below, and under the bulk layer by enough that it
-    // still takes more than one chunk: the claim is a chain against a single
-    // request, and a "chain" of one would prove nothing.
+    // Between the two layers below: the small one under it, the bulk one over.
     const THRESHOLD: u64 = 1024 * 1024;
+
+    // The transport's `UPLOAD_CHUNK`, which the crate keeps private. It is what
+    // sets the streamed event count — one per chunk handed to the client — and
+    // it is not the threshold: what makes the bulk layer a *chain* is being
+    // over this, and a "chain" of one would prove nothing.
+    const CHUNK: u64 = 4 * 1024 * 1024;
 
     // Comfortably over one upload chunk once compressed — the bodies are
     // incompressible, so this is close to what crosses the socket.
@@ -1661,9 +1661,10 @@ fn a_layer_under_the_threshold_goes_up_in_one_request() {
         "the small layer has to be under the threshold: {small_size} against {THRESHOLD}",
     );
     assert!(
-        bulk_size > 2 * THRESHOLD,
-        "the bulk layer has to be over the threshold by more than one chunk: \
-         {bulk_size} against {THRESHOLD}",
+        bulk_size > CHUNK,
+        "the bulk layer has to be over one upload chunk, or it streams as a \
+         single delta and the chain below is a chain of one: \
+         {bulk_size} against {CHUNK}",
     );
 
     let seen = chunks.seen();
@@ -1685,7 +1686,6 @@ fn a_layer_under_the_threshold_goes_up_in_one_request() {
         "the deltas do not add up to what was published: {seen:?}",
     );
 
-    // --- and the same layers, whichever way they went ----------------------
     let stele = registry.pull_latest(&ToyProfile).unwrap();
     let read = stele.read_inscription().unwrap();
 

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1783,7 +1783,22 @@ fn the_single_request_path_is_bounded_by_its_byte_budget() {
                 .unwrap();
         }
 
-        inscription.layers.push(sink.finish().unwrap().descriptor);
+        let written = sink.finish().unwrap();
+
+        // The threshold here is `BUDGET` — `monolithic_max` is left at its
+        // default and clamped down to it — so a layer over this line would
+        // stream, hold one chunk, and sail under the ceiling below without the
+        // byte budget ever being asked for. The assertion is what stops a
+        // change in what `bulk_record` compresses to from quietly turning this
+        // test into one that measures nothing.
+        assert!(
+            written.digests.compressed_size <= BUDGET,
+            "layer {layer} has to be resident for this to measure the budget: \
+             {} against {BUDGET}",
+            written.digests.compressed_size,
+        );
+
+        inscription.layers.push(written.descriptor);
     }
 
     registry.seal(&ToyProfile, &inscription).unwrap();

--- a/crates/stelae/tests/oci.rs
+++ b/crates/stelae/tests/oci.rs
@@ -1290,7 +1290,7 @@ fn bulk_records() -> u64 {
     }
 }
 
-/// What either direction may hold at any one moment.
+/// What either direction may hold at any one moment, on the *streamed* path.
 ///
 /// The push peak is one upload chunk and a little change — 4 MiB and some
 /// tens of kilobytes, measured, and stable to a fraction of a percent across
@@ -1302,6 +1302,12 @@ fn bulk_records() -> u64 {
 /// does: the peak is bound by the chunk, and the layer here is ten times the
 /// budget. `STELAE_TEST_BULK_RECORDS` below asks the same question at a
 /// mainnet shard's scale and this constant does not follow it up.
+///
+/// It is not the bound on the *single-request* path, which holds a whole layer
+/// by construction and is bounded by [`Options::upload_memory`] instead —
+/// [`the_single_request_path_is_bounded_by_its_byte_budget`]. Every push test
+/// here therefore has to say which path it is measuring, and this one says so
+/// by naming a threshold below the layer it sends.
 const TRANSPORT_BUDGET: usize = 5 * 1024 * 1024;
 
 /// A record whose body zstd cannot shrink.
@@ -1397,7 +1403,8 @@ impl Peak {
     }
 }
 
-/// Done criterion 4: neither direction scales with the layer.
+/// Done criterion 4: neither direction scales with the layer, on the streamed
+/// path.
 ///
 /// The layer is fifty times the budget and never fits in it, so a transport
 /// that held one — buffering a blob before uploading it, or decompressing a
@@ -1405,13 +1412,19 @@ impl Peak {
 /// discipline extended to the transport; it lives here rather than there
 /// because it needs a registry, and a bound measured against a mock would only
 /// be a bound on the mock.
+///
+/// The threshold is named rather than left at its default, and that is the
+/// whole reason this test still means what it meant: at the default a fifty
+/// megabyte layer is *under* [`Options::monolithic_max`] and goes up in one
+/// request, holding itself while it does. Sending it as a chain is now a
+/// decision a caller makes, so a test about the chain has to make it.
 #[test]
 #[ignore = "spawns a registry"]
 fn neither_direction_holds_a_layer() {
     let _serial = exclusive();
 
     let fixture = Fixture::spawn();
-    let registry = fixture.registry("stelae/memory");
+    let registry = fixture.options("stelae/memory", |options| options.monolithic_max = 0);
 
     let (header_scope, scope) = notes_scope(1);
     let spec = LayerSpec::new("notes", header_scope, scope);
@@ -1509,6 +1522,299 @@ fn neither_direction_holds_a_layer() {
         pulled < TRANSPORT_BUDGET,
         "pulling a {size}-byte layer held {pulled} bytes at peak; \
          the budget is {TRANSPORT_BUDGET}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// One request, or a chain of them
+// ---------------------------------------------------------------------------
+
+/// Every [`Event::Bytes`] the transport emitted, in order.
+///
+/// The only in-process view of *how many requests* an upload took. The
+/// streamed path emits one of these per chunk handed to the client and a chunk
+/// is one `PATCH` — its own documentation says so — while the single-request
+/// path has nothing finer to report and emits once. So a sequence of deltas is
+/// the shape of the upload, and comparing two of them compares two paths.
+///
+/// Not a request count read off the wire, and it should not be mistaken for
+/// one: a registry's own log would say more, and none of the three servers this
+/// fixture runs against says it the same way.
+#[derive(Default)]
+struct Chunks(Mutex<Vec<u64>>);
+
+impl Progress for Chunks {
+    fn on(&self, event: Event<'_>) {
+        if let Event::Bytes(n) = event {
+            self.0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(n);
+        }
+    }
+}
+
+impl Chunks {
+    fn seen(&self) -> Vec<u64> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+/// A layer that fits goes up in one request; one that does not still streams;
+/// and neither is a different layer for it.
+///
+/// The second half is the one decision 0026 rests on. A stele carries its
+/// predecessor's layers forward by identity, so a layer republished through a
+/// different transport path has to *be* the same layer — same `diffId` over the
+/// same uncompressed bytes, same blob under the same digest — or every stele
+/// after this change would carry nothing forward and every publish would be a
+/// full upload.
+///
+/// Both layers go into one publish, past one threshold, so neither the
+/// registry's blob-skip nor a second server can be what the difference is: the
+/// small layer is under [`Options::monolithic_max`] and the bulk layer is over
+/// it, and they are new blobs in an empty repository either way.
+///
+/// Serial on purpose. The deltas carry no layer identity, so attributing them
+/// needs the uploads not to overlap — which is what a concurrency of one buys,
+/// and the only thing this test wants from it.
+#[test]
+#[ignore = "spawns a registry"]
+fn a_layer_under_the_threshold_goes_up_in_one_request() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    // Between the two layers below, and under the bulk layer by enough that it
+    // still takes more than one chunk: the claim is a chain against a single
+    // request, and a "chain" of one would prove nothing.
+    const THRESHOLD: u64 = 1024 * 1024;
+
+    // Comfortably over one upload chunk once compressed — the bodies are
+    // incompressible, so this is close to what crosses the socket.
+    const BULK: u64 = 6 * 1024;
+
+    let chunks = std::sync::Arc::new(Chunks::default());
+
+    let registry = fixture.options("stelae/one-request", |options| {
+        options.monolithic_max = THRESHOLD;
+        options.concurrency = 1;
+    });
+
+    registry.observe(Observer::new(chunks.clone()));
+
+    let (notes_header, notes_scope) = notes_scope(1);
+    let notes: Vec<CanonicalCbor> = (1..=3).map(note_record).collect();
+
+    let small = registry
+        .write_layer(
+            &ToyProfile,
+            &LayerSpec::new("notes", notes_header, notes_scope),
+            COMPRESSION_LEVEL,
+            &notes,
+        )
+        .unwrap();
+
+    let (index_header, index_scope) = index_scope(1);
+
+    let mut sink = registry
+        .layer_sink(
+            &ToyProfile,
+            &LayerSpec::new("index", index_header, index_scope),
+            COMPRESSION_LEVEL,
+        )
+        .unwrap();
+
+    // Its own range of the record space. Two of the three registries this runs
+    // against address blobs across the whole registry rather than per
+    // repository, so a layer that happened to be another test's layer would be
+    // skipped rather than uploaded and there would be nothing to count.
+    for i in 0..BULK {
+        sink.write_record(&bulk_record(2_000_000 + i)).unwrap();
+    }
+
+    let bulk = sink.finish().unwrap();
+
+    let mut inscription = Inscription::new(
+        &ToyProfile,
+        1,
+        json!({"chapter": 1}),
+        json!({}),
+        Compression {
+            algo: "zstd".to_owned(),
+            level: COMPRESSION_LEVEL as i64,
+        },
+    );
+
+    inscription.layers = vec![small.descriptor.clone(), bulk.descriptor.clone()];
+
+    registry.seal(&ToyProfile, &inscription).unwrap();
+
+    let small_size = small.digests.compressed_size;
+    let bulk_size = bulk.digests.compressed_size;
+
+    assert!(
+        small_size <= THRESHOLD,
+        "the small layer has to be under the threshold: {small_size} against {THRESHOLD}",
+    );
+    assert!(
+        bulk_size > 2 * THRESHOLD,
+        "the bulk layer has to be over the threshold by more than one chunk: \
+         {bulk_size} against {THRESHOLD}",
+    );
+
+    let seen = chunks.seen();
+
+    assert_eq!(
+        seen.first().copied(),
+        Some(small_size),
+        "the layer under the threshold reported {seen:?}; \
+         one request is one delta, and it is the whole layer",
+    );
+    assert!(
+        seen.len() > 2,
+        "the layer over the threshold reported {seen:?}; \
+         a chain is more than one chunk",
+    );
+    assert_eq!(
+        seen.iter().sum::<u64>(),
+        small_size + bulk_size,
+        "the deltas do not add up to what was published: {seen:?}",
+    );
+
+    // --- and the same layers, whichever way they went ----------------------
+    let stele = registry.pull_latest(&ToyProfile).unwrap();
+    let read = stele.read_inscription().unwrap();
+
+    assert_eq!(read, inscription, "the inscription came back different");
+
+    let blobs = stele.blob_index().unwrap();
+
+    for (described, written) in read.layers.iter().zip([&small, &bulk]) {
+        let mut reader = stele
+            .stream_layer(&blobs, &ToyProfile, described, Limits::default())
+            .unwrap();
+
+        while let Some(record) = reader.next_record() {
+            record.unwrap();
+        }
+
+        // Recomputed over every byte the registry gave back, so this is the
+        // identity the carry-forward will look for and not a number copied out
+        // of the descriptor that claimed it.
+        assert_eq!(
+            reader.finish().unwrap().diff_id,
+            written.descriptor.diff_id,
+            "the {} layer is not the layer that was pushed",
+            described.kind,
+        );
+    }
+}
+
+/// The single-request path holds its budget, not its concurrency.
+///
+/// The one thing this change can break in production. A monolithic push is
+/// resident in full, so a bound counted in *layers* would let
+/// [`Options::concurrency`] multiply a hundred megabytes by thirty-two and take
+/// the publisher pod down mid-publish — which costs an epoch and looks like a
+/// registry failure. The bound is counted in bytes instead, and this is the
+/// assertion that it is.
+///
+/// Eight layers, all under the threshold so all resident, against a budget of
+/// one and a half of them. A transport bounded by the layer count would hold
+/// eight; one bounded by the budget holds two and makes the rest wait.
+#[test]
+#[ignore = "spawns a registry"]
+fn the_single_request_path_is_bounded_by_its_byte_budget() {
+    let _serial = exclusive();
+
+    let fixture = Fixture::spawn();
+
+    /// Layers, all in flight at once as far as the permits are concerned.
+    const LAYERS: u64 = 8;
+
+    /// Records each, ~4 MB compressed — incompressible bodies, so the layer and
+    /// the blob are the same order of magnitude.
+    const BULK: u64 = 4 * 1024;
+
+    /// What the transport may hold. Under two layers, so seven eighths of the
+    /// publish cannot be resident whatever the concurrency says.
+    const BUDGET: u64 = 6 * 1024 * 1024;
+
+    let registry = fixture.options("stelae/budget", |options| {
+        options.concurrency = LAYERS as usize;
+        options.upload_memory = BUDGET;
+    });
+
+    let sampler = Peak::start();
+
+    let mut inscription = Inscription::new(
+        &ToyProfile,
+        1,
+        json!({"chapter": 1}),
+        json!({}),
+        Compression {
+            algo: "zstd".to_owned(),
+            level: COMPRESSION_LEVEL as i64,
+        },
+    );
+
+    for layer in 0..LAYERS {
+        let (header, scope) = notes_scope(layer);
+
+        let mut sink = registry
+            .layer_sink(
+                &ToyProfile,
+                &LayerSpec::new("notes", header, scope),
+                COMPRESSION_LEVEL,
+            )
+            .unwrap();
+
+        // Offset per layer so no two layers are the same blob, and offset again
+        // past every other test in this file so no *other* test's blob is one
+        // of these: two of the three registries this runs against address blobs
+        // across the whole registry, and a skipped layer would leave the budget
+        // untested.
+        for i in 0..BULK {
+            sink.write_record(&bulk_record(3_000_000 + layer * BULK + i))
+                .unwrap();
+        }
+
+        inscription.layers.push(sink.finish().unwrap().descriptor);
+    }
+
+    registry.seal(&ToyProfile, &inscription).unwrap();
+
+    let held = sampler.finish();
+
+    let published: u64 = inscription
+        .layers
+        .iter()
+        .map(|layer| layer.uncompressed_size)
+        .sum();
+
+    println!("budget: {published} bytes published, peak {held} bytes held");
+
+    assert_eq!(
+        registry.transfer().layers_uploaded,
+        LAYERS,
+        "every layer has to have been uploaded, or the budget was never asked for",
+    );
+
+    // The budget plus the streaming allowance: the staging, the compressor and
+    // the client's own buffers are not what this bounds, and `TRANSPORT_BUDGET`
+    // is already the measured size of them.
+    let ceiling = BUDGET as usize + TRANSPORT_BUDGET;
+
+    assert!(
+        held < ceiling,
+        "publishing {LAYERS} layers held {held} bytes at peak against a \
+         {BUDGET}-byte budget; a bound counted in layers would hold about \
+         {}",
+        LAYERS as usize * (published as usize / LAYERS as usize),
     );
 }
 


### PR DESCRIPTION
Plan: `plans/dolos-stelae-monolithic-blob-push.md` (Brain/txpipe)

## Why

A `PATCH` costs the stele registry's Worker **about three seconds regardless of
size** — what it pays for is the upload state it round-trips through R2, not the
payload — so a publish's wall clock is its *request count*, not its bytes.

#1273 raised `UPLOAD_CHUNK` 1 MiB → 4 MiB and got mainnet from 12.0 to ~10.1 min,
well short of the predicted 3×, because a 4 MiB `PATCH` is still under the
Worker's 5 MiB `MINIMUM_CHUNK` and takes the recombination path. Going to 5 MiB
is blocked upstream: `oci-client` re-splits at `PUSH_CHUNK_MAX_SIZE` = 4 MiB with
no setter.

This takes the third lever instead: a `POST` + a `PUT` carrying the whole body
reaches the Worker's `monolithicUpload` — one direct R2 `put`, no multipart, no
helper objects, no recombination. Measured against the live registry at
**3.29 MB/s against 0.27 (~12×)**, and it covers **79 of mainnet's 81 layers**.

## What changed

- **`use_monolithic_push: true`** on the client (`crates/stelae/src/oci.rs`), and
  `put_layer` branches on the layer's compressed size: at or under
  `Options::monolithic_max` it calls `push_blob` with the staged bytes; above it,
  today's `push_blob_stream` is untouched. `put_bytes` (the inscription) also
  goes monolithic — one round trip fewer for a few-kilobyte document.
- **A second semaphore, counted in bytes.** A monolithic push is resident in
  full, so the existing layer-count permit — whose job is bounding the *scratch
  directory* — would let a concurrency of 32 multiply a 100 MB threshold into
  3.2 GB on a pod requesting 12 GiB and already sitting at ~7. `Shared::resident`
  is one permit per resident byte against `Options::upload_memory` (default
  1 GiB), taken inside the deferred task where the layer's size is finally known.
  `monolithic_max` is clamped to the budget, so any single acquisition can be
  satisfied by an empty semaphore and tokio's fair queue cannot deadlock.
- **Re-read per attempt, not retained.** `staged_bytes` reads the staging file
  fresh for each attempt and the permit is released with the attempt, so the
  doubling backoff holds no bytes — a registry answering `500` is exactly when
  this transport should be at its smallest. The read is `read_exact` against the
  digest pipeline's own compressed size, so what the permit admitted is what the
  upload holds.
- **`monolithic_max` is a documented default (100 MB), not read from the wire.**
  That is the registry's advertised `OCI-Chunk-Max-Length`, but the header rides
  on the upload session's response and `oci-client` extracts only `Location`
  before dropping it — nothing this crate calls ever sees it. So it is an
  `Options` field a caller overrides, with the reasoning written down at the
  constant. `0` means "never": the escape hatch back to pure streaming.
- **Prose corrected.** The module docs asserted one-chunk-at-a-time staging as a
  deliberate memory bound; that is now true only *above* the threshold, and the
  documentation says which bound is which.

`crates/snapshot/src/registry.rs` pins both new options explicitly rather than
inheriting defaults, alongside `attempts`, for the reason recorded there.

## Verification

All green locally on `6737cb0`:

| check | result |
| --- | --- |
| `cargo test -p stelae -p dolos-snapshot` | pass (73 + 4 + 3 + 5 + 21 unit/integration + 3 doc-tests) |
| `cargo test -p stelae --all-features --test oci -- --ignored --test-threads=1` | 16 passed |
| `cargo test -p dolos-snapshot --features oci --test publish -- --ignored` | 14 passed |
| `cargo test -p dolos-snapshot --features oci --test restore_registry -- --ignored` | 7 passed |
| `cargo clippy --workspace --all-targets --all-features` | no warnings in the changed files |
| `cargo +nightly fmt --all -- --check` | clean |

Two new registry cases:

- `a_layer_under_the_threshold_goes_up_in_one_request` — one publish, one
  threshold, two layers straddling it: the small one reports a single
  whole-layer delta, the bulk one reports a chain of more than two, the deltas
  sum to what was published, and **both layers come back with the `diffId` they
  were pushed with**. That last half is what the layer-compatibility decision
  (0026) rests on — a layer republished through a different transport path has
  to *be* the same layer, or every stele after this change carries nothing
  forward and every publish is a full upload.
- `the_single_request_path_is_bounded_by_its_byte_budget` — 8 layers of ~4 MB,
  concurrency 8, budget 6 MB. Measured peak **4,234,981 bytes held** while
  publishing 33 MB. A bound counted in layers would have held ~33 MB.

`neither_direction_holds_a_layer` now names `monolithic_max = 0` explicitly:
at the default its 50 MB layer would go up in one request, so a test about the
chain has to ask for the chain.

## Known limits, deliberately

- **CI cannot cover the path that matters.** The fixture spawns stock
  `distribution`/`zot`, so a green run proves monolithic push works against *a*
  registry — not that the Worker's `monolithicUpload` branch behaves. That
  branch was measured against the live registry and is known-good today;
  nothing in the suite will catch a regression in it.
- **Progress reporting coarsens.** 79 of 81 layers become all-or-nothing to
  anything watching, since a monolithic layer has no intermediate state to
  report.
- **A failed monolithic `PUT` wastes the whole layer** rather than one chunk.
  At the current `500` rate that still favours fewer requests — and it is the
  reason `attempts` is left as it is rather than trimmed.
- **Out of scope, per the plan**: layer geometry (decision 0025 is signed
  ground), any registry-side change, and `UPLOAD_CHUNK`, left at 4 MiB for the
  two layers that still stream.

## Pre-existing finding (not from this branch)

`cargo clippy --workspace --all-targets --all-features` — the invocation
AGENTS.md's "Code Verification Requirements" prescribes — reports warnings under
the repo's pinned 1.93 toolchain in files this branch does not touch:
`crates/cardano/src/model/proposals.rs:1170` (`filter().next_back()` →
`rfind()`), `crates/cardano/src/ewrap/loading.rs:3197,3305` (`clone()` →
`slice::from_ref`), and four `doc list item without indentation` warnings in
`crates/snapshot/tests/publish.rs:205-208`. All are ancestors of `origin/main`.

CI is green regardless, and the reason is worth writing down: the clippy job runs
`cargo clippy --all-targets --all-features -- -D warnings` **without
`--workspace`**, and the repo root is itself a package — so `--all-targets`
selects the `dolos` binary's targets, not the member crates' test targets, which
is exactly where all four warnings live. The documented local check is therefore
strictly stronger than the gate. Not this PR's to fix; flagging it as drift.

## Measurement to come

The live mainnet backfill is the rig, and its before is recorded: publish 13.8
min for 1801 MB at 2.18 MB/s, ~1600 round trips, 14–55 transient `500`s an hour.
Success is a publish dominated by the two streamed layers rather than by the
other seventy-nine. Adopting mid-run costs one epoch, recoverable by pinning the
previous image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GxJoktiMWC9JrP6CAXYXJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for faster single-request uploads for smaller OCI layers.
  * Larger layers continue to use streaming uploads for efficient transfer.
  * Added configurable limits for single-request upload size and total upload memory.
  * Applied the same upload improvements and safeguards to inscription uploads.

* **Bug Fixes**
  * Improved memory management during retries and concurrent uploads.
  * Upload progress reporting is now consistent across upload methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->