### PR TITLE
refactor(stelae): make the snapshot and restore commands parse and render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ dependencies = [
  "stelae-driver",
  "tempfile",
  "thiserror 2.0.18",
+ "toml 0.8.20",
  "tracing",
 ]
 

--- a/crates/core/src/import.rs
+++ b/crates/core/src/import.rs
@@ -11,7 +11,10 @@
 
 use tracing::{debug, instrument};
 
-use crate::{sync::run_lifecycle, BlockSlot, ChainLogic, Domain, DomainError, RawBlock, WorkUnit};
+use crate::{
+    sync::run_lifecycle, BlockSlot, ChainLogic, ChainPoint, Domain, DomainError, RawBlock,
+    StateError, StateStore, WalError, WalStore, WorkUnit,
+};
 
 /// Extension trait for bulk block import operations.
 ///
@@ -93,4 +96,63 @@ fn execute_work_unit<D: Domain>(domain: &D, work: &mut D::WorkUnit) -> Result<()
 #[cfg(test)]
 mod tests {
     // Tests will be added once we have the full integration in place
+}
+
+/// What seeding the WAL from the state cursor found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WalSeed {
+    /// No cursor: there is nothing to seed from, which is not a failure.
+    NoCursor,
+    /// The WAL now stands at this point.
+    Seeded(ChainPoint),
+}
+
+/// Why the WAL could not be seeded from the state cursor.
+///
+/// One variant per step, each carrying the message the bootstrap command has
+/// always printed, so the move costs an operator nothing.
+#[derive(Debug, thiserror::Error)]
+pub enum WalSeedError {
+    #[error("reading state cursor")]
+    ReadCursor(#[source] StateError),
+
+    #[error("state cursor at slot {slot} has no block hash, cannot seed WAL")]
+    Undefined { slot: BlockSlot },
+
+    #[error("seeding WAL from state cursor")]
+    Reset(#[source] WalError),
+}
+
+/// Seed the WAL from the state cursor so that `find_intersect` works after a
+/// bulk import.
+///
+/// [`ImportExt`] skips WAL commits for throughput, and so do several bootstrap
+/// mechanisms, which leaves the WAL empty or stale beside a state store that
+/// has moved. This puts the WAL tip back on the state cursor whatever filled
+/// the stores — so it sits beside the import path that creates the gap rather
+/// than in any one command that has to close it.
+///
+/// Generic over the two store traits rather than over a [`Domain`], because a
+/// bootstrap has the two stores open and no domain assembled; a caller holding
+/// a domain passes `domain.state()` and `domain.wal()`.
+pub fn seed_wal_from_state<S, W>(state: &S, wal: &W) -> Result<WalSeed, WalSeedError>
+where
+    S: StateStore,
+    W: WalStore,
+{
+    let cursor = state.read_cursor().map_err(WalSeedError::ReadCursor)?;
+
+    let Some(cursor) = cursor else {
+        return Ok(WalSeed::NoCursor);
+    };
+
+    if !cursor.is_fully_defined() {
+        return Err(WalSeedError::Undefined {
+            slot: cursor.slot(),
+        });
+    }
+
+    wal.reset_to(&cursor).map_err(WalSeedError::Reset)?;
+
+    Ok(WalSeed::Seeded(cursor))
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod wal;
 pub mod work_unit;
 
 pub use bootstrap::BootstrapExt;
-pub use import::ImportExt;
+pub use import::{seed_wal_from_state, ImportExt, WalSeed, WalSeedError};
 pub use submit::SubmitExt;
 pub use sync::SyncExt;
 pub use work_unit::{MempoolUpdate, WorkUnit};

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -31,6 +31,9 @@ tracing.workspace = true
 [dev-dependencies]
 tempfile = "3.20.0"
 
+# `node`'s tests build a `[storage]` section the way an operator writes one.
+toml = "0.8.13"
+
 # The registry suites install `ring` as the process-default crypto provider —
 # the precondition `stelae::oci` puts on whatever process opens a `Registry`.
 # The `dolos` binary does it in `main()`; under `cargo test` the test binary

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -903,6 +903,53 @@ where
     )
 }
 
+/// A reproduced stele's document: the bytes a verifier hashes, and what they
+/// hash to.
+///
+/// The canonical encoding rather than the [`Inscription`], because that is what
+/// `dolos snapshot digest` writes and what `--chain-from` reads back: anything
+/// that re-encoded it would carry a digest nobody else computes.
+#[derive(Debug, Clone)]
+pub struct Document {
+    /// The canonical inscription, byte for byte.
+    pub canonical: Vec<u8>,
+    /// Its sha256, which is the stele's identity.
+    pub identity: stelae::Digest,
+    pub layers: usize,
+    pub uncompressed_size: u64,
+}
+
+/// Reproduce a stele from local stores and canonicalize it, writing nothing.
+///
+/// What a publish costs, minus the I/O and the upload: every layer is
+/// compressed, because a reproduction that skipped compression would not be
+/// doing the work a publish does.
+///
+/// `previous` is the chain this reproduction is told to follow. It is an input
+/// and not an inference — `history` rides inside the canonical document, so the
+/// same stores chained differently are two different digests, deliberately.
+pub fn digest_document<A, S, I>(
+    plan: &Plan,
+    archive: &A,
+    state: &S,
+    indexes: &I,
+    previous: &dyn Predecessor,
+) -> Result<Document, Error>
+where
+    A: ArchiveStore,
+    S: StateStore,
+    I: IndexStore,
+{
+    let inscription = reproduce(plan, archive, state, indexes, None, previous)?;
+
+    Ok(Document {
+        canonical: inscription.canonicalize()?,
+        identity: inscription.digest()?,
+        layers: inscription.layers.len(),
+        uncompressed_size: inscription.uncompressed_size(),
+    })
+}
+
 /// Reproduce `published` from local stores and hold the two documents against
 /// each other.
 ///

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -52,10 +52,20 @@
 //!   that cannot fit its volume says so at minute zero.
 //! - `registry` (feature `oci`) — publishing into an OCI repository: the
 //!   history chain, and the layers a publish inherits instead of rebuilding.
+//! - [`planning`] — the epoch selection every command that walks these stores
+//!   takes, and the arithmetic each of them reports.
+//! - [`node`] — what a node's own configuration says about reaching a registry:
+//!   which identity, and where it stages.
+//! - `publisher` (feature `oci`) — the order a repository publish's steps go
+//!   in, and what each reading of the repository means for one.
 
 pub mod export;
 pub mod layers;
 pub mod namespaces;
+pub mod node;
+pub mod planning;
+#[cfg(feature = "oci")]
+pub mod publisher;
 #[cfg(feature = "oci")]
 pub mod registry;
 pub mod restore;
@@ -64,6 +74,12 @@ pub mod restore;
 /// paths and byte counts and knows nothing about what fills them. Re-exported
 /// at its old path.
 pub use stelae_driver::preflight;
+
+/// The bounded patience a run spends on an external that fails in bursts, which
+/// is [`stelae_driver`]'s: one policy over attempts and a clock, and nothing
+/// about what is being retried. Re-exported so a binary reaching for it never
+/// has to name the driver crate.
+pub use stelae_driver::retry;
 
 /// The layer and record arithmetic both drivers report through, which is
 /// [`stelae_driver`]'s for the same reason. Not public here, because it never
@@ -676,6 +692,45 @@ pub enum Error {
     /// shard would already have attested it.
     #[error("snapshot.state_epochs is not a list of retained epochs: {0}")]
     RetainedEpochs(String),
+
+    /// `[stelae.registry]` naming two identities at once.
+    ///
+    /// Not a precedence rule, because on a registry whose credentials carry
+    /// different capabilities, guessing is the difference between a publish and
+    /// a 403 nobody can explain.
+    #[error(
+        "[stelae.registry] sets both `token` and `user`; a registry client authenticates as one \
+         identity and which one was meant is not something to guess at — drop the one you did not \
+         mean, or unset DOLOS_STELAE_REGISTRY_TOKEN / DOLOS_STELAE_REGISTRY_USER"
+    )]
+    AmbiguousRegistryIdentity,
+
+    /// A secret that arrived with nobody to be. Anonymous would be the quiet
+    /// answer and the wrong one: the operator supplied a secret and it would go
+    /// unused.
+    #[error(
+        "[stelae.registry] sets `password` with no `user`; basic registry credentials are a pair"
+    )]
+    OrphanRegistryPassword,
+
+    /// The repository has already reached this node, and `--require-new` said
+    /// that is a failure. The ordinary reading of the same standing is
+    /// [`publisher::Next::Nothing`], which carries this exact sentence.
+    #[error("{0}")]
+    NothingToPublish(String),
+
+    /// A publish further ahead than one sequence, which would leave a gap no
+    /// later stele could close.
+    #[error(
+        "this repository's latest stele is sequence {latest} and this node is at sequence \
+         {sequence}, {distance} sequences ahead: a publish must follow the repository's latest \
+         stele, and this one would leave a gap no later stele could close"
+    )]
+    PublishWouldGap {
+        latest: u64,
+        sequence: u64,
+        distance: u64,
+    },
 }
 
 impl Error {

--- a/crates/snapshot/src/node.rs
+++ b/crates/snapshot/src/node.rs
@@ -86,15 +86,11 @@ mod auth {
         match &registry.user {
             Some(user) => Ok(Auth::Basic {
                 user: user.clone(),
-                // A user and no password means the official registry's.
                 password: registry
                     .password
                     .clone()
                     .unwrap_or_else(|| OFFICIAL_REGISTRY_PASSWORD.to_owned()),
             }),
-            // A password with nobody to be. Anonymous would be the quiet answer
-            // and the wrong one: the operator supplied a secret and it would go
-            // unused.
             None if registry.password.is_some() => Err(Error::OrphanRegistryPassword),
             None => Ok(Auth::Anonymous),
         }
@@ -208,9 +204,6 @@ mod tests {
             assert!(message.contains("user"), "{message}");
         }
 
-        /// A password with nobody to be. Anonymous would be the quiet answer
-        /// and the wrong one: the operator supplied a secret and it
-        /// would go unused.
         #[test]
         fn a_password_with_no_user_is_refused() {
             let orphan = StelaeRegistryConfig {

--- a/crates/snapshot/src/node.rs
+++ b/crates/snapshot/src/node.rs
@@ -1,0 +1,229 @@
+//! What a node's own configuration says about reaching a registry.
+//!
+//! Which identity a node reads a repository as, and where it stages the bytes
+//! it moves, are the node's policy rather than the transport's — but they are
+//! read off `dolos.toml` the same way by every command that opens a repository,
+//! so they are answered here instead of in each one.
+
+use std::path::{Path, PathBuf};
+
+use dolos_core::config::StorageConfig;
+
+/// The directory a registry transfer stages in when the operator names none.
+///
+/// A child of `storage.path` rather than a sibling of it: on a host where the
+/// data lives on a dedicated mount, a sibling is on the *parent* filesystem —
+/// the small root volume this default exists to keep bytes off.
+pub const STELE_SCRATCH_DIR: &str = "scratch";
+
+/// Where this node stages the layers of a registry transfer.
+///
+/// An explicit `--scratch-dir` is taken literally, relative paths included:
+/// it is resolved against the working directory like every other path a binary
+/// takes from a command line.
+pub fn scratch_dir(config: &StorageConfig, chosen: Option<&Path>) -> PathBuf {
+    match chosen {
+        Some(dir) => dir.to_path_buf(),
+        None => config.path.join(STELE_SCRATCH_DIR),
+    }
+}
+
+#[cfg(feature = "oci")]
+mod auth {
+    use dolos_core::config::StelaeConfig;
+
+    use crate::{registry::Auth, Error};
+
+    /// The password that goes with the official registry's published user.
+    ///
+    /// Not a secret: it is a read-only account on a public registry, and the
+    /// only thing it buys over anonymous access is a rate limit that a shared
+    /// NAT does not exhaust. It is compiled in rather than written into every
+    /// generated `dolos.toml` so that a node whose config names the user and no
+    /// password authenticates as that user rather than as nobody.
+    ///
+    /// Rotating the pair is a change here and in `dolos init`'s
+    /// `OFFICIAL_REGISTRY_USER` — paired with a release and comms, because
+    /// generated configs and released binaries carry the old one until their
+    /// nodes update.
+    pub const OFFICIAL_REGISTRY_PASSWORD: &str = "7214892e36157f4051677b51526382cc96693d45eda4e4cd";
+
+    /// Which identity this node reads a registry as.
+    ///
+    /// The environment overrides the file by the ordinary configuration route —
+    /// `DOLOS_STELAE_REGISTRY_USER` / `DOLOS_STELAE_REGISTRY_PASSWORD` reach
+    /// `[stelae.registry]` like any other setting — so the two sources an
+    /// operator sees are the two the configuration has: a consumer's published
+    /// user in `dolos.toml`, and a publisher's real credentials exported into
+    /// the environment and never written down. The configured user is still the
+    /// fallback: it is read-only, so authenticating with it fails a push at the
+    /// registry rather than a step earlier, which is the honest place for
+    /// "these credentials cannot publish" to be said.
+    ///
+    /// Two refusals, because both are operator mistakes worth a sentence rather
+    /// than a precedence rule:
+    ///
+    /// - **a token and a user together** — two identities, and which was meant
+    ///   is not something to guess at. On a registry whose credentials carry
+    ///   different capabilities, guessing is the difference between a publish
+    ///   and a 403 nobody can explain.
+    /// - **a password with no user** — a secret that arrived with nobody to be.
+    ///   It is a typo or half an export, and the half that arrived cannot be
+    ///   sent on its own.
+    pub fn registry_auth(config: &StelaeConfig) -> Result<Auth, Error> {
+        let Some(registry) = &config.registry else {
+            return Ok(Auth::Anonymous);
+        };
+
+        if registry.token.is_some() && registry.user.is_some() {
+            return Err(Error::AmbiguousRegistryIdentity);
+        }
+
+        if let Some(token) = &registry.token {
+            return Ok(Auth::Bearer(token.clone()));
+        }
+
+        match &registry.user {
+            Some(user) => Ok(Auth::Basic {
+                user: user.clone(),
+                // A user and no password means the official registry's.
+                password: registry
+                    .password
+                    .clone()
+                    .unwrap_or_else(|| OFFICIAL_REGISTRY_PASSWORD.to_owned()),
+            }),
+            // A password with nobody to be. Anonymous would be the quiet answer
+            // and the wrong one: the operator supplied a secret and it would go
+            // unused.
+            None if registry.password.is_some() => Err(Error::OrphanRegistryPassword),
+            None => Ok(Auth::Anonymous),
+        }
+    }
+}
+
+#[cfg(feature = "oci")]
+pub use auth::{registry_auth, OFFICIAL_REGISTRY_PASSWORD};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn storage(path: &str) -> StorageConfig {
+        let document = format!(
+            "version = \"v3\"\npath = {}\n",
+            toml::Value::String(path.to_owned()),
+        );
+
+        toml::from_str(&document).expect("a storage section with a path")
+    }
+
+    #[test]
+    fn staging_defaults_inside_the_storage_path_and_takes_a_named_one_literally() {
+        let config = storage("/var/lib/dolos/data");
+
+        assert_eq!(
+            scratch_dir(&config, None),
+            PathBuf::from("/var/lib/dolos/data/scratch"),
+        );
+
+        for named in ["/mnt/big/staging", "staging", "../staging"] {
+            assert_eq!(
+                scratch_dir(&config, Some(Path::new(named))),
+                PathBuf::from(named),
+                "{named}",
+            );
+        }
+    }
+
+    #[cfg(feature = "oci")]
+    mod auth {
+        use dolos_core::config::{StelaeConfig, StelaeRegistryConfig};
+
+        use crate::{
+            node::{registry_auth, OFFICIAL_REGISTRY_PASSWORD},
+            registry::Auth,
+        };
+
+        fn config(registry: Option<StelaeRegistryConfig>) -> StelaeConfig {
+            StelaeConfig { registry }
+        }
+
+        fn basic(user: &str, password: Option<&str>) -> StelaeRegistryConfig {
+            StelaeRegistryConfig {
+                user: Some(user.to_owned()),
+                password: password.map(str::to_owned),
+                token: None,
+            }
+        }
+
+        /// The three shapes `[stelae.registry]` can name, and the one it names
+        /// by saying nothing.
+        #[test]
+        fn the_section_names_a_user_a_token_or_nobody() {
+            assert_eq!(registry_auth(&config(None)).unwrap(), Auth::Anonymous);
+
+            assert_eq!(
+                registry_auth(&config(Some(basic("dolos-reader", Some("published"))))).unwrap(),
+                Auth::Basic {
+                    user: "dolos-reader".to_owned(),
+                    password: "published".to_owned(),
+                }
+            );
+
+            let bearer = StelaeRegistryConfig {
+                token: Some("ghp_x".to_owned()),
+                ..Default::default()
+            };
+
+            assert_eq!(
+                registry_auth(&config(Some(bearer))).unwrap(),
+                Auth::Bearer("ghp_x".to_owned())
+            );
+        }
+
+        /// A user with no password is the shape `dolos init` seeds: the file
+        /// says who, the binary says with what.
+        #[test]
+        fn a_seeded_user_takes_the_compiled_in_password() {
+            assert_eq!(
+                registry_auth(&config(Some(basic("dolos-reader", None)))).unwrap(),
+                Auth::Basic {
+                    user: "dolos-reader".to_owned(),
+                    password: OFFICIAL_REGISTRY_PASSWORD.to_owned(),
+                }
+            );
+        }
+
+        #[test]
+        fn two_identities_at_once_are_refused() {
+            let both = StelaeRegistryConfig {
+                user: Some("dolos-reader".to_owned()),
+                password: None,
+                token: Some("ghp_x".to_owned()),
+            };
+
+            let message = registry_auth(&config(Some(both))).unwrap_err().to_string();
+
+            assert!(message.contains("token"), "{message}");
+            assert!(message.contains("user"), "{message}");
+        }
+
+        /// A password with nobody to be. Anonymous would be the quiet answer
+        /// and the wrong one: the operator supplied a secret and it
+        /// would go unused.
+        #[test]
+        fn a_password_with_no_user_is_refused() {
+            let orphan = StelaeRegistryConfig {
+                password: Some("full-access".to_owned()),
+                ..Default::default()
+            };
+
+            let message = registry_auth(&config(Some(orphan)))
+                .unwrap_err()
+                .to_string();
+
+            assert!(message.contains("password"), "{message}");
+            assert!(message.contains("user"), "{message}");
+        }
+    }
+}

--- a/crates/snapshot/src/planning.rs
+++ b/crates/snapshot/src/planning.rs
@@ -1,0 +1,259 @@
+//! One epoch selection, and one reading of the plan it produces.
+//!
+//! `publish`, `digest` and `verify --reproduce` all build a plan from the same
+//! stores and all narrow it by the same knobs. A publisher that named "epochs
+//! 500 through 519" to one and got a different window from another would be
+//! verifying a different document than the one it published — and being told it
+//! matches. So the parse, the modifiers and the arithmetic a command reports
+//! live here, once, and a command spells none of them again.
+
+use dolos_core::{config::RootConfig, BlockSlot};
+
+use crate::{
+    export::{IndexBand, Plan, Producers},
+    Error, RetainedEpochs,
+};
+
+/// An epoch selection, in Rust's own range spellings.
+///
+/// Spelled the way a reader already knows how to read: `..` excludes its end,
+/// `..=` includes it. Both are accepted because a publisher naming "epochs 500
+/// through 519" and one naming "up to and including 519" are both natural, and
+/// silently picking one of the two meanings is how an operator publishes an
+/// epoch short.
+#[derive(Debug, Clone, Copy)]
+pub struct EpochRange {
+    first: Option<u64>,
+    last: Option<u64>,
+}
+
+impl EpochRange {
+    /// The first epoch selected, or `None` for "from the beginning".
+    pub fn first(&self) -> Option<u64> {
+        self.first
+    }
+
+    /// The last epoch selected, inclusive, or `None` for "to the cursor".
+    pub fn last(&self) -> Option<u64> {
+        self.last
+    }
+}
+
+impl std::str::FromStr for EpochRange {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let bad = |why: &str| format!("{raw:?} is not an epoch range: {why}");
+
+        let parse = |part: &str| -> Result<Option<u64>, String> {
+            match part.trim() {
+                "" => Ok(None),
+                value => value
+                    .parse::<u64>()
+                    .map(Some)
+                    .map_err(|e| bad(&format!("{value:?}: {e}"))),
+            }
+        };
+
+        // `..=` first: `..` is a prefix of it, so testing in the other order
+        // would read `500..=520` as a range ending at `=520`.
+        let (raw, inclusive) = match raw.split_once("..=") {
+            Some(_) => (raw.replacen("..=", "..", 1), true),
+            None => (raw.to_owned(), false),
+        };
+
+        let Some((start, end)) = raw.split_once("..") else {
+            // A bare number: exactly that epoch.
+            let only = parse(&raw)?.ok_or_else(|| bad("it is empty"))?;
+
+            return Ok(Self {
+                first: Some(only),
+                last: Some(only),
+            });
+        };
+
+        let first = parse(start)?;
+        let end = parse(end)?;
+
+        let last = match (end, inclusive) {
+            (Some(end), false) => Some(
+                end.checked_sub(1)
+                    .ok_or_else(|| bad("an exclusive end of 0 selects nothing"))?,
+            ),
+            (None, true) => return Err(bad("`..=` needs an end")),
+            (end, _) => end,
+        };
+
+        if let (Some(first), Some(last)) = (first, last) {
+            if first > last {
+                return Err(bad("it starts after it ends"));
+            }
+        }
+
+        Ok(Self { first, last })
+    }
+}
+
+/// The retained state-dump epochs a node publishes under.
+///
+/// Read here rather than in each command for the same reason [`restrict`] is:
+/// `publish`, `digest` and `verify --reproduce` all put this list in
+/// `parameters`, and a node that gave them different lists would be verifying
+/// a different document than the one it published — and being told it does not
+/// match. An absent `[snapshot]` section means an empty list, which is a
+/// publisher that retains the tip alone.
+pub fn retained_epochs(config: &RootConfig) -> Result<RetainedEpochs, Error> {
+    let configured = config
+        .snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.state_epochs.clone())
+        .unwrap_or_default();
+
+    RetainedEpochs::new(configured)
+}
+
+/// Apply an operator's selection to a plan, or leave it whole.
+///
+/// The one place any command narrows a plan. `restrict_epochs` takes two
+/// options and a caller could always inline the call; the point is that no
+/// command gets to spell the mapping from a range to those two options its own
+/// way.
+pub fn restrict(plan: Plan, range: Option<EpochRange>) -> Plan {
+    match range {
+        Some(range) => plan.restrict_epochs(range.first, range.last),
+        None => plan,
+    }
+}
+
+/// Apply an operator's index band to a plan, or leave the measured default.
+///
+/// The one place any command spells the mapping, for the reason [`restrict`] is
+/// shared: `publish`, `digest` and `verify --reproduce` all pay the same index
+/// traversals, and a knob one of them spelled its own way would be a knob an
+/// operator has to learn three times.
+///
+/// Unlike [`restrict`], this changes nothing about the document: banding
+/// reorders when index records are read, never which layer they land in. Two
+/// runs at different bands produce the same digest, which is why a
+/// reproduction is free to band differently than the publish it checks.
+pub fn banded(plan: Plan, band: Option<std::num::NonZeroUsize>) -> Plan {
+    match band {
+        Some(band) => plan.with_band(IndexBand::new(band)),
+        None => plan,
+    }
+}
+
+/// Apply an operator's producer pool to a plan, or leave the sized default.
+///
+/// Shared for the reason [`banded`] is: the same three commands pay the same
+/// store walks, so the knob that pools them is spelled once. Like the band,
+/// this changes nothing about the document — layers are reassembled by their
+/// position in it, never by completion order — so a reproduction is free to
+/// pool differently than the publish it checks.
+pub fn produced(plan: Plan, producers: Option<std::num::NonZeroUsize>) -> Plan {
+    match producers {
+        Some(producers) => plan.with_producers(Producers::new(producers)),
+        None => plan,
+    }
+}
+
+/// The epochs a plan covers, once there is at least one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochSpan {
+    pub first: u64,
+    pub last: u64,
+    /// How many epochs are selected, which is not `last - first + 1`: a
+    /// restriction can leave gaps the store never held.
+    pub count: usize,
+    pub start_slot: BlockSlot,
+    pub end_slot: BlockSlot,
+}
+
+/// Where the node stands and what the selection covers, as numbers.
+///
+/// Derived here rather than in each command so that a publisher comparing a
+/// `digest` run against the `publish` that produced a stele is comparing the
+/// same arithmetic — the band clamp and the dump count above all, both of which
+/// are easy to spell two ways and impossible to notice when they disagree.
+/// Composing the sentences is the command's.
+#[derive(Debug, Clone)]
+pub struct PlanReport {
+    pub network: String,
+    pub magic: u64,
+    pub cursor: String,
+    pub sequence: u64,
+    /// The tag the sequence renders as, which is the protocol's and can refuse.
+    pub tag: String,
+    /// Epochs per index traversal, **clamped to the epochs actually selected**:
+    /// the band chunks them, so a `--epochs 500..502` publish opens three sinks
+    /// whatever the band says, and the unclamped budget would overstate it by
+    /// orders of magnitude.
+    pub band_epochs: usize,
+    /// What those sinks are budgeted, in MiB.
+    pub band_budget_mib: usize,
+    /// `None` when the state tip alone is selected, which is a legitimate
+    /// publish rather than a mistake.
+    pub epochs: Option<EpochSpan>,
+    /// The dump epochs this publisher retains. An empty list is a choice with
+    /// consequences — it is what makes this publisher's parameters differ from
+    /// a co-signer's that retains dumps — so it is reported either way.
+    pub retained: Vec<u64>,
+    /// How many of them fall due at this sequence.
+    pub dumps_due: usize,
+}
+
+impl PlanReport {
+    pub fn read(plan: &Plan) -> Result<Self, Error> {
+        let band = plan.band.epochs().min(plan.epochs.len());
+
+        Ok(Self {
+            network: plan.network.name().to_owned(),
+            magic: plan.network.magic(),
+            cursor: plan.cursor.to_string(),
+            sequence: plan.sequence,
+            tag: plan.tag()?,
+            band_epochs: band,
+            band_budget_mib: band.saturating_mul(IndexBand::SINK_BYTES) / (1024 * 1024),
+            epochs: match (plan.epochs.first(), plan.epochs.last()) {
+                (Some(first), Some(last)) => Some(EpochSpan {
+                    first: first.epoch,
+                    last: last.epoch,
+                    count: plan.epochs.len(),
+                    start_slot: first.start_slot,
+                    end_slot: last.end_slot,
+                }),
+                _ => None,
+            },
+            retained: plan.retained.as_slice().to_vec(),
+            dumps_due: plan.retained.due(plan.sequence).count(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: &str) -> (Option<u64>, Option<u64>) {
+        let range: EpochRange = raw.parse().unwrap();
+        (range.first, range.last)
+    }
+
+    #[test]
+    fn epoch_ranges_read_the_way_rust_ranges_do() {
+        assert_eq!(parse("500..520"), (Some(500), Some(519)));
+        assert_eq!(parse("500..=520"), (Some(500), Some(520)));
+        assert_eq!(parse("500.."), (Some(500), None));
+        assert_eq!(parse("..520"), (None, Some(519)));
+        assert_eq!(parse("..=520"), (None, Some(520)));
+        assert_eq!(parse(".."), (None, None));
+        assert_eq!(parse("500"), (Some(500), Some(500)));
+    }
+
+    #[test]
+    fn a_nonsensical_range_is_refused() {
+        for raw in ["520..500", "..0", "abc", "", "500..abc", "500..=", "-1"] {
+            assert!(raw.parse::<EpochRange>().is_err(), "{raw:?}");
+        }
+    }
+}

--- a/crates/snapshot/src/publisher.rs
+++ b/crates/snapshot/src/publisher.rs
@@ -1,0 +1,287 @@
+//! Publishing into an OCI repository, as a sequence of steps a command drives.
+//!
+//! [`registry`](crate::registry) is the lifecycle: it opens a transport, reads
+//! the moving tag, chains onto a predecessor and moves blobs. What sits here is
+//! the layer above it — the order those calls go in, where a node's credentials
+//! and staging directory come from, and what each reading of the repository
+//! *means* for a publish that is about to start.
+//!
+//! ## Why the steps are separate calls
+//!
+//! Because a command has something to say between them. It reports where the
+//! node stands before the staging volume is sized, prints a dry run's counts
+//! and stops, and opens a progress renderer only once bytes are actually going
+//! to move — a renderer built any earlier draws an empty bar under a dry run's
+//! report. One call that did all of it would have to take a callback per line;
+//! four calls in an order a reader can see are the cheaper shape.
+
+use std::path::PathBuf;
+
+use dolos_core::{config::RootConfig, ArchiveStore, IndexStore, StateStore};
+use stelae::progress::Observer;
+use stelae_driver::Standing;
+
+use crate::{
+    export::Plan,
+    node,
+    registry::{self, Auth, Preview, Published, Publishing, Registry, Repository, Tuning},
+    DolosProfile, Error,
+};
+
+/// The repository arm's settings, freed of the CLI that spelled them.
+///
+/// Factored so `snapshot backfill` publishes through exactly the code path
+/// `snapshot publish --repo` does — same standing check, same preflight, same
+/// chained predecessor, same report — rather than a second telling of it that
+/// would drift.
+pub struct RepositoryPublish<'a> {
+    /// The repository to publish into.
+    pub repo: &'a Repository,
+
+    /// Talk plaintext HTTP rather than HTTPS.
+    pub insecure: bool,
+
+    /// Where to stage layers; `None` takes `<storage.path>/scratch`.
+    pub scratch_dir: Option<&'a std::path::Path>,
+
+    /// Build every layer instead of carrying forward published ones.
+    pub rebuild: bool,
+
+    /// Report what would be written and stop.
+    pub dry_run: bool,
+
+    /// Fail when the repository is already at this node's sequence.
+    pub require_new: bool,
+
+    /// How the publish moves: concurrency, and the carried-layer check.
+    pub tuning: Tuning,
+}
+
+/// What a publish should do, from where the node stands against the repository.
+///
+/// Three of the four readings [`Standing`] can take are terminal, and two of
+/// those are refusals — so this is the shape that is left once the policy has
+/// had its say: two ways to carry on, and one way to stop having done nothing
+/// wrong.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Next {
+    /// Nothing is published; this stele starts the chain.
+    First,
+
+    /// The repository's latest stele is `latest`, and this one extends it.
+    After { latest: u64 },
+
+    /// The repository has already reached this node, and the sentence that says
+    /// so. A job on a timer that runs more often than epochs close arrives here
+    /// every time it runs, and that is not a failure: a command reports this
+    /// and exits zero. The message is carried rather than composed by the
+    /// caller because `--require-new` refuses with the same one, and two
+    /// spellings of it would drift.
+    Nothing(String),
+}
+
+impl Next {
+    /// Read a standing into what the publish should do.
+    ///
+    /// The two refusals are the policy this exists for:
+    ///
+    /// - **`--require-new` over an up-to-date repository** — the ordinary case
+    ///   made an error, for an operator who ran this expecting a stele.
+    /// - **the node further ahead than one sequence** — refused, and the
+    ///   refusal stands: whether a deliberate gap ever gets a policy is not a
+    ///   command's to invent. The message names the distance alongside both
+    ///   sequences, so "the publisher has been down for a day" and "the
+    ///   publisher has been down for a month" do not read the same.
+    pub fn read(standing: Standing, sequence: u64, require_new: bool) -> Result<Self, Error> {
+        match standing {
+            Standing::Empty => Ok(Self::First),
+            Standing::Next { latest } => Ok(Self::After { latest }),
+            Standing::UpToDate { latest } => {
+                let message = format!(
+                    "nothing to publish: this repository is at sequence {latest} and this node is \
+                     at sequence {sequence}",
+                );
+
+                match require_new {
+                    true => Err(Error::NothingToPublish(message)),
+                    false => Ok(Self::Nothing(message)),
+                }
+            }
+            Standing::Ahead { latest, distance } => Err(Error::PublishWouldGap {
+                latest,
+                sequence,
+                distance,
+            }),
+        }
+    }
+}
+
+/// An opened repository and everything a node knows about publishing into it.
+pub struct Publisher {
+    registry: Registry,
+    record_path: PathBuf,
+    rebuild: bool,
+}
+
+impl Publisher {
+    /// Open the repository, staging where this node's configuration says.
+    ///
+    /// `auth` is resolved by the caller through [`node::registry_auth`], the
+    /// way every command that opens a repository resolves it — a node's
+    /// identity is one question with one answer, asked before a transport
+    /// exists.
+    ///
+    /// **Never call this from inside an async context.** See
+    /// [`registry::open`].
+    pub fn open(
+        config: &RootConfig,
+        publish: &RepositoryPublish<'_>,
+        auth: Auth,
+    ) -> Result<Self, Error> {
+        let scratch = node::scratch_dir(&config.storage, publish.scratch_dir);
+
+        let registry = registry::open(
+            publish.repo,
+            publish.insecure,
+            auth,
+            scratch,
+            publish.tuning,
+        )?;
+
+        Ok(Self {
+            registry,
+            // The resumption record sits beside the stores, so an interrupted
+            // publish restarted against this repository carries forward the
+            // epoch layers it already uploaded instead of rebuilding them.
+            // `--rebuild` starts it over along with everything else.
+            record_path: registry::record_path_in(&config.storage.path),
+            rebuild: publish.rebuild,
+        })
+    }
+
+    /// Read where this node stands against the repository.
+    ///
+    /// A read of the latest manifest and the one network call a publish makes
+    /// before it commits to anything, so running it again is free of
+    /// consequence — which is why the transient retry wraps it here rather than
+    /// anywhere later.
+    ///
+    /// `&|| false` for the abort predicate, `snapshot backfill`'s driver
+    /// included: the publish that follows this read observes no cancellation
+    /// for as long as it runs, so a predicate threaded in here would cut a
+    /// shutdown's wait by the backoff and leave the minutes on either side of
+    /// it untouched.
+    pub fn standing(&self, plan: &Plan) -> Result<Standing, Error> {
+        stelae_driver::retry::transient("reading the repository's latest stele", &|| false, || {
+            registry::standing(&self.registry, plan)
+        })
+    }
+
+    /// Size the staging directory against what the publish would put on it.
+    ///
+    /// Run before anything is built, and before a dry run too: a publisher
+    /// asking what a publish would do wants the same answer the publish gives.
+    /// A dry run that reported the layers and said nothing about the volume
+    /// they would be staged on would be the one rehearsal a publisher does,
+    /// missing the failure it exists to find. After
+    /// [`Publisher::standing`], because a repository holding another
+    /// network's chain is refused there and sizing against it would be
+    /// sizing against the wrong stele.
+    pub fn preflight(&self) -> Result<(), Error> {
+        Ok(registry::preflight(&self.registry, &DolosProfile)?)
+    }
+
+    /// What the publish would do, without writing anything.
+    pub fn preview<A: ArchiveStore>(&self, plan: &Plan, archive: &A) -> Result<Preview, Error> {
+        // `None` here and `None` at [`Publisher::publish`] are one decision: a
+        // dry run describes the publish that follows it, so the two calls are
+        // handed the same digest records or the number is about something else.
+        registry::preview(self.publishing(), plan, archive, None)
+    }
+
+    /// Publish, chained to whatever is already in the repository.
+    pub fn publish<A, S, I>(
+        &self,
+        plan: &Plan,
+        archive: &A,
+        state: &S,
+        indexes: &I,
+        observer: &Observer,
+    ) -> Result<Published, Error>
+    where
+        A: ArchiveStore,
+        S: StateStore,
+        I: IndexStore,
+    {
+        registry::publish(
+            self.publishing(),
+            plan,
+            archive,
+            state,
+            indexes,
+            None,
+            observer,
+        )
+    }
+
+    fn publishing(&self) -> Publishing<'_> {
+        Publishing::new(&self.registry)
+            .recording_in(self.record_path.clone())
+            .rebuilding(self.rebuild)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four readings, mapped one-to-one onto what a command does with them.
+    ///
+    /// The pair that used to live inside the CLI's `standing()`, and the pair
+    /// that is easiest to get wrong: an up-to-date repository is exit zero
+    /// unless `--require-new` says otherwise, and a gap is always a refusal.
+    #[test]
+    fn the_readings_map_onto_carrying_on_stopping_and_refusing() {
+        assert_eq!(
+            Next::read(Standing::Empty, 500, false).unwrap(),
+            Next::First
+        );
+
+        assert_eq!(
+            Next::read(Standing::Next { latest: 499 }, 500, false).unwrap(),
+            Next::After { latest: 499 }
+        );
+
+        let Ok(Next::Nothing(message)) = Next::read(Standing::UpToDate { latest: 500 }, 500, false)
+        else {
+            panic!("an up-to-date repository is not a failure without --require-new");
+        };
+
+        assert_eq!(
+            message,
+            "nothing to publish: this repository is at sequence 500 and this node is at sequence \
+             500",
+        );
+
+        // The same sentence, refused.
+        let refused = Next::read(Standing::UpToDate { latest: 500 }, 500, true).unwrap_err();
+        assert_eq!(refused.to_string(), message);
+
+        let gap = Next::read(
+            Standing::Ahead {
+                latest: 497,
+                distance: 3,
+            },
+            500,
+            false,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            gap.to_string(),
+            "this repository's latest stele is sequence 497 and this node is at sequence 500, 3 \
+             sequences ahead: a publish must follow the repository's latest stele, and this one \
+             would leave a gap no later stele could close",
+        );
+    }
+}

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -251,6 +251,27 @@ pub struct Plan {
     pub skipped_unknown: Vec<LayerDescriptor>,
 }
 
+/// One retained state dump a stele carries, as a report counts it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CarriedDump {
+    /// The epoch the dump's scope names.
+    pub epoch: u64,
+    /// How many state layers it carries.
+    pub carried: usize,
+}
+
+impl CarriedDump {
+    /// Whether the dump carries every state layer an epoch has.
+    pub fn is_whole(&self) -> bool {
+        self.carried == crate::state_layer_count()
+    }
+
+    /// How many it would carry if it were.
+    pub fn expected() -> usize {
+        crate::state_layer_count()
+    }
+}
+
 impl Plan {
     /// Every layer this restore will read.
     pub fn layers(&self) -> impl Iterator<Item = &LayerDescriptor> {
@@ -273,6 +294,45 @@ impl Plan {
     /// documentation for the two independent reasons it holds.
     pub fn tip_layers(&self) -> impl Iterator<Item = &LayerDescriptor> {
         self.state.values().flatten()
+    }
+
+    /// The distinct layer kinds this restore skipped for want of a codec,
+    /// byte-sorted.
+    ///
+    /// Derived here rather than in a report, because it is what an operator
+    /// acts on: an epoch dropped by `sync.max_history` is this node's own
+    /// configuration, and a layer dropped for a kind this build does not
+    /// implement is a stele from a publisher ahead of it. Empty for every stele
+    /// this profile publishes today.
+    pub fn skipped_kinds(&self) -> Vec<&str> {
+        let mut kinds: Vec<&str> = self
+            .skipped_unknown
+            .iter()
+            .map(|layer| layer.kind.as_str())
+            .collect();
+
+        kinds.sort_unstable();
+        kinds.dedup();
+
+        kinds
+    }
+
+    /// The retained dumps this stele carries, each with whether it is whole.
+    ///
+    /// A dump may be short of a whole epoch: only the tip is checked for
+    /// completeness — a publisher whose predecessor did not carry every shard
+    /// of an epoch warns and publishes the short dump anyway — so an epoch
+    /// that restores and an epoch missing nine of its shards would
+    /// otherwise be indistinguishable in a report, and the second is not a
+    /// repository that restores that epoch.
+    pub fn carried_dumps(&self) -> Vec<CarriedDump> {
+        self.state_dumps
+            .iter()
+            .map(|(epoch, kinds)| CarriedDump {
+                epoch: *epoch,
+                carried: kinds.values().map(Vec::len).sum(),
+            })
+            .collect()
     }
 
     /// The retained dumps this stele carries and this restore does not read.
@@ -1471,6 +1531,118 @@ fn rebuild_utxo_indexes<S: StateStore, I: IndexStore>(
 /// `digests` is verification metadata about Mithril immutable files; ADR-004 is
 /// explicit that nothing is written to the stores from it.
 pub const UNRESTORED_KINDS: [&str; 1] = [DIGESTS];
+
+/// Where a `--source` points.
+///
+/// The scheme is what selects a restore path, which is why this is parsed
+/// rather than sniffed: a directory that happens to look like a stele and a URL
+/// that says it is one are different claims, and only the second is the
+/// operator's.
+///
+/// Parsed by a command's argument parser rather than inside its body, so an
+/// unusable source is refused before `--force` has cleared anything. The flags
+/// that decide what to do with existing data are handled a layer above, and a
+/// source rejected any later would have cost the operator the node they still
+/// had.
+#[cfg(feature = "oci")]
+#[derive(Debug, Clone)]
+pub enum Source {
+    /// A stele directory on this filesystem.
+    Dir(std::path::PathBuf),
+    /// A stele repository in an OCI registry.
+    Repo(crate::registry::Repository),
+}
+
+#[cfg(feature = "oci")]
+impl std::str::FromStr for Source {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        use crate::registry::{Repository, SCHEME};
+
+        // `file:///abs/path` is the spelled-out form and leaves a leading slash
+        // behind, which is the absolute path. `file://relative/path` is the one
+        // an operator actually types, and leaves a relative one. Both work, and
+        // neither is guessed at: what follows the scheme is the path.
+        if let Some(path) = raw.strip_prefix("file://") {
+            if path.is_empty() {
+                return Err(format!("{raw:?} names no directory"));
+            }
+
+            return Ok(Self::Dir(std::path::PathBuf::from(path)));
+        }
+
+        if raw.starts_with(SCHEME) {
+            return raw
+                .parse::<Repository>()
+                .map(Self::Repo)
+                .map_err(|e| e.to_string());
+        }
+
+        Err(format!(
+            "{raw:?} is not a stele source; it is `file://DIR` or `{SCHEME}HOST/PATH`",
+        ))
+    }
+}
+
+#[cfg(all(test, feature = "oci"))]
+mod source_tests {
+    use std::path::PathBuf;
+
+    use super::Source;
+
+    #[test]
+    fn a_file_source_names_a_directory() {
+        for (raw, expected) in [
+            ("file:///var/lib/dolos/stele", "/var/lib/dolos/stele"),
+            ("file://stele", "stele"),
+            ("file://./stele", "./stele"),
+        ] {
+            let Source::Dir(dir) = raw.parse::<Source>().unwrap() else {
+                panic!("{raw:?} did not parse as a directory");
+            };
+
+            assert_eq!(dir, PathBuf::from(expected), "{raw:?}");
+        }
+    }
+
+    #[test]
+    fn an_oci_source_names_a_repository() {
+        let Source::Repo(repo) = "oci://ghcr.io/txpipe/dolos-snapshots/mainnet"
+            .parse::<Source>()
+            .unwrap()
+        else {
+            panic!("an oci url did not parse as a repository");
+        };
+
+        assert_eq!(repo.registry(), "ghcr.io");
+        assert_eq!(repo.repository(), "txpipe/dolos-snapshots/mainnet");
+    }
+
+    /// A source a restore cannot use is refused by the parse, not carried to
+    /// the registry — the whole reason `--source` is a parsed type, and what
+    /// makes the refusal land before `--force` clears anything.
+    ///
+    /// Only the scheme dispatch is this type's. What makes a *repository*
+    /// usable is the transport's and is tested there; these are the two cases
+    /// that get here either way, plus one that proves an unusable repository
+    /// does propagate.
+    #[test]
+    fn an_unusable_source_is_refused() {
+        for raw in [
+            "https://example.invalid/snapshot", // not a scheme this understands
+            "/var/lib/dolos/stele",             // a path is not a URL
+            "file://",
+            "",
+            // And a repository the transport refuses is refused here too,
+            // rather than being carried as far as a connection.
+            "oci://ghcr.io",
+            "oci://ghcr.io/txpipe/dolos:v1",
+        ] {
+            assert!(raw.parse::<Source>().is_err(), "{raw:?}");
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/stelae-driver/src/lib.rs
+++ b/crates/stelae-driver/src/lib.rs
@@ -27,6 +27,8 @@
 //!   forward from it.
 //! - [`publish`] — the chained-publish lifecycle against a repository, behind
 //!   the `oci` feature because that is where a repository lives.
+//! - [`retry`] — the bounded patience a run spends on an external that fails in
+//!   bursts.
 //! - [`Standing`] — where a node stands against a repository's latest stele.
 //! - [`scope_key`] — the pair that identifies one layer.
 
@@ -37,6 +39,7 @@ pub mod profile;
 #[cfg(feature = "oci")]
 pub mod publish;
 pub mod reporting;
+pub mod retry;
 
 pub use predecessor::{First, Predecessor};
 pub use profile::DriverProfile;

--- a/crates/stelae-driver/src/retry.rs
+++ b/crates/stelae-driver/src/retry.rs
@@ -1,0 +1,199 @@
+//! Bounded patience for an external that fails in bursts.
+//!
+//! A registry round trip and an aggregator fetch fail the same way — briefly,
+//! and for reasons neither end can classify — so the policy that absorbs them
+//! is one policy rather than one per caller.
+
+use std::time::Duration;
+
+/// Attempts a transient-prone external gets before its failure is fatal.
+///
+/// Bounded on purpose. The preprod G1 backfill measured why the retry exists —
+/// four container exits between 06:39Z and 08:53Z on 2026-08-23, each one
+/// paying a store restore, a window re-download and the in-flight epoch's
+/// re-replay for what a half-minute wait would have absorbed — and the same
+/// measurement is why it is not open-ended: a misconfigured aggregator or a
+/// repository the credentials cannot read has to keep failing, and keep
+/// failing while whoever launched the run is still watching.
+pub const RETRY_ATTEMPTS: u32 = 4;
+
+/// The first wait between attempts; each later one doubles it. Three waits of
+/// 5s, 10s and 20s put the ceiling at 35 seconds of patience.
+pub const RETRY_BASE_DELAY: Duration = Duration::from_secs(5);
+
+/// Sleep, unless a shutdown is requested first. `false` means it was.
+///
+/// Sliced rather than slept in one call so a signal that arrives during a
+/// backoff is honoured at the next slice instead of at the end of the wait —
+/// the driver's whole shutdown budget is a container's SIGTERM grace period,
+/// which a 20-second sleep would eat.
+fn sleep_unless_aborted(delay: Duration, abort: &dyn Fn() -> bool) -> bool {
+    const SLICE: Duration = Duration::from_millis(250);
+
+    let mut left = delay;
+
+    while !left.is_zero() {
+        if abort() {
+            return false;
+        }
+
+        let slice = left.min(SLICE);
+        std::thread::sleep(slice);
+        left -= slice;
+    }
+
+    !abort()
+}
+
+/// Run `op`, retrying a failure with exponential backoff, then let it be fatal.
+///
+/// The last attempt's error is returned untouched, so every caller keeps the
+/// diagnostic it had before the retry was wrapped around it — the retry moves
+/// where the fatal path is reached, never what it says. Nothing here decides a
+/// failure is transient: the classification the alternative would need does not
+/// exist at these seams (an aggregator's errors arrive as opaque strings), and
+/// guessing it wrong reinstates exactly the fatal exits this is here to absorb.
+/// What bounds the patience is [`RETRY_ATTEMPTS`], not a judgement about the
+/// error.
+///
+/// `abort` is polled between and during the waits, so a shutdown ends the run
+/// on the failure in hand rather than after the remaining backoff. Callers with
+/// no shutdown to observe pass `&|| false`.
+///
+/// Only for operations that are safe to simply run again: reads, and downloads
+/// whose destination is rewritten from the same arguments.
+pub fn transient<T, E, F>(what: &str, abort: &dyn Fn() -> bool, op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    E: std::fmt::Display,
+{
+    bounded(what, RETRY_ATTEMPTS, RETRY_BASE_DELAY, abort, op)
+}
+
+/// [`transient`] with its two constants spelled out, so a caller under test can
+/// exercise the loop without waiting out a real backoff.
+pub fn bounded<T, E, F>(
+    what: &str,
+    attempts: u32,
+    base_delay: Duration,
+    abort: &dyn Fn() -> bool,
+    mut op: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    E: std::fmt::Display,
+{
+    let mut delay = base_delay;
+
+    for attempt in 1..attempts {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if abort() {
+                    return Err(err);
+                }
+
+                tracing::warn!(
+                    what,
+                    attempt,
+                    remaining = attempts - attempt,
+                    backoff_secs = delay.as_secs(),
+                    error = %err,
+                    "transient failure; retrying",
+                );
+
+                if !sleep_unless_aborted(delay, abort) {
+                    return Err(err);
+                }
+
+                delay = delay.saturating_mul(2);
+            }
+        }
+    }
+
+    op()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The retry loop, with the real backoff replaced by none of it.
+    fn retried<T, E: std::fmt::Display>(
+        abort: &dyn Fn() -> bool,
+        op: impl FnMut() -> Result<T, E>,
+    ) -> Result<T, E> {
+        bounded("a test", RETRY_ATTEMPTS, Duration::ZERO, abort, op)
+    }
+
+    #[test]
+    fn a_call_that_succeeds_is_made_once() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+            Ok(7)
+        });
+
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls, 1, "a success must not be retried");
+    }
+
+    #[test]
+    fn a_transient_failure_is_absorbed() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+
+            if calls < 3 {
+                Err("the aggregator hung up".to_owned())
+            } else {
+                Ok(7)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls, 3, "the loop stops at the first success");
+    }
+
+    #[test]
+    fn patience_is_bounded_and_the_last_error_is_the_one_raised() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| false, || {
+            calls += 1;
+            Err(format!("attempt {calls} failed"))
+        });
+
+        assert_eq!(
+            calls, RETRY_ATTEMPTS as usize,
+            "a persistent failure must still reach the fatal path",
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            format!("attempt {RETRY_ATTEMPTS} failed"),
+            "the caller keeps the diagnostic the final attempt produced",
+        );
+    }
+
+    #[test]
+    fn a_shutdown_ends_the_run_on_the_failure_in_hand() {
+        let mut calls = 0;
+
+        let result: Result<u8, String> = retried(&|| true, || {
+            calls += 1;
+            Err("interrupted".to_owned())
+        });
+
+        assert_eq!(calls, 1, "a requested shutdown is not waited out");
+        assert_eq!(result.unwrap_err(), "interrupted");
+    }
+
+    #[test]
+    fn a_shutdown_during_a_backoff_cuts_the_wait_short() {
+        assert!(!sleep_unless_aborted(Duration::from_secs(60), &|| true));
+        assert!(sleep_unless_aborted(Duration::ZERO, &|| false));
+    }
+}

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -53,6 +53,91 @@ pub fn ensure_storage_path(config: &RootConfig) -> Result<PathBuf, Error> {
     Ok(config.storage.path.clone())
 }
 
