### PR TITLE
refactor(stelae): make the chained-publish lifecycle profile-generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5391,6 +5391,7 @@ version = "1.7.0-alpha.1"
 dependencies = [
  "fs4",
  "minicbor 0.26.4",
+ "serde",
  "serde_json",
  "stelae",
  "tempfile",

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -440,118 +440,13 @@ pub fn plan<S: StateStore>(
     )
 }
 
-/// The publish this one follows.
-///
-/// Two questions, one concept: what a new inscription attests about the steles
-/// before it, and which of their layers it may carry forward rather than build
-/// again. Both are answers only the previous publish has, and holding them
-/// together is what lets a publisher rebuild everything while still chaining —
-/// the `--rebuild` case, which suppresses [`Predecessor::adopt`] and leaves
-/// [`Predecessor::history`] exactly as it was.
-///
-/// The publish this one follows can be **this publish, interrupted**, which is
-/// what [`Predecessor::landed`] is for: a stele that never got sealed left
-/// layers behind that a restart may carry forward on exactly the terms a
-/// predecessor's do. Nothing here decides where that is written down — that is
-/// the implementor's, as `adopt` already is.
-///
-/// `Sync`, because [`export`] drives its layer producers from a pool of
-/// threads and each producer asks these questions for its own layers. An
-/// implementor that keeps state — an adoption counter, a resumption record —
-/// keeps it behind its own synchronization.
-pub trait Predecessor: Sync {
-    /// The history the new inscription carries: every prior publication,
-    /// contiguous and ascending, ending at `sequence - 1`.
-    ///
-    /// Assembling it is the implementor's business, and the protocol holds it
-    /// to the invariant when the document is validated
-    /// (`stelae::inscription`).
-    fn history(&self) -> &[HistoryEntry];
-
-    /// The descriptor to adopt for a layer of `kind` at `scope`, or `None` to
-    /// build it from the stores.
-    ///
-    /// An implementation that answers `Some` **has already arranged for the
-    /// transport to carry the layer's blob**; all that is left for [`export`]
-    /// is to not walk the store. That ordering is why this returns a descriptor
-    /// rather than a boolean: the answer and the arrangement are one act, and
-    /// an export that reused a descriptor whose blob nothing carried would
-    /// publish a manifest with a hole in it.
-    ///
-    /// The default reuses nothing, which is what makes [`First`] one line and
-    /// what a transport with no notion of "already there" — a directory —
-    /// wants.
-    fn adopt(
-        &self,
-        kind: &str,
-        scope: &serde_json::Value,
-    ) -> Result<Option<LayerDescriptor>, Error> {
-        let _ = (kind, scope);
-
-        Ok(None)
-    }
-
-    /// Whether a layer of `kind` at `scope` would be carried forward rather
-    /// than built — [`Predecessor::adopt`]'s question, asked without arranging
-    /// anything.
-    ///
-    /// Separate because `adopt` *acts*: it puts the blob in the transport and
-    /// counts the layer as reused. Forecasting how many layers a publish will
-    /// write has to ask the same question without taking either step, and a
-    /// forecast that called `adopt` would double-count every layer it looked
-    /// at.
-    ///
-    /// It may answer `true` where `adopt` will later answer `None`, in exactly
-    /// one case: a layer an interrupted publish recorded, whose blob the
-    /// repository has since dropped. That is only discovered by reaching for
-    /// it, which is the step this deliberately does not take — so this is the
-    /// honest forecast and `adopt` is the outcome.
-    ///
-    /// The default reuses nothing, matching [`Predecessor::adopt`]'s.
-    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
-        let _ = (kind, scope);
-
-        Ok(false)
-    }
-
-    /// Note that `descriptor`'s layer is in the transport and will be in the
-    /// manifest, whether it was built here or adopted.
-    ///
-    /// Called once per epoch layer, the moment it lands, so an implementor
-    /// writing it down leaves a record that means "this layer is up" rather
-    /// than "this layer was attempted" — the same boundary
-    /// [`crate::restore::Checkpoint`] records on its side. Layers land from
-    /// concurrent producers, so calls interleave; the record is keyed by kind
-    /// and scope, never by arrival order. The state shards are deliberately
-    /// never offered: they describe a moving tip, and a restart must rebuild
-    /// them.
-    ///
-    /// A failure here **fails the publish**. Recording is not a courtesy: a
-    /// record that silently stopped being written would cost the hours it
-    /// exists to save, at the moment nobody is watching.
-    ///
-    /// The default does nothing, which is what a publish with no host behind it
-    /// — a directory, a reproduction — wants.
-    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
-        let _ = descriptor;
-
-        Ok(())
-    }
-}
-
-/// The first stele of a repository: no history, nothing to inherit.
-///
-/// The protocol permits an empty history at any sequence, so this is not only
-/// the very first publish — it is every publish into a directory, which has no
-/// way to be asked what it already holds.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct First;
-
-impl Predecessor for First {
-    fn history(&self) -> &[HistoryEntry] {
-        &[]
-    }
-}
+/// The publish this one follows, which is [`stelae_driver::Predecessor`]: two
+/// questions — what a new inscription attests about the steles before it, and
+/// which of their layers it may carry forward — over documents, and nothing a
+/// store or a profile owns. Re-exported at its old path, with [`First`]
+/// alongside it, where every caller and the module documentation above already
+/// name them.
+pub use stelae_driver::{First, Predecessor};
 
 /// The stele this one follows, held as a document rather than as a repository.
 ///
@@ -655,11 +550,15 @@ impl Predecessor for Following {
         &self,
         kind: &str,
         scope: &serde_json::Value,
-    ) -> Result<Option<LayerDescriptor>, Error> {
+    ) -> Result<Option<LayerDescriptor>, stelae_driver::Error> {
         Ok(self.dumps.get(&crate::scope_key(kind, scope)?).cloned())
     }
 
-    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
+    fn carried_forward(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<bool, stelae_driver::Error> {
         Ok(self.dumps.contains_key(&crate::scope_key(kind, scope)?))
     }
 }
@@ -708,11 +607,15 @@ impl Predecessor for Attested {
         &self,
         kind: &str,
         scope: &serde_json::Value,
-    ) -> Result<Option<LayerDescriptor>, Error> {
+    ) -> Result<Option<LayerDescriptor>, stelae_driver::Error> {
         Ok(self.dumps.get(&crate::scope_key(kind, scope)?).cloned())
     }
 
-    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
+    fn carried_forward(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<bool, stelae_driver::Error> {
         Ok(self.dumps.contains_key(&crate::scope_key(kind, scope)?))
     }
 }

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -443,9 +443,7 @@ pub fn plan<S: StateStore>(
 /// The publish this one follows, which is [`stelae_driver::Predecessor`]: two
 /// questions — what a new inscription attests about the steles before it, and
 /// which of their layers it may carry forward — over documents, and nothing a
-/// store or a profile owns. Re-exported at its old path, with [`First`]
-/// alongside it, where every caller and the module documentation above already
-/// name them.
+/// store or a profile owns.
 pub use stelae_driver::{First, Predecessor};
 
 /// The stele this one follows, held as a document rather than as a repository.
@@ -653,8 +651,6 @@ fn retained_dumps(
 
 /// The history rule, which is [`stelae::inscription::history_for`]: it reads a
 /// predecessor's sequence and digest and composes nothing this profile owns.
-/// Re-exported at its old path, where every caller and the module documentation
-/// above already name it.
 pub use stelae::inscription::history_for;
 
 /// Refuse a predecessor from another chain.
@@ -677,7 +673,6 @@ pub fn same_network(previous: &Inscription, plan: &Plan) -> Result<(), Error> {
 
 /// Where a node stands against the repository's newest stele, which is
 /// [`stelae_driver::Standing`]: a comparison over two sequence numbers.
-/// Re-exported at its old path.
 pub use stelae_driver::Standing;
 
 /// Export a complete stele into `stele`: every layer, then the inscription.

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -756,6 +756,9 @@ impl From<stelae_driver::Error> for Error {
                 publishing,
                 reason,
             },
+            stelae_driver::Error::DatasetMismatch { expected, found } => {
+                Self::NetworkMismatch { expected, found }
+            }
         }
     }
 }
