### PR TITLE
ci: pin the cargo fmt nightly to 2026-08-27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,25 @@ jobs:
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
+    # rustfmt.toml enables `wrap_comments`, an unstable option that only the
+    # nightly rustfmt applies — stable silently ignores it. Run nightly here so
+    # the check actually enforces comment wrapping.
+    #
+    # Pinned, because unstable options give no output-stability guarantee: the
+    # nightly published 2026-08-30 rewraps comments across 85 files. Held at the
+    # last nightly that formats `main` clean; taking that rewrap is #1280.
+    # Local devs: `cargo +nightly-2026-08-27 fmt`.
+    env:
+      RUSTFMT_NIGHTLY: nightly-2026-08-27
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # rustfmt.toml enables `wrap_comments`, an unstable option that only the
-      # nightly rustfmt applies — stable silently ignores it. Run nightly here so
-      # the check actually enforces comment wrapping. Local devs: `cargo +nightly fmt`.
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUSTFMT_NIGHTLY }}
           components: rustfmt
-      - run: cargo +nightly fmt --all -- --check
+      - run: cargo +$RUSTFMT_NIGHTLY fmt --all -- --check
 
   clippy:
     name: cargo clippy


### PR DESCRIPTION
## What

The `cargo fmt` job installs an unpinned nightly on every run, and `rustfmt.toml` enables `wrap_comments` — an unstable option, so its output carries no stability guarantee. The nightly published 2026-08-30 changed how it computes available width. A clean checkout of `main` stopped formatting clean, and every open PR has been failing the gate since on comment re-wraps in files it never touched.

This pins the gate to the last nightly that formats `main` clean. No source changes.

| Run | Toolchain | `cargo fmt` |
| --- | --- | --- |
| [33074814675](https://github.com/txpipe/dolos/actions/runs/33074814675) (`main` @ `e7973d4`) | `1.100.0-nightly (bff8e12ff 2026-08-26)` | pass |
| [33316136811](https://github.com/txpipe/dolos/actions/runs/33316136811) | `1.100.0-nightly (fd7ed57df 2026-08-29)` | fail |

`main` has not moved off `e7973d4`, so this restores a state already proven green.

## Scope

The pin only. #1280 carries the 85-file comment re-wrap for the newer nightly and stays open as the deferred upgrade — when we take it, bumping `RUSTFMT_NIGHTLY` and applying the re-wrap belong in the same commit.

## Notes on the diff

- The `run` step names the pinned toolchain. The dated toolchain installs as `nightly-2026-08-27`, not `nightly`, so the old `cargo +nightly` would resolve elsewhere. A bare `cargo fmt` would not work either — `rust-toolchain.toml` pins `channel = "1.93"` as a directory override that beats the action's `rustup default`, and stable ignores `wrap_comments` silently.
- The date lives in one job-level `env` var. `rustup` auto-installs on `cargo +<channel>`, so a drifted second copy of the date would be silently installed and used rather than reported.
- `dtolnay/rust-toolchain@master` rather than `@nightly`, since the `@nightly` ref hard-codes the floating channel. The action ref stays unpinned, matching the rest of the file.

## Testing

`cargo +nightly-2026-08-27 fmt --all -- --check` on `main` exits 0 with no diff.

Heads-up for anyone who ran a bare `cargo +nightly fmt` in the last few days: your branch may carry newly re-wrapped comments that the pinned rustfmt will flag. Re-run `cargo +nightly-2026-08-27 fmt --all` to undo them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated formatting checks to use a pinned Rust toolchain for more consistent results.
  * Standardized formatting verification across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->