+/// Empty the storage directory.
+///
+/// A `remove_dir_all` of the whole path and not a per-store wipe, which matters
+/// for one thing that is not a store: a stele restore's progress file lives
+/// inside `storage.path`, and a progress file that outlived the stores it
+/// describes would tell the next `--continue` to skip layers whose data is
+/// gone. Anything that clears storage has to clear that too, and taking the
+/// directory is how this does it without having to remember.
+pub fn clear_storage(storage_path: &Path) -> Result<(), Error> {
+    std::fs::remove_dir_all(storage_path)
+        .map_err(|e| Error::StorageError(format!("removing existing storage: {e}")))?;
+
+    std::fs::create_dir_all(storage_path)
+        .map_err(|e| Error::StorageError(format!("recreating storage directory: {e}")))?;
+
+    Ok(())
+}
+
+/// What to do about data already in storage.
+///
+/// Deciding is separated from doing because only one of the outcomes is
+/// destructive, and it must not happen until the run is fully known. An
+/// interactive bootstrap asks which method to use — and, for a stele, where the
+/// stele is — *after* the flags are parsed, so a `--force` that cleared first
+/// would take a working node away on a typo, a cancel, or a machine with no
+/// terminal, and hand back nothing in its place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Existing {
+    /// Data is there and `--skip-if-data` says to leave it alone.
+    Skip,
+    /// Go ahead, but clear storage first.
+    Clear,
+    /// Go ahead as things are.
+    Proceed,
+}
+
+/// The three flags that say what to do about data already in storage.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExistingDataPolicy {
+    /// `--force`: clear storage and re-bootstrap.
+    pub force: bool,
+    /// `--skip-if-data`: leave it alone and exit zero.
+    pub skip_if_data: bool,
+    /// `--continue`: go ahead, trusting the run to resume.
+    pub r#continue: bool,
+}
+
+/// Whether storage already holds a node: a state cursor is the whole test.
+pub fn has_existing_data(config: &RootConfig) -> Result<bool, Error> {
+    let state = open_state_store(config)?;
+
+    Ok(state.read_cursor()?.is_some())
+}
+
+/// Read what is in storage and decide, without touching any of it.
+///
+/// The refusals happen here — a skip, and the refusal for existing data with no
+/// flag saying what to do about it — so neither is a question asked of an
+/// operator whose answer is then thrown away.
+pub fn inspect_existing_data(
+    config: &RootConfig,
+    policy: ExistingDataPolicy,
+) -> Result<Existing, Error> {
+    if policy.r#continue {
+        return Ok(Existing::Proceed);
+    }
+
+    if !has_existing_data(config)? {
+        return Ok(Existing::Proceed);
+    }
+
+    if policy.skip_if_data {
+        return Ok(Existing::Skip);
+    }
+
+    if policy.force {
+        return Ok(Existing::Clear);
+    }
+
+    Err(Error::message(
+        "existing data detected in storage. Use --force to clear and re-bootstrap, \
+         --skip-if-data to skip, or --continue to resume",
+    ))
+}
+
 fn check_storage_version(config: &RootConfig) -> Result<(), Error> {
     if config.storage.version != StorageVersion::V3 {
         return Err(Error::StorageError(format!(
@@ -1527,5 +1612,69 @@ mod tests {
             message.contains("fjall"),
             "refusal must name the supported backend"
         );
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use dolos_snapshot::restore::Checkpoint;
+
+    /// A `--force` wipe takes the progress file with the data it describes.
+    ///
+    /// The hazard this rules out is specific and quiet. `--continue` reads the
+    /// progress file and skips every layer it names; `--force` clears the
+    /// stores. A progress file that survived a wipe would therefore tell the
+    /// next run that layers it has no data for are already done, and the node
+    /// that came out would be missing a slice of chain with nothing reporting
+    /// it.
+    ///
+    /// Asserted against [`super::clear_storage`]'s actual behaviour rather than
+    /// against the fact that it happens to call `remove_dir_all`: what has to
+    /// stay true is the outcome, however the wipe is later spelled.
+    #[test]
+    fn clearing_storage_removes_a_restore_in_progress() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = temp.path().join("data");
+
+        std::fs::create_dir_all(&storage).unwrap();
+
+        let progress = Checkpoint::path_in(&storage);
+        std::fs::write(&progress, b"{}").unwrap();
+
+        // A stand-in for the stores the progress file describes, so the
+        // assertion is about a directory that had a node in it.
+        std::fs::write(storage.join("state"), b"a store").unwrap();
+
+        assert!(progress.exists());
+
+        super::clear_storage(&storage).unwrap();
+
+        assert!(
+            !progress.exists(),
+            "a progress file outlived the stores it describes"
+        );
+
+        assert!(
+            storage.is_dir(),
+            "the storage directory itself has to come back, empty"
+        );
+
+        assert_eq!(
+            std::fs::read_dir(&storage).unwrap().count(),
+            0,
+            "and come back empty"
+        );
+    }
+
+    /// The progress file is *inside* the storage path.
+    ///
+    /// The other half of the test above, and the half that would fail first if
+    /// the file were ever moved: a wipe of `storage.path` only takes it while
+    /// it lives there.
+    #[test]
+    fn the_progress_file_lives_inside_the_storage_path() {
+        let storage = std::path::Path::new("/var/lib/dolos/data");
+
+        assert!(Checkpoint::path_in(storage).starts_with(storage));
     }
 }

--- a/src/bin/dolos/bootstrap/mod.rs
+++ b/src/bin/dolos/bootstrap/mod.rs
@@ -2,11 +2,12 @@ use std::io::IsTerminal;
 
 use clap::{Parser, Subcommand};
 use inquire::list_option::ListOption;
-use miette::{bail, Context, IntoDiagnostic};
+use miette::{bail, IntoDiagnostic};
 use tracing::info;
 
 use crate::feedback::Feedback;
-use dolos_core::{StateStore, WalStore};
+use dolos::storage::{Existing, ExistingDataPolicy};
+use dolos_core::{seed_wal_from_state, WalSeed};
 
 pub(crate) mod mithril;
 mod ranged;
@@ -87,82 +88,19 @@ pub struct Args {
 
 use dolos_core::config::RootConfig;
 
-fn has_existing_data(config: &RootConfig) -> miette::Result<bool> {
-    let state = crate::common::open_state_store(config)?;
-    let cursor = state
-        .read_cursor()
-        .into_diagnostic()
-        .context("reading state cursor")?;
-
-    Ok(cursor.is_some())
-}
-
-/// Empty the storage directory.
+/// What to do about data already in storage, and the flags that say it.
 ///
-/// A `remove_dir_all` of the whole path and not a per-store wipe, which matters
-/// for one thing that is not a store: a stele restore's progress file lives
-/// inside `storage.path`, and a progress file that outlived the stores it
-/// describes would tell the next `--continue` to skip layers whose data is
-/// gone. Anything that clears storage has to clear that too, and taking the
-/// directory is how this does it without having to remember.
-fn clear_storage(config: &RootConfig) -> miette::Result<()> {
-    info!("existing data detected, clearing storage due to --force");
-
-    clear_storage_path(&config.storage.path)
-}
-
-fn clear_storage_path(storage_path: &std::path::Path) -> miette::Result<()> {
-    std::fs::remove_dir_all(storage_path)
-        .into_diagnostic()
-        .context("removing existing storage")?;
-
-    std::fs::create_dir_all(storage_path)
-        .into_diagnostic()
-        .context("recreating storage directory")?;
-
-    Ok(())
-}
-
-/// What to do about data already in storage.
-///
-/// Deciding is separated from doing because only one of the outcomes is
-/// destructive, and it must not happen until the run is fully known. An
-/// interactive bootstrap asks which method to use — and, for a stele, where the
-/// stele is — *after* the flags are parsed, so a `--force` that cleared first
-/// would take a working node away on a typo, a cancel, or a machine with no
-/// terminal, and hand back nothing in its place.
-enum Existing {
-    /// Data is there and `--skip-if-data` says to leave it alone.
-    Skip,
-    /// Go ahead, but clear storage first.
-    Clear,
-    /// Go ahead as things are.
-    Proceed,
-}
-
-/// Read what is in storage and decide, without touching any of it.
-///
-/// The refusals happen here — a skip, and the bail for existing data with no
-/// flag saying what to do about it — so neither is a question asked of an
-/// operator whose answer is then thrown away.
+/// The decision is [`dolos::storage::inspect_existing_data`]'s — a wipe is
+/// storage lifecycle rather than anything a bootstrap method knows about — and
+/// what is here is the three flags that reach it.
 fn inspect_existing_data(config: &RootConfig, args: &Args) -> miette::Result<Existing> {
-    if args.r#continue {
-        return Ok(Existing::Proceed);
-    }
+    let policy = ExistingDataPolicy {
+        force: args.force,
+        skip_if_data: args.skip_if_data,
+        r#continue: args.r#continue,
+    };
 
-    if !has_existing_data(config)? {
-        return Ok(Existing::Proceed);
-    }
-
-    if args.skip_if_data {
-        return Ok(Existing::Skip);
-    }
-
-    if args.force {
-        return Ok(Existing::Clear);
-    }
-
-    bail!("existing data detected in storage. Use --force to clear and re-bootstrap, --skip-if-data to skip, or --continue to resume");
+    dolos::storage::inspect_existing_data(config, policy).into_diagnostic()
 }
 
 fn dispatch(
@@ -188,35 +126,17 @@ fn dispatch(
 /// Seed the WAL from the state cursor so that `find_intersect` works after
 /// bootstrap.
 ///
-/// Some bootstrap mechanisms skip WAL commits for performance, leaving it
-/// empty. This ensures the WAL tip matches the state cursor regardless of which
-/// bootstrap method was used.
-fn seed_wal_from_state(config: &RootConfig) -> miette::Result<()> {
+/// The seed itself is [`dolos_core::seed_wal_from_state`], beside the bulk
+/// import that leaves the gap; what is here is opening the two stores and
+/// saying what happened.
+fn seed_wal(config: &RootConfig) -> miette::Result<()> {
     let state = crate::common::open_state_store(config)?;
     let wal = crate::common::open_wal_store(config)?;
 
-    let cursor = state
-        .read_cursor()
-        .into_diagnostic()
-        .context("reading state cursor")?;
-
-    let Some(cursor) = cursor else {
-        info!("no state cursor after bootstrap, skipping WAL seed");
-        return Ok(());
-    };
-
-    if !cursor.is_fully_defined() {
-        return Err(miette::miette!(
-            "state cursor at slot {} has no block hash, cannot seed WAL",
-            cursor.slot(),
-        ));
+    match seed_wal_from_state(&state, &wal).into_diagnostic()? {
+        WalSeed::NoCursor => info!("no state cursor after bootstrap, skipping WAL seed"),
+        WalSeed::Seeded(cursor) => info!(%cursor, "seeded WAL from state cursor"),
     }
-
-    wal.reset_to(&cursor)
-        .into_diagnostic()
-        .context("seeding WAL from state cursor")?;
-
-    info!(%cursor, "seeded WAL from state cursor");
 
     Ok(())
 }
@@ -250,7 +170,9 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     // everything that could still refuse — the flags, the prompts, the source a
     // stele restore was given — has already had its say.
     if matches!(existing, Existing::Clear) {
-        clear_storage(config)?;
+        info!("existing data detected, clearing storage due to --force");
+
+        dolos::storage::clear_storage(&config.storage.path).into_diagnostic()?;
     }
 
     dispatch(config, &command, feedback, args.r#continue)?;
@@ -259,73 +181,9 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     // Some bootstrap mechanisms skip WAL commits for performance, leaving it empty
     // or stale. This ensures the WAL tip matches the state cursor regardless of
     // which bootstrap method was used.
-    if let Err(e) = seed_wal_from_state(config) {
+    if let Err(e) = seed_wal(config) {
         tracing::error!("failed to seed WAL from state: {}", e);
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use dolos_snapshot::restore::Checkpoint;
-
-    /// A `--force` wipe takes the progress file with the data it describes.
-    ///
-    /// The hazard this rules out is specific and quiet. `--continue` reads the
-    /// progress file and skips every layer it names; `--force` clears the
-    /// stores. A progress file that survived a wipe would therefore tell the
-    /// next run that layers it has no data for are already done, and the node
-    /// that came out would be missing a slice of chain with nothing reporting
-    /// it.
-    ///
-    /// Asserted against [`clear_storage`]'s actual behaviour rather than
-    /// against the fact that it happens to call `remove_dir_all`: what has to
-    /// stay true is the outcome, however the wipe is later spelled.
-    #[test]
-    fn clearing_storage_removes_a_restore_in_progress() {
-        let temp = tempfile::tempdir().unwrap();
-        let storage = temp.path().join("data");
-
-        std::fs::create_dir_all(&storage).unwrap();
-
-        let progress = Checkpoint::path_in(&storage);
-        std::fs::write(&progress, b"{}").unwrap();
-
-        // A stand-in for the stores the progress file describes, so the
-        // assertion is about a directory that had a node in it.
-        std::fs::write(storage.join("state"), b"a store").unwrap();
-
-        assert!(progress.exists());
-
-        super::clear_storage_path(&storage).unwrap();
-
-        assert!(
-            !progress.exists(),
-            "a progress file outlived the stores it describes"
-        );
-
-        assert!(
-            storage.is_dir(),
-            "the storage directory itself has to come back, empty"
-        );
-
-        assert_eq!(
-            std::fs::read_dir(&storage).unwrap().count(),
-            0,
-            "and come back empty"
-        );
-    }
-
-    /// The progress file is *inside* the storage path.
-    ///
-    /// The other half of the test above, and the half that would fail first if
-    /// the file were ever moved: a wipe of `storage.path` only takes it while
-    /// it lives there.
-    #[test]
-    fn the_progress_file_lives_inside_the_storage_path() {
-        let storage = std::path::Path::new("/var/lib/dolos/data");
-
-        assert!(Checkpoint::path_in(storage).starts_with(storage));
-    }
 }

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -39,7 +39,11 @@ use std::path::PathBuf;
 use dolos_core::config::RootConfig;
 use miette::{Context as _, IntoDiagnostic as _};
 
-use dolos_snapshot::registry::{self, Point, Repository};
+use dolos_snapshot::{
+    node,
+    registry::{self, Point, Repository},
+    restore::Source,
+};
 
 use crate::feedback::{Feedback, SteleProgress};
 
@@ -85,55 +89,6 @@ impl Args {
             insecure: false,
             scratch_dir: None,
         })
-    }
-}
-
-/// Where a `--source` points.
-///
-/// The scheme is what selects a restore path, which is why this is parsed
-/// rather than sniffed: a directory that happens to look like a stele and a URL
-/// that says it is one are different claims, and only the second is the
-/// operator's.
-///
-/// Parsed by clap rather than inside [`run`], so an unusable source is refused
-/// before `--force` has cleared anything. The flags that decide what to do with
-/// existing data are handled a layer above this command, and a source rejected
-/// any later would have cost the operator the node they still had.
-#[derive(Debug, Clone)]
-pub enum Source {
-    /// A stele directory on this filesystem.
-    Dir(PathBuf),
-    /// A stele repository in an OCI registry.
-    Repo(Repository),
-}
-
-impl std::str::FromStr for Source {
-    type Err = String;
-
-    fn from_str(raw: &str) -> Result<Self, Self::Err> {
-        // `file:///abs/path` is the spelled-out form and leaves a leading slash
-        // behind, which is the absolute path. `file://relative/path` is the one
-        // an operator actually types, and leaves a relative one. Both work, and
-        // neither is guessed at: what follows the scheme is the path.
-        if let Some(path) = raw.strip_prefix("file://") {
-            if path.is_empty() {
-                return Err(format!("{raw:?} names no directory"));
-            }
-
-            return Ok(Self::Dir(PathBuf::from(path)));
-        }
-
-        if raw.starts_with(registry::SCHEME) {
-            return raw
-                .parse::<Repository>()
-                .map(Self::Repo)
-                .map_err(|e| e.to_string());
-        }
-
-        Err(format!(
-            "{raw:?} is not a stele source; it is `file://DIR` or `{}HOST/PATH`",
-            registry::SCHEME,
-        ))
     }
 }
 
@@ -232,11 +187,11 @@ fn restore_repo(
     let node = Node::open(config)?;
 
     // Resolved here rather than inside the transport: which identity this node
-    // reads a registry as is the node's policy, and `crate::common` is where
-    // this program keeps its own. Where it stages comes from the same place.
-    let auth = crate::common::stele_registry_auth(&config.stelae)?;
+    // reads a registry as is the node's policy, and `dolos_snapshot::node` is
+    // where that policy lives. Where it stages comes from the same place.
+    let auth = node::registry_auth(&config.stelae).into_diagnostic()?;
 
-    let scratch = crate::common::stele_scratch_dir(&config.storage, scratch_dir);
+    let scratch = node::scratch_dir(&config.storage, scratch_dir);
 
     let registry = registry::open(repo, insecure, auth, scratch, registry::Tuning::default())
         .into_diagnostic()
@@ -298,19 +253,10 @@ fn report(
     // a layer dropped for a kind this build does not implement is a stele from
     // a publisher ahead of it. An operator acts on the second by upgrading.
     if !plan.skipped_unknown.is_empty() {
-        let mut kinds: Vec<&str> = plan
-            .skipped_unknown
-            .iter()
-            .map(|layer| layer.kind.as_str())
-            .collect();
-
-        kinds.sort_unstable();
-        kinds.dedup();
-
         println!(
             "skipped:  {} layer(s) this build has no kind for ({}); upgrade to restore them",
             plan.skipped_unknown.len(),
-            kinds.join(", "),
+            plan.skipped_kinds().join(", "),
         );
     }
 
@@ -326,26 +272,25 @@ fn report(
     // short dump anyway — so an epoch listed bare here and an epoch missing
     // nine of its shards would otherwise read identically, and the second is
     // not a repository that restores that epoch.
-    if !plan.state_dumps.is_empty() {
-        let epochs: Vec<String> = plan
-            .state_dumps
-            .iter()
-            .map(|(epoch, kinds)| {
-                let carried: usize = kinds.values().map(Vec::len).sum();
+    let dumps = plan.carried_dumps();
 
-                match carried == dolos_snapshot::state_layer_count() {
-                    true => epoch.to_string(),
-                    false => format!(
-                        "{epoch} (partial: {carried} of {} layers)",
-                        dolos_snapshot::state_layer_count(),
-                    ),
-                }
+    if !dumps.is_empty() {
+        let epochs: Vec<String> = dumps
+            .iter()
+            .map(|dump| match dump.is_whole() {
+                true => dump.epoch.to_string(),
+                false => format!(
+                    "{} (partial: {} of {} layers)",
+                    dump.epoch,
+                    dump.carried,
+                    dolos_snapshot::restore::CarriedDump::expected(),
+                ),
             })
             .collect();
 
         println!(
             "dumps:    {} retained state dump(s) carried and not restored (epochs {})",
-            plan.state_dumps.len(),
+            dumps.len(),
             epochs.join(", "),
         );
     }
@@ -385,63 +330,6 @@ pub fn run(
             feedback,
             resume,
         ),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn a_file_source_names_a_directory() {
-        for (raw, expected) in [
-            ("file:///var/lib/dolos/stele", "/var/lib/dolos/stele"),
-            ("file://stele", "stele"),
-            ("file://./stele", "./stele"),
-        ] {
-            let Source::Dir(dir) = raw.parse::<Source>().unwrap() else {
-                panic!("{raw:?} did not parse as a directory");
-            };
-
-            assert_eq!(dir, PathBuf::from(expected), "{raw:?}");
-        }
-    }
-
-    #[test]
-    fn an_oci_source_names_a_repository() {
-        let Source::Repo(repo) = "oci://ghcr.io/txpipe/dolos-snapshots/mainnet"
-            .parse::<Source>()
-            .unwrap()
-        else {
-            panic!("an oci url did not parse as a repository");
-        };
-
-        assert_eq!(repo.registry(), "ghcr.io");
-        assert_eq!(repo.repository(), "txpipe/dolos-snapshots/mainnet");
-    }
-
-    /// A source this command cannot use is refused by the parse, not carried to
-    /// the registry — the whole reason `--source` is a parsed type, and what
-    /// makes the refusal land before `--force` clears anything.
-    ///
-    /// Only the scheme dispatch is this module's. What makes a *repository*
-    /// usable is the transport's and is tested there; these are the two cases
-    /// that get here either way, plus one that proves an unusable repository
-    /// does propagate.
-    #[test]
-    fn an_unusable_source_is_refused() {
-        for raw in [
-            "https://example.invalid/snapshot", // not a scheme this understands
-            "/var/lib/dolos/stele",             // a path is not a URL
-            "file://",
-            "",
-            // And a repository the transport refuses is refused here too,
-            // rather than being carried as far as a connection.
-            "oci://ghcr.io",
-            "oci://ghcr.io/txpipe/dolos:v1",
-        ] {
-            assert!(raw.parse::<Source>().is_err(), "{raw:?}");
-        }
     }
 }
 

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -1,9 +1,5 @@
-use dolos_core::config::{
-    ChainConfig, GenesisConfig, LoggingConfig, RootConfig, StelaeConfig, StorageConfig,
-    TelemetryConfig,
-};
+use dolos_core::config::{ChainConfig, GenesisConfig, LoggingConfig, RootConfig, TelemetryConfig};
 use dolos_core::BootstrapExt;
-use dolos_snapshot::registry::Auth;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use miette::{Context as _, IntoDiagnostic};
 use opentelemetry::trace::TracerProvider as _;
@@ -65,88 +61,6 @@ pub fn load_config(
     s = s.add_source(::config::Environment::with_prefix("DOLOS").separator("_"));
 
     s.build()?.try_deserialize()
-}
-
-/// Who this node authenticates to a stele registry as.
-///
-/// A pure function of `[stelae.registry]`, and deliberately nothing more.
-/// **Dolos reads no environment variable of its own here**, because it does not
-/// have to: `load_config` layers `config::Environment` with the `DOLOS` prefix
-/// over every setting, so `DOLOS_STELAE_REGISTRY_USER` and
-/// `DOLOS_STELAE_REGISTRY_PASSWORD` already override what the file says, by the
-/// same mechanism and with the same precedence as every other field. A second,
-/// hand-rolled set of variables would be a second answer to a question the
-/// configuration has already answered — and this binary has no other.
-///
-/// So the two sources the operator sees are the two the configuration has: a
-/// consumer's published user in `dolos.toml`, and a publisher's real
-/// credentials exported into the environment and never written down.
-///
-/// Two refusals, because both are operator mistakes worth a sentence rather
-/// than a precedence rule:
-///
-/// - **a token and a user together** — two identities, and which was meant is
-///   not something to guess at. On a registry whose credentials carry different
-///   capabilities, guessing is the difference between a publish and a 403
-///   nobody can explain.
-/// - **a password with no user** — a secret that arrived with nobody to be. It
-///   is a typo or half an export, and the half that arrived cannot be sent on
-///   its own.
-pub fn stele_registry_auth(config: &StelaeConfig) -> miette::Result<Auth> {
-    let Some(registry) = &config.registry else {
-        return Ok(Auth::Anonymous);
-    };
-
-    if registry.token.is_some() && registry.user.is_some() {
-        miette::bail!(
-            "[stelae.registry] sets both `token` and `user`; a registry client authenticates as \
-             one identity and which one was meant is not something to guess at — drop the one \
-             you did not mean, or unset DOLOS_STELAE_REGISTRY_TOKEN / DOLOS_STELAE_REGISTRY_USER"
-        );
-    }
-
-    if let Some(token) = &registry.token {
-        return Ok(Auth::Bearer(token.clone()));
-    }
-
-    match &registry.user {
-        Some(user) => Ok(Auth::Basic {
-            user: user.clone(),
-            // A user and no password means the official registry's, which is
-            // compiled in beside the rest of the hardcoded defaults rather than
-            // written into every generated `dolos.toml`.
-            password: registry
-                .password
-                .clone()
-                .unwrap_or_else(|| crate::init::OFFICIAL_REGISTRY_PASSWORD.to_owned()),
-        }),
-        // A password with nobody to be. Anonymous would be the quiet answer and
-        // the wrong one: the operator supplied a secret and it would go unused.
-        None if registry.password.is_some() => miette::bail!(
-            "[stelae.registry] sets `password` with no `user`; basic registry credentials are a \
-             pair"
-        ),
-        None => Ok(Auth::Anonymous),
-    }
-}
-
-/// The directory a registry transfer stages in when the operator names none.
-///
-/// A child of `storage.path` rather than a sibling of it: on a host where the
-/// data lives on a dedicated mount, a sibling is on the *parent* filesystem —
-/// the small root volume this default exists to keep bytes off.
-pub const STELE_SCRATCH_DIR: &str = "scratch";
-
-/// Where this node stages the layers of a registry transfer.
-///
-/// An explicit `--scratch-dir` is taken literally, relative paths included:
-/// it is resolved against the working directory like every other path this
-/// binary takes from a command line.
-pub fn stele_scratch_dir(config: &StorageConfig, chosen: Option<&std::path::Path>) -> PathBuf {
-    match chosen {
-        Some(dir) => dir.to_path_buf(),
-        None => config.path.join(STELE_SCRATCH_DIR),
-    }
 }
 
 pub fn setup_domain(config: &RootConfig) -> miette::Result<DomainAdapter> {
@@ -385,114 +299,6 @@ pub fn hook_exit_token() -> CancellationToken {
     cancel
 }
 
-/// Attempts a transient-prone external gets before its failure is fatal.
-///
-/// Bounded on purpose. The preprod G1 backfill measured why the retry exists —
-/// four container exits between 06:39Z and 08:53Z on 2026-08-23, each one
-/// paying a store restore, a window re-download and the in-flight epoch's
-/// re-replay for what a half-minute wait would have absorbed — and the same
-/// measurement is why it is not open-ended: a misconfigured aggregator or a
-/// repository the credentials cannot read has to keep failing, and keep
-/// failing while whoever launched the run is still watching.
-const RETRY_ATTEMPTS: u32 = 4;
-
-/// The first wait between attempts; each later one doubles it. Three waits of
-/// 5s, 10s and 20s put the ceiling at 35 seconds of patience.
-const RETRY_BASE_DELAY: Duration = Duration::from_secs(5);
-
-/// Sleep, unless a shutdown is requested first. `false` means it was.
-///
-/// Sliced rather than slept in one call so a signal that arrives during a
-/// backoff is honoured at the next slice instead of at the end of the wait —
-/// the driver's whole shutdown budget is a container's SIGTERM grace period,
-/// which a 20-second sleep would eat.
-fn sleep_unless_aborted(delay: Duration, abort: &dyn Fn() -> bool) -> bool {
-    const SLICE: Duration = Duration::from_millis(250);
-
-    let mut left = delay;
-
-    while !left.is_zero() {
-        if abort() {
-            return false;
-        }
-
-        let slice = left.min(SLICE);
-        std::thread::sleep(slice);
-        left -= slice;
-    }
-
-    !abort()
-}
-
-/// Run `op`, retrying a failure with exponential backoff, then let it be fatal.
-///
-/// The last attempt's error is returned untouched, so every caller keeps the
-/// diagnostic it had before the retry was wrapped around it — the retry moves
-/// where the fatal path is reached, never what it says. Nothing here decides a
-/// failure is transient: the classification the alternative would need does not
-/// exist at these seams (an aggregator's errors arrive as opaque strings), and
-/// guessing it wrong reinstates exactly the fatal exits this is here to absorb.
-/// What bounds the patience is [`RETRY_ATTEMPTS`], not a judgement about the
-/// error.
-///
-/// `abort` is polled between and during the waits, so a shutdown ends the run
-/// on the failure in hand rather than after the remaining backoff. Callers with
-/// no shutdown to observe pass `&|| false`.
-///
-/// Only for operations that are safe to simply run again: reads, and downloads
-/// whose destination is rewritten from the same arguments.
-pub fn retry_transient<T, E, F>(what: &str, abort: &dyn Fn() -> bool, op: F) -> Result<T, E>
-where
-    F: FnMut() -> Result<T, E>,
-    E: std::fmt::Display,
-{
-    retry_bounded(what, RETRY_ATTEMPTS, RETRY_BASE_DELAY, abort, op)
-}
-
-/// [`retry_transient`] with its two constants spelled out, so the tests can
-/// exercise the loop without waiting out a real backoff.
-fn retry_bounded<T, E, F>(
-    what: &str,
-    attempts: u32,
-    base_delay: Duration,
-    abort: &dyn Fn() -> bool,
-    mut op: F,
-) -> Result<T, E>
-where
-    F: FnMut() -> Result<T, E>,
-    E: std::fmt::Display,
-{
-    let mut delay = base_delay;
-
-    for attempt in 1..attempts {
-        match op() {
-            Ok(value) => return Ok(value),
-            Err(err) => {
-                if abort() {
-                    return Err(err);
-                }
-
-                tracing::warn!(
-                    what,
-                    attempt,
-                    remaining = attempts - attempt,
-                    backoff_secs = delay.as_secs(),
-                    error = %err,
-                    "transient failure; retrying",
-                );
-
-                if !sleep_unless_aborted(delay, abort) {
-                    return Err(err);
-                }
-
-                delay = delay.saturating_mul(2);
-            }
-        }
-    }
-
-    op()
-}
-
 pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationToken) {
     loop {
         tokio::select! {
@@ -570,208 +376,22 @@ pub fn cleanup_data(config: &RootConfig) -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod tests {
-    use dolos_core::config::StelaeRegistryConfig;
+    use dolos_core::config::StelaeConfig;
+    use dolos_snapshot::{node::registry_auth, registry::Auth};
     use futures_util::stream::FuturesUnordered;
     use std::io;
     use tokio::task::JoinHandle;
 
     use super::*;
-    use crate::init::OFFICIAL_REGISTRY_PASSWORD;
 
-    /// The retry loop, with the real backoff replaced by none of it.
-    fn retried<T, E: std::fmt::Display>(
-        abort: &dyn Fn() -> bool,
-        op: impl FnMut() -> Result<T, E>,
-    ) -> Result<T, E> {
-        super::retry_bounded("a test", super::RETRY_ATTEMPTS, Duration::ZERO, abort, op)
-    }
-
-    #[test]
-    fn a_call_that_succeeds_is_made_once() {
-        let mut calls = 0;
-
-        let result: Result<u8, String> = retried(&|| false, || {
-            calls += 1;
-            Ok(7)
-        });
-
-        assert_eq!(result.unwrap(), 7);
-        assert_eq!(calls, 1, "a success must not be retried");
-    }
-
-    #[test]
-    fn a_transient_failure_is_absorbed() {
-        let mut calls = 0;
-
-        let result: Result<u8, String> = retried(&|| false, || {
-            calls += 1;
-
-            if calls < 3 {
-                Err("the aggregator hung up".to_owned())
-            } else {
-                Ok(7)
-            }
-        });
-
-        assert_eq!(result.unwrap(), 7);
-        assert_eq!(calls, 3, "the loop stops at the first success");
-    }
-
-    #[test]
-    fn patience_is_bounded_and_the_last_error_is_the_one_raised() {
-        let mut calls = 0;
-
-        let result: Result<u8, String> = retried(&|| false, || {
-            calls += 1;
-            Err(format!("attempt {calls} failed"))
-        });
-
-        assert_eq!(
-            calls, RETRY_ATTEMPTS as usize,
-            "a persistent failure must still reach the fatal path",
-        );
-
-        assert_eq!(
-            result.unwrap_err(),
-            format!("attempt {RETRY_ATTEMPTS} failed"),
-            "the caller keeps the diagnostic the final attempt produced",
-        );
-    }
-
-    #[test]
-    fn a_shutdown_ends_the_run_on_the_failure_in_hand() {
-        let mut calls = 0;
-
-        let result: Result<u8, String> = retried(&|| true, || {
-            calls += 1;
-            Err("interrupted".to_owned())
-        });
-
-        assert_eq!(calls, 1, "a requested shutdown is not waited out");
-        assert_eq!(result.unwrap_err(), "interrupted");
-    }
-
-    #[test]
-    fn a_shutdown_during_a_backoff_cuts_the_wait_short() {
-        assert!(!sleep_unless_aborted(Duration::from_secs(60), &|| true));
-        assert!(sleep_unless_aborted(Duration::ZERO, &|| false));
-    }
-
-    fn storage(path: &str) -> StorageConfig {
-        let document = format!(
-            "version = \"v3\"\npath = {}\n",
-            toml::Value::String(path.to_owned()),
-        );
-
-        toml::from_str(&document).expect("a storage section with a path")
-    }
-
-    #[test]
-    fn staging_defaults_inside_the_storage_path_and_takes_a_named_one_literally() {
-        let config = storage("/var/lib/dolos/data");
-
-        assert_eq!(
-            stele_scratch_dir(&config, None),
-            PathBuf::from("/var/lib/dolos/data/scratch"),
-        );
-
-        for named in ["/mnt/big/staging", "staging", "../staging"] {
-            assert_eq!(
-                stele_scratch_dir(&config, Some(std::path::Path::new(named))),
-                PathBuf::from(named),
-                "{named}",
-            );
-        }
-    }
-
-    fn config(registry: Option<StelaeRegistryConfig>) -> StelaeConfig {
-        StelaeConfig { registry }
-    }
-
-    fn basic(user: &str, password: Option<&str>) -> StelaeRegistryConfig {
-        StelaeRegistryConfig {
-            user: Some(user.to_owned()),
-            password: password.map(str::to_owned),
-            token: None,
-        }
-    }
-
-    /// The three shapes `[stelae.registry]` can name, and the one it names by
-    /// saying nothing.
-    #[test]
-    fn the_section_names_a_user_a_token_or_nobody() {
-        assert_eq!(stele_registry_auth(&config(None)).unwrap(), Auth::Anonymous);
-
-        assert_eq!(
-            stele_registry_auth(&config(Some(basic("dolos-reader", Some("published"))))).unwrap(),
-            Auth::Basic {
-                user: "dolos-reader".to_owned(),
-                password: "published".to_owned(),
-            }
-        );
-
-        let bearer = StelaeRegistryConfig {
-            token: Some("ghp_x".to_owned()),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            stele_registry_auth(&config(Some(bearer))).unwrap(),
-            Auth::Bearer("ghp_x".to_owned())
-        );
-    }
-
-    /// A user with no password is the shape `dolos init` seeds: the file says
-    /// who, the binary says with what.
-    #[test]
-    fn a_seeded_user_takes_the_compiled_in_password() {
-        assert_eq!(
-            stele_registry_auth(&config(Some(basic("dolos-reader", None)))).unwrap(),
-            Auth::Basic {
-                user: "dolos-reader".to_owned(),
-                password: OFFICIAL_REGISTRY_PASSWORD.to_owned(),
-            }
-        );
-    }
-
-    #[test]
-    fn two_identities_at_once_are_refused() {
-        let both = StelaeRegistryConfig {
-            user: Some("dolos-reader".to_owned()),
-            password: None,
-            token: Some("ghp_x".to_owned()),
-        };
-
-        let message = stele_registry_auth(&config(Some(both)))
-            .unwrap_err()
-            .to_string();
-
-        assert!(message.contains("token"), "{message}");
-        assert!(message.contains("user"), "{message}");
-    }
-
-    /// A password with nobody to be. Anonymous would be the quiet answer and
-    /// the wrong one: the operator supplied a secret and it would go unused.
-    #[test]
-    fn a_password_with_no_user_is_refused() {
-        let orphan = StelaeRegistryConfig {
-            password: Some("full-access".to_owned()),
-            ..Default::default()
-        };
-
-        let message = stele_registry_auth(&config(Some(orphan)))
-            .unwrap_err()
-            .to_string();
-
-        assert!(message.contains("password"), "{message}");
-        assert!(message.contains("user"), "{message}");
-    }
-
-    /// The environment reaches this section by the same route as every other
-    /// setting, and *this* is the assertion that says so.
+    /// The environment reaches `[stelae.registry]` by the same route as every
+    /// other setting, and *this* is the assertion that says so.
     ///
-    /// It is the whole of Dolos's registry-credential environment story — a
-    /// publisher exports `DOLOS_STELAE_REGISTRY_USER` and
+    /// It stays here, beside [`load_config`], while the credential policy it
+    /// feeds is [`dolos_snapshot::node::registry_auth`]'s: what is being pinned
+    /// is this binary's configuration sources, not what the profile crate makes
+    /// of them. It is the whole of Dolos's registry-credential environment
+    /// story — a publisher exports `DOLOS_STELAE_REGISTRY_USER` and
     /// `DOLOS_STELAE_REGISTRY_PASSWORD` and nothing in this binary reads them —
     /// so it is worth pinning rather than trusting. The source is built exactly
     /// as [`load_config`] builds it; only the file layers are left off, because
@@ -820,7 +440,7 @@ mod tests {
         }
 
         assert_eq!(
-            stele_registry_auth(&built.stelae).unwrap(),
+            registry_auth(&built.stelae).unwrap(),
             Auth::Basic {
                 user: "publisher".to_owned(),
                 password: "full-access".to_owned(),

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -199,29 +199,12 @@ impl From<&KnownNetwork> for MithrilConfig {
 /// Issued by the official registry at `oci.stelae.store`.
 const OFFICIAL_REGISTRY_USER: &str = "stelae";
 
-/// The password that goes with [`OFFICIAL_REGISTRY_USER`], compiled in rather
-/// than written to `dolos.toml`.
-///
-/// **Deliberately a published secret**, and the only one this project has:
-/// stele distribution is free and identity-less, but never unrestricted — the
-/// registry authenticates every request, and this is what a consumer
-/// authenticates with. So it gates out-of-band tooling and nothing else.
-///
-/// Compiled in rather than seeded into the file because a password copied into
-/// every generated `dolos.toml` is a password that has to be found again in
-/// every one of them. Here, a rotation reaches every node that takes the
-/// release; a node that overrode it in its own config keeps its override.
-///
-/// That makes this the one default here with a runtime reader as well as an
-/// init-time one: [`crate::common::stele_registry_auth`] answers a section that
-/// names a user and no password with it, reaching into this module the way
-/// `doctor` reaches into it for [`KnownNetwork`] rather than keeping a second
-/// account of what the defaults are.
-///
-/// Rotating the pair is a change here and nowhere else — paired with a release
-/// and comms, because generated configs and released binaries carry the old one
-/// until their nodes update.
-pub const OFFICIAL_REGISTRY_PASSWORD: &str = "7214892e36157f4051677b51526382cc96693d45eda4e4cd";
+// The password that goes with `OFFICIAL_REGISTRY_USER` is not here: it is
+// `dolos_snapshot::node::OFFICIAL_REGISTRY_PASSWORD`, compiled in beside the
+// code that reads it rather than written into every generated `dolos.toml`.
+// Rotating the pair is a change in both places, paired with a release and
+// comms, because generated configs and released binaries carry the old one
+// until their nodes update.
 
 /// `[stelae]` as a generated config carries it: the official registry's user,
 /// and no password.
@@ -843,9 +826,9 @@ mod tests {
     /// configurable in the file the same command generates.
     ///
     /// Only the round trip is asserted here. What a section with *no* password
-    /// authenticates with is [`crate::common::stele_registry_auth`]'s question,
-    /// and is answered by its tests against
-    /// [`OFFICIAL_REGISTRY_PASSWORD`].
+    /// authenticates with is [`dolos_snapshot::node::registry_auth`]'s
+    /// question, and is answered by its tests against
+    /// [`dolos_snapshot::node::OFFICIAL_REGISTRY_PASSWORD`].
     #[test]
     fn a_configured_password_survives_the_round_trip() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/bin/dolos/init.rs
+++ b/src/bin/dolos/init.rs
@@ -199,12 +199,9 @@ impl From<&KnownNetwork> for MithrilConfig {
 /// Issued by the official registry at `oci.stelae.store`.
 const OFFICIAL_REGISTRY_USER: &str = "stelae";
 
-// The password that goes with `OFFICIAL_REGISTRY_USER` is not here: it is
-// `dolos_snapshot::node::OFFICIAL_REGISTRY_PASSWORD`, compiled in beside the
-// code that reads it rather than written into every generated `dolos.toml`.
-// Rotating the pair is a change in both places, paired with a release and
-// comms, because generated configs and released binaries carry the old one
-// until their nodes update.
+// The password that goes with `OFFICIAL_REGISTRY_USER` is
+// `dolos_snapshot::node::OFFICIAL_REGISTRY_PASSWORD`, which is where rotating
+// the pair is documented.
 
 /// `[stelae]` as a generated config carries it: the official registry's user,
 /// and no password.

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -40,7 +40,7 @@
 //! the same shape on the other external — eight transient registry `500`s in
 //! eleven hours, each costing an epoch, ~7% of the night's wall clock spent
 //! redoing work over a failure class that lasts milliseconds. The patience is
-//! bounded at [`common::retry_transient`](crate::common::retry_transient)'s
+//! bounded at [`dolos_snapshot::retry::transient`]'s
 //! four attempts, so an aggregator that is wrong rather than flaky still
 //! fails, and fails while an operator is watching.
 //!
@@ -469,14 +469,14 @@ impl Driver<'_> {
         let plan = export::plan(
             &stores.state,
             u64::from(genesis.network_magic()),
-            super::retained_epochs(self.config)?,
+            dolos_snapshot::planning::retained_epochs(self.config).into_diagnostic()?,
         )
         .into_diagnostic()
         .context("planning the publish")?;
 
         super::report_plan(&plan)?;
 
-        let publish = super::publish::RepositoryPublish {
+        let publish = dolos_snapshot::publisher::RepositoryPublish {
             repo: &self.args.repo,
             insecure: self.args.insecure,
             scratch_dir: self.args.scratch_dir.as_deref(),
@@ -502,7 +502,7 @@ impl Driver<'_> {
         // the whole publish where it can be, per this method's own note — so a
         // SIGTERM arriving during a backoff ends the run on the failure in hand
         // rather than after the remaining patience.
-        crate::common::retry_transient(
+        dolos_snapshot::retry::transient(
             "publishing the pending sequence",
             &|| self.cancel.is_cancelled(),
             || super::publish::to_repository(self.config, &publish, &plan, &stores, self.feedback),
@@ -591,7 +591,7 @@ impl Driver<'_> {
 
             // A cancellation resolves to `Ok(None)` rather than an error, so
             // a shutdown is never something the retry waits out.
-            let Some(beacon) = crate::common::retry_transient(
+            let Some(beacon) = dolos_snapshot::retry::transient(
                 "listing mithril snapshots",
                 &|| self.cancel.is_cancelled(),
                 || {
@@ -657,7 +657,7 @@ impl Driver<'_> {
 
             // Safe to run again: the explicit `download_start`/`download_end`
             // make a retry plan the identical download over the same files.
-            let fetched = crate::common::retry_transient(
+            let fetched = dolos_snapshot::retry::transient(
                 "fetching a mithril immutable window",
                 &|| self.cancel.is_cancelled(),
                 || {

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -91,19 +91,13 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         .into_diagnostic()
         .context("opening the data stores")?;
 
-    let genesis = crate::common::open_genesis_files(&config.genesis)?;
+    let selection = super::Selection {
+        epochs: args.epochs,
+        index_band: args.index_band,
+        producers: args.producers,
+    };
 
-    let plan = export::plan(
-        &stores.state,
-        u64::from(genesis.network_magic()),
-        super::retained_epochs(config)?,
-    )
-    .into_diagnostic()
-    .context("planning the reproduction")?;
-
-    let plan = super::restrict(plan, args.epochs);
-    let plan = super::banded(plan, args.index_band);
-    let plan = super::produced(plan, args.producers);
+    let plan = super::planned(config, &stores, &selection, "planning the reproduction")?;
 
     super::report_plan(&plan)?;
 
@@ -126,34 +120,29 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         None => eprintln!("history:  none; this reproduction starts a chain"),
     }
 
-    let inscription = export::reproduce(
+    // The bytes, not a re-encoding of the content: they are what a verifier
+    // hashes, so anything that pretty-printed them would carry a digest nobody
+    // else computes. The identity is their sha256.
+    let document = export::digest_document(
         &plan,
         &stores.archive,
         &stores.state,
         &stores.indexes,
-        None,
         predecessor,
     )
     .into_diagnostic()
     .context("reproducing the stele")?;
 
-    // The bytes, not a re-encoding of the content: they are what a verifier
-    // hashes, so anything that pretty-printed them would carry a digest nobody
-    // else computes. The identity is their sha256, which is what
-    // `Inscription::digest` is.
-    let canonical = inscription.canonicalize().into_diagnostic()?;
-    let identity = inscription.digest().into_diagnostic()?;
-
-    eprintln!("layers:   {}", inscription.layers.len());
+    eprintln!("layers:   {}", document.layers);
     eprintln!(
         "size:     {} uncompressed bytes",
-        inscription.uncompressed_size()
+        document.uncompressed_size
     );
-    eprintln!("identity: {identity}");
+    eprintln!("identity: {}", document.identity);
 
     match args.output.as_deref() {
         Some(path) => {
-            std::fs::write(path, &canonical)
+            std::fs::write(path, &document.canonical)
                 .into_diagnostic()
                 .with_context(|| format!("writing {}", path.display()))?;
 
@@ -176,7 +165,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
             let mut stdout = std::io::stdout();
 
             stdout
-                .write_all(&canonical)
+                .write_all(&document.canonical)
                 .into_diagnostic()
                 .context("writing the inscription to stdout")?;
 

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -120,9 +120,6 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         None => eprintln!("history:  none; this reproduction starts a chain"),
     }
 
-    // The bytes, not a re-encoding of the content: they are what a verifier
-    // hashes, so anything that pretty-printed them would carry a digest nobody
-    // else computes. The identity is their sha256.
     let document = export::digest_document(
         &plan,
         &stores.archive,

--- a/src/bin/dolos/snapshot/inspect.rs
+++ b/src/bin/dolos/snapshot/inspect.rs
@@ -21,7 +21,10 @@
 
 use clap::Parser;
 use dolos_core::config::RootConfig;
-use dolos_snapshot::registry::{self, Point, Repository};
+use dolos_snapshot::{
+    node,
+    registry::{self, Point, Repository},
+};
 use miette::{Context as _, IntoDiagnostic as _};
 
 #[derive(Debug, Parser)]
@@ -51,11 +54,11 @@ pub struct Args {
 }
 
 pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
-    let auth = crate::common::stele_registry_auth(&config.stelae)?;
+    let auth = node::registry_auth(&config.stelae).into_diagnostic()?;
 
     // An inspection reads two small blobs into memory, so nothing is staged
     // and this directory is never created here.
-    let scratch = crate::common::stele_scratch_dir(&config.storage, None);
+    let scratch = node::scratch_dir(&config.storage, None);
 
     let registry = registry::open(
         &args.repo,

--- a/src/bin/dolos/snapshot/mod.rs
+++ b/src/bin/dolos/snapshot/mod.rs
@@ -15,17 +15,17 @@
 //!
 //! ## One epoch selection, however many commands take one
 //!
-//! [`EpochRange`] lives here rather than in either command, because a publisher
-//! that names "epochs 500 through 519" to one and gets a different window from
-//! the other is a publisher verifying a different stele than the one they
-//! published — and being told it matches. One parser, one restriction, applied
-//! by [`restrict`].
+//! [`EpochRange`] is the profile crate's rather than either command's, because
+//! a publisher that names "epochs 500 through 519" to one and gets a different
+//! window from the other is a publisher verifying a different stele than the
+//! one they published — and being told it matches. One parser, one restriction,
+//! one reading of the plan they produce: [`dolos_snapshot::planning`].
 
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
 use dolos_snapshot::{
-    export::{IndexBand, Plan, Producers},
-    RetainedEpochs,
+    export::{self, Plan},
+    planning::{self, PlanReport},
 };
 use miette::{Context as _, IntoDiagnostic as _};
 
@@ -37,6 +37,8 @@ mod digest;
 mod inspect;
 mod publish;
 mod verify;
+
+pub use dolos_snapshot::planning::EpochRange;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -80,219 +82,84 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
     }
 }
 
-/// An epoch selection, in Rust's own range spellings.
+/// The three knobs every command that walks these stores takes.
 ///
-/// Spelled the way a reader already knows how to read: `..` excludes its end,
-/// `..=` includes it. Both are accepted because a publisher naming "epochs 500
-/// through 519" and one naming "up to and including 519" are both natural, and
-/// silently picking one of the two meanings is how an operator publishes an
-/// epoch short.
-#[derive(Debug, Clone, Copy)]
-pub struct EpochRange {
-    first: Option<u64>,
-    last: Option<u64>,
+/// Spelled per command rather than flattened into one clap group, because the
+/// help text is not the same everywhere: `verify` takes all three only under
+/// `--reproduce`, and says so. What is shared is what they mean, which is
+/// [`dolos_snapshot::planning`]'s.
+pub struct Selection {
+    pub epochs: Option<EpochRange>,
+    pub index_band: Option<std::num::NonZeroUsize>,
+    pub producers: Option<std::num::NonZeroUsize>,
 }
 
-impl std::str::FromStr for EpochRange {
-    type Err = String;
-
-    fn from_str(raw: &str) -> Result<Self, Self::Err> {
-        let bad = |why: &str| format!("{raw:?} is not an epoch range: {why}");
-
-        let parse = |part: &str| -> Result<Option<u64>, String> {
-            match part.trim() {
-                "" => Ok(None),
-                value => value
-                    .parse::<u64>()
-                    .map(Some)
-                    .map_err(|e| bad(&format!("{value:?}: {e}"))),
-            }
-        };
-
-        // `..=` first: `..` is a prefix of it, so testing in the other order
-        // would read `500..=520` as a range ending at `=520`.
-        let (raw, inclusive) = match raw.split_once("..=") {
-            Some(_) => (raw.replacen("..=", "..", 1), true),
-            None => (raw.to_owned(), false),
-        };
-
-        let Some((start, end)) = raw.split_once("..") else {
-            // A bare number: exactly that epoch.
-            let only = parse(&raw)?.ok_or_else(|| bad("it is empty"))?;
-
-            return Ok(Self {
-                first: Some(only),
-                last: Some(only),
-            });
-        };
-
-        let first = parse(start)?;
-        let end = parse(end)?;
-
-        let last = match (end, inclusive) {
-            (Some(end), false) => Some(
-                end.checked_sub(1)
-                    .ok_or_else(|| bad("an exclusive end of 0 selects nothing"))?,
-            ),
-            (None, true) => return Err(bad("`..=` needs an end")),
-            (end, _) => end,
-        };
-
-        if let (Some(first), Some(last)) = (first, last) {
-            if first > last {
-                return Err(bad("it starts after it ends"));
-            }
-        }
-
-        Ok(Self { first, last })
-    }
-}
-
-/// The retained state-dump epochs this node publishes under.
+/// This node's plan, narrowed by the operator's selection.
 ///
-/// Read here rather than in each command for the same reason [`restrict`] is:
-/// `publish`, `digest` and `verify --reproduce` all put this list in
-/// `parameters`, and a node that gave them different lists would be verifying
-/// a different document than the one it published — and being told it does not
-/// match. An absent `[snapshot]` section means an empty list, which is a
-/// publisher that retains the tip alone.
-pub fn retained_epochs(config: &RootConfig) -> miette::Result<RetainedEpochs> {
-    let configured = config
-        .snapshot
-        .as_ref()
-        .map(|snapshot| snapshot.state_epochs.clone())
-        .unwrap_or_default();
+/// One sequence for `publish`, `digest` and `verify --reproduce`, because a
+/// node that gave them different plans would be verifying a different document
+/// than the one it published — and being told it does not match. `what` is the
+/// word the failing command uses for the plan it was building.
+pub fn planned(
+    config: &RootConfig,
+    stores: &crate::common::Stores,
+    selection: &Selection,
+    what: &'static str,
+) -> miette::Result<Plan> {
+    let genesis = crate::common::open_genesis_files(&config.genesis)?;
 
-    RetainedEpochs::new(configured)
+    let retained = planning::retained_epochs(config)
         .into_diagnostic()
-        .context("reading snapshot.state_epochs")
-}
+        .context("reading snapshot.state_epochs")?;
 
-/// Apply an operator's selection to a plan, or leave it whole.
-///
-/// The one place either command narrows a plan. `restrict_epochs` takes two
-/// options and a caller could always inline the call; the point is that neither
-/// command gets to spell the mapping from a range to those two options its own
-/// way.
-pub fn restrict(plan: Plan, range: Option<EpochRange>) -> Plan {
-    match range {
-        Some(range) => plan.restrict_epochs(range.first, range.last),
-        None => plan,
-    }
-}
+    let plan = export::plan(&stores.state, u64::from(genesis.network_magic()), retained)
+        .into_diagnostic()
+        .context(what)?;
 
-/// Apply an operator's index band to a plan, or leave the measured default.
-///
-/// The one place any command spells the mapping, for the reason [`restrict`] is
-/// shared: `publish`, `digest` and `verify --reproduce` all pay the same index
-/// traversals, and a knob one of them spelled its own way would be a knob an
-/// operator has to learn three times.
-///
-/// Unlike [`restrict`], this changes nothing about the document: banding
-/// reorders when index records are read, never which layer they land in. Two
-/// runs at different bands produce the same digest, which is why a
-/// reproduction is free to band differently than the publish it checks.
-pub fn banded(plan: Plan, band: Option<std::num::NonZeroUsize>) -> Plan {
-    match band {
-        Some(band) => plan.with_band(IndexBand::new(band)),
-        None => plan,
-    }
-}
+    let plan = planning::restrict(plan, selection.epochs);
+    let plan = planning::banded(plan, selection.index_band);
 
-/// Apply an operator's producer pool to a plan, or leave the sized default.
-///
-/// Shared for the reason [`banded`] is: the same three commands pay the same
-/// store walks, so the knob that pools them is spelled once. Like the band,
-/// this changes nothing about the document — layers are reassembled by their
-/// position in it, never by completion order — so a reproduction is free to
-/// pool differently than the publish it checks.
-pub fn produced(plan: Plan, producers: Option<std::num::NonZeroUsize>) -> Plan {
-    match producers {
-        Some(producers) => plan.with_producers(Producers::new(producers)),
-        None => plan,
-    }
+    Ok(planning::produced(plan, selection.producers))
 }
 
 /// The report every command opens with: where the node stands and what the
 /// selection covers.
 ///
-/// Shared so that a publisher comparing a `digest` run against the `publish`
-/// that produced a stele is comparing the same four lines. Written to `stderr`,
-/// because `digest` puts a document on `stdout` and a report interleaved with
-/// it would not be one.
+/// The numbers are [`PlanReport`]'s, so a publisher comparing a `digest` run
+/// against the `publish` that produced a stele is comparing the same
+/// arithmetic. What is here is the four lines it is said in. Written to
+/// `stderr`, because `digest` puts a document on `stdout` and a report
+/// interleaved with it would not be one.
 pub fn report_plan(plan: &Plan) -> miette::Result<()> {
-    let tag = plan.tag().into_diagnostic()?;
+    let report = PlanReport::read(plan).into_diagnostic()?;
+
+    eprintln!("network:  {} ({})", report.network, report.magic);
+    eprintln!("cursor:   {}", report.cursor);
+    eprintln!("sequence: {} (tag {})", report.sequence, report.tag);
 
     eprintln!(
-        "network:  {} ({})",
-        plan.network.name(),
-        plan.network.magic()
-    );
-    eprintln!("cursor:   {}", plan.cursor);
-    eprintln!("sequence: {} (tag {tag})", plan.sequence);
-
-    // Clamped to the epochs actually selected, because the band chunks them:
-    // a `--epochs 500..502` publish opens three sinks whatever the band says,
-    // and the unclamped budget would overstate it by orders of magnitude.
-    let band = plan.band.epochs().min(plan.epochs.len());
-
-    eprintln!(
-        "band:     {band} epochs per index traversal ({} MiB budgeted)",
-        band.saturating_mul(IndexBand::SINK_BYTES) / (1024 * 1024),
+        "band:     {} epochs per index traversal ({} MiB budgeted)",
+        report.band_epochs, report.band_budget_mib,
     );
 
-    match (plan.epochs.first(), plan.epochs.last()) {
-        (Some(first), Some(last)) => eprintln!(
+    match report.epochs {
+        Some(span) => eprintln!(
             "epochs:   {}..={} ({} of them, slots {}..={})",
-            first.epoch,
-            last.epoch,
-            plan.epochs.len(),
-            first.start_slot,
-            last.end_slot,
+            span.first, span.last, span.count, span.start_slot, span.end_slot,
         ),
         // The state tip alone is a legitimate publish; say so rather than
         // printing an empty range and looking like a mistake.
-        _ => eprintln!("epochs:   none selected; the state tip only"),
+        None => eprintln!("epochs:   none selected; the state tip only"),
     }
 
     // Printed always and not only when it is set, because an empty list is a
     // choice with consequences — it is what makes this publisher's parameters
     // differ from a co-signer's that retains dumps, and the line is where an
     // operator sees the two do not match.
-    let due = plan.retained.due(plan.sequence).count();
-
     eprintln!(
-        "dumps:    {:?} retained ({due} due at this sequence)",
-        plan.retained.as_slice(),
+        "dumps:    {:?} retained ({} due at this sequence)",
+        report.retained, report.dumps_due,
     );
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse(raw: &str) -> (Option<u64>, Option<u64>) {
-        let range: EpochRange = raw.parse().unwrap();
-        (range.first, range.last)
-    }
-
-    #[test]
-    fn epoch_ranges_read_the_way_rust_ranges_do() {
-        assert_eq!(parse("500..520"), (Some(500), Some(519)));
-        assert_eq!(parse("500..=520"), (Some(500), Some(520)));
-        assert_eq!(parse("500.."), (Some(500), None));
-        assert_eq!(parse("..520"), (None, Some(519)));
-        assert_eq!(parse("..=520"), (None, Some(520)));
-        assert_eq!(parse(".."), (None, None));
-        assert_eq!(parse("500"), (Some(500), Some(500)));
-    }
-
-    #[test]
-    fn a_nonsensical_range_is_refused() {
-        for raw in ["520..500", "..0", "abc", "", "500..abc", "500..=", "-1"] {
-            assert!(raw.parse::<EpochRange>().is_err(), "{raw:?}");
-        }
-    }
 }

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -2,13 +2,12 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use dolos_core::config::RootConfig;
-use dolos_snapshot::export;
 use miette::{Context as _, IntoDiagnostic as _};
 
 use dolos_snapshot::{
-    export::Standing,
-    registry::{self, Registry, Repository},
-    DolosProfile,
+    export, node,
+    publisher::{Next, Publisher, RepositoryPublish},
+    registry::{self, Repository},
 };
 
 use super::EpochRange;
@@ -103,19 +102,13 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         .into_diagnostic()
         .context("opening the data stores")?;
 
-    let genesis = crate::common::open_genesis_files(&config.genesis)?;
+    let selection = super::Selection {
+        epochs: args.epochs,
+        index_band: args.index_band,
+        producers: args.producers,
+    };
 
-    let plan = export::plan(
-        &stores.state,
-        u64::from(genesis.network_magic()),
-        super::retained_epochs(config)?,
-    )
-    .into_diagnostic()
-    .context("planning the publish")?;
-
-    let plan = super::restrict(plan, args.epochs);
-    let plan = super::banded(plan, args.index_band);
-    let plan = super::produced(plan, args.producers);
+    let plan = super::planned(config, &stores, &selection, "planning the publish")?;
 
     super::report_plan(&plan)?;
 
@@ -140,35 +133,6 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         // The required `destination` group already refuses this.
         (None, None) => unreachable!("one of --output-dir and --repo is required"),
     }
-}
-
-/// The repository arm's settings, freed of the CLI that spelled them.
-///
-/// Factored so `snapshot backfill` publishes through exactly the code path
-/// `snapshot publish --repo` does — same standing check, same preflight, same
-/// chained predecessor, same report — rather than a second telling of it that
-/// would drift.
-pub(super) struct RepositoryPublish<'a> {
-    /// The repository to publish into.
-    pub repo: &'a Repository,
-
-    /// Talk plaintext HTTP rather than HTTPS.
-    pub insecure: bool,
-
-    /// Where to stage layers; `None` takes `<storage.path>/scratch`.
-    pub scratch_dir: Option<&'a std::path::Path>,
-
-    /// Build every layer instead of carrying forward published ones.
-    pub rebuild: bool,
-
-    /// Report what would be written and stop.
-    pub dry_run: bool,
-
-    /// Fail when the repository is already at this node's sequence.
-    pub require_new: bool,
-
-    /// How the publish moves: concurrency, and the carried-layer check.
-    pub tuning: registry::Tuning,
 }
 
 fn to_directory(
@@ -217,9 +181,12 @@ fn to_directory(
 
 /// Publish into an OCI repository, chained to whatever is already in it.
 ///
-/// The report is what a publisher wants to check rather than trust: how much of
-/// this stele was inherited rather than built, and how much of it moved. Both
-/// are numbers the code counted, not an inference from a duration.
+/// Parse and render: [`Publisher`] is the lifecycle, [`Next`] is what each
+/// reading of the repository means for it, and what is here is the order the
+/// operator sees it in. The report is what a publisher wants to check rather
+/// than trust: how much of this stele was inherited rather than built, and how
+/// much of it moved. Both are numbers the code counted, not an inference from a
+/// duration.
 pub(super) fn to_repository(
     config: &RootConfig,
     publish: &RepositoryPublish,
@@ -229,48 +196,39 @@ pub(super) fn to_repository(
 ) -> miette::Result<()> {
     let repo = publish.repo;
 
-    // A publisher's credentials come from `STELAE_REGISTRY_USER` /
-    // `STELAE_REGISTRY_PASSWORD`, which override anything configured. The
-    // configured user is still the fallback: it is read-only, so authenticating
-    // with it fails the push at the registry rather than a step earlier — which
-    // is the honest place for "these credentials cannot publish" to be said.
-    let auth = crate::common::stele_registry_auth(&config.stelae)?;
+    let auth = node::registry_auth(&config.stelae).into_diagnostic()?;
 
-    let scratch = crate::common::stele_scratch_dir(&config.storage, publish.scratch_dir);
-
-    let registry = registry::open(repo, publish.insecure, auth, scratch, publish.tuning)
+    let publisher = Publisher::open(config, publish, auth)
         .into_diagnostic()
         .context("opening the repository")?;
 
-    // The resumption record sits beside the stores, so an interrupted publish
-    // restarted against this repository carries forward the epoch layers it
-    // already uploaded instead of rebuilding them. `--rebuild` starts it over
-    // along with everything else.
-    let publishing = registry::Publishing::new(&registry)
-        .recording_in(registry::record_path_in(&config.storage.path))
-        .rebuilding(publish.rebuild);
-
     // Before anything is built, and before the dry run too: a publisher asking
     // what a publish would do wants the same answer the publish gives.
-    if !standing(&registry, plan, publish.require_new)? {
-        return Ok(());
+    let standing = publisher
+        .standing(plan)
+        .into_diagnostic()
+        .context("reading the repository's latest stele")?;
+
+    match Next::read(standing, plan.sequence, publish.require_new).into_diagnostic()? {
+        Next::First => println!("follows:  nothing; this repository holds no stele"),
+        Next::After { latest } => println!("follows:  sequence {latest}"),
+        // Not a failure, and not this command's to dress up as one: the message
+        // is the crate's, the exit code is zero, and `--require-new` is what
+        // turns the same reading into the refusal above.
+        Next::Nothing(message) => {
+            println!("{message}");
+            return Ok(());
+        }
     }
 
-    // And on the same terms, for the same reason. A dry run that reported the
-    // layers and said nothing about the volume they would be staged on would be
-    // the one rehearsal a publisher does, missing the failure it exists to find.
-    // After `standing`, because a repository holding another network's chain is
-    // refused there and sizing against it would be sizing against the wrong
-    // stele.
-    registry::preflight(&registry, &DolosProfile)
+    publisher
+        .preflight()
         .into_diagnostic()
         .context("sizing the staging directory")?;
 
     if publish.dry_run {
-        // `None` here and `None` at the `publish` below are one decision: a dry
-        // run describes the publish that follows it, so the two calls are
-        // handed the same digest records or the number is about something else.
-        let preview = registry::preview(publishing, plan, &stores.archive, None)
+        let preview = publisher
+            .preview(plan, &stores.archive)
             .into_diagnostic()
             .context("planning the publish")?;
 
@@ -292,17 +250,16 @@ pub(super) fn to_repository(
     // under the report.
     let progress = SteleProgress::publishing(feedback);
 
-    let published = registry::publish(
-        publishing,
-        plan,
-        &stores.archive,
-        &stores.state,
-        &stores.indexes,
-        None,
-        &progress.observer(),
-    )
-    .into_diagnostic()
-    .context("publishing the stele")?;
+    let published = publisher
+        .publish(
+            plan,
+            &stores.archive,
+            &stores.state,
+            &stores.indexes,
+            &progress.observer(),
+        )
+        .into_diagnostic()
+        .context("publishing the stele")?;
 
     progress.finish();
 
@@ -331,69 +288,6 @@ pub(super) fn to_repository(
     println!("identity: {}", published.identity);
 
     Ok(())
-}
-
-/// Read where this node stands against the repository, and report it.
-///
-/// Returns whether the publish should go on. Three of the four readings are
-/// terminal here, and it is the *middle* one that this exists for:
-///
-/// - **nothing published, or exactly one sequence behind** — carry on.
-/// - **the repository has already reached this node** — there is nothing to
-///   publish. A job on a timer that runs more often than epochs close arrives
-///   here every time it runs, and that is not a failure, so it is reported and
-///   the process exits zero. `--require-new` makes the same case an error, for
-///   an operator who ran it expecting a stele.
-/// - **the node is further ahead than one sequence** — refused, and the refusal
-///   stands: whether a deliberate gap ever gets a policy is not this command's
-///   to invent. What is new is that the message names the distance alongside
-///   both sequences, so "the publisher has been down for a day" and "the
-///   publisher has been down for a month" do not read the same.
-fn standing(registry: &Registry, plan: &export::Plan, require_new: bool) -> miette::Result<bool> {
-    // A read of the latest manifest and the one network call a publish makes
-    // before it commits to anything, so running it again is free of consequence.
-    //
-    // `&|| false` for every caller, `snapshot backfill`'s driver included: the
-    // publish that follows this read observes no cancellation for as long as it
-    // runs, so a predicate threaded in here would cut a shutdown's wait by the
-    // backoff and leave the minutes on either side of it untouched.
-    let standing =
-        crate::common::retry_transient("reading the repository's latest stele", &|| false, || {
-            registry::standing(registry, plan)
-        })
-        .into_diagnostic()
-        .context("reading the repository's latest stele")?;
-
-    match standing {
-        Standing::Empty => {
-            println!("follows:  nothing; this repository holds no stele");
-            Ok(true)
-        }
-        Standing::Next { latest } => {
-            println!("follows:  sequence {latest}");
-            Ok(true)
-        }
-        Standing::UpToDate { latest } => {
-            let message = format!(
-                "nothing to publish: this repository is at sequence {latest} and this node is at \
-                 sequence {}",
-                plan.sequence,
-            );
-
-            if require_new {
-                return Err(miette::miette!("{message}"));
-            }
-
-            println!("{message}");
-            Ok(false)
-        }
-        Standing::Ahead { latest, distance } => Err(miette::miette!(
-            "this repository's latest stele is sequence {latest} and this node is at sequence \
-             {}, {distance} sequences ahead: a publish must follow the repository's latest \
-             stele, and this one would leave a gap no later stele could close",
-            plan.sequence,
-        )),
-    }
 }
 
 #[cfg(test)]

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -202,8 +202,6 @@ pub(super) fn to_repository(
         .into_diagnostic()
         .context("opening the repository")?;
 
-    // Before anything is built, and before the dry run too: a publisher asking
-    // what a publish would do wants the same answer the publish gives.
     let standing = publisher
         .standing(plan)
         .into_diagnostic()
@@ -212,9 +210,6 @@ pub(super) fn to_repository(
     match Next::read(standing, plan.sequence, publish.require_new).into_diagnostic()? {
         Next::First => println!("follows:  nothing; this repository holds no stele"),
         Next::After { latest } => println!("follows:  sequence {latest}"),
-        // Not a failure, and not this command's to dress up as one: the message
-        // is the crate's, the exit code is zero, and `--require-new` is what
-        // turns the same reading into the refusal above.
         Next::Nothing(message) => {
             println!("{message}");
             return Ok(());

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -34,7 +34,7 @@
 use clap::Parser;
 use dolos_core::config::RootConfig;
 use dolos_snapshot::{
-    export,
+    node,
     registry::{self, Point, Repository},
 };
 use miette::{Context as _, IntoDiagnostic as _};
@@ -88,12 +88,12 @@ pub struct Args {
 }
 
 pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
-    let auth = crate::common::stele_registry_auth(&config.stelae)?;
+    let auth = node::registry_auth(&config.stelae).into_diagnostic()?;
 
     // A verification streams every blob through a staged file. No
     // `--scratch-dir` of its own: it reads what is already published rather
     // than moving a node's own data.
-    let scratch = crate::common::stele_scratch_dir(&config.storage, None);
+    let scratch = node::scratch_dir(&config.storage, None);
 
     let registry = registry::open(
         &args.repo,
@@ -141,23 +141,17 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         .into_diagnostic()
         .context("opening the data stores")?;
 
-    let genesis = crate::common::open_genesis_files(&config.genesis)?;
+    let selection = super::Selection {
+        epochs: args.epochs,
+        index_band: args.index_band,
+        producers: args.producers,
+    };
 
-    let plan = export::plan(
-        &stores.state,
-        u64::from(genesis.network_magic()),
-        super::retained_epochs(config)?,
-    )
-    .into_diagnostic()
-    .context("planning the reproduction")?;
-
-    let plan = super::restrict(plan, args.epochs);
-    let plan = super::banded(plan, args.index_band);
-    let plan = super::produced(plan, args.producers);
+    let plan = super::planned(config, &stores, &selection, "planning the reproduction")?;
 
     super::report_plan(&plan)?;
 
-    let reproduced = export::verify_reproduction(
+    let reproduced = dolos_snapshot::export::verify_reproduction(
         &verified.inscription,
         &plan,
         &stores.archive,


### PR DESCRIPTION
Plan: `plans/dolos-stelae-repo-split-cli-thinning.md` — third sub-plan of the
[stelae repo split](https://github.com/txpipe/dolos/pull/1286), after driver
genericization (#1286).

## What this does

Every stelae CLI module except `backfill.rs` now contains only clap
definitions, TUI (`Progress` impls, `inquire` prompts, rendering), exit-code
mapping and byte-exact output writing. The orchestration, policy and derivation
they held moved into `crates/snapshot` — or into `stelae-driver`, `dolos-core`
and the root `dolos` lib where the subject belonged there instead.

| Was | Is |
| --- | --- |
| `common.rs` `retry_transient` / `retry_bounded`, `RETRY_ATTEMPTS`, the backoff | `stelae_driver::retry`, re-exported at `dolos_snapshot::retry` |
| `snapshot/mod.rs` `EpochRange`, `retained_epochs`, `restrict`/`banded`/`produced`, `report_plan`'s arithmetic | `dolos_snapshot::planning` (`EpochRange`, `PlanReport`, `EpochSpan`) |
| `common.rs` `stele_registry_auth`, `stele_scratch_dir`, `init.rs`'s `OFFICIAL_REGISTRY_PASSWORD` | `dolos_snapshot::node` |
| `publish.rs` `to_repository`'s lifecycle, `standing()`'s interpretation, `RepositoryPublish` | `dolos_snapshot::publisher` (`Publisher`, `Next`, `RepositoryPublish`) |
| `digest.rs` plan → reproduce → canonicalize | `dolos_snapshot::export::digest_document` (`Document`) |
| `bootstrap/stelae.rs` `Source` FromStr, the report's `skipped_unknown` dedup and partial-dump detection | `dolos_snapshot::restore` (`Source`, `Plan::skipped_kinds`, `Plan::carried_dumps`) |
| `bootstrap/mod.rs` `clear_storage`, `inspect_existing_data` | `dolos::storage` (`clear_storage`, `Existing`, `ExistingDataPolicy`) |
| `bootstrap/mod.rs` `seed_wal_from_state` | `dolos_core::seed_wal_from_state`, beside `ImportExt` |

The CLI files lose 1,111 lines and gain 698, and the plan-building sequence
that was told three times is now one `snapshot::planned` call.

### The typed outcome

`standing()`'s four readings map one-to-one onto `publisher::Next`:

- `Standing::Empty` → `Next::First` — "follows: nothing; this repository holds no stele"
- `Standing::Next` → `Next::After { latest }` — "follows: sequence {latest}"
- `Standing::UpToDate` → `Next::Nothing(message)`, exit zero — or, under
  `--require-new`, `Error::NothingToPublish` carrying **the same sentence**, so
  the report and the refusal cannot drift
- `Standing::Ahead` → `Error::PublishWouldGap`, the refusal that stands

Both refusal texts are pinned by a new unit test in `publisher.rs`.

## Verification

Run on `4b7fa8b` against the merge base `4e6f2f7` (#1286).

**1. The full gate**

- `cargo test --workspace --all-targets` — **44 binaries, 1503 passed, 0 failed, 64 ignored**
- `cargo clippy --all-targets --all-features -- -D warnings` (CI's own command) — clean
- `cargo +nightly-2026-08-27 fmt --all -- --check` — clean

**2. `goldens.rs` — zero re-pins.** `descriptors_match_the_per_kind_goldens`
and the rest of the suite pass; `print_current_canary_encodings` stays
`ignored`, which is what "no golden was re-pinned" looks like.

**3. Parse + render.** `snapshot/{mod,publish,digest,verify,inspect}.rs` and
`bootstrap/{mod,stelae}.rs` hold clap definitions, `println!`/`eprintln!`,
`SteleProgress`, `inquire`, and calls into the crates. The umbrella's done
criterion 6, minus backfill.

**4. Byte-identical output.** A scratch integration test built the
`tests/node` fixture (synthetic preview chain, real `open_data_stores`
backends) on **both** `main` and this branch, ran six commands through the
built `dolos` binary, and captured stdout, stderr and exit code with only the
temp root normalized. `diff` over the two captures is **empty**:

| Command | Covers |
| --- | --- |
| `snapshot digest` | the canonical inscription on stdout, the plan report on stderr |
| `snapshot digest --epochs 0..=0` | `EpochRange`'s inclusive parse and the restriction |
| `snapshot digest --epochs 5..2` | the range refusal's text and exit code |
| `snapshot publish --dry-run --output-dir …` | the dry-run branch |
| `bootstrap` (data present, no flag, no tty) | the existing-data refusal |
| `bootstrap stelae --source https://…` | `Source`'s refusal, before `--force` clears anything |

The scratch test was removed before this commit.

## Notes for review

- **`seed_wal_from_state` is generic over the two store traits, not over
  `Domain`.** The plan said `Domain`; `bootstrap` has the two stores open and
  no domain assembled, and building one there would open the archive, indexes
  and mempool a bootstrap does not need — a behavior change the plan freezes.
  The store-trait form serves both callers: `backfill` reuses it next sub-plan
  by passing `domain.state()` and `domain.wal()`.
- **One error *shape* changed**, in the rarest path here: `clear_storage`'s two
  IO failures were `miette` contexts and are now `Error::StorageError` carrying
  the same two sentences ("removing existing storage", "recreating storage
  directory"), so the rendering gains a `storage error:` prefix. Every other
  message is unchanged.
- **`backfill.rs` is untouched** beyond mechanical fallout: it now names
  `dolos_snapshot::planning::retained_epochs`,
  `dolos_snapshot::publisher::RepositoryPublish` and
  `dolos_snapshot::retry::transient`. Thinning it is the fourth sub-plan.
- **Pre-existing, not from this branch**: `cargo clippy --workspace
  --all-targets --all-features -- -D warnings` (broader than CI's, which omits
  `--workspace`) fails on `crates/snapshot/tests/publish.rs`
  (`doc_lazy_continuation`) and `crates/cardano` (`filter_next`,
  `cloned_ref_to_slice_refs`) under the repo's pinned 1.93 toolchain. None of
  those files are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqY17jKWkD22X3mi5frDBN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable snapshot planning with epoch ranges, index bands, producer limits, retention reporting, and plan summaries.
  * Added OCI publishing with dry runs, resumable transfers, preflight checks, and publish-safety validation.
  * Added file and OCI restore sources, storage lifecycle controls, and registry authentication options.
  * Added document digesting and canonical output support.
  * Added bounded retries for transient external failures.
  * Added automatic WAL seeding from saved state.

* **Bug Fixes**
  * Improved handling of existing storage, incomplete cursors, invalid registry credentials, and sequence gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->