@@ -804,6 +807,63 @@ impl Profile for DolosProfile {
 
     fn max_record(&self) -> usize {
         MAX_RECORD
+    }
+}
+
+/// The lifecycle's half of the same answer.
+///
+/// Four questions [`Profile`] deliberately does not ask, because none of them
+/// is about naming: which kinds a closed window produces, which layers may be
+/// carried forward, and whether two documents stand on one chain. Every one of
+/// them is already decided somewhere in this crate — the constants, the
+/// inheritance rule and the position check — so this is delegation and not a
+/// second statement of any of it.
+impl stelae_driver::DriverProfile for DolosProfile {
+    fn epoch_kinds(&self) -> &[&str] {
+        &EPOCH_KINDS
+    }
+
+    fn dense_epoch_kinds(&self) -> &[&str] {
+        &DENSE_EPOCH_KINDS
+    }
+
+    fn is_inheritable(&self, kind: &str, scope: &serde_json::Value) -> bool {
+        is_inheritable(kind, scope)
+    }
+
+    /// Two steles stand on the same dataset when their `position` names the
+    /// same network magic. The check a publish and a reproduction share, and
+    /// the refusal an operator reads is still [`Error::NetworkMismatch`] — the
+    /// driver carries the two numbers and this crate spells the sentence.
+    fn check_same_dataset(
+        &self,
+        previous: &stelae::inscription::Inscription,
+        position: &serde_json::Value,
+    ) -> Result<(), stelae_driver::Error> {
+        // Read on the driver's terms and refused in this crate's words. The
+        // only failure `read_position` has is a malformed field, which is a
+        // refusal the driver names too — so the round trip back through
+        // `From<stelae_driver::Error>` restores the very variant and message
+        // this crate would have raised on its own.
+        let magic = |value: &serde_json::Value| match read_position(value) {
+            Ok(position) => Ok(position.network.magic()),
+            Err(Error::MalformedInscription { field, reason }) => {
+                Err(stelae_driver::Error::MalformedInscription { field, reason })
+            }
+            Err(other) => Err(stelae_driver::Error::MalformedInscription {
+                field: "position".to_owned(),
+                reason: other.to_string(),
+            }),
+        };
+
+        let found = magic(&previous.position)?;
+        let expected = magic(position)?;
+
+        if found != expected {
+            return Err(stelae_driver::Error::DatasetMismatch { expected, found });
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -214,7 +214,8 @@ pub fn state_ns_for(kind: &str) -> Option<Namespace> {
 }
 
 /// Whether `kind` is one of the fourteen state kinds — the tip predicate the
-/// staging arithmetic in [`registry`] sums under.
+/// driver's staging arithmetic sums under, reaching it through
+/// [`stelae_driver::DriverProfile::is_state_kind`].
 pub fn is_state_kind(kind: &str) -> bool {
     state_ns_for(kind).is_some()
 }
@@ -812,12 +813,13 @@ impl Profile for DolosProfile {
 
 /// The lifecycle's half of the same answer.
 ///
-/// Four questions [`Profile`] deliberately does not ask, because none of them
-/// is about naming: which kinds a closed window produces, which layers may be
-/// carried forward, and whether two documents stand on one chain. Every one of
-/// them is already decided somewhere in this crate — the constants, the
-/// inheritance rule and the position check — so this is delegation and not a
-/// second statement of any of it.
+/// Five questions [`Profile`] deliberately does not ask, because none of them
+/// is about naming: which kinds a closed window produces, which of them carry
+/// the tip, which layers may be carried forward, and whether two documents
+/// stand on one chain. Every one of them is already decided somewhere in this
+/// crate — the constants, the state split, the inheritance rule and the
+/// position check — so this is delegation and not a second statement of any of
+/// it.
 impl stelae_driver::DriverProfile for DolosProfile {
     fn epoch_kinds(&self) -> &[&str] {
         &EPOCH_KINDS
@@ -825,6 +827,10 @@ impl stelae_driver::DriverProfile for DolosProfile {
 
     fn dense_epoch_kinds(&self) -> &[&str] {
         &DENSE_EPOCH_KINDS
+    }
+
+    fn is_state_kind(&self, kind: &str) -> bool {
+        is_state_kind(kind)
     }
 
     fn is_inheritable(&self, kind: &str, scope: &serde_json::Value) -> bool {

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -544,167 +544,14 @@ pub fn inspect(registry: &Registry, point: Point) -> Result<Inspected, Error> {
     })
 }
 
-/// What a publish holds staged on disk at its peak.
-///
-/// Not the size of the stele: a publish never has the whole document on disk at
-/// once. What it does have at once is a state kind's pass, which keeps that
-/// kind's shard sinks open across a single walk of its namespace — see
-/// [`crate::export`] for why sixteen passes over `utxos` is the alternative —
-/// plus whatever epoch layers are in flight beside it. Summing *every* state
-/// layer rather than the widest kind's is deliberately conservative: the peak
-/// it prices is the pre-split one, an upper bound on any per-kind pass.
-///
-/// "Epoch layers beside it" is a handful and not one, because the transport
-/// uploads concurrently: a layer's staging file lives until its own round trip
-/// lands, so as many finished layers as the transport has permits can sit on
-/// disk at once alongside the pass. How many that is comes from
-/// [`stelae::oci::Registry::concurrency`] — asked of the transport rather than
-/// assumed here — and *which* ones is the largest that many, since the peak is
-/// the worst arrangement and nothing orders the uploads.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct StagingPeak {
-    /// Every state layer, summed — the conservative reading above.
-    pub state_bytes: u64,
-    /// The non-state layers that can be staged at once, largest first: as many
-    /// as the transport uploads concurrently, or all of them where the stele
-    /// has fewer than that. Empty on a stele that is all state, and on a
-    /// [`StagingPeak::default`] nothing was measured into.
-    pub concurrent_other_bytes: Vec<u64>,
-    /// Layers the predecessor's manifest stated no size for. Non-zero makes
-    /// every number here a floor rather than an estimate.
-    pub unsized_layers: usize,
-}
-
-impl StagingPeak {
-    /// Compressed bytes the scratch volume has to hold at once.
-    ///
-    /// Saturating throughout, because these are a manifest's numbers and a
-    /// manifest is not this node's document: a wrapped sum would be a *small*
-    /// need, which is the one direction a refusal must never be wrong in.
-    pub fn bytes(&self) -> u64 {
-        self.concurrent_other_bytes
-            .iter()
-            .fold(self.state_bytes, |total, bytes| {
-                total.saturating_add(*bytes)
-            })
-    }
-
-    /// The largest non-state layer, which is the first of the ones staged at
-    /// once.
-    pub fn largest_other_bytes(&self) -> u64 {
-        self.concurrent_other_bytes.first().copied().unwrap_or(0)
-    }
-}
-
-/// Size the staging peak of the next publish from the stele before it.
-///
-/// A proxy, and deliberately so: the numbers are the *predecessor's* layers,
-/// not this publish's, because this publish's layers do not exist until it
-/// builds them and sizing them would mean building them. One epoch of drift is
-/// what the proxy costs, against a check that otherwise cannot exist at all —
-/// and the refuse/warn split is what keeps it honest, since a shortfall against
-/// last epoch's sizes is still a measured shortfall.
-///
-/// Off the manifest the pull already fetched, and no per-layer `HEAD`: the
-/// promise [`preview`] makes about a dry run holds here too.
-///
-/// `Ok(None)` is a first publish — no predecessor, nothing to size from — which
-/// [`preflight`] turns into a warning rather than a refusal.
-///
-/// **Never call this from inside an async context.** See [`open`].
-pub fn staging_peak(registry: &Registry) -> Result<Option<StagingPeak>, Error> {
-    let Some(previous) = registry.latest(&DolosProfile)? else {
-        return Ok(None);
-    };
-
-    let inscription = previous.read_inscription()?;
-    let blobs = previous.blob_index()?;
-
-    let mut peak = StagingPeak::default();
-    let mut others = Vec::new();
-
-    for descriptor in &inscription.layers {
-        match previous.compressed_size(&blobs, descriptor)? {
-            None => peak.unsized_layers += 1,
-            // Every state layer adds — the conservative sum-all-state rule the
-            // type documents.
-            Some(bytes) if crate::is_state_kind(&descriptor.kind) => {
-                peak.state_bytes = peak.state_bytes.saturating_add(bytes)
-            }
-            Some(bytes) => others.push(bytes),
-        }
-    }
-
-    // The largest as many as the transport stages at once, and no more: a stele
-    // with fewer non-state layers than the transport has permits cannot put
-    // more of them on disk than it has.
-    others.sort_unstable_by(|a, b| b.cmp(a));
-    others.truncate(registry.concurrency());
-
-    peak.concurrent_other_bytes = others;
-
-    Ok(Some(peak))
-}
-
-/// Refuse a publish whose scratch volume cannot hold what it stages at once.
-///
-/// The publish side of [`crate::preflight`]'s one policy, which
-/// [`crate::restore::Plan::preflight`] is the other side of: a measured
-/// shortfall refuses, naming the volume and the shortfall, and what cannot be
-/// sized warns and proceeds.
-///
-/// The volume is the transport's own — [`stelae::oci::Registry::scratch_dir`] —
-/// so the directory sized here and the directory written to cannot come apart.
-/// A transport opened without one stages in the platform temporary directory,
-/// which it does not name, so there is nothing to size and nothing to refuse;
-/// [`open`] always sets one, so no `dolos` command reaches that case.
-///
-/// **Never call this from inside an async context.** See [`open`].
-pub fn preflight(registry: &Registry) -> Result<(), Error> {
-    let Some(scratch_dir) = registry.scratch_dir() else {
-        tracing::warn!(
-            "this transport stages in the platform temporary directory, which it does not name; \
-             skipping the free-space check for {STAGING}"
-        );
-
-        return Ok(());
-    };
-
-    Ok(crate::preflight::check(&[staging_need(
-        staging_peak(registry)?,
-        scratch_dir,
-    )])?)
-}
-
-/// What the staging asks of its volume, as [`crate::preflight`] takes it.
-///
-/// Split out of [`preflight`] so the demand and the transport that produced it
-/// can be tested apart: sizing a peak needs a registry, and deciding what a
-/// peak means for a volume needs none.
-const STAGING: &str = "staging this publish";
-
-fn staging_need(
-    peak: Option<StagingPeak>,
-    scratch_dir: &std::path::Path,
-) -> crate::preflight::Need {
-    let Some(peak) = peak else {
-        return crate::preflight::Need::unsized_because(
-            STAGING,
-            scratch_dir,
-            "this repository holds no stele to size the staging from",
-        );
-    };
-
-    if peak.unsized_layers > 0 {
-        tracing::warn!(
-            unsized_layers = peak.unsized_layers,
-            "the predecessor's manifest states no size for some of its layers; the staging \
-             estimate is a floor"
-        );
-    }
-
-    crate::preflight::Need::of(STAGING, scratch_dir, peak.bytes())
-}
+/// What a publish holds staged on disk at its peak, and the free-space refusal
+/// built on it — which are [`stelae_driver::publish`]'s: sizing a stele's
+/// layers is lifecycle arithmetic, and the only thing about it that was ever
+/// this profile's is which kinds carry the tip. That is now
+/// [`stelae_driver::DriverProfile::is_state_kind`], answered by
+/// [`crate::is_state_kind`]. Re-exported at their old paths; the profile they
+/// need is supplied by the caller.
+pub use stelae_driver::publish::{preflight, staging_peak, StagingPeak};
 
 /// Publish `plan` into the repository `publishing` names, chained to whatever
 /// is already there.
@@ -891,6 +738,8 @@ fn chained<'a>(
     latest: Option<&'a Stele>,
     plan: &Plan,
 ) -> Result<Chained<'a>, Error> {
+    // This profile identifies a dataset by its network magic; the driver holds
+    // the number and never reads it.
     let origin = Origin::of(
         publishing.registry,
         plan.network.magic(),
@@ -1086,7 +935,7 @@ mod tests {
     fn origin(repository: &str) -> Origin {
         Origin {
             repository: repository.to_owned(),
-            network_magic: 2,
+            dataset_id: 2,
             parameters: crate::parameters(&Default::default()),
             compression: crate::compression(),
         }
@@ -1224,10 +1073,10 @@ mod tests {
             (origin("oci://example.test/dolos-preprod"), "repository"),
             (
                 Origin {
-                    network_magic: 1,
+                    dataset_id: 1,
                     ..mine.clone()
                 },
-                "network magic",
+                "dataset id",
             ),
             (
                 Origin {
@@ -1271,7 +1120,7 @@ mod tests {
         assert!(mine.differences_from(&mine).is_empty());
         assert_eq!(
             origin("oci://example.test/other").differences_from(&Origin {
-                network_magic: 1,
+                dataset_id: 1,
                 parameters: json!({"stateShards": 1}),
                 compression: Compression {
                     algo: "zstd".to_owned(),
@@ -1279,7 +1128,7 @@ mod tests {
                 },
                 ..mine.clone()
             }),
-            vec!["repository", "network magic", "parameters", "compression"]
+            vec!["repository", "dataset id", "parameters", "compression"]
         );
     }
 
@@ -1292,45 +1141,5 @@ mod tests {
             uncompressed_size: 1,
             scope,
         }
-    }
-
-    /// The publish half of the one policy, over a peak this test supplies.
-    ///
-    /// The other half of the chain — that the peak is the predecessor's
-    /// sixteen shards plus its largest other layer — needs a registry to state
-    /// a manifest and is in `tests/publish.rs`. Between them the composition
-    /// `preflight` performs is covered: this end decides, that end measures.
-    #[test]
-    fn a_measured_staging_shortfall_refuses_and_a_first_publish_does_not() {
-        let temp = tempfile::tempdir().unwrap();
-
-        let check = |peak| -> Result<(), Error> {
-            Ok(crate::preflight::check(&[staging_need(peak, temp.path())])?)
-        };
-
-        // No predecessor, so nothing sized it, so nothing refuses.
-        check(None).unwrap();
-
-        check(Some(StagingPeak::default())).unwrap();
-
-        // A peak no volume holds. Both halves are set, so the refusal is on
-        // their sum and not on either alone.
-        let err = check(Some(StagingPeak {
-            state_bytes: u64::MAX / 2,
-            concurrent_other_bytes: vec![u64::MAX / 4, u64::MAX / 4],
-            unsized_layers: 0,
-        }))
-        .unwrap_err();
-
-        let Error::NotEnoughSpace(message) = &err else {
-            panic!("{err:?}");
-        };
-
-        assert!(message.contains(STAGING), "{message}");
-        assert!(
-            message.contains(&temp.path().display().to_string()),
-            "{message}"
-        );
-        assert!(message.contains("short"), "{message}");
     }
 }

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -133,26 +133,16 @@
 //! configuration and its own environment and hands the answer to [`open`]. The
 //! same goes for where the layers are staged on the way through.
 
-use std::{
-    collections::BTreeMap,
-    io::Write as _,
-    num::NonZeroUsize,
-    path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Mutex,
-    },
-};
+use std::path::{Path, PathBuf};
 
 use dolos_core::{ArchiveStore, IndexStore, StateStore};
-use serde::{Deserialize, Serialize};
 use stelae::{
     digest::LayerDigests,
     frame::Limits,
-    inscription::{Compression, HistoryEntry, Inscription, LayerDescriptor},
-    oci::{Options, Stele, Transfer},
+    inscription::{Inscription, LayerDescriptor},
+    oci::{Stele, Transfer},
     progress::Observer,
-    transport::{BlobIndex, WrittenLayer},
+    transport::BlobIndex,
     Digest, SteleReader as _, SteleWriter,
 };
 
@@ -169,11 +159,13 @@ use stelae::{
 /// resolved them to.
 pub use stelae::oci::{Auth, Registry, Repository, DEFAULT_CONCURRENCY, SCHEME};
 
+use stelae_driver::publish::Chained;
+
 use crate::{
-    export::{self, history_for, same_network, Plan, Predecessor, Standing},
+    export::{self, Plan, Predecessor as _, Standing},
     layers::digests,
     restore::{Outlook, Restoring, Summary, Target},
-    scope_key, DolosProfile, Error, Scope as _, DENSE_EPOCH_KINDS, EPOCH_KINDS,
+    DolosProfile, Error, Scope as _, DENSE_EPOCH_KINDS, EPOCH_KINDS,
 };
 
 /// Which stele in a repository a restore wants.
@@ -276,27 +268,10 @@ where
     crate::restore::restore_stele(&stele, node, registry.scratch_dir(), target, observer)
 }
 
-/// Open a repository in a registry.
-///
-/// Here rather than at the call site so the `dolos` binary keeps never naming
-/// the protocol crate — the same property [`crate::export::publish`] and
-/// [`crate::restore::restore_dir`] hold for a directory.
-///
-/// `insecure` speaks plaintext HTTP. It is for a registry on a loopback address
-/// or a mirror inside a cluster, and for nothing that is reachable from outside
-/// one.
-///
-/// `auth` is who to authenticate as, decided by the caller. A node resolves it
-/// from its own configuration and environment; nothing here goes looking, for
-/// the reason `stelae::oci` states one layer down and this crate has no more
-/// standing to override than that one does.
-///
-/// `scratch_dir` is where layers are staged, in both directions. The transport
-/// creates it when the first layer needs it, so it need not exist yet.
-///
-/// `tuning` is the publish path's concurrency and the one check an operator may
-/// want back; [`Tuning::default`] is what every caller that is not publishing
-/// wants.
+/// Open a repository in a registry, which is [`stelae_driver::publish::open`]:
+/// a transport's own configuration, and nothing this profile decides.
+/// Re-exported at its old path, with [`Tuning`] alongside it, and wrapped only
+/// to keep this crate's error at the boundary.
 ///
 /// **Never call any of this from inside an async context.** The transport owns
 /// a runtime and enters it with `block_on`; `stelae::oci`'s module
@@ -308,98 +283,27 @@ pub fn open(
     scratch_dir: PathBuf,
     tuning: Tuning,
 ) -> Result<Registry, Error> {
-    Ok(Registry::open(
+    Ok(stelae_driver::publish::open(
         repository,
-        Options {
-            insecure,
-            scratch_dir: Some(scratch_dir),
-            auth,
-            concurrency: tuning.concurrency.map_or(DEFAULT_CONCURRENCY, Into::into),
-            verify_adopted: tuning.verify_adopted,
-            // Not an operator's knob and deliberately not one: the number that
-            // absorbs a registry's transient `5xx` is the transport's own
-            // measurement, and an outage longer than it is answered a level up,
-            // where `snapshot backfill` re-runs the whole publish rather than
-            // dying into a pod restart.
-            attempts: stelae::oci::DEFAULT_ATTEMPTS,
-            // Nor these, for a related reason: both are facts about the
-            // registry this publishes to and about the pod the publisher runs
-            // in, measured rather than chosen, and neither moves when an
-            // operator changes how fast a publish goes. `upload_memory` in
-            // particular is what keeps `--concurrency` from being a claim on
-            // memory — raising one does not raise the other.
-            monolithic_max: stelae::oci::DEFAULT_MONOLITHIC_MAX,
-            upload_memory: stelae::oci::DEFAULT_UPLOAD_MEMORY,
-        },
+        insecure,
+        auth,
+        scratch_dir,
+        tuning,
     )?)
 }
 
-/// What an operator may set about *how* a publish moves, as against where it
-/// goes.
+pub use stelae_driver::publish::Tuning;
+
+/// Where a publish is going and what the host running it knows about itself,
+/// which is [`stelae_driver::publish::Publishing`]. Re-exported at its old
+/// path.
 ///
-/// Separated from [`open`]'s other arguments because it is the only one of them
-/// a caller can leave alone: a repository, a credential and a staging directory
-/// are facts a publish cannot be run without, and these two are a default and
-/// an escape hatch. A restore or an inspection passes [`Tuning::default`] and
-/// means it.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Tuning {
-    /// How many layer round trips run at once; `None` is
-    /// [`DEFAULT_CONCURRENCY`].
-    pub concurrency: Option<NonZeroUsize>,
-
-    /// Re-prove that the registry still holds each blob carried forward out of
-    /// the predecessor's manifest. See [`stelae::oci::Options::verify_adopted`]
-    /// for why this is off.
-    pub verify_adopted: bool,
-}
-
-/// Where a publish is going, and what the host running it knows about itself.
-///
-/// The publish-side counterpart of [`crate::restore::Restoring`], and it holds
-/// the transport for the same reason that one holds `storage_path`: these are
-/// the facts a publish is *given*, as against the ones it derives. Threading
-/// them separately is what took [`publish`] to the edge of its signature, and
-/// they have never been supplied from different places.
-#[derive(Clone, Copy)]
-pub struct Publishing<'a> {
-    /// The repository being published into, already opened.
-    pub registry: &'a Registry,
-
-    /// `storage.path` — where the stores live, and with them the resumption
-    /// record. `None` for a caller with no node behind it, which records
-    /// nothing and resumes nothing.
-    pub storage_path: Option<&'a Path>,
-
-    /// The operator's `--rebuild`: build every layer, inherit none, and start
-    /// the record over.
-    pub rebuild: bool,
-}
-
-impl<'a> Publishing<'a> {
-    /// A publish into `registry` that keeps no record and rebuilds nothing.
-    pub fn new(registry: &'a Registry) -> Self {
-        Self {
-            registry,
-            storage_path: None,
-            rebuild: false,
-        }
-    }
-
-    /// The same publish, recording what it finishes beside the stores at
-    /// `storage_path`.
-    pub fn recording_in(self, storage_path: &'a Path) -> Self {
-        Self {
-            storage_path: Some(storage_path),
-            ..self
-        }
-    }
-
-    /// The same publish, with the operator's `--rebuild`.
-    pub fn rebuilding(self, rebuild: bool) -> Self {
-        Self { rebuild, ..self }
-    }
-}
+/// The one thing that changed on the way down is `storage_path`, which is now
+/// `record_path`: the driver takes the resumption record's path rather than a
+/// node's storage directory, because deriving one from the other is this
+/// profile's layout and not a lifecycle's. [`record_path_in`] is the
+/// derivation, and it stays here.
+pub use stelae_driver::publish::Publishing;
 
 /// Name of the resumption record inside a node's storage directory.
 ///
@@ -414,214 +318,12 @@ pub fn record_path_in(storage_path: &Path) -> PathBuf {
     storage_path.join(PUBLISH_RECORD_FILE)
 }
 
-/// What a record has to agree with before a single layer in it is adopted.
-///
-/// Everything a recorded layer's bytes and address depend on that is *not* in
-/// the layer's own key. The key is the kind plus the descriptor scope, and that
-/// scope names an epoch and a slot window and nothing else — so:
-///
-/// - **the repository**, because a blob digest is an address in one repository
-///   and means nothing in another;
-/// - **the network magic**, because two chains' epoch 500 are different bytes
-///   under one key. The descriptor scope deliberately carries no magic — the
-///   layer's own header record does — so this is the only place the record can
-///   hold it;
-/// - **the parameters and the compression**, which are the inscription's own
-///   statement of how its layers were built. A binary that changed either would
-///   rebuild a recorded layer into different bytes, and the record would be
-///   offering an answer to a question nobody is asking any more.
-///
-/// A mismatch in any of them makes the record a fresh one for the origin at
-/// hand. Nothing is repaired and nothing is merged: the layers it named are
-/// still in the registry, and the publish that wants them will build them
-/// again and find them there.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct Origin {
-    /// The repository the layers were uploaded to, as the transport names it.
-    pub repository: String,
-    /// The network the stores stood on.
-    pub network_magic: u64,
-    /// The inscription parameters the layers were built under.
-    pub parameters: serde_json::Value,
-    /// The compression they were built with.
-    pub compression: Compression,
-}
-
-impl Origin {
-    /// What a publish of `plan` into `registry` would record under.
-    fn of(registry: &Registry, plan: &Plan) -> Self {
-        Self {
-            repository: registry.repository().to_string(),
-            network_magic: plan.network.magic(),
-            parameters: crate::parameters(&plan.retained),
-            compression: crate::compression(),
-        }
-    }
-
-    /// The fields `self` and `other` disagree on, in the order [`Origin`]
-    /// states them.
-    ///
-    /// One of the four ways to differ changes the repository, so a refusal
-    /// that reported the two repository names alone would read, in the other
-    /// three, as though the two publishes matched. Names rather than values:
-    /// `parameters` is arbitrary JSON, and what an operator needs from the
-    /// event is which knob moved between the two runs.
-    fn differences_from(&self, other: &Self) -> Vec<&'static str> {
-        [
-            (self.repository != other.repository, "repository"),
-            (self.network_magic != other.network_magic, "network magic"),
-            (self.parameters != other.parameters, "parameters"),
-            (self.compression != other.compression, "compression"),
-        ]
-        .into_iter()
-        .filter_map(|(differs, field)| differs.then_some(field))
-        .collect()
-    }
-}
-
-/// The epoch layers an interrupted publish got as far as uploading.
-///
-/// Written after each layer's upload succeeds and deleted once the stele is
-/// sealed, so a record that exists describes a publish that did not finish. See
-/// the module documentation for what it is and — more to the point — what it is
-/// not.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct PublishRecord {
-    pub origin: Origin,
-
-    /// The layers whose blobs are up, each as the transport measured it.
-    ///
-    /// The whole [`WrittenLayer`] rather than the digest pair the adoption
-    /// needs: the descriptor is what the new manifest has to state about the
-    /// layer, and a record that held only its identity would have to invent the
-    /// rest. In the canonical order of their keys, so the same progress is the
-    /// same bytes.
-    pub layers: Vec<WrittenLayer>,
-}
-
-impl PublishRecord {
-    /// Read the record at `path`, or `None` if there is none.
-    ///
-    /// **Only absence is `None`**, on [`crate::restore::PROGRESS_FILE`]'s
-    /// reasoning turned around: a file that exists and does not parse is an
-    /// error rather than an empty resume, because reading it as "nothing has
-    /// been uploaded" silently costs the rebuild this file exists to avoid.
-    /// `--rebuild` is how an operator asks for that outcome on purpose.
-    pub fn load(path: &Path) -> Result<Option<Self>, Error> {
-        let raw = match read_file(path) {
-            Ok(raw) => raw,
-            Err(e) => return Err(Error::Stelae(e)),
-        };
-
-        let Some(raw) = raw else {
-            return Ok(None);
-        };
-
-        Ok(Some(
-            serde_json::from_slice(&raw).map_err(|e| Error::Stelae(e.into()))?,
-        ))
-    }
-
-    /// Delete the record at `path`. A file that is not there is not an error.
-    pub fn remove(path: &Path) -> Result<(), Error> {
-        match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(Error::Stelae(e.into())),
-        }
-    }
-
-    /// Write the record at `path`, atomically.
-    ///
-    /// Through a temporary sibling and a rename, for the reason
-    /// `stelae::plan::RestoreProgress::save` states on its side: the failure
-    /// this file exists to survive is a process that stops mid-write, and a
-    /// half-written record would be refused by [`PublishRecord::load`] —
-    /// correctly, and uselessly, since the publish it described would then have
-    /// to start over.
-    pub fn save(&self, path: &Path) -> Result<(), Error> {
-        save_atomically(
-            path,
-            &serde_json::to_vec(self).map_err(stelae::Error::from)?,
-        )
-        .map_err(Error::Stelae)
-    }
-
-    /// The layers this record offers, keyed the way [`Chained`] looks them up.
-    ///
-    /// An [`Origin`] the caller is not publishing under offers nothing: see
-    /// [`Origin`] for why a mismatch is a fresh start rather than a merge.
-    fn table(&self, origin: &Origin) -> Result<BTreeMap<(String, String), WrittenLayer>, Error> {
-        if &self.origin != origin {
-            tracing::info!(
-                differs = %self.origin.differences_from(origin).join(", "),
-                recorded = %self.origin.repository,
-                publishing = %origin.repository,
-                "a resumption record was left by a publish this one does not continue; \
-                 every layer will be rebuilt"
-            );
-
-            return Ok(BTreeMap::new());
-        }
-
-        let mut table = BTreeMap::new();
-
-        for layer in &self.layers {
-            // The same filter `inheritable_layers` applies to a predecessor's
-            // manifest, applied again on the way in: a record naming a state
-            // *tip* shard is a record nothing wrote, and honouring one would
-            // carry a stale tip into a manifest. A retained dump's scope names
-            // its epoch, so it passes here for the same reason an epoch layer
-            // does.
-            if !crate::is_inheritable(&layer.descriptor.kind, &layer.descriptor.scope) {
-                continue;
-            }
-
-            table.insert(
-                scope_key(&layer.descriptor.kind, &layer.descriptor.scope)?,
-                layer.clone(),
-            );
-        }
-
-        Ok(table)
-    }
-}
-
-fn read_file(path: &Path) -> Result<Option<Vec<u8>>, stelae::Error> {
-    match std::fs::read(path) {
-        Ok(raw) => Ok(Some(raw)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(e.into()),
-    }
-}
-
-fn save_atomically(path: &Path, bytes: &[u8]) -> Result<(), stelae::Error> {
-    let name = path
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_default();
-
-    let staging = path.with_file_name(format!(".{name}.{}.tmp", std::process::id()));
-
-    // Scoped so the handle is closed before the rename: Windows refuses to
-    // rename a file that is still open.
-    {
-        let mut file = std::fs::File::create(&staging)?;
-
-        file.write_all(bytes)?;
-
-        // Before the rename, not after: a rename that lands pointing at bytes
-        // the page cache has not written yet is the same truncated file by
-        // another route.
-        file.sync_all()?;
-    }
-
-    std::fs::rename(&staging, path)?;
-
-    Ok(())
-}
+/// What an interrupted publish left behind and what it has to agree with
+/// before a single layer of it is adopted, which is
+/// [`stelae_driver::publish`]'s: a note about blobs in a repository, keyed by
+/// the pair that identifies a layer. Re-exported at their old paths, and their
+/// serialized shape is frozen by the fixtures that carry it.
+pub use stelae_driver::publish::{Origin, PublishRecord};
 
 /// What a publish into a repository did.
 #[derive(Debug, Clone)]
@@ -669,22 +371,12 @@ pub struct Preview {
 ///
 /// **Never call this from inside an async context.** See [`open`].
 pub fn standing(registry: &Registry, plan: &Plan) -> Result<Standing, Error> {
-    let latest = registry
-        .latest(&DolosProfile)?
-        .map(|stele| stele.read_inscription())
-        .transpose()?;
-
-    if let Some(previous) = &latest {
-        // The same refusal a publish makes, made before the report rather than
-        // after it: a repository holding another network's chain is not "up to
-        // date" with this node in any sense worth reporting.
-        same_network(previous, plan)?;
-    }
-
-    Ok(Standing::read(
-        latest.map(|previous| previous.sequence),
+    Ok(stelae_driver::publish::standing(
+        registry,
+        &DolosProfile,
         plan.sequence,
-    ))
+        &plan.position()?,
+    )?)
 }
 
 /// What `snapshot verify` established about a published stele, transport side.
@@ -1083,7 +775,7 @@ where
 {
     let registry = publishing.registry;
     let latest = registry.latest(&DolosProfile)?;
-    let previous = Chained::new(publishing, latest.as_ref(), plan)?;
+    let previous = chained(publishing, latest.as_ref(), plan)?;
 
     // Reset before the export, so what comes back is this publish's cost and
     // not a total carried over from an earlier one through the same transport.
@@ -1106,7 +798,7 @@ where
     previous.forget_record()?;
 
     let identity = inscription.digest()?;
-    let layers_reused = previous.adopted.load(Ordering::Relaxed);
+    let layers_reused = previous.adopted();
 
     Ok(Published {
         layers_built: inscription.layers.len() - layers_reused,
@@ -1138,7 +830,7 @@ pub fn preview<A: ArchiveStore>(
 ) -> Result<Preview, Error> {
     let registry = publishing.registry;
     let latest = registry.latest(&DolosProfile)?;
-    let previous = Chained::new(publishing, latest.as_ref(), plan)?;
+    let previous = chained(publishing, latest.as_ref(), plan)?;
 
     // Every epoch selected contributes one `blocks` and one `indexes` layer and
     // as many log layers as it has namespaces with logs, the state tip
@@ -1178,326 +870,56 @@ pub fn preview<A: ArchiveStore>(
     // too — see `export::log_layers`, which asks the predecessor first.
     Ok(Preview {
         sequence: plan.sequence,
-        predecessor: previous.predecessor,
-        history: previous.history.len(),
+        predecessor: previous.predecessor(),
+        history: previous.history().len(),
         layers_built: total - layers_reused,
         layers_reused,
     })
 }
 
-/// The publish this one follows, in a repository — which may be itself.
+/// The publish `plan` follows in `publishing`'s repository.
 ///
-/// Holds the history it hands to the new inscription and the two tables of
-/// layers it is willing to let the new stele carry forward rather than build,
-/// both keyed by the pair that decides it: the layer's kind and the canonical
-/// encoding of its profile-owned scope.
-///
-/// The tables answer the same question from different standing. `inheritable`
-/// is the *predecessor's manifest* — a stele the repository serves, so a layer
-/// missing from it is a fault. `resumable` is *this publish's own record* of an
-/// attempt that died before it could write a manifest — a note, so a layer
-/// missing from the registry is only a rebuild. The manifest is consulted
-/// first, because a repository that states it holds a layer needs no note to
-/// say so.
-struct Chained<'a> {
-    registry: &'a Registry,
-    source: Option<&'a Stele>,
-    predecessor: Option<(u64, Digest)>,
-    history: Vec<HistoryEntry>,
-    inheritable: BTreeMap<(String, String), LayerDescriptor>,
-    resumable: BTreeMap<(String, String), WrittenLayer>,
-    record: Option<Recording>,
-    /// Atomic, like the record's lock below: [`export::export`] asks a
-    /// predecessor about layers from a pool of producer threads.
-    adopted: AtomicUsize,
-}
+/// [`stelae_driver::publish::Chained`] holds the history the new inscription
+/// carries and the two tables of layers it may take rather than build; nothing
+/// in it is this profile's but the policy it asks for, which arrives through
+/// [`stelae_driver::DriverProfile`]. This is the whole of the wiring: the parts
+/// the driver takes are the ones this profile composes — the sequence, the
+/// `position` document, the [`Origin`] a record is filed under, and the
+/// record's path, which is [`record_path_in`]'s and never derived down there.
+fn chained<'a>(
+    publishing: Publishing<'a>,
+    latest: Option<&'a Stele>,
+    plan: &Plan,
+) -> Result<Chained<'a>, Error> {
+    let origin = Origin::of(
+        publishing.registry,
+        plan.network.magic(),
+        crate::parameters(&plan.retained),
+        crate::compression(),
+    );
 
-/// The resumption record this publish is writing, open.
-///
-/// Seeded with what it inherits, so the file is the whole of what is up rather
-/// than the whole of what *this attempt* put up: an attempt that adopts twenty
-/// layers and adds one, then dies, has to leave twenty-one behind or the third
-/// attempt pays for the difference.
-///
-/// The lock is held across the file write as well as the map insert: each
-/// write rewrites the whole record, so two producers landing layers at once
-/// must serialize on the file or the later write would drop the earlier
-/// layer.
-struct Recording {
-    path: PathBuf,
-    origin: Origin,
-    layers: Mutex<BTreeMap<(String, String), WrittenLayer>>,
-}
-
-impl<'a> Chained<'a> {
-    fn new(
-        publishing: Publishing<'a>,
-        latest: Option<&'a Stele>,
-        plan: &Plan,
-    ) -> Result<Self, Error> {
-        let Publishing {
-            registry,
-            storage_path,
-            rebuild,
-        } = publishing;
-
-        let inscription = latest.map(|stele| stele.read_inscription()).transpose()?;
-
-        if let Some(previous) = &inscription {
-            // The pull that fetched this checked as a reader; this is the
-            // publish side, which inherits the chain and must attest it.
-            previous.check_profile_strict(&DolosProfile)?;
-            same_network(previous, plan)?;
-        }
-
-        let history = history_for(inscription.as_ref(), plan.sequence)?;
-
-        let predecessor = inscription
-            .as_ref()
-            .map(|previous| Ok::<_, Error>((previous.sequence, previous.digest()?)))
-            .transpose()?;
-
-        // Built only when it can be used. `rebuild` is the publisher choosing
-        // to reproduce rather than inherit, and it stops here rather than at
-        // `adopt` so that nothing downstream has to remember it was set.
-        let inheritable = match (rebuild, &inscription) {
-            (false, Some(previous)) => inheritable_layers(previous)?,
-            _ => BTreeMap::new(),
-        };
-
-        let origin = Origin::of(registry, plan);
-
-        // Read on the same terms, and it is the *honouring* that `rebuild`
-        // gates rather than the reading — the asymmetry
-        // `crate::restore::Checkpoint::open` states, for the same reason. A
-        // publisher that asked to rebuild gets a record that starts empty and
-        // overwrites whatever was there, so nothing an earlier attempt believed
-        // can survive the run that was meant to settle it.
-        let resumable = match (rebuild, storage_path) {
-            (false, Some(storage_path)) => {
-                match PublishRecord::load(&record_path_in(storage_path))? {
-                    Some(record) => record.table(&origin)?,
-                    None => BTreeMap::new(),
-                }
-            }
-            _ => BTreeMap::new(),
-        };
-
-        if !resumable.is_empty() {
-            tracing::info!(
-                layers = resumable.len(),
-                "an interrupted publish left epoch layers in this repository; \
-                 they will be carried forward rather than rebuilt"
-            );
-        }
-
-        let record = storage_path.map(|storage_path| Recording {
-            path: record_path_in(storage_path),
-            origin,
-            layers: Mutex::new(resumable.clone()),
-        });
-
-        Ok(Self {
-            registry,
-            source: latest.filter(|_| !rebuild),
-            predecessor,
-            history,
-            inheritable,
-            resumable,
-            record,
-            adopted: AtomicUsize::new(0),
-        })
-    }
-
-    /// Delete the resumption record.
-    ///
-    /// Called once the stele is sealed and never before it. See
-    /// [`publish_into`].
-    fn forget_record(&self) -> Result<(), Error> {
-        match &self.record {
-            Some(record) => PublishRecord::remove(&record.path),
-            None => Ok(()),
-        }
-    }
-}
-
-impl Predecessor for Chained<'_> {
-    fn history(&self) -> &[HistoryEntry] {
-        &self.history
-    }
-
-    /// What [`preview`] reports, and it spends no `HEAD`: the promise a dry run
-    /// makes is about what the scopes permit. The record's own gate — that the
-    /// registry still holds the blob — runs in [`Predecessor::adopt`] and can
-    /// turn one of these into a rebuild, which is the direction a dry run is
-    /// allowed to be wrong in.
-    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
-        let key = scope_key(kind, scope)?;
-
-        Ok(self.inheritable.contains_key(&key) || self.resumable.contains_key(&key))
-    }
-
-    fn adopt(
-        &self,
-        kind: &str,
-        scope: &serde_json::Value,
-    ) -> Result<Option<LayerDescriptor>, Error> {
-        let key = scope_key(kind, scope)?;
-
-        // The arrangement and the answer are one act, in both branches: by the
-        // time this returns a descriptor, the transport is already carrying the
-        // blob, and the `HEAD` that proves the registry still has it has already
-        // happened.
-        if let (Some(source), Some(descriptor)) = (self.source, self.inheritable.get(&key)) {
-            self.registry.adopt_layer(source, descriptor.clone())?;
-            self.adopted.fetch_add(1, Ordering::Relaxed);
-
-            return Ok(Some(descriptor.clone()));
-        }
-
-        let Some(recorded) = self.resumable.get(&key) else {
-            return Ok(None);
-        };
-
-        if !self.registry.adopt_carried(recorded.clone())? {
-            tracing::warn!(
-                kind,
-                %scope,
-                "a recorded layer's blob is no longer in the repository; rebuilding it"
-            );
-
-            return Ok(None);
-        }
-
-        self.adopted.fetch_add(1, Ordering::Relaxed);
-
-        Ok(Some(recorded.descriptor.clone()))
-    }
-
-    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
-        let Some(record) = &self.record else {
-            return Ok(());
-        };
-
-        if !crate::is_inheritable(&descriptor.kind, &descriptor.scope) {
-            return Ok(());
-        }
-
-        let Some(written) = self.registry.carried(&descriptor.diff_id) else {
-            tracing::warn!(
-                kind = descriptor.kind,
-                scope = %descriptor.scope,
-                "this layer is not in the transport, so nothing was recorded for it; \
-                 an interrupted publish will rebuild it"
-            );
-
-            return Ok(());
-        };
-
-        // The transport is asked for its *measurement* and not for its
-        // descriptor. `carried` finds a layer by `diffId`, and one `diffId` can
-        // now wear two descriptors — the dump a publish cuts out of its own tip
-        // is the tip's bytes — so recording what the lookup returned verbatim
-        // would file the dump under the tip's scope, where nothing looks for it
-        // and where it would be discarded on the way back in.
-        let written = WrittenLayer {
-            descriptor: descriptor.clone(),
-            digests: written.digests,
-        };
-
-        // Held across the save below, not just the insert — see [`Recording`].
-        let mut layers = record
-            .layers
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
-        layers.insert(scope_key(&descriptor.kind, &descriptor.scope)?, written);
-
-        PublishRecord {
-            origin: record.origin.clone(),
-            layers: layers.values().cloned().collect(),
-        }
-        .save(&record.path)
-    }
-}
-
-/// The layers a new stele may inherit from `previous`, keyed by kind and scope.
-///
-/// [`crate::is_inheritable`] decides, and it decides on the scope as well as
-/// the kind. A state *tip* shard is out: it changes every publish, and —
-/// independently — its descriptor scope names no epoch, so scope equality
-/// could not tell one publish's shard from another's. A retained state dump is
-/// in: it is a closed epoch's state under a scope that names that epoch.
-/// `digests` has no source in this slice.
-///
-/// Two layers of one kind claiming one scope, described differently in any
-/// respect, is a refusal rather than a first-wins: it means the stele being
-/// chained to describes the same window twice and disagrees with itself about
-/// what is in it, and inheriting either answer would publish that disagreement
-/// forward. "In any respect" and not "with different identities", because
-/// `records` and `uncompressed_size` are determined by the bytes a `diff_id`
-/// names — so a disagreement about them under one identity is the same
-/// contradiction wearing a quieter shape.
-fn inheritable_layers(
-    previous: &Inscription,
-) -> Result<BTreeMap<(String, String), LayerDescriptor>, Error> {
-    let mut inheritable = BTreeMap::new();
-
-    for layer in &previous.layers {
-        if !crate::is_inheritable(&layer.kind, &layer.scope) {
-            continue;
-        }
-
-        let key = scope_key(&layer.kind, &layer.scope)?;
-
-        if let Some(existing) = inheritable.get(&key) {
-            let existing: &LayerDescriptor = existing;
-
-            // The whole descriptor, not the identity alone. `records` and
-            // `uncompressed_size` are functions of the bytes `diff_id` names,
-            // so two descriptors sharing an identity and disagreeing about
-            // either are a stele contradicting itself just as surely as two
-            // identities would be — and `adopt_layer` carries
-            // `uncompressed_size` forward into a stele that never reads the
-            // bytes that would settle it.
-            if existing != layer {
-                // Spelled out rather than named by identity alone: the two can
-                // now differ while sharing a `diff_id`, and a message printing
-                // one digest twice would describe nothing.
-                let describe = |layer: &LayerDescriptor| {
-                    format!(
-                        "{} ({} records, {} bytes)",
-                        layer.diff_id, layer.records, layer.uncompressed_size,
-                    )
-                };
-
-                return Err(Error::malformed_inscription(
-                    format!("layers[{}]", layer.kind),
-                    format!(
-                        "sequence {} describes {} twice at one scope, as {} and as {}",
-                        previous.sequence,
-                        layer.kind,
-                        describe(existing),
-                        describe(layer),
-                    ),
-                ));
-            }
-
-            continue;
-        }
-
-        inheritable.insert(key, layer.clone());
-    }
-
-    Ok(inheritable)
+    Ok(Chained::new(
+        &DolosProfile,
+        publishing,
+        latest,
+        plan.sequence,
+        &plan.position()?,
+        origin,
+    )?)
 }
 
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use stelae::Profile as _;
+    use stelae::{
+        inscription::{Compression, HistoryEntry},
+        transport::WrittenLayer,
+        Profile as _,
+    };
+    use stelae_driver::publish::inheritable_layers;
 
     use super::*;
+    use crate::scope_key;
 
     fn inscription(sequence: u64, history: Vec<HistoryEntry>) -> Inscription {
         let mut inscription = Inscription::new(
@@ -1532,7 +954,7 @@ mod tests {
             layer(crate::DIGESTS, json!({"lastImmutable": 7}), 3),
         ];
 
-        let table = inheritable_layers(&previous).unwrap();
+        let table = inheritable_layers(&previous, &DolosProfile).unwrap();
 
         assert_eq!(table.len(), 1);
         assert!(table.contains_key(
@@ -1557,7 +979,7 @@ mod tests {
             1,
         )];
 
-        let table = inheritable_layers(&previous).unwrap();
+        let table = inheritable_layers(&previous, &DolosProfile).unwrap();
 
         let full = scope_key(
             crate::BLOCKS,
@@ -1578,7 +1000,9 @@ mod tests {
             layer(crate::BLOCKS, scope, 2),
         ];
 
-        let err = inheritable_layers(&previous).unwrap_err();
+        let err: Error = inheritable_layers(&previous, &DolosProfile)
+            .unwrap_err()
+            .into();
 
         assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
     }
@@ -1602,7 +1026,9 @@ mod tests {
 
         previous.layers = vec![layer(crate::BLOCKS, scope, 1), second];
 
-        let err = inheritable_layers(&previous).unwrap_err();
+        let err: Error = inheritable_layers(&previous, &DolosProfile)
+            .unwrap_err()
+            .into();
 
         assert!(matches!(err, Error::MalformedInscription { .. }), "{err:?}");
 
@@ -1749,7 +1175,9 @@ mod tests {
     #[test]
     fn a_record_offers_epoch_layers_and_nothing_else() {
         let origin = origin("oci://example.test/dolos");
-        let table = record(origin.clone()).table(&origin).unwrap();
+        let table = record(origin.clone())
+            .table(&origin, &DolosProfile)
+            .unwrap();
 
         assert_eq!(table.len(), 2);
         assert!(table.contains_key(
@@ -1822,14 +1250,20 @@ mod tests {
             assert_ne!(theirs, mine);
             assert_eq!(theirs.differences_from(&mine), vec![named]);
 
-            let table = record(theirs.clone()).table(&mine).unwrap();
+            let table = record(theirs.clone()).table(&mine, &DolosProfile).unwrap();
 
             assert!(table.is_empty(), "{theirs:?}");
 
             // And the same layers under the origin they were written for are
             // offered, so what the guard refuses is the mismatch and not the
             // record.
-            assert_eq!(record(theirs.clone()).table(&theirs).unwrap().len(), 2);
+            assert_eq!(
+                record(theirs.clone())
+                    .table(&theirs, &DolosProfile)
+                    .unwrap()
+                    .len(),
+                2
+            );
         }
 
         // An origin that matches names nothing, and one that differs in every

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -269,9 +269,8 @@ where
 }
 
 /// Open a repository in a registry, which is [`stelae_driver::publish::open`]:
-/// a transport's own configuration, and nothing this profile decides.
-/// Re-exported at its old path, with [`Tuning`] alongside it, and wrapped only
-/// to keep this crate's error at the boundary.
+/// a transport's own configuration, and nothing this profile decides. Wrapped
+/// only to keep this crate's error at the boundary.
 ///
 /// **Never call any of this from inside an async context.** The transport owns
 /// a runtime and enters it with `block_on`; `stelae::oci`'s module
@@ -295,14 +294,11 @@ pub fn open(
 pub use stelae_driver::publish::Tuning;
 
 /// Where a publish is going and what the host running it knows about itself,
-/// which is [`stelae_driver::publish::Publishing`]. Re-exported at its old
-/// path.
+/// which is [`stelae_driver::publish::Publishing`].
 ///
-/// The one thing that changed on the way down is `storage_path`, which is now
-/// `record_path`: the driver takes the resumption record's path rather than a
-/// node's storage directory, because deriving one from the other is this
-/// profile's layout and not a lifecycle's. [`record_path_in`] is the
-/// derivation, and it stays here.
+/// It takes the resumption record's path rather than a node's storage
+/// directory, because deriving one from the other is this profile's layout and
+/// not a lifecycle's. [`record_path_in`] is the derivation, and it stays here.
 pub use stelae_driver::publish::Publishing;
 
 /// Name of the resumption record inside a node's storage directory.
@@ -321,8 +317,8 @@ pub fn record_path_in(storage_path: &Path) -> PathBuf {
 /// What an interrupted publish left behind and what it has to agree with
 /// before a single layer of it is adopted, which is
 /// [`stelae_driver::publish`]'s: a note about blobs in a repository, keyed by
-/// the pair that identifies a layer. Re-exported at their old paths, and their
-/// serialized shape is frozen by the fixtures that carry it.
+/// the pair that identifies a layer. Their serialized shape is frozen by the
+/// fixtures that carry it.
 pub use stelae_driver::publish::{Origin, PublishRecord};
 
 /// What a publish into a repository did.
@@ -549,8 +545,7 @@ pub fn inspect(registry: &Registry, point: Point) -> Result<Inspected, Error> {
 /// layers is lifecycle arithmetic, and the only thing about it that was ever
 /// this profile's is which kinds carry the tip. That is now
 /// [`stelae_driver::DriverProfile::is_state_kind`], answered by
-/// [`crate::is_state_kind`]. Re-exported at their old paths; the profile they
-/// need is supplied by the caller.
+/// [`crate::is_state_kind`]. The profile they need is supplied by the caller.
 pub use stelae_driver::publish::{preflight, staging_peak, StagingPeak};
 
 /// Publish `plan` into the repository `publishing` names, chained to whatever

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -967,12 +967,17 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
 
     // The no-predecessor path: an empty repository states no sizes, so nothing
     // can be measured, so nothing is refused. A first publish runs.
-    assert_eq!(registry::staging_peak(&repository).unwrap(), None);
-    registry::preflight(&repository).unwrap();
+    assert_eq!(
+        registry::staging_peak(&repository, &DolosProfile).unwrap(),
+        None
+    );
+    registry::preflight(&repository, &DolosProfile).unwrap();
 
     node.publish(&repository, &node.first, false);
 
-    let peak = registry::staging_peak(&repository).unwrap().unwrap();
+    let peak = registry::staging_peak(&repository, &DolosProfile)
+        .unwrap()
+        .unwrap();
 
     assert_eq!(
         peak.unsized_layers, 0,
@@ -1056,14 +1061,16 @@ fn a_publish_sizes_its_staging_off_the_stele_before_it() {
         },
     );
 
-    let alone = registry::staging_peak(&serial).unwrap().unwrap();
+    let alone = registry::staging_peak(&serial, &DolosProfile)
+        .unwrap()
+        .unwrap();
 
     assert_eq!(alone.bytes(), state_bytes + others[0]);
     assert!(alone.bytes() < inspected.total_compressed);
 
     // And the volume the fixture stages on holds it, so the publish that
     // follows is not refused.
-    registry::preflight(&repository).unwrap();
+    registry::preflight(&repository, &DolosProfile).unwrap();
 
     eprintln!(
         "staging peak: {} bytes ({state_bytes} across sixteen shards, {:?} for the {staged} \

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -1318,7 +1318,7 @@ fn publishing<'a>(
     repository: &'a registry::Registry,
     storage: &'a tempfile::TempDir,
 ) -> registry::Publishing<'a> {
-    registry::Publishing::new(repository).recording_in(storage.path())
+    registry::Publishing::new(repository).recording_in(record_path(storage))
 }
 
 fn record_path(storage: &tempfile::TempDir) -> std::path::PathBuf {

--- a/crates/stelae-driver/Cargo.toml
+++ b/crates/stelae-driver/Cargo.toml
@@ -20,6 +20,7 @@ stelae = { path = "../stelae" }
 
 fs4.workspace = true
 minicbor.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/stelae-driver/src/lib.rs
+++ b/crates/stelae-driver/src/lib.rs
@@ -21,12 +21,25 @@
 //!   sha256 over immutable-database files, which is a Cardano shape described
 //!   in Cardano words; the code depends on nothing but this crate and the
 //!   protocol, which is why it sits here.
+//! - [`profile`] — [`DriverProfile`], the little a lifecycle has to ask a
+//!   profile that the protocol's own trait deliberately does not answer.
+//! - [`predecessor`] — the publish a publish follows, and what it may carry
+//!   forward from it.
+//! - [`publish`] — the chained-publish lifecycle against a repository, behind
+//!   the `oci` feature because that is where a repository lives.
 //! - [`Standing`] — where a node stands against a repository's latest stele.
 //! - [`scope_key`] — the pair that identifies one layer.
 
 pub mod digests;
+pub mod predecessor;
 pub mod preflight;
+pub mod profile;
+#[cfg(feature = "oci")]
+pub mod publish;
 pub mod reporting;
+
+pub use predecessor::{First, Predecessor};
+pub use profile::DriverProfile;
 
 /// Errors raised by the driver.
 ///
@@ -59,6 +72,16 @@ pub enum Error {
     /// `scope` — is not a shape that canonicalizes.
     #[error("the inscription's {field} is not the shape this profile writes: {reason}")]
     MalformedInscription { field: String, reason: String },
+
+    /// A predecessor describing a different dataset than the one being
+    /// published, as [`DriverProfile::check_same_dataset`] judged it.
+    ///
+    /// The two identities are the profile's own — this crate carries the
+    /// numbers and composes no sentence about what they name — so a profile
+    /// that spells the refusal itself keeps the message it always had, the way
+    /// every other shared refusal here does.
+    #[error("this stele describes dataset {found}, but this node is configured for {expected}")]
+    DatasetMismatch { expected: u64, found: u64 },
 
     /// A publish that would not extend the repository's chain. Raised by
     /// [`stelae::inscription::history_for`] and carried here unchanged.

--- a/crates/stelae-driver/src/predecessor.rs
+++ b/crates/stelae-driver/src/predecessor.rs
@@ -1,0 +1,122 @@
+//! The publish a publish follows, and what it may carry forward from it.
+//!
+//! The seam an export walks against: one trait, and the two implementations
+//! that need nothing but a document. The transport-shaped one — the publish
+//! this one follows *in a repository* — is [`crate::publish::Chained`].
+
+use stelae::inscription::{HistoryEntry, LayerDescriptor};
+
+use crate::Error;
+
+/// The publish this one follows.
+///
+/// Two questions, one concept: what a new inscription attests about the steles
+/// before it, and which of their layers it may carry forward rather than build
+/// again. Both are answers only the previous publish has, and holding them
+/// together is what lets a publisher rebuild everything while still chaining —
+/// the `--rebuild` case, which suppresses [`Predecessor::adopt`] and leaves
+/// [`Predecessor::history`] exactly as it was.
+///
+/// The publish this one follows can be **this publish, interrupted**, which is
+/// what [`Predecessor::landed`] is for: a stele that never got sealed left
+/// layers behind that a restart may carry forward on exactly the terms a
+/// predecessor's do. Nothing here decides where that is written down — that is
+/// the implementor's, as `adopt` already is.
+///
+/// `Sync`, because an export drives its layer producers from a pool of
+/// threads and each producer asks these questions for its own layers. An
+/// implementor that keeps state — an adoption counter, a resumption record —
+/// keeps it behind its own synchronization.
+pub trait Predecessor: Sync {
+    /// The history the new inscription carries: every prior publication,
+    /// contiguous and ascending, ending at `sequence - 1`.
+    ///
+    /// Assembling it is the implementor's business, and the protocol holds it
+    /// to the invariant when the document is validated
+    /// (`stelae::inscription`).
+    fn history(&self) -> &[HistoryEntry];
+
+    /// The descriptor to adopt for a layer of `kind` at `scope`, or `None` to
+    /// build it from the stores.
+    ///
+    /// An implementation that answers `Some` **has already arranged for the
+    /// transport to carry the layer's blob**; all that is left for an export
+    /// is to not walk the store. That ordering is why this returns a descriptor
+    /// rather than a boolean: the answer and the arrangement are one act, and
+    /// an export that reused a descriptor whose blob nothing carried would
+    /// publish a manifest with a hole in it.
+    ///
+    /// The default reuses nothing, which is what makes [`First`] one line and
+    /// what a transport with no notion of "already there" — a directory —
+    /// wants.
+    fn adopt(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<Option<LayerDescriptor>, Error> {
+        let _ = (kind, scope);
+
+        Ok(None)
+    }
+
+    /// Whether a layer of `kind` at `scope` would be carried forward rather
+    /// than built — [`Predecessor::adopt`]'s question, asked without arranging
+    /// anything.
+    ///
+    /// Separate because `adopt` *acts*: it puts the blob in the transport and
+    /// counts the layer as reused. Forecasting how many layers a publish will
+    /// write has to ask the same question without taking either step, and a
+    /// forecast that called `adopt` would double-count every layer it looked
+    /// at.
+    ///
+    /// It may answer `true` where `adopt` will later answer `None`, in exactly
+    /// one case: a layer an interrupted publish recorded, whose blob the
+    /// repository has since dropped. That is only discovered by reaching for
+    /// it, which is the step this deliberately does not take — so this is the
+    /// honest forecast and `adopt` is the outcome.
+    ///
+    /// The default reuses nothing, matching [`Predecessor::adopt`]'s.
+    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
+        let _ = (kind, scope);
+
+        Ok(false)
+    }
+
+    /// Note that `descriptor`'s layer is in the transport and will be in the
+    /// manifest, whether it was built here or adopted.
+    ///
+    /// Called once per epoch layer, the moment it lands, so an implementor
+    /// writing it down leaves a record that means "this layer is up" rather
+    /// than "this layer was attempted" — the same boundary
+    /// a restore's checkpoint records on its side. Layers land from
+    /// concurrent producers, so calls interleave; the record is keyed by kind
+    /// and scope, never by arrival order. The state shards are deliberately
+    /// never offered: they describe a moving tip, and a restart must rebuild
+    /// them.
+    ///
+    /// A failure here **fails the publish**. Recording is not a courtesy: a
+    /// record that silently stopped being written would cost the hours it
+    /// exists to save, at the moment nobody is watching.
+    ///
+    /// The default does nothing, which is what a publish with no host behind it
+    /// — a directory, a reproduction — wants.
+    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
+        let _ = descriptor;
+
+        Ok(())
+    }
+}
+
+/// The first stele of a repository: no history, nothing to inherit.
+///
+/// The protocol permits an empty history at any sequence, so this is not only
+/// the very first publish — it is every publish into a directory, which has no
+/// way to be asked what it already holds.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct First;
+
+impl Predecessor for First {
+    fn history(&self) -> &[HistoryEntry] {
+        &[]
+    }
+}

--- a/crates/stelae-driver/src/profile.rs
+++ b/crates/stelae-driver/src/profile.rs
@@ -1,0 +1,58 @@
+//! What the lifecycle has to ask a profile.
+
+use stelae::inscription::Inscription;
+
+use crate::Error;
+
+/// The questions the publish and restore lifecycle asks of a profile.
+///
+/// [`stelae::Profile`] answers what the *protocol* needs — naming, kinds, tags,
+/// the record ceiling — and deliberately has no hook for anything
+/// dataset-shaped. The lifecycle needs a little more than that and strictly
+/// less than a dataset: which kinds an epoch produces, whether a layer may be
+/// carried forward, and whether two documents describe the same dataset at all.
+/// None of those answers reaches into a store, a chain or a node, which is why
+/// they can live on a companion trait here rather than growing the protocol's.
+///
+/// Everything crossing this boundary in either direction is opaque: a `scope`
+/// and a `position` are [`serde_json::Value`], composed by the profile and
+/// never composed here. The driver reads a document's shape only through the
+/// implementor.
+pub trait DriverProfile: stelae::Profile {
+    /// The kinds a closed window always produces a layer for, plus the sparse
+    /// ones it may.
+    ///
+    /// The set a publish enumerates when it asks what it could carry forward
+    /// rather than build.
+    fn epoch_kinds(&self) -> &[&str];
+
+    /// The subset of [`DriverProfile::epoch_kinds`] a window produces
+    /// unconditionally.
+    ///
+    /// Split from the whole because the layer arithmetic is made of the two
+    /// arities: the dense kinds multiply out by the number of windows, and the
+    /// sparse ones have to be counted against the data.
+    fn dense_epoch_kinds(&self) -> &[&str];
+
+    /// Whether a layer of `kind` at `scope` may be carried forward from an
+    /// earlier publish rather than built again.
+    ///
+    /// A question about the scope as well as the kind, and the one rule three
+    /// callers share: the predecessor's manifest, an interrupted publish's
+    /// record, and the note a landed layer leaves.
+    fn is_inheritable(&self, kind: &str, scope: &serde_json::Value) -> bool;
+
+    /// Refuse a predecessor that describes a different dataset than the one
+    /// being published.
+    ///
+    /// `previous` is the stele being chained to; `position` is the document the
+    /// new stele will carry. Both halves are the profile's own shape, so what
+    /// "the same dataset" means is the profile's to decide — the driver only
+    /// knows that a repository holding two of them is a fault, and refuses
+    /// before anything is built.
+    fn check_same_dataset(
+        &self,
+        previous: &Inscription,
+        position: &serde_json::Value,
+    ) -> Result<(), Error>;
+}

--- a/crates/stelae-driver/src/profile.rs
+++ b/crates/stelae-driver/src/profile.rs
@@ -9,10 +9,11 @@ use crate::Error;
 /// [`stelae::Profile`] answers what the *protocol* needs — naming, kinds, tags,
 /// the record ceiling — and deliberately has no hook for anything
 /// dataset-shaped. The lifecycle needs a little more than that and strictly
-/// less than a dataset: which kinds an epoch produces, whether a layer may be
-/// carried forward, and whether two documents describe the same dataset at all.
-/// None of those answers reaches into a store, a chain or a node, which is why
-/// they can live on a companion trait here rather than growing the protocol's.
+/// less than a dataset: which kinds an epoch produces, which kinds carry the
+/// tip, whether a layer may be carried forward, and whether two documents
+/// describe the same dataset at all. None of those answers reaches into a
+/// store, a chain or a node, which is why they can live on a companion trait
+/// here rather than growing the protocol's.
 ///
 /// Everything crossing this boundary in either direction is opaque: a `scope`
 /// and a `position` are [`serde_json::Value`], composed by the profile and
@@ -33,6 +34,20 @@ pub trait DriverProfile: stelae::Profile {
     /// arities: the dense kinds multiply out by the number of windows, and the
     /// sparse ones have to be counted against the data.
     fn dense_epoch_kinds(&self) -> &[&str];
+
+    /// Whether `kind` carries the dataset's tip rather than one window of its
+    /// history.
+    ///
+    /// Kind classification like [`DriverProfile::epoch_kinds`], and asked for
+    /// one reason: the staging arithmetic sizes the two halves of a stele
+    /// differently. A tip is rewritten whole by every publish, so all of it is
+    /// staged together and every such layer sums; anything else is staged a few
+    /// at a time and only the largest few count. [`is_inheritable`] cannot
+    /// stand in for this — it answers a different question, and a stele has
+    /// layers that are neither inheritable nor tip.
+    ///
+    /// [`is_inheritable`]: DriverProfile::is_inheritable
+    fn is_state_kind(&self, kind: &str) -> bool;
 
     /// Whether a layer of `kind` at `scope` may be carried forward from an
     /// earlier publish rather than built again.

--- a/crates/stelae-driver/src/publish.rs
+++ b/crates/stelae-driver/src/publish.rs
@@ -1,0 +1,754 @@
+//! The chained-publish lifecycle against a repository.
+//!
+//! Everything a publisher does once it is standing in front of a *repository*
+//! rather than a transport: what the new stele says about the ones already in
+//! it, and what it may take from them. Generic over
+//! [`DriverProfile`][crate::DriverProfile] throughout — every document that
+//! crosses this module is composed by a profile and only compared here.
+//!
+//! What is *not* here is where any of it lives on a host: a resumption record's
+//! path is handed in, never derived. A node's storage layout is the profile's.
+//!
+//! See the profile-side module that wraps this for the publish rules
+//! themselves — the chain-or-refuse contract, what a reused layer asserts, and
+//! what an interrupted publish leaves behind.
+
+use std::{
+    collections::BTreeMap,
+    io::Write as _,
+    num::NonZeroUsize,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    },
+};
+
+use serde::{Deserialize, Serialize};
+use stelae::{
+    inscription::{Compression, HistoryEntry, Inscription, LayerDescriptor},
+    oci::{Auth, Options, Registry, Repository, Stele, DEFAULT_CONCURRENCY},
+    transport::WrittenLayer,
+    Digest, SteleReader as _,
+};
+
+use crate::{scope_key, DriverProfile, Error, Predecessor, Standing};
+
+/// Open a repository in a registry.
+///
+/// Here rather than at the call site so a node's binary keeps never naming the
+/// protocol crate — the same property a profile's own publish and restore entry
+/// points hold for a directory.
+///
+/// `insecure` speaks plaintext HTTP. It is for a registry on a loopback address
+/// or a mirror inside a cluster, and for nothing that is reachable from outside
+/// one.
+///
+/// `auth` is who to authenticate as, decided by the caller. A node resolves it
+/// from its own configuration and environment; nothing here goes looking, for
+/// the reason `stelae::oci` states one layer down and this crate has no more
+/// standing to override than that one does.
+///
+/// `scratch_dir` is where layers are staged, in both directions. The transport
+/// creates it when the first layer needs it, so it need not exist yet.
+///
+/// `tuning` is the publish path's concurrency and the one check an operator may
+/// want back; [`Tuning::default`] is what every caller that is not publishing
+/// wants.
+///
+/// **Never call any of this from inside an async context.** The transport owns
+/// a runtime and enters it with `block_on`; `stelae::oci`'s module
+/// documentation states the rule and the reason.
+pub fn open(
+    repository: &Repository,
+    insecure: bool,
+    auth: Auth,
+    scratch_dir: PathBuf,
+    tuning: Tuning,
+) -> Result<Registry, Error> {
+    Ok(Registry::open(
+        repository,
+        Options {
+            insecure,
+            scratch_dir: Some(scratch_dir),
+            auth,
+            concurrency: tuning.concurrency.map_or(DEFAULT_CONCURRENCY, Into::into),
+            verify_adopted: tuning.verify_adopted,
+            // Not an operator's knob and deliberately not one: the number that
+            // absorbs a registry's transient `5xx` is the transport's own
+            // measurement, and an outage longer than it is answered a level up,
+            // where `snapshot backfill` re-runs the whole publish rather than
+            // dying into a pod restart.
+            attempts: stelae::oci::DEFAULT_ATTEMPTS,
+            // Nor these, for a related reason: both are facts about the
+            // registry this publishes to and about the pod the publisher runs
+            // in, measured rather than chosen, and neither moves when an
+            // operator changes how fast a publish goes. `upload_memory` in
+            // particular is what keeps `--concurrency` from being a claim on
+            // memory — raising one does not raise the other.
+            monolithic_max: stelae::oci::DEFAULT_MONOLITHIC_MAX,
+            upload_memory: stelae::oci::DEFAULT_UPLOAD_MEMORY,
+        },
+    )?)
+}
+
+/// What an operator may set about *how* a publish moves, as against where it
+/// goes.
+///
+/// Separated from [`open`]'s other arguments because it is the only one of them
+/// a caller can leave alone: a repository, a credential and a staging directory
+/// are facts a publish cannot be run without, and these two are a default and
+/// an escape hatch. A restore or an inspection passes [`Tuning::default`] and
+/// means it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Tuning {
+    /// How many layer round trips run at once; `None` is
+    /// [`DEFAULT_CONCURRENCY`].
+    pub concurrency: Option<NonZeroUsize>,
+
+    /// Re-prove that the registry still holds each blob carried forward out of
+    /// the predecessor's manifest. See [`stelae::oci::Options::verify_adopted`]
+    /// for why this is off.
+    pub verify_adopted: bool,
+}
+
+/// Where a publish is going, and what the host running it knows about itself.
+///
+/// The publish-side counterpart of a restore's node-side facts, and it holds
+/// the transport for the same reason that one holds a storage path: these are
+/// the facts a publish is *given*, as against the ones it derives. Threading
+/// them separately is what took [`publish`] to the edge of its signature, and
+/// they have never been supplied from different places.
+///
+/// The record's path is owned rather than borrowed, and the type is `Clone`
+/// rather than `Copy` because of it. Both are deliberate: a builder that took a
+/// `&Path` would accept a node's *storage directory* as readily as its record,
+/// silently, and the two are one `join` apart.
+#[derive(Clone)]
+pub struct Publishing<'a> {
+    /// The repository being published into, already opened.
+    pub registry: &'a Registry,
+
+    /// Where the resumption record is kept, handed in rather than derived:
+    /// a node's storage layout is the profile's and this crate never composes
+    /// one. `None` for a caller with no node behind it, which records nothing
+    /// and resumes nothing.
+    pub record_path: Option<PathBuf>,
+
+    /// The operator's `--rebuild`: build every layer, inherit none, and start
+    /// the record over.
+    pub rebuild: bool,
+}
+
+impl<'a> Publishing<'a> {
+    /// A publish into `registry` that keeps no record and rebuilds nothing.
+    pub fn new(registry: &'a Registry) -> Self {
+        Self {
+            registry,
+            record_path: None,
+            rebuild: false,
+        }
+    }
+
+    /// The same publish, recording what it finishes at `record_path`.
+    pub fn recording_in(self, record_path: impl Into<PathBuf>) -> Self {
+        Self {
+            record_path: Some(record_path.into()),
+            ..self
+        }
+    }
+
+    /// The same publish, with the operator's `--rebuild`.
+    pub fn rebuilding(self, rebuild: bool) -> Self {
+        Self { rebuild, ..self }
+    }
+}
+
+/// What a record has to agree with before a single layer in it is adopted.
+///
+/// Everything a recorded layer's bytes and address depend on that is *not* in
+/// the layer's own key. The key is the kind plus the descriptor scope, and that
+/// scope names an epoch and a slot window and nothing else — so:
+///
+/// - **the repository**, because a blob digest is an address in one repository
+///   and means nothing in another;
+/// - **the network magic**, because two chains' epoch 500 are different bytes
+///   under one key. The descriptor scope deliberately carries no magic — the
+///   layer's own header record does — so this is the only place the record can
+///   hold it;
+/// - **the parameters and the compression**, which are the inscription's own
+///   statement of how its layers were built. A binary that changed either would
+///   rebuild a recorded layer into different bytes, and the record would be
+///   offering an answer to a question nobody is asking any more.
+///
+/// A mismatch in any of them makes the record a fresh one for the origin at
+/// hand. Nothing is repaired and nothing is merged: the layers it named are
+/// still in the registry, and the publish that wants them will build them
+/// again and find them there.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Origin {
+    /// The repository the layers were uploaded to, as the transport names it.
+    pub repository: String,
+    /// The network the stores stood on.
+    pub network_magic: u64,
+    /// The inscription parameters the layers were built under.
+    pub parameters: serde_json::Value,
+    /// The compression they were built with.
+    pub compression: Compression,
+}
+
+impl Origin {
+    /// What a publish into `registry` of a dataset identified by
+    /// `network_magic`, under `parameters` and `compression`, records under.
+    ///
+    /// Rebuilt from parts rather than read off a plan: every one of them is the
+    /// profile's own statement about the publish, and the record's field names
+    /// are frozen by the fixtures that already carry them.
+    pub fn of(
+        registry: &Registry,
+        network_magic: u64,
+        parameters: serde_json::Value,
+        compression: Compression,
+    ) -> Self {
+        Self {
+            repository: registry.repository().to_string(),
+            network_magic,
+            parameters,
+            compression,
+        }
+    }
+
+    /// The fields `self` and `other` disagree on, in the order [`Origin`]
+    /// states them.
+    ///
+    /// One of the four ways to differ changes the repository, so a refusal
+    /// that reported the two repository names alone would read, in the other
+    /// three, as though the two publishes matched. Names rather than values:
+    /// `parameters` is arbitrary JSON, and what an operator needs from the
+    /// event is which knob moved between the two runs.
+    pub fn differences_from(&self, other: &Self) -> Vec<&'static str> {
+        [
+            (self.repository != other.repository, "repository"),
+            (self.network_magic != other.network_magic, "network magic"),
+            (self.parameters != other.parameters, "parameters"),
+            (self.compression != other.compression, "compression"),
+        ]
+        .into_iter()
+        .filter_map(|(differs, field)| differs.then_some(field))
+        .collect()
+    }
+}
+
+/// The epoch layers an interrupted publish got as far as uploading.
+///
+/// Written after each layer's upload succeeds and deleted once the stele is
+/// sealed, so a record that exists describes a publish that did not finish. See
+/// the module documentation for what it is and — more to the point — what it is
+/// not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PublishRecord {
+    pub origin: Origin,
+
+    /// The layers whose blobs are up, each as the transport measured it.
+    ///
+    /// The whole [`WrittenLayer`] rather than the digest pair the adoption
+    /// needs: the descriptor is what the new manifest has to state about the
+    /// layer, and a record that held only its identity would have to invent the
+    /// rest. In the canonical order of their keys, so the same progress is the
+    /// same bytes.
+    pub layers: Vec<WrittenLayer>,
+}
+
+impl PublishRecord {
+    /// Read the record at `path`, or `None` if there is none.
+    ///
+    /// **Only absence is `None`**, on a restore's progress file's reasoning
+    /// turned around: a file that exists and does not parse is an
+    /// error rather than an empty resume, because reading it as "nothing has
+    /// been uploaded" silently costs the rebuild this file exists to avoid.
+    /// `--rebuild` is how an operator asks for that outcome on purpose.
+    pub fn load(path: &Path) -> Result<Option<Self>, Error> {
+        let raw = match read_file(path) {
+            Ok(raw) => raw,
+            Err(e) => return Err(Error::Stelae(e)),
+        };
+
+        let Some(raw) = raw else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            serde_json::from_slice(&raw).map_err(|e| Error::Stelae(e.into()))?,
+        ))
+    }
+
+    /// Delete the record at `path`. A file that is not there is not an error.
+    pub fn remove(path: &Path) -> Result<(), Error> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::Stelae(e.into())),
+        }
+    }
+
+    /// Write the record at `path`, atomically.
+    ///
+    /// Through a temporary sibling and a rename, for the reason
+    /// `stelae::plan::RestoreProgress::save` states on its side: the failure
+    /// this file exists to survive is a process that stops mid-write, and a
+    /// half-written record would be refused by [`PublishRecord::load`] —
+    /// correctly, and uselessly, since the publish it described would then have
+    /// to start over.
+    pub fn save(&self, path: &Path) -> Result<(), Error> {
+        save_atomically(
+            path,
+            &serde_json::to_vec(self).map_err(stelae::Error::from)?,
+        )
+        .map_err(Error::Stelae)
+    }
+
+    /// The layers this record offers, keyed the way [`Chained`] looks them up.
+    ///
+    /// An [`Origin`] the caller is not publishing under offers nothing: see
+    /// [`Origin`] for why a mismatch is a fresh start rather than a merge.
+    pub fn table(
+        &self,
+        origin: &Origin,
+        profile: &dyn DriverProfile,
+    ) -> Result<BTreeMap<(String, String), WrittenLayer>, Error> {
+        if &self.origin != origin {
+            tracing::info!(
+                differs = %self.origin.differences_from(origin).join(", "),
+                recorded = %self.origin.repository,
+                publishing = %origin.repository,
+                "a resumption record was left by a publish this one does not continue; \
+                 every layer will be rebuilt"
+            );
+
+            return Ok(BTreeMap::new());
+        }
+
+        let mut table = BTreeMap::new();
+
+        for layer in &self.layers {
+            // The same filter `inheritable_layers` applies to a predecessor's
+            // manifest, applied again on the way in: a record naming a state
+            // *tip* shard is a record nothing wrote, and honouring one would
+            // carry a stale tip into a manifest. A retained dump's scope names
+            // its epoch, so it passes here for the same reason an epoch layer
+            // does.
+            if !profile.is_inheritable(&layer.descriptor.kind, &layer.descriptor.scope) {
+                continue;
+            }
+
+            table.insert(
+                scope_key(&layer.descriptor.kind, &layer.descriptor.scope)?,
+                layer.clone(),
+            );
+        }
+
+        Ok(table)
+    }
+}
+
+fn read_file(path: &Path) -> Result<Option<Vec<u8>>, stelae::Error> {
+    match std::fs::read(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn save_atomically(path: &Path, bytes: &[u8]) -> Result<(), stelae::Error> {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let staging = path.with_file_name(format!(".{name}.{}.tmp", std::process::id()));
+
+    // Scoped so the handle is closed before the rename: Windows refuses to
+    // rename a file that is still open.
+    {
+        let mut file = std::fs::File::create(&staging)?;
+
+        file.write_all(bytes)?;
+
+        // Before the rename, not after: a rename that lands pointing at bytes
+        // the page cache has not written yet is the same truncated file by
+        // another route.
+        file.sync_all()?;
+    }
+
+    std::fs::rename(&staging, path)?;
+
+    Ok(())
+}
+
+/// Where this node stands relative to what `registry` already holds.
+///
+/// One read of the moving tag, and no store is touched. It is what turns "the
+/// node has not entered a new epoch" from the same refusal a skipped epoch
+/// raises into an answer a job on a timer can act on — see [`Standing`].
+///
+/// Cheap enough to ask before every publish: a manifest pull against the
+/// moving tag, which [`publish`] and [`preview`] are each about to make anyway.
+/// Asking twice is one HTTP round trip against the alternative, which is
+/// threading the answer out of a call that has already started building.
+///
+/// **Never call this from inside an async context.** See [`open`].
+pub fn standing(
+    registry: &Registry,
+    profile: &dyn DriverProfile,
+    sequence: u64,
+    position: &serde_json::Value,
+) -> Result<Standing, Error> {
+    let latest = registry
+        .latest(profile)?
+        .map(|stele| stele.read_inscription())
+        .transpose()?;
+
+    if let Some(previous) = &latest {
+        // The same refusal a publish makes, made before the report rather than
+        // after it: a repository holding another dataset's chain is not "up to
+        // date" with this node in any sense worth reporting.
+        profile.check_same_dataset(previous, position)?;
+    }
+
+    Ok(Standing::read(
+        latest.map(|previous| previous.sequence),
+        sequence,
+    ))
+}
+
+/// The publish this one follows, in a repository — which may be itself.
+///
+/// Holds the history it hands to the new inscription and the two tables of
+/// layers it is willing to let the new stele carry forward rather than build,
+/// both keyed by the pair that decides it: the layer's kind and the canonical
+/// encoding of its profile-owned scope.
+///
+/// The tables answer the same question from different standing. `inheritable`
+/// is the *predecessor's manifest* — a stele the repository serves, so a layer
+/// missing from it is a fault. `resumable` is *this publish's own record* of an
+/// attempt that died before it could write a manifest — a note, so a layer
+/// missing from the registry is only a rebuild. The manifest is consulted
+/// first, because a repository that states it holds a layer needs no note to
+/// say so.
+pub struct Chained<'a> {
+    registry: &'a Registry,
+    /// Held rather than threaded, because [`Predecessor::landed`] is asked by
+    /// the export's producer pool and has nowhere to take one from.
+    profile: &'a (dyn DriverProfile + Sync),
+    source: Option<&'a Stele>,
+    predecessor: Option<(u64, Digest)>,
+    history: Vec<HistoryEntry>,
+    inheritable: BTreeMap<(String, String), LayerDescriptor>,
+    resumable: BTreeMap<(String, String), WrittenLayer>,
+    record: Option<Recording>,
+    /// Atomic, like the record's lock below: [`export::export`] asks a
+    /// predecessor about layers from a pool of producer threads.
+    adopted: AtomicUsize,
+}
+
+/// The resumption record this publish is writing, open.
+///
+/// Seeded with what it inherits, so the file is the whole of what is up rather
+/// than the whole of what *this attempt* put up: an attempt that adopts twenty
+/// layers and adds one, then dies, has to leave twenty-one behind or the third
+/// attempt pays for the difference.
+///
+/// The lock is held across the file write as well as the map insert: each
+/// write rewrites the whole record, so two producers landing layers at once
+/// must serialize on the file or the later write would drop the earlier
+/// layer.
+struct Recording {
+    path: PathBuf,
+    origin: Origin,
+    layers: Mutex<BTreeMap<(String, String), WrittenLayer>>,
+}
+
+impl<'a> Chained<'a> {
+    /// The publish `sequence` follows in `publishing`'s repository.
+    ///
+    /// Every input is a part rather than a plan: the sequence being published,
+    /// the `position` document the new stele will carry — read only by the
+    /// profile, through [`DriverProfile::check_same_dataset`] — and the
+    /// [`Origin`] the profile records under.
+    pub fn new(
+        profile: &'a (dyn DriverProfile + Sync),
+        publishing: Publishing<'a>,
+        latest: Option<&'a Stele>,
+        sequence: u64,
+        position: &serde_json::Value,
+        origin: Origin,
+    ) -> Result<Self, Error> {
+        let Publishing {
+            registry,
+            record_path,
+            rebuild,
+        } = publishing;
+
+        let inscription = latest.map(|stele| stele.read_inscription()).transpose()?;
+
+        if let Some(previous) = &inscription {
+            // The pull that fetched this checked as a reader; this is the
+            // publish side, which inherits the chain and must attest it.
+            previous.check_profile_strict(profile)?;
+            profile.check_same_dataset(previous, position)?;
+        }
+
+        let history = stelae::inscription::history_for(inscription.as_ref(), sequence)?;
+
+        let predecessor = inscription
+            .as_ref()
+            .map(|previous| Ok::<_, Error>((previous.sequence, previous.digest()?)))
+            .transpose()?;
+
+        // Built only when it can be used. `rebuild` is the publisher choosing
+        // to reproduce rather than inherit, and it stops here rather than at
+        // `adopt` so that nothing downstream has to remember it was set.
+        let inheritable = match (rebuild, &inscription) {
+            (false, Some(previous)) => inheritable_layers(previous, profile)?,
+            _ => BTreeMap::new(),
+        };
+
+        // Read on the same terms, and it is the *honouring* that `rebuild`
+        // gates rather than the reading — the asymmetry a restore's checkpoint
+        // states, for the same reason. A publisher that asked to rebuild gets a
+        // record that starts empty and overwrites whatever was there, so
+        // nothing an earlier attempt believed can survive the run that was
+        // meant to settle it.
+        let resumable = match (rebuild, record_path.as_deref()) {
+            (false, Some(record_path)) => match PublishRecord::load(record_path)? {
+                Some(record) => record.table(&origin, profile)?,
+                None => BTreeMap::new(),
+            },
+            _ => BTreeMap::new(),
+        };
+
+        if !resumable.is_empty() {
+            tracing::info!(
+                layers = resumable.len(),
+                "an interrupted publish left epoch layers in this repository; \
+                 they will be carried forward rather than rebuilt"
+            );
+        }
+
+        let record = record_path.map(|record_path| Recording {
+            path: record_path,
+            origin,
+            layers: Mutex::new(resumable.clone()),
+        });
+
+        Ok(Self {
+            registry,
+            profile,
+            source: latest.filter(|_| !rebuild),
+            predecessor,
+            history,
+            inheritable,
+            resumable,
+            record,
+            adopted: AtomicUsize::new(0),
+        })
+    }
+
+    /// The stele this one chains to, if the repository holds one.
+    pub fn predecessor(&self) -> Option<(u64, Digest)> {
+        self.predecessor
+    }
+
+    /// How many layers this publish carried forward rather than built.
+    pub fn adopted(&self) -> usize {
+        self.adopted.load(Ordering::Relaxed)
+    }
+
+    /// Delete the resumption record.
+    ///
+    /// Called once the stele is sealed and never before it: before the seal it
+    /// would be a record that outlived neither the run nor its usefulness.
+    pub fn forget_record(&self) -> Result<(), Error> {
+        match &self.record {
+            Some(record) => PublishRecord::remove(&record.path),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Predecessor for Chained<'_> {
+    fn history(&self) -> &[HistoryEntry] {
+        &self.history
+    }
+
+    /// What [`preview`] reports, and it spends no `HEAD`: the promise a dry run
+    /// makes is about what the scopes permit. The record's own gate — that the
+    /// registry still holds the blob — runs in [`Predecessor::adopt`] and can
+    /// turn one of these into a rebuild, which is the direction a dry run is
+    /// allowed to be wrong in.
+    fn carried_forward(&self, kind: &str, scope: &serde_json::Value) -> Result<bool, Error> {
+        let key = scope_key(kind, scope)?;
+
+        Ok(self.inheritable.contains_key(&key) || self.resumable.contains_key(&key))
+    }
+
+    fn adopt(
+        &self,
+        kind: &str,
+        scope: &serde_json::Value,
+    ) -> Result<Option<LayerDescriptor>, Error> {
+        let key = scope_key(kind, scope)?;
+
+        // The arrangement and the answer are one act, in both branches: by the
+        // time this returns a descriptor, the transport is already carrying the
+        // blob, and the `HEAD` that proves the registry still has it has already
+        // happened.
+        if let (Some(source), Some(descriptor)) = (self.source, self.inheritable.get(&key)) {
+            self.registry.adopt_layer(source, descriptor.clone())?;
+            self.adopted.fetch_add(1, Ordering::Relaxed);
+
+            return Ok(Some(descriptor.clone()));
+        }
+
+        let Some(recorded) = self.resumable.get(&key) else {
+            return Ok(None);
+        };
+
+        if !self.registry.adopt_carried(recorded.clone())? {
+            tracing::warn!(
+                kind,
+                %scope,
+                "a recorded layer's blob is no longer in the repository; rebuilding it"
+            );
+
+            return Ok(None);
+        }
+
+        self.adopted.fetch_add(1, Ordering::Relaxed);
+
+        Ok(Some(recorded.descriptor.clone()))
+    }
+
+    fn landed(&self, descriptor: &LayerDescriptor) -> Result<(), Error> {
+        let Some(record) = &self.record else {
+            return Ok(());
+        };
+
+        if !self
+            .profile
+            .is_inheritable(&descriptor.kind, &descriptor.scope)
+        {
+            return Ok(());
+        }
+
+        let Some(written) = self.registry.carried(&descriptor.diff_id) else {
+            tracing::warn!(
+                kind = descriptor.kind,
+                scope = %descriptor.scope,
+                "this layer is not in the transport, so nothing was recorded for it; \
+                 an interrupted publish will rebuild it"
+            );
+
+            return Ok(());
+        };
+
+        // The transport is asked for its *measurement* and not for its
+        // descriptor. `carried` finds a layer by `diffId`, and one `diffId` can
+        // now wear two descriptors — the dump a publish cuts out of its own tip
+        // is the tip's bytes — so recording what the lookup returned verbatim
+        // would file the dump under the tip's scope, where nothing looks for it
+        // and where it would be discarded on the way back in.
+        let written = WrittenLayer {
+            descriptor: descriptor.clone(),
+            digests: written.digests,
+        };
+
+        // Held across the save below, not just the insert — see [`Recording`].
+        let mut layers = record
+            .layers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        layers.insert(scope_key(&descriptor.kind, &descriptor.scope)?, written);
+
+        PublishRecord {
+            origin: record.origin.clone(),
+            layers: layers.values().cloned().collect(),
+        }
+        .save(&record.path)
+    }
+}
+
+/// The layers a new stele may inherit from `previous`, keyed by kind and scope.
+///
+/// [`DriverProfile::is_inheritable`] decides, and it decides on the scope as
+/// well as the kind. A state *tip* shard is out: it changes every publish, and
+/// — independently — its descriptor scope names no epoch, so scope equality
+/// could not tell one publish's shard from another's. A retained state dump is
+/// in: it is a closed epoch's state under a scope that names that epoch.
+/// `digests` has no source in this slice.
+///
+/// Two layers of one kind claiming one scope, described differently in any
+/// respect, is a refusal rather than a first-wins: it means the stele being
+/// chained to describes the same window twice and disagrees with itself about
+/// what is in it, and inheriting either answer would publish that disagreement
+/// forward. "In any respect" and not "with different identities", because
+/// `records` and `uncompressed_size` are determined by the bytes a `diff_id`
+/// names — so a disagreement about them under one identity is the same
+/// contradiction wearing a quieter shape.
+pub fn inheritable_layers(
+    previous: &Inscription,
+    profile: &dyn DriverProfile,
+) -> Result<BTreeMap<(String, String), LayerDescriptor>, Error> {
+    let mut inheritable = BTreeMap::new();
+
+    for layer in &previous.layers {
+        if !profile.is_inheritable(&layer.kind, &layer.scope) {
+            continue;
+        }
+
+        let key = scope_key(&layer.kind, &layer.scope)?;
+
+        if let Some(existing) = inheritable.get(&key) {
+            let existing: &LayerDescriptor = existing;
+
+            // The whole descriptor, not the identity alone. `records` and
+            // `uncompressed_size` are functions of the bytes `diff_id` names,
+            // so two descriptors sharing an identity and disagreeing about
+            // either are a stele contradicting itself just as surely as two
+            // identities would be — and `adopt_layer` carries
+            // `uncompressed_size` forward into a stele that never reads the
+            // bytes that would settle it.
+            if existing != layer {
+                // Spelled out rather than named by identity alone: the two can
+                // now differ while sharing a `diff_id`, and a message printing
+                // one digest twice would describe nothing.
+                let describe = |layer: &LayerDescriptor| {
+                    format!(
+                        "{} ({} records, {} bytes)",
+                        layer.diff_id, layer.records, layer.uncompressed_size,
+                    )
+                };
+
+                return Err(Error::malformed_inscription(
+                    format!("layers[{}]", layer.kind),
+                    format!(
+                        "sequence {} describes {} twice at one scope, as {} and as {}",
+                        previous.sequence,
+                        layer.kind,
+                        describe(existing),
+                        describe(layer),
+                    ),
+                ));
+            }
+
+            continue;
+        }
+
+        inheritable.insert(key, layer.clone());
+    }
+
+    Ok(inheritable)
+}

--- a/crates/stelae-driver/src/publish.rs
+++ b/crates/stelae-driver/src/publish.rs
@@ -172,10 +172,10 @@ impl<'a> Publishing<'a> {
 ///
 /// - **the repository**, because a blob digest is an address in one repository
 ///   and means nothing in another;
-/// - **the network magic**, because two chains' epoch 500 are different bytes
-///   under one key. The descriptor scope deliberately carries no magic — the
-///   layer's own header record does — so this is the only place the record can
-///   hold it;
+/// - **the dataset**, because one sequence of two different datasets is two
+///   different sets of bytes under one key. A descriptor scope names a window
+///   and not a dataset — the layer's own header record carries that — so this
+///   is the only place the record can hold it;
 /// - **the parameters and the compression**, which are the inscription's own
 ///   statement of how its layers were built. A binary that changed either would
 ///   rebuild a recorded layer into different bytes, and the record would be
@@ -190,8 +190,13 @@ impl<'a> Publishing<'a> {
 pub struct Origin {
     /// The repository the layers were uploaded to, as the transport names it.
     pub repository: String,
-    /// The network the stores stood on.
-    pub network_magic: u64,
+    /// The dataset the layers were built from, as the profile identifies it.
+    ///
+    /// Opaque here: this crate compares it and never reads it. A profile that
+    /// numbers its datasets one way and a profile that numbers them another
+    /// both fit, which is the whole reason the field is not named after
+    /// either.
+    pub dataset_id: u64,
     /// The inscription parameters the layers were built under.
     pub parameters: serde_json::Value,
     /// The compression they were built with.
@@ -199,21 +204,20 @@ pub struct Origin {
 }
 
 impl Origin {
-    /// What a publish into `registry` of a dataset identified by
-    /// `network_magic`, under `parameters` and `compression`, records under.
+    /// What a publish into `registry` of the dataset `dataset_id` identifies,
+    /// under `parameters` and `compression`, records under.
     ///
     /// Rebuilt from parts rather than read off a plan: every one of them is the
-    /// profile's own statement about the publish, and the record's field names
-    /// are frozen by the fixtures that already carry them.
+    /// profile's own statement about the publish.
     pub fn of(
         registry: &Registry,
-        network_magic: u64,
+        dataset_id: u64,
         parameters: serde_json::Value,
         compression: Compression,
     ) -> Self {
         Self {
             repository: registry.repository().to_string(),
-            network_magic,
+            dataset_id,
             parameters,
             compression,
         }
@@ -230,7 +234,7 @@ impl Origin {
     pub fn differences_from(&self, other: &Self) -> Vec<&'static str> {
         [
             (self.repository != other.repository, "repository"),
-            (self.network_magic != other.network_magic, "network magic"),
+            (self.dataset_id != other.dataset_id, "dataset id"),
             (self.parameters != other.parameters, "parameters"),
             (self.compression != other.compression, "compression"),
         ]
@@ -751,4 +755,212 @@ pub fn inheritable_layers(
     }
 
     Ok(inheritable)
+}
+
+/// What a publish holds staged on disk at its peak.
+///
+/// Not the size of the stele: a publish never has the whole document on disk at
+/// once. What it does have at once is a *tip* pass — the profile's export keeps
+/// one state kind's shard sinks open across a single walk of its namespace —
+/// plus whatever other layers are in flight beside it. Summing *every* state
+/// layer rather than the widest kind's is deliberately conservative: the peak
+/// it prices is the pre-split one, an upper bound on any per-kind pass.
+///
+/// Which layers are the tip is [`DriverProfile::is_state_kind`]'s answer and
+/// not one this crate could reach: it is the one place the arithmetic has to
+/// know something about a kind beyond its name.
+///
+/// "Layers beside it" is a handful and not one, because the transport uploads
+/// concurrently: a layer's staging file lives until its own round trip lands,
+/// so as many finished layers as the transport has permits can sit on disk at
+/// once alongside the pass. How many that is comes from
+/// [`stelae::oci::Registry::concurrency`] — asked of the transport rather than
+/// assumed here — and *which* ones is the largest that many, since the peak is
+/// the worst arrangement and nothing orders the uploads.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StagingPeak {
+    /// Every state layer, summed — the conservative reading above.
+    pub state_bytes: u64,
+    /// The non-state layers that can be staged at once, largest first: as many
+    /// as the transport uploads concurrently, or all of them where the stele
+    /// has fewer than that. Empty on a stele that is all state, and on a
+    /// [`StagingPeak::default`] nothing was measured into.
+    pub concurrent_other_bytes: Vec<u64>,
+    /// Layers the predecessor's manifest stated no size for. Non-zero makes
+    /// every number here a floor rather than an estimate.
+    pub unsized_layers: usize,
+}
+
+impl StagingPeak {
+    /// Compressed bytes the scratch volume has to hold at once.
+    ///
+    /// Saturating throughout, because these are a manifest's numbers and a
+    /// manifest is not this node's document: a wrapped sum would be a *small*
+    /// need, which is the one direction a refusal must never be wrong in.
+    pub fn bytes(&self) -> u64 {
+        self.concurrent_other_bytes
+            .iter()
+            .fold(self.state_bytes, |total, bytes| {
+                total.saturating_add(*bytes)
+            })
+    }
+
+    /// The largest non-state layer, which is the first of the ones staged at
+    /// once.
+    pub fn largest_other_bytes(&self) -> u64 {
+        self.concurrent_other_bytes.first().copied().unwrap_or(0)
+    }
+}
+
+/// Size the staging peak of the next publish from the stele before it.
+///
+/// A proxy, and deliberately so: the numbers are the *predecessor's* layers,
+/// not this publish's, because this publish's layers do not exist until it
+/// builds them and sizing them would mean building them. One sequence of drift
+/// is what the proxy costs, against a check that otherwise cannot exist at all
+/// — and the refuse/warn split is what keeps it honest, since a shortfall
+/// against the last publish's sizes is still a measured shortfall.
+///
+/// Off the manifest the pull already fetched, and no per-layer `HEAD`: the
+/// promise a profile's dry run makes about touching nothing holds here too.
+///
+/// `Ok(None)` is a first publish — no predecessor, nothing to size from — which
+/// [`preflight`] turns into a warning rather than a refusal.
+///
+/// **Never call this from inside an async context.** See [`open`].
+pub fn staging_peak(
+    registry: &Registry,
+    profile: &dyn DriverProfile,
+) -> Result<Option<StagingPeak>, Error> {
+    let Some(previous) = registry.latest(profile)? else {
+        return Ok(None);
+    };
+
+    let inscription = previous.read_inscription()?;
+    let blobs = previous.blob_index()?;
+
+    let mut peak = StagingPeak::default();
+    let mut others = Vec::new();
+
+    for descriptor in &inscription.layers {
+        match previous.compressed_size(&blobs, descriptor)? {
+            None => peak.unsized_layers += 1,
+            // Every state layer adds — the conservative sum-all-state rule the
+            // type documents.
+            Some(bytes) if profile.is_state_kind(&descriptor.kind) => {
+                peak.state_bytes = peak.state_bytes.saturating_add(bytes)
+            }
+            Some(bytes) => others.push(bytes),
+        }
+    }
+
+    // The largest as many as the transport stages at once, and no more: a stele
+    // with fewer non-state layers than the transport has permits cannot put
+    // more of them on disk than it has.
+    others.sort_unstable_by(|a, b| b.cmp(a));
+    others.truncate(registry.concurrency());
+
+    peak.concurrent_other_bytes = others;
+
+    Ok(Some(peak))
+}
+
+/// Refuse a publish whose scratch volume cannot hold what it stages at once.
+///
+/// The publish side of [`crate::preflight`]'s one policy, which a profile's
+/// restore is the other side of: a measured shortfall refuses, naming the
+/// volume and the shortfall, and what cannot be sized warns and proceeds.
+///
+/// The volume is the transport's own — [`stelae::oci::Registry::scratch_dir`] —
+/// so the directory sized here and the directory written to cannot come apart.
+/// A transport opened without one stages in the platform temporary directory,
+/// which it does not name, so there is nothing to size and nothing to refuse;
+/// [`open`] always sets one, so no caller that came through it reaches that
+/// case.
+///
+/// **Never call this from inside an async context.** See [`open`].
+pub fn preflight(registry: &Registry, profile: &dyn DriverProfile) -> Result<(), Error> {
+    let Some(scratch_dir) = registry.scratch_dir() else {
+        tracing::warn!(
+            "this transport stages in the platform temporary directory, which it does not name; \
+             skipping the free-space check for {STAGING}"
+        );
+
+        return Ok(());
+    };
+
+    crate::preflight::check(&[staging_need(staging_peak(registry, profile)?, scratch_dir)])
+}
+
+/// What the staging asks of its volume, as [`crate::preflight`] takes it.
+///
+/// Split out of [`preflight`] so the demand and the transport that produced it
+/// can be tested apart: sizing a peak needs a registry, and deciding what a
+/// peak means for a volume needs none.
+const STAGING: &str = "staging this publish";
+
+fn staging_need(peak: Option<StagingPeak>, scratch_dir: &Path) -> crate::preflight::Need {
+    let Some(peak) = peak else {
+        return crate::preflight::Need::unsized_because(
+            STAGING,
+            scratch_dir,
+            "this repository holds no stele to size the staging from",
+        );
+    };
+
+    if peak.unsized_layers > 0 {
+        tracing::warn!(
+            unsized_layers = peak.unsized_layers,
+            "the predecessor's manifest states no size for some of its layers; the staging \
+             estimate is a floor"
+        );
+    }
+
+    crate::preflight::Need::of(STAGING, scratch_dir, peak.bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The publish half of the one policy, over a peak this test supplies.
+    ///
+    /// The other half of the chain — that the peak is the predecessor's tip
+    /// shards plus its largest other layer — needs a registry to state a
+    /// manifest, so it lives with a profile that can build one. Between them
+    /// the composition [`preflight`] performs is covered: this end decides,
+    /// that end measures.
+    #[test]
+    fn a_measured_staging_shortfall_refuses_and_a_first_publish_does_not() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let check = |peak| -> Result<(), Error> {
+            crate::preflight::check(&[staging_need(peak, temp.path())])
+        };
+
+        // No predecessor, so nothing sized it, so nothing refuses.
+        check(None).unwrap();
+
+        check(Some(StagingPeak::default())).unwrap();
+
+        // A peak no volume holds. Both halves are set, so the refusal is on
+        // their sum and not on either alone.
+        let err = check(Some(StagingPeak {
+            state_bytes: u64::MAX / 2,
+            concurrent_other_bytes: vec![u64::MAX / 4, u64::MAX / 4],
+            unsized_layers: 0,
+        }))
+        .unwrap_err();
+
+        let Error::NotEnoughSpace(message) = &err else {
+            panic!("{err:?}");
+        };
+
+        assert!(message.contains(STAGING), "{message}");
+        assert!(
+            message.contains(&temp.path().display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("short"), "{message}");
+    }
 }

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -8,6 +8,7 @@ use miette::{Context as _, IntoDiagnostic as _};
 use dolos_snapshot::{
     export::Standing,
     registry::{self, Registry, Repository},
+    DolosProfile,
 };
 
 use super::EpochRange;
@@ -261,7 +262,7 @@ pub(super) fn to_repository(
     // After `standing`, because a repository holding another network's chain is
     // refused there and sizing against it would be sizing against the wrong
     // stele.
-    registry::preflight(&registry)
+    registry::preflight(&registry, &DolosProfile)
         .into_diagnostic()
         .context("sizing the staging directory")?;
 

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -246,7 +246,7 @@ pub(super) fn to_repository(
     // already uploaded instead of rebuilding them. `--rebuild` starts it over
     // along with everything else.
     let publishing = registry::Publishing::new(&registry)
-        .recording_in(&config.storage.path)
+        .recording_in(registry::record_path_in(&config.storage.path))
         .rebuilding(publish.rebuild);
 
     // Before anything is built, and before the dry run too: a publisher asking


### PR DESCRIPTION
Plan: `plans/dolos-stelae-repo-split-driver-genericization.md`, second in the
[repo-split](https://github.com/txpipe/dolos/pull/1285) chain.

`stelae-driver` takes over the chained-publish lifecycle, generic over a new
`DriverProfile`; `crates/snapshot/src/registry.rs` keeps the store-typed
wrappers, the profile's policy impl, path derivation, and the operator-facing
tag surface. Every hunk is a re-typing — nothing canonicalized changed.

The trait's shape was escalated mid-implementation and ruled on 2026-09-01.
The ruling is applied here in full; the "What stayed, and why" section below is
its four points.

## What moved

`crates/stelae-driver` gains three modules:

- `profile.rs` — `trait DriverProfile: stelae::Profile` with `epoch_kinds`,
  `dense_epoch_kinds`, `is_state_kind`, `is_inheritable` and
  `check_same_dataset`. `DolosProfile` implements it in `crates/snapshot` by
  delegating to the constants, the state split, today's `is_inheritable`, and
  `same_network`'s body. The constants and the position schema stay
  profile-side.
- `predecessor.rs` — the `Predecessor` trait and `First`, verbatim, returning
  `stelae_driver::Error`. Re-exported from `export` at their old paths.
- `publish.rs` (behind `oci`) — `Origin`, `PublishRecord`, `Recording`,
  `Chained`, `inheritable_layers`, `Publishing`, `Tuning`, `open`, `standing`,
  and the staging arithmetic (`StagingPeak`, `staging_peak`, `staging_need`,
  `preflight`).

`Chained::new` takes parts rather than a plan: a profile, the sequence, the
`position` document (read only by the profile, through `check_same_dataset`)
and the `Origin` the profile composes. `record_path_in` stays in
`crates/snapshot` — the driver takes an explicit path and never derives a
node's layout.

`crates/snapshot/src/registry.rs` goes 1,902 → 1,145 lines.

## `is_state_kind`, the one hook the ruling added

The staging arithmetic sizes a stele's two halves differently: every tip layer
sums, and only the largest few of everything else do. The other four methods
cannot separate them — `is_inheritable` is true for `blocks` and `indexes` and
false for *both* a tip shard and `digests` — so no combination distinguishes
the layers that must be summed from the one that must not. `is_state_kind` is
pure kind classification, the same nature as `epoch_kinds`, and
`DolosProfile` answers it by delegating to the existing `is_state_kind`.

## `Origin::network_magic` → `dataset_id`

Renamed field and wire (`networkMagic` → `datasetId`). A dataset-shaped name
has no place in a profile-generic crate's record schema, and this is the cheap
moment — before an external consumer exists and before the repo boundary
freezes it.

Consequence, accepted knowingly: **a resumption record written by an older
binary no longer matches**, so a publish in flight across the upgrade restarts
instead of resuming. That is host-local operational state, not published
protocol — the record is a stand-in for a manifest an interrupted publish never
wrote, and a stale one has always cost a rebuild rather than a wrong publish.

The ruling anticipated regenerating the `registry_fixture` `PublishRecord`
fixtures as the one sanctioned regeneration. **In the end none existed to
regenerate**: `registry_fixture` spawns a real registry per run and the records
are written and read back inside the suite, so no serialized `PublishRecord`
is frozen on disk. The rename is source-only.

## What stayed, and why (the 2026-09-01 ruling)

1. **`Point`, `verify`, `inspect`, `check_layer`** stay profile-side. Tag
   strings are operator-facing profile surface; parsing them is profile work,
   and trading `Display`/`FromStr` for profile-taking constructors would churn
   the call shape for no boundary gain.
2. **`Following`, `Attested`, `retained_dumps`** stay profile-side,
   implementing the driver's `Predecessor` trait. They read
   `layer.scope["epoch"]`, and the opaque-JSON scope decision is about exactly
   that read.
3. **Restore planning re-scoped** to `Budget`, `Checkpoint`, `Outlook`.
   `restore::Plan` (a `ChainPoint` via `Position`), `plan()` (the profile's
   reading rules) and `Summary` (dataset-shaped fields) stay in
   `crates/snapshot`.

## One signature change worth reading

`Publishing::storage_path` is now `record_path: Option<PathBuf>`, and the type
is `Clone` rather than `Copy`. The plan asks the driver to take explicit paths,
and a builder taking a `&Path` would accept a node's storage directory as
readily as its record — silently, one `join` apart. Both call sites go through
`record_path_in`.

`preflight` and `staging_peak` now take the profile as a second argument, since
the driver cannot name `DolosProfile`. Re-exported at their old paths in
`registry`.

## Nothing canonicalized changed

- `goldens.rs` passes with **zero re-pins**, and no golden file is in the diff.
- No published scope changed: the `network_magic` on `EpochScope`/`StateScope`
  — the fields that reach an inscription — is untouched. Only the local
  resumption record's `Origin` was renamed.
- The driver's `DatasetMismatch` flattens back into `Error::NetworkMismatch`
  with the same two numbers and the same message.

## Verification

Run at `6dbb478`, rebased onto `main`:

- `cargo +nightly-2026-08-27 fmt --all -- --check` — clean (the nightly #1284
  pins).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` —
  clean on CI.
- `cargo test --workspace --all-targets --all-features --exclude dolos-minibf
  --exclude dolos-minikupo --exclude dolos-trp` — 86 suites, 0 failures.
- `cargo test --workspace --all-targets` — 0 failures.
- Both runs include `goldens.rs`, `export.rs`, `publish.rs`,
  `restore_registry.rs` and `snapshot_verify.rs` against a real registry
  (docker), locally as well as on the three CI round-trip legs.
- `cargo tree -e normal --all-features -p stelae -p stelae-driver` — no
  `dolos-*` package in either tree.
