### PR TITLE
style: rewrap comments for the 2026-08-30 nightly rustfmt

### DIFF
--- a/crates/cardano/src/estart/commit.rs
+++ b/crates/cardano/src/estart/commit.rs
@@ -208,7 +208,8 @@ impl super::WorkContext {
             .into());
         }
 
-        // Collect era transition data first (only 1-2 entities, not a memory concern)
+        // Collect era transition data first (only 1-2 entities, not a memory
+        // concern)
         let era_transition = self.collect_era_transition(state)?;
 
         // Prepare archive logs
@@ -258,8 +259,8 @@ impl super::WorkContext {
                 .write_entity_typed::<EraSummary>(&transition.new_key, &transition.new_summary)?;
         }
 
-        // Write archive logs (accumulated during compute_global_deltas, much smaller
-        // than entities)
+        // Write archive logs (accumulated during compute_global_deltas, much
+        // smaller than entities)
         debug!(log_count = self.logs.len(), "writing archive logs");
         for (entity_key, log) in self.logs.drain(..) {
             let log_key = LogKey::from((temporal_key.clone(), entity_key));

--- a/crates/cardano/src/ewrap/drops.rs
+++ b/crates/cardano/src/ewrap/drops.rs
@@ -25,9 +25,10 @@ impl super::BoundaryVisitor for BoundaryVisitor {
     ) -> Result<(), ChainError> {
         let current_epoch = ctx.ending_state.number;
 
-        // Notice that instead of dropping delegators when a pool is retired, we're
-        // moving the data to a different field to be able to still track the
-        // relationsihp between the pool and the delegators.
+        // Notice that instead of dropping delegators when a pool is retired,
+        // we're moving the data to a different field to be able to
+        // still track the relationsihp between the pool and the
+        // delegators.
 
         if let Some(pool) = account.delegated_pool_at(current_epoch) {
             if ctx.retiring_pools.contains_key(pool) {

--- a/crates/cardano/src/ewrap/loading.rs
+++ b/crates/cardano/src/ewrap/loading.rs
@@ -457,13 +457,14 @@ impl BoundaryWork {
                         }
                     }
                 }
-                // HACK: rewards must apply before drops. Rewards update the live
-                // value before the snapshot; drops schedule refunds for after the
-                // snapshot. If reordered, the rewards would be overwritten by the
+                // HACK: rewards must apply before drops. Rewards update the
+                // live value before the snapshot; drops
+                // schedule refunds for after the snapshot. If
+                // reordered, the rewards would be overwritten by the
                 // refund schedule. With this order, the refund clones the live
                 // values with rewards already applied.
-                // TODO: move retires to ESTART (after the snapshot has been taken)
-                // and drop this ordering hack. (#1037)
+                // TODO: move retires to ESTART (after the snapshot has been
+                // taken) and drop this ordering hack. (#1037)
                 let rewards_before = visitor_rewards.deltas.len();
                 let applied_before = self.applied_rewards.len();
                 visitor_rewards.visit_account(self, &account_id, &account)?;
@@ -561,11 +562,12 @@ impl BoundaryWork {
         state: &D::State,
         pool: &PoolState,
     ) -> Result<Option<AccountState>, ChainError> {
-        // Use scheduled (next) params if available, matching the Haskell ledger's
-        // SNAP → POOLREAP ordering where future pool params become current before
-        // pool reaping. This ensures the deposit refund goes to the correct reward
-        // account when a pool is re-registered with a new reward account and then
-        // retired in the same epoch.
+        // Use scheduled (next) params if available, matching the Haskell
+        // ledger's SNAP → POOLREAP ordering where future pool params
+        // become current before pool reaping. This ensures the deposit
+        // refund goes to the correct reward account when a pool is
+        // re-registered with a new reward account and then retired in
+        // the same epoch.
         let snapshot = pool
             .snapshot
             .next()
@@ -904,7 +906,8 @@ impl BoundaryWork {
                         );
                     }
                 } else {
-                    // Account is unregistered at epoch boundary - MIR stays in source pot
+                    // Account is unregistered at epoch boundary - MIR stays in
+                    // source pot
                     self.invalid_treasury_mirs += pending_mir.from_treasury;
                     self.invalid_reserve_mirs += pending_mir.from_reserves;
 

--- a/crates/cardano/src/ewrap/rewards.rs
+++ b/crates/cardano/src/ewrap/rewards.rs
@@ -51,14 +51,16 @@ impl crate::ewrap::BoundaryVisitor for BoundaryVisitor {
         if !account.is_registered() {
             let total = reward.total_value();
 
-            // Accounts that were registered at RUPD startStep time but deregistered
-            // before EWRAP. Their rewards go to treasury per the Haskell ledger's
-            // applyRUpdFiltered (frTotalUnregistered → casTreasury).
+            // Accounts that were registered at RUPD startStep time but
+            // deregistered before EWRAP. Their rewards go to
+            // treasury per the Haskell ledger's applyRUpdFiltered
+            // (frTotalUnregistered → casTreasury).
             //
             // Note: accounts deregistered BEFORE the RUPD startStep slot
-            // (epoch_start + randomness_stability_window) are pre-filtered during
-            // reward computation and never appear here. Their share stays in reserves
-            // implicitly through returned_rewards.
+            // (epoch_start + randomness_stability_window) are pre-filtered
+            // during reward computation and never appear here.
+            // Their share stays in reserves implicitly through
+            // returned_rewards.
             debug!(
                 account=%id,
                 credential=?account.credential,
@@ -103,8 +105,8 @@ impl crate::ewrap::BoundaryVisitor for BoundaryVisitor {
 
         let pending_before_drain = ctx.rewards.len();
 
-        // Log any remaining pending rewards before draining (spendable rewards for
-        // accounts not visited)
+        // Log any remaining pending rewards before draining (spendable rewards
+        // for accounts not visited)
         if pending_before_drain > 0 {
             let pending_spendable: u64 = ctx
                 .rewards

--- a/crates/cardano/src/forks.rs
+++ b/crates/cardano/src/forks.rs
@@ -155,8 +155,8 @@ pub fn into_alonzo(previous: &PParamsSet, genesis: &alonzo::GenesisFile) -> PPar
 
 pub fn into_babbage(previous: &PParamsSet, genesis: &alonzo::GenesisFile) -> PParamsSet {
     // In the hardfork, the value got translated from words to bytes
-    // Since the transformation from words to bytes is hardcoded, the transformation
-    // here is also hardcoded
+    // Since the transformation from words to bytes is hardcoded, the
+    // transformation here is also hardcoded
     let ada_per_utxo_byte = previous.ada_per_utxo_byte().unwrap_or_default() / 8;
 
     let set = previous

--- a/crates/cardano/src/genesis/mod.rs
+++ b/crates/cardano/src/genesis/mod.rs
@@ -58,7 +58,8 @@ pub fn bootstrap_epoch<D: Domain>(
         pparams = crate::forks::force_pparams_version(&pparams, genesis, 0, force_protocol as u16)?;
 
         if force_protocol >= 2 {
-            // When we start on Shelley or beyond, we need to bootstrap the nonces.
+            // When we start on Shelley or beyond, we need to bootstrap the
+            // nonces.
             nonces = Some(Nonces::bootstrap(genesis.shelley_hash));
         }
     }

--- a/crates/cardano/src/lib.rs
+++ b/crates/cardano/src/lib.rs
@@ -386,9 +386,10 @@ impl dolos_core::ChainLogic for CardanoLogic {
 
         // Use randomness_stability_window (4k/f) for the RUPD trigger boundary.
         // The Haskell ledger's startStep fires at randomnessStabilisationWindow
-        // into the epoch, capturing addrsRew (registered accounts) for the pre-Babbage
-        // prefilter. Using 4k/f instead of 3k/f ensures the state at RUPD time includes
-        // all deregistrations up to the correct threshold.
+        // into the epoch, capturing addrsRew (registered accounts) for the
+        // pre-Babbage prefilter. Using 4k/f instead of 3k/f ensures the
+        // state at RUPD time includes all deregistrations up to the
+        // correct threshold.
         let stability_window = utils::randomness_stability_window(genesis);
 
         Ok(Self {

--- a/crates/cardano/src/model/accounts.rs
+++ b/crates/cardano/src/model/accounts.rs
@@ -779,11 +779,12 @@ impl dolos_core::EntityDelta for DRepDelegatorDrop {
         // save undo info
         self.prev_drep = Some(entity.drep.clone());
 
-        // TODO: guard the `schedule` call on `entity.drep.epoch() == Some(self.epoch)`
-        // with skip-on-mismatch, mirroring the planned hardening in
-        // `PoolDelegatorRetire::apply`. `schedule` writes to `next` regardless
-        // of the entity's current epoch; if the entity has been rotated past
-        // `self.epoch`, this scheduling lands on the wrong boundary.
+        // TODO: guard the `schedule` call on `entity.drep.epoch() ==
+        // Some(self.epoch)` with skip-on-mismatch, mirroring the
+        // planned hardening in `PoolDelegatorRetire::apply`. `schedule`
+        // writes to `next` regardless of the entity's current epoch; if
+        // the entity has been rotated past `self.epoch`, this
+        // scheduling lands on the wrong boundary.
         entity
             .drep
             .schedule(self.epoch, Some(DRepDelegation::NotDelegated));

--- a/crates/cardano/src/model/epochs.rs
+++ b/crates/cardano/src/model/epochs.rs
@@ -660,8 +660,8 @@ impl dolos_core::EntityDelta for NoncesUpdate {
     }
 
     fn undo(&self, entity: &mut Option<EpochState>) {
-        // apply is a no-op when entity was None or when nonces were None, so in those
-        // cases undo is also a no-op.
+        // apply is a no-op when entity was None or when nonces were None, so in
+        // those cases undo is also a no-op.
         let Some(entity) = entity else { return };
         if self.previous.is_some() {
             entity.nonces = self.previous.clone();
@@ -1389,8 +1389,8 @@ impl dolos_core::EntityDelta for EpochTransition {
             .new_pots
             .is_consistent(entity.initial_pots.max_supply()));
 
-        // save undo info (snapshot whole EpochValues so rotation + any era migration
-        // are both covered)
+        // save undo info (snapshot whole EpochValues so rotation + any era
+        // migration are both covered)
         self.prev_number = entity.number;
         self.prev_initial_pots = Some(entity.initial_pots.clone());
         self.prev_rolling = Some(entity.rolling.clone());
@@ -1497,8 +1497,8 @@ impl dolos_core::EntityDelta for EpochTransitionV2 {
             .new_pots
             .is_consistent(entity.initial_pots.max_supply()));
 
-        // save undo info (snapshot whole EpochValues so rotation + any era migration
-        // are both covered)
+        // save undo info (snapshot whole EpochValues so rotation + any era
+        // migration are both covered)
         self.prev_number = entity.number;
         self.prev_initial_pots = Some(entity.initial_pots.clone());
         self.prev_rolling = Some(entity.rolling.clone());

--- a/crates/cardano/src/model/pending.rs
+++ b/crates/cardano/src/model/pending.rs
@@ -250,9 +250,10 @@ impl dolos_core::EntityDelta for EnqueueMir {
         self.prev = entity.clone();
 
         // Behavior depends on overwrite flag (determined by protocol version):
-        // - Pre-Alonzo (overwrite=true): Later MIRs overwrite earlier ones (Map.union
+        // - Pre-Alonzo (overwrite=true): Later MIRs overwrite earlier ones
+        //   (Map.union semantics)
+        // - Alonzo+ (overwrite=false): MIRs accumulate (Map.unionWith (<>)
         //   semantics)
-        // - Alonzo+ (overwrite=false): MIRs accumulate (Map.unionWith (<>) semantics)
         if self.overwrite {
             // Pre-Alonzo: overwrite with new values
             *entity = Some(PendingMirState {

--- a/crates/cardano/src/model/pools.rs
+++ b/crates/cardano/src/model/pools.rs
@@ -247,9 +247,10 @@ impl dolos_core::EntityDelta for PoolRegistration {
             let is_currently_retired = entity.snapshot.unwrap_live().is_retired;
 
             if is_currently_retired {
-                // if the pool is currently retired, we need to assume this overrides the record
-                // as a new registration. Preserve blocks_minted accrued in the
-                // current epoch so we don't lose leader rewards.
+                // if the pool is currently retired, we need to assume this
+                // overrides the record as a new registration.
+                // Preserve blocks_minted accrued in the current
+                // epoch so we don't lose leader rewards.
                 let preserved_blocks = entity.snapshot.unwrap_live().blocks_minted;
                 entity.snapshot.replace(
                     PoolSnapshot {

--- a/crates/cardano/src/pots.rs
+++ b/crates/cardano/src/pots.rs
@@ -305,9 +305,9 @@ pub fn calculate_eta(minted_blocks: u64, d: Ratio, f: f32, epoch_length: u64) ->
 
     let expected_non_obft_blocks = expected_blocks * (&one - d);
 
-    // eta is the ratio between the number of blocks that have been produced during
-    // the epoch, and the expectation value of blocks that should have been
-    // produced during the epoch under ideal conditions.
+    // eta is the ratio between the number of blocks that have been produced
+    // during the epoch, and the expectation value of blocks that should
+    // have been produced during the epoch under ideal conditions.
 
     let minted_blocks = ratio!(minted_blocks);
 
@@ -417,9 +417,9 @@ pub fn apply_shelley_delta(mut pots: Pots, incentives: &EpochIncentives, delta: 
     pots.rewards = add!(pots.rewards, delta.treasury_mirs);
     pots.rewards = add!(pots.rewards, delta.treasury_withdrawals);
 
-    // we don't need to return account deposit refunds to the rewards pot because
-    // these refunds are returned directly as utxos in the deregistration
-    // transaction.
+    // we don't need to return account deposit refunds to the rewards pot
+    // because these refunds are returned directly as utxos in the
+    // deregistration transaction.
 
     // utxos pot
     pots.utxos = add!(pots.utxos, delta.produced_utxos);
@@ -439,8 +439,8 @@ pub fn apply_shelley_delta(mut pots: Pots, incentives: &EpochIncentives, delta: 
     pots.account_count = add!(pots.account_count, delta.new_accounts);
     pots.account_count = sub!(pots.account_count, delta.removed_accounts);
 
-    // for governance, since each cert contains the specific deposit amount, we deal
-    // directly with lovelace values.
+    // for governance, since each cert contains the specific deposit amount, we
+    // deal directly with lovelace values.
 
     pots.drep_deposits = add!(pots.drep_deposits, delta.drep_deposits);
     pots.drep_deposits = sub!(pots.drep_deposits, delta.drep_refunds);

--- a/crates/cardano/src/rewards/formulas.rs
+++ b/crates/cardano/src/rewards/formulas.rs
@@ -176,8 +176,8 @@ pub fn pool_operator_share(
     let s = ratio!(live_pledge, circulating_supply);
     let theta = ratio!(pool_stake, circulating_supply);
 
-    // s/σ — ratio of owner's pledge to pool stake (denominator cancels, so we can
-    // use amounts)
+    // s/σ — ratio of owner's pledge to pool stake (denominator cancels, so we
+    // can use amounts)
     let s_over_sigma = s / theta;
 
     let one = ratio!(1);
@@ -257,7 +257,8 @@ mod tests {
 
         //let expected = 367414432; <- what BF returns
         //let expected = 372133077; <- what we see in DBSync
-        let expected = 372133076; // <- what we're getting right now which is close enough
+        let expected = 372133076; // <- what we're getting right now which is
+                                  // close enough
 
         assert_eq!(out, expected);
     }

--- a/crates/cardano/src/rewards/mod.rs
+++ b/crates/cardano/src/rewards/mod.rs
@@ -268,8 +268,8 @@ impl<C: RewardsContext> RewardMap<C> {
         }
     }
 
-    // TODO: this is very inefficient. We should should probably revisit the data
-    // structure.
+    // TODO: this is very inefficient. We should should probably revisit the
+    // data structure.
     pub fn aggregate_pool_rewards(&self) -> HashMap<PoolHash, (TotalPoolRewards, OperatorShare)> {
         let mut rewards = HashMap::new();
 

--- a/crates/cardano/src/roll/accounts.rs
+++ b/crates/cardano/src/roll/accounts.rs
@@ -147,17 +147,20 @@ impl BlockVisitor for AccountVisitor {
             let MoveInstantaneousReward { source, target, .. } = cert;
 
             if let InstantaneousRewardTarget::StakeCredentials(creds) = target {
-                // Pre-Alonzo (protocol < 5): MIRs overwrite previous values (Map.union
-                // semantics) Alonzo+ (protocol >= 5): MIRs accumulate
-                // (Map.unionWith (<>) semantics) TODO: move this logic out of
+                // Pre-Alonzo (protocol < 5): MIRs overwrite previous values
+                // (Map.union semantics) Alonzo+ (protocol >=
+                // 5): MIRs accumulate (Map.unionWith (<>)
+                // semantics) TODO: move this logic out of
                 // the visitor and into a module more ledger-related.
                 let overwrite = self.protocol_version.unwrap_or(0) < 5;
 
                 for (cred, amount) in creds {
                     let amount = amount.max(0) as u64;
-                    // Store pending MIR to be applied at EWRAP (not immediately)
-                    // This ensures MIRs are only applied to accounts that are
-                    // registered at epoch boundary, matching the Cardano ledger.
+                    // Store pending MIR to be applied at EWRAP (not
+                    // immediately) This ensures MIRs are
+                    // only applied to accounts that are
+                    // registered at epoch boundary, matching the Cardano
+                    // ledger.
                     match source {
                         InstantaneousRewardSource::Reserves => {
                             deltas

--- a/crates/cardano/src/roll/batch.rs
+++ b/crates/cardano/src/roll/batch.rs
@@ -322,9 +322,11 @@ impl WorkBatch {
                 let to_apply = block.deltas.entities.get_mut(key);
 
                 if let Some(to_apply) = to_apply {
-                    // Deltas are applied in their natural order from block traversal.
-                    // This matches the Haskell ledger which processes certificates
-                    // sequentially in the order they appear (no priority logic).
+                    // Deltas are applied in their natural order from block
+                    // traversal. This matches the Haskell
+                    // ledger which processes certificates
+                    // sequentially in the order they appear (no priority
+                    // logic).
                     for delta in to_apply {
                         delta.apply(entity);
                     }
@@ -348,8 +350,8 @@ impl WorkBatch {
             writer.save_entity_typed(ns, key, entity.as_ref())?;
         }
 
-        // TODO: we treat the UTxO set differently due to tech-debt. We should migrate
-        // this into the entity system. (#1042)
+        // TODO: we treat the UTxO set differently due to tech-debt. We should
+        // migrate this into the entity system. (#1042)
         for block in self.blocks.iter() {
             if let Some(utxo_delta) = &block.utxo_delta {
                 writer.apply_utxoset(utxo_delta)?;

--- a/crates/cardano/src/roll/epochs.rs
+++ b/crates/cardano/src/roll/epochs.rs
@@ -167,10 +167,10 @@ impl BlockVisitor for EpochStateVisitor {
         let amount = output.value().coin();
         let stats = self.stats_delta.as_mut().unwrap();
         stats.utxo_delta += amount as i64;
-        // Gross, unsigned sum of all produced outputs (db-sync `epoch.out_sum`).
-        // The driver iterates `tx.produces()`. So this sum includes the regular
-        // outputs of valid transactions and the collateral-return outputs of
-        // phase-2 failures.
+        // Gross, unsigned sum of all produced outputs (db-sync
+        // `epoch.out_sum`). The driver iterates `tx.produces()`. So
+        // this sum includes the regular outputs of valid transactions
+        // and the collateral-return outputs of phase-2 failures.
         stats.output += amount;
 
         Ok(())

--- a/crates/cardano/src/roll/mod.rs
+++ b/crates/cardano/src/roll/mod.rs
@@ -642,8 +642,8 @@ pub(crate) fn compute_delta<D: Domain>(
 
         dormancy = builder.take_dormancy();
 
-        // TODO: we treat the UTxO set differently due to tech-debt. We should migrate
-        // this into the entity system. (#1042)
+        // TODO: we treat the UTxO set differently due to tech-debt. We should
+        // migrate this into the entity system. (#1042)
         let blockd = block.decoded();
         let blockd = blockd.view();
         let utxos = utxoset::compute_apply_delta(blockd, &batch.utxos_decoded)?;

--- a/crates/cardano/src/roll/proposals.rs
+++ b/crates/cardano/src/roll/proposals.rs
@@ -84,8 +84,8 @@ fn conway_to_pparamset(update: &ProtocolParamUpdate) -> PParamsSet {
         drep_inactivity_period => DrepInactivityPeriod
     };
 
-    // TODO: these are special cases where we don't have automatic type mappings. We
-    // should fix this at the Pallas level.
+    // TODO: these are special cases where we don't have automatic type
+    // mappings. We should fix this at the Pallas level.
 
     if let Some(updated) = update.max_tx_ex_units {
         let value = PParamValue::MaxTxExUnits(pallas::ledger::primitives::ExUnits {

--- a/crates/cardano/src/roll/work_unit.rs
+++ b/crates/cardano/src/roll/work_unit.rs
@@ -73,9 +73,10 @@ where
             &mut self.batch,
         )?;
 
-        // Load entities here so `compute` can apply deltas before WAL serialization;
-        // this is what populates each delta's `prev_*` undo state in time for
-        // `commit_wal` to capture it on the wire.
+        // Load entities here so `compute` can apply deltas before WAL
+        // serialization; this is what populates each delta's `prev_*`
+        // undo state in time for `commit_wal` to capture it on the
+        // wire.
         self.batch.load_entities(domain)?;
 
         debug!("roll batch loaded and deltas computed");
@@ -83,10 +84,11 @@ where
     }
 
     fn compute(&mut self, _shard_index: u32) -> Result<(), DomainError> {
-        // Apply deltas to in-memory entities BEFORE the WAL commit. This captures
-        // each delta's `prev_*` undo state on the in-memory delta instances; the
-        // subsequent `commit_wal` then serializes deltas that already carry the
-        // information `delta.undo()` needs during a future rollback.
+        // Apply deltas to in-memory entities BEFORE the WAL commit. This
+        // captures each delta's `prev_*` undo state on the in-memory
+        // delta instances; the subsequent `commit_wal` then serializes
+        // deltas that already carry the information `delta.undo()`
+        // needs during a future rollback.
         self.batch.sort_by_slot();
         self.batch.apply_entities()?;
         Ok(())

--- a/crates/cardano/src/rupd/loading.rs
+++ b/crates/cardano/src/rupd/loading.rs
@@ -189,8 +189,9 @@ impl StakeSnapshot {
             // the admission window is caught rather than silently dropped.
             ensure_pool_aligned(&pool.operator, &pool.snapshot, current_epoch)?;
 
-            // Sum blocks from ALL pools that have mark() data for the performance epoch.
-            // This is needed for epoch_blocks() denominator in apparent performance.
+            // Sum blocks from ALL pools that have mark() data for the
+            // performance epoch. This is needed for epoch_blocks()
+            // denominator in apparent performance.
             if let Some(mark_snapshot) = pool.snapshot.mark() {
                 snapshot.performance_epoch_pool_blocks += mark_snapshot.blocks_minted as u64;
             }
@@ -402,8 +403,8 @@ impl RupdWork {
 
         let pots = epoch.initial_pots.clone();
 
-        // Use non-overlay block count for eta calculation (matches ledger BlocksMade
-        // total).
+        // Use non-overlay block count for eta calculation (matches ledger
+        // BlocksMade total).
         let blocks_made_total = epoch
             .rolling
             .mark()
@@ -439,10 +440,11 @@ impl RupdWork {
         };
 
         if let Some((snapshot_epoch, performance_epoch)) = work.relevant_epochs() {
-            // The snapshot data was "live" at snapshot_epoch and becomes the "mark"
-            // snapshot at snapshot_epoch + 1. The Haskell ledger computes the mark
-            // snapshot under the entering epoch's protocol rules, so we use
-            // snapshot_epoch + 1 to determine the era (e.g., Conway excludes pointer
+            // The snapshot data was "live" at snapshot_epoch and becomes the
+            // "mark" snapshot at snapshot_epoch + 1. The Haskell
+            // ledger computes the mark snapshot under the entering
+            // epoch's protocol rules, so we use snapshot_epoch + 1
+            // to determine the era (e.g., Conway excludes pointer
             // address UTxOs from stake).
             let era = work.chain.era_for_epoch(snapshot_epoch + 1);
             let protocol = EraProtocol::from(era.protocol);
@@ -564,7 +566,8 @@ impl crate::rewards::RewardsContext for RupdWork {
     }
 
     fn pool_blocks(&self, pool: PoolHash) -> u64 {
-        // As in `pool_params`: an aligned pool always has a mark (E-1) snapshot.
+        // As in `pool_params`: an aligned pool always has a mark (E-1)
+        // snapshot.
         self.snapshot
             .pools
             .get(&pool)

--- a/crates/cardano/src/work.rs
+++ b/crates/cardano/src/work.rs
@@ -544,7 +544,8 @@ mod tests {
     fn restart_safety_no_skipped_work() {
         let eras = test_chain_summary();
         let stability_window = 40;
-        // Sequence that crosses RUPD boundary (slot 40) and epoch boundary (slot 100)
+        // Sequence that crosses RUPD boundary (slot 40) and epoch boundary
+        // (slot 100)
         let slots: Vec<BlockSlot> = vec![0, 10, 30, 50, 70, 90, 110, 130];
 
         let full =
@@ -557,9 +558,10 @@ mod tests {
             let (_, ref cursor) = full[i];
 
             // Mirror real initialization: Origin → Empty, otherwise → Restart.
-            // Slot cursors mean "epoch boundary processed, block not yet rolled",
-            // so we replay from that slot inclusive. Specific cursors mean the block
-            // at that slot was fully committed, so we replay strictly after.
+            // Slot cursors mean "epoch boundary processed, block not yet
+            // rolled", so we replay from that slot inclusive.
+            // Specific cursors mean the block at that slot was
+            // fully committed, so we replay strictly after.
             let (restart_buf, replay_slots) = match cursor {
                 ChainPoint::Origin => (WorkBuffer::Empty, slots.to_vec()),
                 ChainPoint::Slot(s) => {
@@ -725,7 +727,8 @@ mod tests {
             let restart_tags =
                 feed_and_drain(restart_buf, &replay_slots, &eras, stability_window, None);
 
-            // The boundary block (110) should be the start of a Blocks work unit
+            // The boundary block (110) should be the start of a Blocks work
+            // unit
             assert!(
                 restart_tags.iter().any(|t| matches!(t, WorkTag::Blocks { first, .. } if *first == 110)),
                 "Boundary block 110 should be the start of a Blocks unit after restart from EStart. Got: {:?}",

--- a/crates/core/src/archive.rs
+++ b/crates/core/src/archive.rs
@@ -83,8 +83,8 @@ impl From<(TemporalKey, EntityKey)> for LogKey {
 
 impl From<TemporalKey> for LogKey {
     fn from(value: TemporalKey) -> Self {
-        // Safe to unwrap, we know the length matches. We extend the key with 0 to match
-        // length.
+        // Safe to unwrap, we know the length matches. We extend the key with 0
+        // to match length.
         let bytes: [u8; LOG_KEY_SIZE] = [value.as_ref(), &[0; KEY_SIZE]]
             .concat()
             .try_into()

--- a/crates/core/src/bootstrap.rs
+++ b/crates/core/src/bootstrap.rs
@@ -65,7 +65,8 @@ fn check_wal_in_sync_with_state<D: Domain>(domain: &D) -> Result<(), DomainError
     match (wal, state) {
         (Some(ref wal_tip), Some(ref state)) if wal_tip.slot() >= state.slot() => {
             // WAL is at or ahead of state. Normal case (including post-crash
-            // where WAL committed but state didn't). catch_up_stores handles it.
+            // where WAL committed but state didn't). catch_up_stores handles
+            // it.
             info!(%wal_tip, %state, "WAL is in sync with state");
         }
         (Some(ref wal_tip), Some(ref state)) => {
@@ -315,7 +316,8 @@ fn catch_up_archive<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), Do
     let mut count = 0u64;
 
     for (point, block) in blocks {
-        // Skip the start point itself (already in archive) and anything at or before it
+        // Skip the start point itself (already in archive) and anything at or
+        // before it
         if Some(point.slot()) <= archive_tip {
             continue;
         }

--- a/crates/core/src/crawl.rs
+++ b/crates/core/src/crawl.rs
@@ -26,8 +26,8 @@ impl<D: Domain> Batch<D> {
             .take(LOAD_BATCH_SIZE)
             .collect::<VecDeque<_>>();
 
-        // if the wal page is empty, this means we reached the end and we need to
-        // await the next tip change.
+        // if the wal page is empty, this means we reached the end and we need
+        // to await the next tip change.
         if page.is_empty() {
             return Self::from_tip(point, domain);
         }
@@ -45,8 +45,8 @@ impl<D: Domain> Batch<D> {
             .map(|(slot, body)| (ChainPoint::Slot(slot), Arc::new(body)))
             .collect::<VecDeque<_>>();
 
-        // if the archive page is empty, this means we reached the end of the archive
-        // store and we need to transition to the wal.
+        // if the archive page is empty, this means we reached the end of the
+        // archive store and we need to transition to the wal.
         if page.is_empty() {
             let intersect = domain.wal().find_intersect(&[last_point])?;
 

--- a/crates/core/src/mempool.rs
+++ b/crates/core/src/mempool.rs
@@ -610,7 +610,8 @@ mod tests {
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 
-        // Should skip both non-matching items and return Pending from the inner stream.
+        // Should skip both non-matching items and return Pending from the inner
+        // stream.
         let result = poll_once(&mut filter, &mut cx);
         assert!(result.is_pending());
     }

--- a/crates/core/src/point.rs
+++ b/crates/core/src/point.rs
@@ -165,7 +165,8 @@ impl FromStr for ChainPoint {
             return Ok(ChainPoint::Origin);
         }
 
-        // Regex to match slot(hash) format where hash is 64 hex characters (32 bytes)
+        // Regex to match slot(hash) format where hash is 64 hex characters (32
+        // bytes)
         let re = Regex::new(r"^(\d+)\(([0-9a-fA-F]{64})\)$").unwrap();
 
         if let Some(caps) = re.captures(s) {

--- a/crates/core/src/sync.rs
+++ b/crates/core/src/sync.rs
@@ -53,8 +53,8 @@ impl<D: Domain> SyncExt for D {
     fn roll_forward(&self, block: RawBlock) -> Result<BlockSlot, DomainError> {
         let mut chain = self.write_chain();
 
-        // Drain first in case there's previous work that needs to be applied (eg:
-        // initialization)
+        // Drain first in case there's previous work that needs to be applied
+        // (eg: initialization)
         drain_pending_work::<D>(&mut *chain, self)?;
 
         let last = chain.receive_block(block)?;
@@ -78,7 +78,8 @@ impl<D: Domain> SyncExt for D {
 
         for (point, log) in undo_blocks.rev() {
             if point == *to {
-                // Final cursor update - build an empty delta with just the cursor
+                // Final cursor update - build an empty delta with just the
+                // cursor
                 let empty_delta = crate::IndexDelta {
                     cursor: point.clone(),
                     ..Default::default()

--- a/crates/core/src/wal.rs
+++ b/crates/core/src/wal.rs
@@ -83,7 +83,8 @@ pub trait WalStore: Clone + Send + Sync + 'static {
 
         // crawl the wal exponentially
         while let Some((point, _)) = iter.next() {
-            // Skip synthetic entries with zero hash (from reset_to with ChainPoint::Slot)
+            // Skip synthetic entries with zero hash (from reset_to with
+            // ChainPoint::Slot)
             if !point.is_fully_defined() {
                 continue;
             }

--- a/crates/fjall/src/index/archive_tags.rs
+++ b/crates/fjall/src/index/archive_tags.rs
@@ -438,7 +438,8 @@ mod tests {
 
     #[test]
     fn test_utxo_block_separation() {
-        // UTxO and block tags with same dimension name should have different prefixes
+        // UTxO and block tags with same dimension name should have different
+        // prefixes
         let utxo_dim_hash = hash_dimension(dim_prefix::UTXO, "address");
         let block_key = build_block_tag_key("address", stored("address", b"addr"), 0);
 

--- a/crates/fjall/src/state/mod.rs
+++ b/crates/fjall/src/state/mod.rs
@@ -85,12 +85,14 @@ impl StateStore {
 
         let mut builder = Database::builder(path.as_ref()).cache_size(cache_bytes);
 
-        // Apply optional max journal size (otherwise use Fjall default of 512 MiB)
+        // Apply optional max journal size (otherwise use Fjall default of 512
+        // MiB)
         if let Some(journal_mb) = config.max_journal_size {
             builder = builder.max_journaling_size((journal_mb as u64) * 1024 * 1024);
         }
 
-        // Apply optional worker threads (otherwise use Fjall default of min(cores, 4))
+        // Apply optional worker threads (otherwise use Fjall default of
+        // min(cores, 4))
         if let Some(threads) = config.worker_threads {
             builder = builder.worker_threads(threads);
         }

--- a/crates/minibf/src/cache.rs
+++ b/crates/minibf/src/cache.rs
@@ -214,7 +214,8 @@ impl CacheService {
                 {
                     return entry.clone();
                 } else {
-                    // This path theoretically shouldn't happen if T maps 1:1 to TypeId
+                    // This path theoretically shouldn't happen if T maps 1:1 to
+                    // TypeId
                     eprintln!("CacheService: downcast failed for type {:?}", type_id);
                 }
             }
@@ -272,7 +273,8 @@ mod tests {
         // 2. Wait for TTL to expire
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // 3. Fetch again - should return stale "initial" but trigger background refresh
+        // 3. Fetch again - should return stale "initial" but trigger background
+        //    refresh
         let c = counter.clone();
         let fetcher = move || {
             c.fetch_add(1, Ordering::SeqCst);

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -290,9 +290,9 @@ impl<D: Domain> Facade<D> {
     // Dolos starts to write `StakeLog`s only after the stake-snapshot pipeline
     // is ready. So the first snapshot epoch has logs, but the epoch just before
     // it has none. Both epochs share the same genesis stake distribution, and
-    // the reference implementation reports the same value for both. For that one
-    // epoch, this function reads the logs of the next epoch instead. Each
-    // earlier epoch has no active stake and stays `None`.
+    // the reference implementation reports the same value for both. For that
+    // one epoch, this function reads the logs of the next epoch instead.
+    // Each earlier epoch has no active stake and stays `None`.
     pub fn sum_active_stake_for_epoch(
         &self,
         epoch: Epoch,

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -1571,9 +1571,9 @@ impl IntoModel<Vec<TxContentDelegationsInner>> for TxModelBuilder<'_> {
 
         let network = self.network.ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
-        // TODO: we're hardcoding a ledger rule here by saying that the active epoch is
-        // the epoch number + 1. Although this is correct, the mapping layer
-        // shouldn't be the one defining this.
+        // TODO: we're hardcoding a ledger rule here by saying that the active
+        // epoch is the epoch number + 1. Although this is correct, the
+        // mapping layer shouldn't be the one defining this.
         let active_epoch = self
             .chain
             .as_ref()

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -816,8 +816,8 @@ where
     }
 
     // Pagination depends on first-mint order. An ascending scan stops after it
-    // collects the requested prefix. A descending scan reads all asset names and
-    // then reverses them, because one name can occur in many blocks.
+    // collects the requested prefix. A descending scan reads all asset names
+    // and then reverses them, because one name can occur in many blocks.
     let end_slot = domain.get_tip_slot()?;
     let stream = domain
         .query()

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -198,7 +198,8 @@ where
             .get_range(None, Some(curr_slot))
             .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
 
-        // Skip past pages we don't need using key-only traversal (no block data read).
+        // Skip past pages we don't need using key-only traversal (no block data
+        // read).
         iter.skip_backward(from);
 
         iter.rev()
@@ -274,7 +275,8 @@ where
             .get_range(None, None)
             .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
 
-        // Skip past pages we don't need using key-only traversal (no block data read).
+        // Skip past pages we don't need using key-only traversal (no block data
+        // read).
         iterator.skip_forward(pagination.from());
 
         iterator
@@ -295,7 +297,8 @@ where
             // Discard first block (the reference block itself).
             iterator.skip_forward(1);
 
-            // Skip past pages we don't need using key-only traversal (no block data read).
+            // Skip past pages we don't need using key-only traversal (no block
+            // data read).
             iterator.skip_forward(pagination.from());
 
             iterator

--- a/crates/minibf/src/routes/epochs/mod.rs
+++ b/crates/minibf/src/routes/epochs/mod.rs
@@ -66,10 +66,11 @@ fn build_epoch_content<D: Domain>(
     // had no block.
     //
     // A Byron epoch boundary block (EBB) does not pass through the roll
-    // pipeline. So `first_block_slot` is the first *regular* block of the epoch.
-    // Every Byron epoch opens with an EBB. For these epochs, Blockfrost reports
-    // the time of the EBB, so `first_block_time` differs. See the systemic EBB
-    // omission tracked for `/epochs/{n}/blocks` and `/blocks/{block}`.
+    // pipeline. So `first_block_slot` is the first *regular* block of the
+    // epoch. Every Byron epoch opens with an EBB. For these epochs,
+    // Blockfrost reports the time of the EBB, so `first_block_time`
+    // differs. See the systemic EBB omission tracked for
+    // `/epochs/{n}/blocks` and `/blocks/{block}`.
     let rolling = state.rolling.live().cloned().unwrap_or_default();
     let first_block_time = if rolling.first_block_slot == 0 {
         0
@@ -1395,8 +1396,9 @@ mod tests {
 
     #[tokio::test]
     async fn epochs_by_number_out_of_range() {
-        // An epoch number greater than the `i32` range of the reference API gets a
-        // bad-request error, not a 404 error for a missing epoch.
+        // An epoch number greater than the `i32` range of the reference API
+        // gets a bad-request error, not a 404 error for a missing
+        // epoch.
         let app = TestApp::new();
         assert_status(&app, "/epochs/696969696969", StatusCode::BAD_REQUEST).await;
         assert_status(&app, "/epochs/696969696969/next", StatusCode::BAD_REQUEST).await;
@@ -1431,8 +1433,8 @@ mod tests {
         let content: Vec<EpochContent> =
             serde_json::from_slice(&bytes).expect("failed to parse epoch content array");
 
-        // The result is in strict ascending order. Every epoch is greater than the
-        // requested epoch.
+        // The result is in strict ascending order. Every epoch is greater than
+        // the requested epoch.
         let mut prev = None;
         for item in &content {
             assert!(item.epoch > 0);

--- a/crates/minibf/src/routes/network.rs
+++ b/crates/minibf/src/routes/network.rs
@@ -225,8 +225,8 @@ impl<'a> IntoModel<Network> for NetworkModelBuilder<'a> {
         let max_supply = self.genesis.shelley.max_lovelace_supply.unwrap_or_default();
 
         // TODO: check why we have this semantic discrepancy. BF uses the name
-        // `total_supply` for what we call `circulating`. For BF, the `circulating`
-        // supply is total supply minus deposits.
+        // `total_supply` for what we call `circulating`. For BF, the
+        // `circulating` supply is total supply minus deposits.
         let total_supply = self.active.initial_pots.circulating();
         let circulating = self.active.initial_pots.utxos + self.active.initial_pots.rewards;
 

--- a/crates/redb3/src/archive/tests.rs
+++ b/crates/redb3/src/archive/tests.rs
@@ -225,7 +225,8 @@ fn test_prune_history_no_excess_is_noop() {
     }
     writer.commit().unwrap();
 
-    // History (300 - 100 = 200) is within the 1000-slot window: nothing to prune.
+    // History (300 - 100 = 200) is within the 1000-slot window: nothing to
+    // prune.
     let done = store.prune_history(1_000, Some(10)).unwrap();
     assert!(done, "no-excess prune must report done");
     assert_eq!(stored_slots(&store), vec![100, 200, 300], "nothing removed");

--- a/crates/redb3/src/mempool.rs
+++ b/crates/redb3/src/mempool.rs
@@ -1090,8 +1090,8 @@ mod tests {
             store.check_status(&hash).stage,
             MempoolTxStage::Acknowledged
         ));
-        // find_inflight now returns any inflight sub-stage (Propagated, Acknowledged,
-        // Confirmed)
+        // find_inflight now returns any inflight sub-stage (Propagated,
+        // Acknowledged, Confirmed)
         assert!(store.find_inflight(&hash).is_some());
     }
 

--- a/crates/redb3/src/state/utxoset.rs
+++ b/crates/redb3/src/state/utxoset.rs
@@ -179,8 +179,8 @@ mod tests {
         let mut produced = Vec::new();
         let mut consumed = Vec::new();
 
-        // Handle forward operations: produced_utxo -> add to index, consumed_utxo ->
-        // remove from index
+        // Handle forward operations: produced_utxo -> add to index,
+        // consumed_utxo -> remove from index
         for (txo_ref, era_cbor) in utxo_delta.produced_utxo.iter() {
             if let Ok(output) = MultiEraOutput::try_from(era_cbor.as_ref()) {
                 let tags = extract_utxo_tags(&output);
@@ -283,9 +283,10 @@ mod tests {
         let genesis = fake_genesis_delta(1_000_000_000);
         apply_utxoset!(store, &indexes, [&genesis]);
 
-        // TODO: the store is not persisting the cursor unless it's a specific point. We
-        // need to fix this in the next breaking change version. (#1035)
-        //assert_eq!(store.cursor().unwrap(), Some(ChainPoint::Origin));
+        // TODO: the store is not persisting the cursor unless it's a specific
+        // point. We need to fix this in the next breaking change
+        // version. (#1035) assert_eq!(store.cursor().unwrap(),
+        // Some(ChainPoint::Origin));
 
         let bobs = get_test_address_utxos(&store, &indexes, TestAddress::Bob);
         assert_eq!(bobs.len(), 1);
@@ -332,8 +333,9 @@ mod tests {
         let undo = revert_delta(forward);
         apply_utxoset!(store, &indexes, [&undo]);
 
-        // TODO: the store is not persisting the origin cursor, instead it's keeping it
-        // empty. We should fix this in the next breaking change version. (#1035)
+        // TODO: the store is not persisting the origin cursor, instead it's
+        // keeping it empty. We should fix this in the next breaking
+        // change version. (#1035)
         assert_eq!(store.read_cursor().unwrap(), None);
 
         let bobs = get_test_address_utxos(&store, &indexes, TestAddress::Bob);
@@ -349,8 +351,8 @@ mod tests {
     fn test_apply_in_batch() {
         let mut batch = Vec::new();
 
-        // first we do a step-by-step apply to use as reference. We keep the deltas in a
-        // vector to apply them in batch later.
+        // first we do a step-by-step apply to use as reference. We keep the
+        // deltas in a vector to apply them in batch later.
         let store = StateStore::in_memory(StateSchema::default()).unwrap();
         let indexes = build_indexes(&store);
 

--- a/crates/redb3/src/wal/mod.rs
+++ b/crates/redb3/src/wal/mod.rs
@@ -84,7 +84,8 @@ impl DbChainPoint {
         use std::ops::Bound;
 
         // Map bounds to key bounds directly; no `+1`/`-1` shift (would overflow
-        // at BlockSlot::MAX / underflow at MIN). Excluded flips the hash extreme.
+        // at BlockSlot::MAX / underflow at MIN). Excluded flips the hash
+        // extreme.
         let start = match range.start_bound() {
             Bound::Included(x) => Bound::Included(DbChainPoint::min_bound(*x)),
             Bound::Excluded(x) => Bound::Excluded(DbChainPoint::max_bound(*x)),
@@ -998,7 +999,8 @@ mod tests {
         // First open: stamps current version.
         open_test_store(&path).unwrap();
 
-        // Second open: should succeed without rewriting (no panic, version intact).
+        // Second open: should succeed without rewriting (no panic, version
+        // intact).
         let store = open_test_store(&path).unwrap();
         assert_eq!(store.read_version().unwrap(), Some(CURRENT_WAL_VERSION));
     }

--- a/crates/snapshot/src/layers/indexes.rs
+++ b/crates/snapshot/src/layers/indexes.rs
@@ -78,9 +78,10 @@ pub fn encode(record: &IndexRecord) -> Result<CanonicalCbor, Error> {
 }
 
 fn encode_tag(record: &TagRecord) -> Result<CanonicalCbor, Error> {
-    // Resolved rather than trusted: a `TagRecord` decoded from an outside source
-    // carries an owned dimension string, and shipping one no store has a table
-    // for would produce a layer that restores cleanly and can never be queried.
+    // Resolved rather than trusted: a `TagRecord` decoded from an outside
+    // source carries an owned dimension string, and shipping one no store
+    // has a table for would produce a layer that restores cleanly and can
+    // never be queried.
     let dimension = resolve_dimension(record.dimension())?;
 
     Ok(frame::encode(|e| {

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -1097,9 +1097,9 @@ where
         observer,
     )?;
 
-    // Only here: the stele is sealed, so the note about what was uploaded on the
-    // way to it has nothing left to say. Before the seal it would be a record
-    // that outlived neither the run nor its usefulness.
+    // Only here: the stele is sealed, so the note about what was uploaded on
+    // the way to it has nothing left to say. Before the seal it would be a
+    // record that outlived neither the run nor its usefulness.
     previous.forget_record()?;
 
     let identity = inscription.digest()?;
@@ -1343,8 +1343,8 @@ impl Predecessor for Chained<'_> {
 
         // The arrangement and the answer are one act, in both branches: by the
         // time this returns a descriptor, the transport is already carrying the
-        // blob, and the `HEAD` that proves the registry still has it has already
-        // happened.
+        // blob, and the `HEAD` that proves the registry still has it has
+        // already happened.
         if let (Some(source), Some(descriptor)) = (self.source, self.inheritable.get(&key)) {
             self.registry.adopt_layer(source, descriptor.clone())?;
             self.adopted.fetch_add(1, Ordering::Relaxed);

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -1580,7 +1580,8 @@ mod tests {
         let err = select_state(&inscription(short)).unwrap_err();
         assert!(matches!(err, Error::IncompleteStele(_)), "{err:?}");
 
-        // An absent kind: tip completeness is all seventeen, not "what's there".
+        // An absent kind: tip completeness is all seventeen, not "what's
+        // there".
         let absent: Vec<LayerDescriptor> = state_layers()
             .into_iter()
             .filter(|layer| layer.kind != "state-epochs")

--- a/crates/snapshot/tests/common/mod.rs
+++ b/crates/snapshot/tests/common/mod.rs
@@ -132,9 +132,10 @@ pub fn indexes() -> Vec<IndexRecord> {
         .enumerate()
         .map(|(i, dimension)| {
             let stored = if dimension == VERBATIM_KEY_DIMENSION {
-                // The exception, and the only place the fixture derives a stored
-                // key rather than pinning one: the point of this record is that
-                // the label survives untouched.
+                // The exception, and the only place the fixture derives a
+                // stored key rather than pinning one: the point
+                // of this record is that the label survives
+                // untouched.
                 key_hash(dimension, &METADATA_LABEL.to_be_bytes()).unwrap()
             } else {
                 [0x10 + i as u8; 8]

--- a/crates/snapshot/tests/coverage.rs
+++ b/crates/snapshot/tests/coverage.rs
@@ -77,9 +77,10 @@ fn every_dimension_resolves_and_nothing_else_does() {
         assert_eq!(indexes::resolve_dimension(dimension).unwrap(), dimension);
     }
 
-    // The UTxO filter dimensions are live-state indexes, rebuilt at restore from
-    // the UTxO set rather than shipped — so they are deliberately not archive
-    // dimensions, and `spent_txo` is the archive one whose name is nearest.
+    // The UTxO filter dimensions are live-state indexes, rebuilt at restore
+    // from the UTxO set rather than shipped — so they are deliberately not
+    // archive dimensions, and `spent_txo` is the archive one whose name is
+    // nearest.
     for absent in ["utxo::address", "spent-txo", "", "Address"] {
         assert!(indexes::resolve_dimension(absent).is_err(), "{absent:?}");
     }
@@ -226,9 +227,9 @@ fn log_kinds_derive_from_their_namespaces() {
         kinds.push(kind);
     }
 
-    // Injective in both columns. Two namespaces sharing a kind would publish one
-    // namespace's logs under another's name; two kinds sharing a namespace would
-    // restore the same records twice.
+    // Injective in both columns. Two namespaces sharing a kind would publish
+    // one namespace's logs under another's name; two kinds sharing a
+    // namespace would restore the same records twice.
     let distinct_kinds: BTreeSet<&str> = kinds.iter().copied().collect();
     let distinct_namespaces: BTreeSet<Namespace> =
         LOG_KINDS.into_iter().map(|(_, ns)| ns).collect();
@@ -236,8 +237,8 @@ fn log_kinds_derive_from_their_namespaces() {
     assert_eq!(distinct_kinds.len(), LOG_KINDS.len());
     assert_eq!(distinct_namespaces.len(), LOG_KINDS.len());
 
-    // Ascending, in both columns: the inscription lists layers in `KINDS` order,
-    // so the table's order is published order.
+    // Ascending, in both columns: the inscription lists layers in `KINDS`
+    // order, so the table's order is published order.
     let mut sorted = kinds.clone();
     sorted.sort_unstable();
     assert_eq!(kinds, sorted, "LOG_KINDS must be in byte order");
@@ -317,9 +318,9 @@ fn state_kinds_derive_from_their_namespaces() {
     );
     assert_eq!(state_kind_for("pending_mirs"), Some("state-pending-mirs"));
 
-    // Injective in both columns. Two namespaces sharing a kind would publish one
-    // namespace's tip under another's name; two kinds sharing a namespace would
-    // restore the same records twice.
+    // Injective in both columns. Two namespaces sharing a kind would publish
+    // one namespace's tip under another's name; two kinds sharing a
+    // namespace would restore the same records twice.
     let distinct_kinds: BTreeSet<&str> = kinds.iter().copied().collect();
     let distinct_namespaces: BTreeSet<Namespace> =
         STATE_KINDS.into_iter().map(|(_, ns, _)| ns).collect();
@@ -327,8 +328,8 @@ fn state_kinds_derive_from_their_namespaces() {
     assert_eq!(distinct_kinds.len(), STATE_KINDS.len());
     assert_eq!(distinct_namespaces.len(), STATE_KINDS.len());
 
-    // Ascending, in both columns: the inscription lists layers in `KINDS` order,
-    // so the table's order is published order.
+    // Ascending, in both columns: the inscription lists layers in `KINDS`
+    // order, so the table's order is published order.
     let mut sorted = kinds.clone();
     sorted.sort_unstable();
     assert_eq!(kinds, sorted, "STATE_KINDS must be in byte order");
@@ -341,8 +342,8 @@ fn state_kinds_derive_from_their_namespaces() {
 
     // The shard map is the spec's, not the data's: four chain-scale namespaces
     // split sixteen ways, and every other namespace is a single blob. Changing
-    // one of these is a media-type-version event for that kind, so it is spelled
-    // out here rather than derived from the table it is checking.
+    // one of these is a media-type-version event for that kind, so it is
+    // spelled out here rather than derived from the table it is checking.
     for (_, ns, shards) in STATE_KINDS {
         let expected = match ns {
             "utxos" | "accounts" | "assets" | "datums" => 16,

--- a/crates/snapshot/tests/goldens.rs
+++ b/crates/snapshot/tests/goldens.rs
@@ -347,8 +347,8 @@ fn per_kind_diff_ids_are_pinned() {
     let layers = all_layers();
 
     // Before the zip, not after: `zip` stops at the shorter side, so a dropped
-    // layer would quietly shorten the loop rather than fail it — in the one test
-    // whose whole job is to notice a layer changing.
+    // layer would quietly shorten the loop rather than fail it — in the one
+    // test whose whole job is to notice a layer changing.
     assert_eq!(
         layers.len(),
         GOLDEN_LAYERS.len(),

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -65,8 +65,8 @@ pub fn harness<B: ToyStores>() -> ToyDomain<B> {
 
     assert_eq!(epoch, 0, "the fixture left the epoch it was built for");
 
-    // What makes the `logs` layer non-empty, which the export's done criterion 2
-    // asks for by name: an all-empty layer set would prove nothing about
+    // What makes the `logs` layer non-empty, which the export's done criterion
+    // 2 asks for by name: an all-empty layer set would prove nothing about
     // ordering.
     seed_epoch_logs(&domain, &[epoch]).unwrap();
     seed_reward_logs(&domain, &vectors.stake_address, &vectors.pool_id, &[epoch]).unwrap();

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -1379,8 +1379,9 @@ fn the_remaining_download_excludes_what_is_already_done() {
     // The tip is still in it, always.
     assert_eq!(resumed.layers, state_layer_count());
 
-    // So the peak a resumed run stages is the widest state layer, not the widest
-    // layer of the stele — the epoch layers it skips are not staged either.
+    // So the peak a resumed run stages is the widest state layer, not the
+    // widest layer of the stele — the epoch layers it skips are not staged
+    // either.
     assert_eq!(resumed.largest_compressed, widest(&mut plan.tip_layers()));
     assert!(resumed.largest_compressed <= fresh.largest_compressed);
 }

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -292,9 +292,9 @@ fn a_registry_restore_is_a_directory_restore() {
     // The *cursor* is deliberately not in this comparison. `Node::build` stands
     // at a synthetic epoch boundary so that epoch 0's window publishes
     // unclamped, which is a chain point the harness ledger never reached; the
-    // restored node carries the stele's position, correctly, and that is not the
-    // domain's. What a stele has to reproduce is the data, and that is what is
-    // asserted.
+    // restored node carries the stele's position, correctly, and that is not
+    // the domain's. What a stele has to reproduce is the data, and that is
+    // what is asserted.
     assert_eq!(
         utxos_of(from_registry.state()),
         utxos_of(node.domain.state()),
@@ -891,8 +891,8 @@ fn a_registry_restore_reports_every_byte_it_pulls() {
         "the blobs announced, against what the plan said was left to fetch"
     );
 
-    // And the deltas — reported as the bytes were written, one `poll_write` at a
-    // time — sum to the same total.
+    // And the deltas — reported as the bytes were written, one `poll_write` at
+    // a time — sum to the same total.
     assert_eq!(
         watcher.bytes(),
         outlook.remaining.compressed_bytes,
@@ -932,8 +932,9 @@ fn a_resumed_registry_restore_reports_what_it_skipped() {
     let blank = Blank::<MemoryStores>::open();
 
     // The interruption, at the second epoch layer the driver reaches — the same
-    // deterministic placement `a_killed_registry_restore_resumes_where_it_stopped`
-    // uses, and for the same reason: a wall-clock kill against a loopback
+    // deterministic placement
+    // `a_killed_registry_restore_resumes_where_it_stopped` uses, and for
+    // the same reason: a wall-clock kill against a loopback
     // registry holding a kilobyte-scale stele interrupts nothing.
     {
         let stele = Point::Latest.pull(&repository).unwrap();

--- a/crates/snapshot/tests/roundtrip.rs
+++ b/crates/snapshot/tests/roundtrip.rs
@@ -235,7 +235,8 @@ fn an_over_wide_exact_key_survives_the_layer_and_is_refused_by_the_codec() {
     let err = indexes::decode(&raw[0]).unwrap_err();
     assert!(matches!(err, Error::Index(_)), "{err:?}");
 
-    // And the width the type does accept is refused when it is the wrong kind's.
+    // And the width the type does accept is refused when it is the wrong
+    // kind's.
     assert!(ExactRecord::new(ExactKind::TxHash, &4242u64.to_be_bytes(), 1).is_err());
 }
 

--- a/crates/stelae/src/digest.rs
+++ b/crates/stelae/src/digest.rs
@@ -265,8 +265,8 @@ fn digest_blob<R: Read, W: Write>(
 
     // Decoding runs to EOF, so the tap has already seen the whole blob; the
     // drain is a safety net in case a future decoder stops at a frame boundary
-    // instead. Either way the blob digest must cover every byte of the file, not
-    // only the part decompression happened to need.
+    // instead. Either way the blob digest must cover every byte of the file,
+    // not only the part decompression happened to need.
     std::io::copy(&mut tap, &mut std::io::sink())?;
 
     let (_, blob_digest, compressed_size) = tap.finish();

--- a/crates/stelae/src/dir.rs
+++ b/crates/stelae/src/dir.rs
@@ -344,8 +344,8 @@ impl SteleWriter for SteleDir {
         // byte is written, so it is staged first. The counter keeps two writers
         // of the same kind apart — a profile sharding one logical layer into
         // many is the normal case, not an edge one. Staging sits beside
-        // `sha256/` rather than in it, so a half-written layer is never mistaken
-        // for a blob.
+        // `sha256/` rather than in it, so a half-written layer is never
+        // mistaken for a blob.
         static STAGING: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
         let staging = Staging::new(self.root.join(BLOBS_DIR).join(format!(
@@ -590,11 +590,11 @@ impl SteleDir {
 
         check_header(&header, profile, descriptor)?;
 
-        // Counted by iterating rather than with `count()`: `SeqReader` reports a
-        // malformed record as one `Err` item and then ends, so counting items
-        // would tally the failure as a record and drop the error with it. A
-        // descriptor written to match that inflated number would then read back
-        // clean.
+        // Counted by iterating rather than with `count()`: `SeqReader` reports
+        // a malformed record as one `Err` item and then ends, so
+        // counting items would tally the failure as a record and drop
+        // the error with it. A descriptor written to match that
+        // inflated number would then read back clean.
         let mut records = 1u64;
 
         for record in SeqReader::new(&content[header_len..]) {

--- a/crates/stelae/src/frame.rs
+++ b/crates/stelae/src/frame.rs
@@ -397,9 +397,10 @@ impl<'a> Scanner<'a> {
                 Ok(())
             }
             4 => {
-                // `remaining` counts the elements *after* the one being scanned,
-                // so a truncation deep inside can be charged for the ones that
-                // never got their turn.
+                // `remaining` counts the elements *after* the one being
+                // scanned, so a truncation deep inside can be
+                // charged for the ones that never got their
+                // turn.
                 for remaining in (0..arg).rev() {
                     if let Err(e) = self.item(depth + 1) {
                         self.note_pending(&e, remaining);

--- a/crates/stelae/src/inscription.rs
+++ b/crates/stelae/src/inscription.rs
@@ -850,7 +850,8 @@ mod tests {
         );
 
         // `56.0` is an integral value but a JSON float, and RFC 8785 renders it
-        // through the float path. The rule is about the encoding, not the value.
+        // through the float path. The rule is about the encoding, not the
+        // value.
         let mut inscription = sample();
         inscription.parameters = json!({"whole": 56.0});
         assert!(matches!(

--- a/crates/stelae/tests/toy_profile.rs
+++ b/crates/stelae/tests/toy_profile.rs
@@ -313,7 +313,8 @@ fn writes_a_stele_and_reads_it_back() {
         assert_eq!(*record, note_record(note).as_bytes());
     }
 
-    // And the profile can decode its own records, which the protocol never does.
+    // And the profile can decode its own records, which the protocol never
+    // does.
     let mut decoder = minicbor::Decoder::new(records[1]);
     assert_eq!(decoder.array().unwrap(), Some(3));
     assert_eq!(decoder.u64().unwrap(), 2);
@@ -463,8 +464,8 @@ fn layers_round_trip_byte_identically() {
         let layer = stele.read_layer(&index, &ToyProfile, descriptor).unwrap();
 
         // Re-frame the records that came back and compare the whole sequence.
-        // The header is re-encoded from its parsed form, so a field that did not
-        // survive parsing would show up as a byte difference here.
+        // The header is re-encoded from its parsed form, so a field that did
+        // not survive parsing would show up as a byte difference here.
         let mut rewritten = Vec::new();
         let mut writer = stelae::SeqWriter::new(&mut rewritten);
 

--- a/crates/testing/src/harness/cardano.rs
+++ b/crates/testing/src/harness/cardano.rs
@@ -270,7 +270,8 @@ impl LedgerHarness {
             cursor.clone(),
         )?;
 
-        // Skip first block when resuming (cursor points at last processed block)
+        // Skip first block when resuming (cursor points at last processed
+        // block)
         if cursor != Point::Origin {
             iter.next();
         }

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -86,10 +86,10 @@ impl Default for SyntheticBlockConfig {
     fn default() -> Self {
         // Use dedicated seeds to avoid collision with person seeds (11-15)
         // and the submit key seed (3) used inside build_synthetic_blocks.
-        // address has a stake part (needed for stake registration certs in synthetic
-        // txs). seed_address is payment-only (its UTxOs are consumed as inputs
-        // and its stake account is never registered, so no stake part is
-        // needed).
+        // address has a stake part (needed for stake registration certs in
+        // synthetic txs). seed_address is payment-only (its UTxOs are
+        // consumed as inputs and its stake account is never registered,
+        // so no stake part is needed).
         let address = synthetic_address_with_stake([20u8; 64]);
         let seed_address = crate::TestAddress::Eve.as_str().to_string();
         Self {

--- a/crates/testing/src/toy_domain.rs
+++ b/crates/testing/src/toy_domain.rs
@@ -360,9 +360,10 @@ impl<B: ToyStores> ToyDomain<B> {
         ));
         execute_work_unit(&domain, &mut genesis_work).unwrap();
 
-        // Manually refresh the chain cache after genesis since we bypassed pop_work.
-        // In normal operation, the cache refresh happens automatically via the
-        // needs_cache_refresh flag in CardanoLogic::pop_work.
+        // Manually refresh the chain cache after genesis since we bypassed
+        // pop_work. In normal operation, the cache refresh happens
+        // automatically via the needs_cache_refresh flag in
+        // CardanoLogic::pop_work.
         {
             let mut chain = domain.chain.write().expect("chain lock poisoned");
             chain.refresh_cache::<Self>(domain.stores.state()).unwrap();

--- a/crates/trp/src/methods.rs
+++ b/crates/trp/src/methods.rs
@@ -339,8 +339,8 @@ mod tests {
     use super::*;
 
     async fn setup_test_context() -> Arc<Context<ToyDomain>> {
-        // Use devnet genesis (protocol 9 = Conway, has Plutus cost models needed by tx3
-        // compiler)
+        // Use devnet genesis (protocol 9 = Conway, has Plutus cost models
+        // needed by tx3 compiler)
         let genesis = std::sync::Arc::new(dolos_cardano::include::devnet::load());
 
         // Compute minimum slot for the genesis era summary
@@ -365,9 +365,10 @@ mod tests {
         };
         let (blocks, _vectors, chain_config) = build_synthetic_blocks(cfg);
 
-        // Build sender/receiver UTxOs with offset hashes (100+) to avoid collision
-        // with synthetic block sequences (1-7).
-        // Use Carol/Dave to avoid colliding with synthetic block addresses (Alice/Bob).
+        // Build sender/receiver UTxOs with offset hashes (100+) to avoid
+        // collision with synthetic block sequences (1-7).
+        // Use Carol/Dave to avoid colliding with synthetic block addresses
+        // (Alice/Bob).
         let delta = {
             let sender = TestAddress::Carol;
             let receiver = TestAddress::Dave;
@@ -388,7 +389,8 @@ mod tests {
             }
         };
 
-        // Pass delta through domain — applied after genesis, before block import
+        // Pass delta through domain — applied after genesis, before block
+        // import
         let domain =
             ToyDomain::new_with_genesis_and_config(genesis, chain_config, Some(delta), None);
 

--- a/crates/trp/src/utxos.rs
+++ b/crates/trp/src/utxos.rs
@@ -14,7 +14,8 @@ fn search_state_utxos<D: Domain>(
     pattern: &UtxoPattern<'_>,
     store: &MempoolAwareUtxoStore<D>,
 ) -> Result<HashSet<TxoRef>, IndexError> {
-    // Dummy filter that always returns true (we want all UTxOs matching the index)
+    // Dummy filter that always returns true (we want all UTxOs matching the
+    // index)
     let no_filter = |_: &MultiEraOutput<'_>| true;
 
     let refs = match pattern {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -125,15 +125,16 @@ impl Domain for DomainAdapter {
         // TODO: do a more thorough analysis to understand if this approach is
         // susceptible to race conditions. Things to explore:
         // - a mutex to block the sending of events while gathering the replay.
-        // - storing the previous block hash in the db to use for consistency checks.
+        // - storing the previous block hash in the db to use for consistency
+        //   checks.
 
-        // We first create the receiver so that the subscriber internal ring-buffer
-        // position is defined.
+        // We first create the receiver so that the subscriber internal
+        // ring-buffer position is defined.
         let receiver = self.tip_broadcast.subscribe();
 
-        // We then collect any gap between the from point and the current tip. This
-        // assumes that no event will be sent between the creation of the receiver and
-        // the collection of the replay.
+        // We then collect any gap between the from point and the current tip.
+        // This assumes that no event will be sent between the creation
+        // of the receiver and the collection of the replay.
         let replay = self.wal().iter_blocks(from, None)?.collect::<Vec<_>>();
 
         Ok(TipSubscription { replay, receiver })

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -405,9 +405,9 @@ fn do_import(
     .map_err(|err| miette::miette!(err.to_string()))
     .context("reading immutable db tip")?;
 
-    // unless we're starting from the origin of the chain, we need to skip the first
-    // result since the iterator will be standing in the last slot already
-    // processed, we don't want to import it twice.
+    // unless we're starting from the origin of the chain, we need to skip the
+    // first result since the iterator will be standing in the last slot
+    // already processed, we don't want to import it twice.
     if cursor != pallas::network::miniprotocols::Point::Origin {
         iter.next();
     }
@@ -423,8 +423,8 @@ fn do_import(
             .into_diagnostic()
             .context("reading block data")?;
 
-        // we need to wrap them on a ref counter since bytes are going to be shared
-        // around throughout the pipeline
+        // we need to wrap them on a ref counter since bytes are going to be
+        // shared around throughout the pipeline
         let batch: Vec<_> = batch.into_iter().map(Arc::new).collect();
 
         let last = domain

--- a/src/bin/dolos/bootstrap/mod.rs
+++ b/src/bin/dolos/bootstrap/mod.rs
@@ -256,9 +256,9 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     dispatch(config, &command, feedback, args.r#continue)?;
 
     // Reset WAL after any successful bootstrap so that `find_intersect` works.
-    // Some bootstrap mechanisms skip WAL commits for performance, leaving it empty
-    // or stale. This ensures the WAL tip matches the state cursor regardless of
-    // which bootstrap method was used.
+    // Some bootstrap mechanisms skip WAL commits for performance, leaving it
+    // empty or stale. This ensures the WAL tip matches the state cursor
+    // regardless of which bootstrap method was used.
     if let Err(e) = seed_wal_from_state(config) {
         tracing::error!("failed to seed WAL from state: {}", e);
     }

--- a/src/bin/dolos/bootstrap/ranged.rs
+++ b/src/bin/dolos/bootstrap/ranged.rs
@@ -121,8 +121,9 @@ impl RangedReader {
     fn finish_current(&mut self) {
         if let Some((_, path)) = self.current.take() {
             let _ = std::fs::remove_file(&path);
-            // Returning a permit lets the downloader stage one more chunk. If the
-            // downloader is already gone, the send simply fails and we ignore it.
+            // Returning a permit lets the downloader stage one more chunk. If
+            // the downloader is already gone, the send simply fails
+            // and we ignore it.
             if let Some(tx) = self.permits_tx.as_ref() {
                 let _ = tx.send(());
             }
@@ -138,7 +139,8 @@ impl Read for RangedReader {
                 if n > 0 {
                     return Ok(n);
                 }
-                // Current chunk exhausted: delete it, free a permit, fetch next.
+                // Current chunk exhausted: delete it, free a permit, fetch
+                // next.
                 self.finish_current();
                 continue;
             }
@@ -164,9 +166,10 @@ impl Drop for RangedReader {
         self.finish_current();
 
         // Release the permit sender first. A downloader blocked waiting for a
-        // free slot will see `permits_rx.recv()` fail and wind down; one blocked
-        // on `data_tx.send()` unblocks as we drain below. Either way it stops
-        // issuing requests and eventually drops `data_tx`, ending the drain.
+        // free slot will see `permits_rx.recv()` fail and wind down; one
+        // blocked on `data_tx.send()` unblocks as we drain below.
+        // Either way it stops issuing requests and eventually drops
+        // `data_tx`, ending the drain.
         self.permits_tx = None;
 
         // Drain and delete any chunks already staged so nothing lingers, then
@@ -299,9 +302,9 @@ pub fn ranged_reader_with_chunk(
         let mut idx = 0u64;
 
         while offset < total_size {
-            // Backpressure point: block here, with NO connection open, until the
-            // extractor frees a slot. This is what keeps R2 from ever seeing an
-            // idle/slow-drained connection.
+            // Backpressure point: block here, with NO connection open, until
+            // the extractor frees a slot. This is what keeps R2
+            // from ever seeing an idle/slow-drained connection.
             if permits_rx.recv().is_err() {
                 // Reader dropped; stop downloading.
                 return;

--- a/src/bin/dolos/bootstrap/snapshot.rs
+++ b/src/bin/dolos/bootstrap/snapshot.rs
@@ -134,7 +134,8 @@ fn fetch_snapshot_ranged(
 ) -> miette::Result<()> {
     let staging = root.join(".dolos-snapshot-tmp");
 
-    // Start from a clean staging dir in case a previous attempt left chunks behind.
+    // Start from a clean staging dir in case a previous attempt left chunks
+    // behind.
     let _ = std::fs::remove_dir_all(&staging);
     std::fs::create_dir_all(&staging)
         .into_diagnostic()
@@ -178,8 +179,9 @@ fn fetch_snapshot_streaming(
     snapshot_url: String,
     feedback: &Feedback,
 ) -> miette::Result<()> {
-    // A single full-body stream must NOT carry an overall request timeout, which
-    // would cap the entire multi-GB transfer. Use a dedicated untimed client.
+    // A single full-body stream must NOT carry an overall request timeout,
+    // which would cap the entire multi-GB transfer. Use a dedicated untimed
+    // client.
     let client = reqwest::blocking::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(10))
         .build()

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -466,8 +466,8 @@ mod progress_tests {
         let epoch = serde_json::json!({"networkMagic": 2, "epoch": 0});
         let shard = serde_json::json!({"networkMagic": 2, "epoch": 0, "shard": 0});
 
-        // The layer an earlier attempt had already committed: announced, closed,
-        // nothing pulled for it.
+        // The layer an earlier attempt had already committed: announced,
+        // closed, nothing pulled for it.
         progress.on(Event::LayerStarted {
             index: 0,
             total: PER_RESTORE,

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -203,7 +203,8 @@ pub fn setup_domain_with_stop_epoch(
         tip_broadcast,
     };
 
-    // this will make sure the domain is correctly initialized and in a valid state.
+    // this will make sure the domain is correctly initialized and in a valid
+    // state.
     domain.bootstrap().map_err(|e| match e {
         dolos_core::DomainError::InconsistentState { ref wal, ref state } => {
             let msg = match (wal, state) {
@@ -330,9 +331,9 @@ pub fn setup_tracing(config: &LoggingConfig, telemetry: &TelemetryConfig) -> mie
             .init();
     }
 
-    // Initialize the log-to-tracing bridge AFTER the tracing subscriber is set up.
-    // This allows crates using the `log` crate (like fjall) to have their messages
-    // forwarded to the tracing subscriber.
+    // Initialize the log-to-tracing bridge AFTER the tracing subscriber is set
+    // up. This allows crates using the `log` crate (like fjall) to have
+    // their messages forwarded to the tracing subscriber.
     tracing_log::LogTracer::init().ok();
 
     Ok(())

--- a/src/bin/dolos/data/dump_logs.rs
+++ b/src/bin/dolos/data/dump_logs.rs
@@ -346,8 +346,9 @@ impl TableRow for AccountEpochRewards {
         let entity = EntityKey::from(key.clone());
         let slot = u64::from_be_bytes(temporal.as_ref().try_into().unwrap());
 
-        // A slot under a column headed `epoch` is off by orders of magnitude and
-        // says nothing about being wrong, so absence renders as absence.
+        // A slot under a column headed `epoch` is off by orders of magnitude
+        // and says nothing about being wrong, so absence renders as
+        // absence.
         let epoch = ctx
             .summary
             .as_ref()

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -942,7 +942,8 @@ mod tests {
 
     #[test]
     fn a_genesis_without_a_security_param_keeps_the_old_value() {
-        // guessing small is the expensive direction, so an unknown `k` falls back
+        // guessing small is the expensive direction, so an unknown `k` falls
+        // back
         let mut genesis = dolos_cardano::include::preview::load();
         genesis.shelley.security_param = None;
 

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -257,10 +257,10 @@ pub(super) fn to_repository(
 
     // And on the same terms, for the same reason. A dry run that reported the
     // layers and said nothing about the volume they would be staged on would be
-    // the one rehearsal a publisher does, missing the failure it exists to find.
-    // After `standing`, because a repository holding another network's chain is
-    // refused there and sizing against it would be sizing against the wrong
-    // stele.
+    // the one rehearsal a publisher does, missing the failure it exists to
+    // find. After `standing`, because a repository holding another
+    // network's chain is refused there and sizing against it would be
+    // sizing against the wrong stele.
     registry::preflight(&registry)
         .into_diagnostic()
         .context("sizing the staging directory")?;
@@ -350,7 +350,8 @@ pub(super) fn to_repository(
 ///   publisher has been down for a month" do not read the same.
 fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
     // A read of the latest manifest and the one network call a publish makes
-    // before it commits to anything, so running it again is free of consequence.
+    // before it commits to anything, so running it again is free of
+    // consequence.
     //
     // `&|| false` for every caller, `snapshot backfill`'s driver included: the
     // publish that follows this read observes no cancellation for as long as it
@@ -453,8 +454,8 @@ mod tests {
             });
         }
 
-        // The state pass: sixteen layers open at once, closed in order, with one
-        // record stream feeding all of them.
+        // The state pass: sixteen layers open at once, closed in order, with
+        // one record stream feeding all of them.
         for index in 3..PER_PUBLISH {
             progress.on(Event::LayerStarted {
                 index,

--- a/src/relay/chainsync.rs
+++ b/src/relay/chainsync.rs
@@ -77,9 +77,10 @@ impl<D: Domain> Session<D> {
 
         let point = Point::try_from(point).map_err(|_| Error::custom("invalid point"))?;
 
-        // Ouroboros chain-sync always starts by sending the intersection point as an
-        // initial rollback event. The `is_new_intersection`` flag allows us to track if
-        // we have already sent that initial rollback or not
+        // Ouroboros chain-sync always starts by sending the intersection point
+        // as an initial rollback event. The `is_new_intersection`` flag
+        // allows us to track if we have already sent that initial
+        // rollback or not
         if self.is_new_intersection {
             self.connection
                 .send_roll_backward(point, tip)
@@ -140,8 +141,8 @@ impl<D: Domain> Session<D> {
 
         let tip = self.prepare_tip()?;
 
-        // TODO: if points are empty it means that client wants to start sync from
-        // origin?.
+        // TODO: if points are empty it means that client wants to start sync
+        // from origin?.
         if points.is_empty() {
             debug!("intersect candidates empty, using origin");
             points.push(Point::Origin);

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -93,8 +93,8 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
             }
         }
 
-        // notify the tracker that we're done receiving new tasks. Without this explicit
-        // close, the wait will block forever.
+        // notify the tracker that we're done receiving new tasks. Without this
+        // explicit close, the wait will block forever.
         debug!("closing task manger");
         tasks.close();
 

--- a/src/serve/grpc/stream.rs
+++ b/src/serve/grpc/stream.rs
@@ -115,7 +115,8 @@ mod tests {
             domain.roll_forward(block).unwrap();
         }
 
-        // this point was never rolled forward, so the domain can't intersect it.
+        // this point was never rolled forward, so the domain can't intersect
+        // it.
         let unknown_point = make_conway_block(9999).0;
 
         let result = ChainStream::start::<ToyDomain, CancelTokenImpl>(

--- a/src/serve/o7s_unix/chainsync.rs
+++ b/src/serve/o7s_unix/chainsync.rs
@@ -79,9 +79,10 @@ impl<D: Domain> Session<D> {
 
         let point = Point::try_from(point).map_err(|_| Error::custom("invalid point"))?;
 
-        // Ouroboros chain-sync always starts by sending the intersection point as an
-        // initial rollback event. The `is_new_intersection`` flag allows us to track if
-        // we have already sent that initial rollback or not
+        // Ouroboros chain-sync always starts by sending the intersection point
+        // as an initial rollback event. The `is_new_intersection`` flag
+        // allows us to track if we have already sent that initial
+        // rollback or not
         if self.is_new_intersection {
             self.connection
                 .send_roll_backward(point, tip)
@@ -142,8 +143,8 @@ impl<D: Domain> Session<D> {
 
         let tip = self.prepare_tip()?;
 
-        // TODO: if points are empty it means that client wants to start sync from
-        // origin?.
+        // TODO: if points are empty it means that client wants to start sync
+        // from origin?.
         if points.is_empty() {
             debug!("intersect candidates empty, using origin");
             points.push(Point::Origin);

--- a/src/serve/o7s_unix/mod.rs
+++ b/src/serve/o7s_unix/mod.rs
@@ -120,8 +120,8 @@ impl<D: Domain, C: CancelToken> dolos_core::Driver<D, C> for Driver {
             }
         }
 
-        // notify the tracker that we're done receiving new tasks. Without this explicit
-        // close, the wait will block forever.
+        // notify the tracker that we're done receiving new tasks. Without this
+        // explicit close, the wait will block forever.
         debug!("closing task manger");
         tasks.close();
 

--- a/src/serve/o7s_unix/statequery.rs
+++ b/src/serve/o7s_unix/statequery.rs
@@ -114,11 +114,13 @@ impl<D: Domain> Session<D> {
     /// Decode cardano-cli tagged query format.
     /// cardano-cli wraps queries like: [0, [0, [era, [era, tag(258), data]]]]
     fn decode_cardano_cli_tagged_query(raw_bytes: &[u8]) -> Result<q16::Request, ()> {
-        // Look for tag marker (0xd9 = tag with 2-byte value) within array structure
+        // Look for tag marker (0xd9 = tag with 2-byte value) within array
+        // structure
         if raw_bytes.len() >= 10 && raw_bytes[0] == 0x82 {
             if let Some(tag_pos) = raw_bytes.iter().position(|&b| b == 0xd9) {
                 if tag_pos + 3 < raw_bytes.len() {
-                    // Extract era from position 5 (the first era byte in the structure)
+                    // Extract era from position 5 (the first era byte in the
+                    // structure)
                     let era = raw_bytes.get(5).ok_or(())?.to_owned() as u16;
 
                     let after_tag = &raw_bytes[tag_pos + 3..];

--- a/src/sync/submit.rs
+++ b/src/sync/submit.rs
@@ -91,20 +91,21 @@ impl Worker {
         if stage.mempool.has_pending() {
             debug!(request, "found txs to fulfill request");
 
-            // we have txs available so we process the work unit as a new one. We don't
-            // acknowledge anything because that already happened on the initial attempt to
-            // fulfill the request.
+            // we have txs available so we process the work unit as a new one.
+            // We don't acknowledge anything because that already
+            // happened on the initial attempt to fulfill the
+            // request.
             Ok(WorkSchedule::Unit(Request::TxIds(0, request as u16)))
         } else {
             debug!(request, "still not enough txs to fulfill request");
 
             // we wait a few secs to avoid turning this stage into a hot loop.
-            // TODO: we need to watch the mempool and abort the wait if there's a change in
-            // the list of available txs.
+            // TODO: we need to watch the mempool and abort the wait if there's
+            // a change in the list of available txs.
             tokio::time::sleep(Duration::from_secs(10)).await;
 
-            // we store the request again so that the next schedule knows we're still
-            // waiting for new transactions.
+            // we store the request again so that the next schedule knows we're
+            // still waiting for new transactions.
             self.unfulfilled_request = Some(request);
 
             Ok(WorkSchedule::Idle)

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -432,9 +432,10 @@ fn test_bootstrap_origin_cursor_is_noop() {
 
     domain.wal().reset_to(&ChainPoint::Origin).unwrap();
 
-    // bootstrap() should succeed without crashing on the empty Origin WAL entry.
-    // Previously this would fail with UnknownCbor("") when catch_up_stores tried
-    // to CBOR-decode the synthetic Origin entry's empty block bytes.
+    // bootstrap() should succeed without crashing on the empty Origin WAL
+    // entry. Previously this would fail with UnknownCbor("") when
+    // catch_up_stores tried to CBOR-decode the synthetic Origin entry's
+    // empty block bytes.
     domain.bootstrap().unwrap();
 
     // Archive should still be empty — no real blocks were processed.

--- a/tests/e2e/sync.rs
+++ b/tests/e2e/sync.rs
@@ -211,8 +211,8 @@ fn fork_simulation_applies_canonical_after_rollback() {
         "cursor should be at A after rollback"
     );
 
-    // Canonical sibling C: same parent (A), same slot (2), different block_number
-    // → different hash than O'.
+    // Canonical sibling C: same parent (A), same slot (2), different
+    // block_number → different hash than O'.
     let (point_c, block_c) = make_conway_block_with_prev(2, Some(hash_a), 2);
     assert_ne!(
         point_c.hash(),

--- a/tests/epoch_pots/main.rs
+++ b/tests/epoch_pots/main.rs
@@ -458,7 +458,8 @@ fn run_epoch_pots_test(
     let cardano_network = dolos_cardano::network_from_genesis(&harness.domain().genesis());
 
     // Capture the completed subject epoch via the estart callback.
-    // When estart fires for epoch N+1, ended_state() holds the completed epoch N.
+    // When estart fires for epoch N+1, ended_state() holds the completed epoch
+    // N.
     let mut captured_epoch: Option<EpochState> = None;
 
     // Accumulate applied rewards across all Ewrap work units for the

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -113,7 +113,8 @@ fn test_redb3_lazy_iter() {
 // ---------------------------------------------------------------------------
 
 const SHARD_ENTITY_COUNT: u64 = 50_000;
-const SHARD_KEY_PREFIX_RANGE: std::ops::Range<u8> = 0x10..0x20; // one 16-bucket shard
+const SHARD_KEY_PREFIX_RANGE: std::ops::Range<u8> = 0x10..0x20; // one 16-bucket
+                                                                // shard
 
 fn seed_account_namespace<S: CoreStateStore>(store: &S) {
     let value = vec![0xABu8; ENTITY_SIZE];

--- a/xtask/src/ground_truth/delegation.rs
+++ b/xtask/src/ground_truth/delegation.rs
@@ -20,7 +20,8 @@ pub(super) fn fetch(dbsync_url: &str, epoch: u64) -> Result<Vec<PoolDelegationRo
     let epoch = i32::try_from(epoch)
         .map_err(|_| anyhow::anyhow!("epoch out of range for dbsync (expected i32)"))?;
 
-    // Aggregate client-side in pages to avoid server-side timeout on large epochs.
+    // Aggregate client-side in pages to avoid server-side timeout on large
+    // epochs.
     let query = r#"
         SELECT
             ph.view AS pool_bech32,

--- a/xtask/src/ground_truth/generate.rs
+++ b/xtask/src/ground_truth/generate.rs
@@ -98,9 +98,9 @@ pub fn run(args: &GenerateArgs) -> Result<()> {
     println!("  DBSync URL: {}", dbsync_url);
     println!("  Output dir: {}", output_dir.display());
 
-    // performance_epoch = subject_epoch - 2: the epoch where rewards were earned.
-    // RUPD at subject_epoch uses the mark snapshot (subject - 1) to compute rewards
-    // for performance done in subject - 2.
+    // performance_epoch = subject_epoch - 2: the epoch where rewards were
+    // earned. RUPD at subject_epoch uses the mark snapshot (subject - 1) to
+    // compute rewards for performance done in subject - 2.
     let performance_epoch = args.subject_epoch.saturating_sub(2);
 
     // Conditionally fetch and write each dataset


### PR DESCRIPTION
## What

The `cargo fmt` CI gate installs the latest nightly on each run. The 2026-08-30 nightly changed the unstable `wrap_comments` behavior. A clean checkout of `main` now fails `cargo +nightly fmt --all -- --check`, so every open PR fails the gate (see the fmt failure on #1219 for an example).

This PR applies `cargo +nightly fmt --all` with `rustfmt 1.10.0-nightly (9085017724 2026-08-30)`.

- **Scope**: comment re-wraps only, across 85 files. No code changes.
- **Verified**: the diff contains no changed line outside a comment.

## Testing

- `cargo +nightly fmt --all -- --check` passes after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted and clarified internal comments across Cardano processing, synchronization, storage, snapshot, relay, and testing components.
  * Improved explanations for pagination, epoch transitions, rewards, bootstrapping, restoration, and state handling.
  * No user-visible functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->