### PR TITLE
fix(snapshot): the destination preflight is the resume's need, not the plan's

### DIFF
--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -99,7 +99,9 @@
 //! so a redone `blocks` layer leaves the superseded bodies in the segment file
 //! with nothing pointing at them. Reads go through the table, so the node is
 //! correct; the dead space is bounded by one layer and is the price of not
-//! starting over.
+//! starting over. [`Plan::preflight`] carries no addend for it: free space is
+//! read at check time, so an interrupted attempt's dead bytes are already out
+//! of what the check compares against.
 //!
 //! ## Memory
 //!
@@ -356,15 +358,23 @@ impl Plan {
         index: &BlobIndex,
         resume: &Resume,
     ) -> Result<Remaining, Error> {
-        let epochs = self
-            .immutable_layers()
-            .filter(|descriptor| !resume.is_done(&descriptor.diff_id));
+        Ok(Remaining::of(stele, index, self.remaining_layers(resume))?)
+    }
 
-        Ok(Remaining::of(
-            stele,
-            index,
-            epochs.chain(self.tip_layers()),
-        )?)
+    /// The layers a run with `resume` behind it still has to read: the
+    /// immutable ones it has not recorded, and every tip layer.
+    ///
+    /// One definition for both halves of "what is left" — the compressed bytes
+    /// [`Plan::remaining`] reports and the uncompressed room
+    /// [`Plan::remaining_uncompressed_size`] demands. Two filters saying the
+    /// same thing is two places for the resume rule to drift.
+    pub fn remaining_layers<'a>(
+        &'a self,
+        resume: &'a Resume,
+    ) -> impl Iterator<Item = &'a LayerDescriptor> {
+        self.immutable_layers()
+            .filter(|descriptor| !resume.is_done(&descriptor.diff_id))
+            .chain(self.tip_layers())
     }
 
     /// Uncompressed bytes across the selected layers.
@@ -376,6 +386,30 @@ impl Plan {
         self.layers().map(|l| l.uncompressed_size).sum()
     }
 
+    /// Uncompressed bytes a run with `resume` behind it still has to write.
+    ///
+    /// [`Plan::uncompressed_size`] made resume-aware, and the number
+    /// [`Plan::preflight`] sizes the destination on: the layers a resumed run
+    /// will actually write, which is the immutable ones the resume has not
+    /// recorded plus every tip layer. Charging a resume for layers its own
+    /// earlier attempt already committed measures it against free space those
+    /// layers consumed and then bills for them a second time, which refuses
+    /// runs that would finish.
+    ///
+    /// **No addend.** A redone layer is rewritten and not appended — every
+    /// write path is keyed — with one exception, the redb archive, which
+    /// leaves the superseded block bodies of an interrupted `blocks` layer as
+    /// dead space in its segment file. That is past spend, not future spend:
+    /// [`preflight::check`] reads free space at check time, so those bytes are
+    /// already out of what it compares against, and the layer that left them
+    /// is not recorded as done, so its full uncompressed size is charged
+    /// again.
+    pub fn remaining_uncompressed_size(&self, resume: &Resume) -> u64 {
+        self.remaining_layers(resume)
+            .map(|l| l.uncompressed_size)
+            .sum()
+    }
+
     /// Refuse a restore that cannot fit, before it starts writing.
     ///
     /// Two needs, one policy ([`crate::preflight`]): the stores this restore
@@ -385,17 +419,27 @@ impl Plan {
     /// the storage filesystem they are two claims on one pool of free bytes,
     /// and the default `<storage.path>/scratch` makes that the ordinary case.
     ///
+    /// Both needs are resume-aware, and for the same reason: what a run has to
+    /// fit is what *this* run will move, not what the plan describes. The
+    /// destination's is [`Plan::remaining_uncompressed_size`], the staging
+    /// volume's is the largest layer the caller's [`Remaining`] names.
+    ///
     /// The destination comparison is deliberately against the *uncompressed*
-    /// size of the selected layers rather than against a prediction of what the
+    /// size of those layers rather than against a prediction of what the
     /// stores will occupy. It is the only number the inscription carries, it is
     /// an underestimate for every backend (a store keeps indexes and slack of
     /// its own), and an underestimate is the safe direction for a check whose
     /// job is to catch the obviously-doomed run.
-    pub fn preflight(&self, path: &Path, staging: Option<Staging<'_>>) -> Result<(), Error> {
+    pub fn preflight(
+        &self,
+        path: &Path,
+        resume: &Resume,
+        staging: Option<Staging<'_>>,
+    ) -> Result<(), Error> {
         let mut needs = vec![preflight::Need::of(
             "restoring it",
             path,
-            self.uncompressed_size(),
+            self.remaining_uncompressed_size(resume),
         )];
 
         if let Some(staging) = staging {
@@ -1044,11 +1088,11 @@ where
         inherited: checkpoint.resume().len(),
     };
 
-    // Below the sizes rather than above them, and still ADR-004's step 2:
-    // what the staging volume has to hold is the largest layer this run will
-    // *actually* pull, which is a question about the resume and so cannot be
-    // asked before the checkpoint is open. Nothing between the plan and here
-    // writes — `Checkpoint::open` only reads the progress file and
+    // Below the checkpoint rather than above it, and still ADR-004's step 2:
+    // both needs are questions about what this run will actually move — the
+    // largest layer it will pull, and the layers it still has to write — so
+    // neither can be asked before the resume is known. Nothing between the plan
+    // and here writes — `Checkpoint::open` only reads the progress file and
     // `blob_index` only reads the stele — so the preflight still refuses before
     // the first byte is written, which is the whole of its promise.
     let staging = scratch_dir.map(|dir| Staging {
@@ -1057,7 +1101,7 @@ where
         unsized_layers: outlook.remaining.unsized_layers,
     });
 
-    plan.preflight(node.storage_path, staging)?;
+    plan.preflight(node.storage_path, checkpoint.resume(), staging)?;
 
     let summary = restore(
         stele,
@@ -1515,7 +1559,7 @@ mod source_tests {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use stelae::{inscription::LayerDescriptor, Digest};
+    use stelae::{inscription::LayerDescriptor, Digest, RestoreProgress};
 
     use super::*;
     use crate::MAINNET_MAGIC;
@@ -2108,12 +2152,16 @@ mod tests {
             skipped_unknown: Vec::new(),
         };
 
-        plan.preflight(temp.path(), None).unwrap();
+        plan.preflight(temp.path(), &Resume::none(), None).unwrap();
 
         // A directory that does not exist yet is measured through its parent,
         // which is the shape a fresh node's storage path has.
-        plan.preflight(&temp.path().join("not").join("created").join("yet"), None)
-            .unwrap();
+        plan.preflight(
+            &temp.path().join("not").join("created").join("yet"),
+            &Resume::none(),
+            None,
+        )
+        .unwrap();
 
         let tip = crate::state_layer_count() as u64;
 
@@ -2121,8 +2169,94 @@ mod tests {
             descriptor.uncompressed_size = u64::MAX / tip;
         }
 
-        let err = plan.preflight(temp.path(), None).unwrap_err();
+        let err = plan
+            .preflight(temp.path(), &Resume::none(), None)
+            .unwrap_err();
         assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+    }
+
+    /// The destination need is the resume's, not the plan's: a resumed
+    /// restore is charged for the layers it still has to write and not for the
+    /// ones an earlier attempt already put on the volume.
+    ///
+    /// Two-sided, because both directions are failures. Charging for committed
+    /// layers refuses a run that would finish; charging for none of them would
+    /// pass a run that dies at hour eight.
+    #[test]
+    fn the_preflight_charges_a_resume_only_for_what_is_left() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let mut layers = state_layers();
+        layers.push(epoch_descriptor(BLOCKS, 0, 0xa0));
+        layers.push(epoch_descriptor(BLOCKS, 1, 0xa1));
+        layers.push(epoch_descriptor(BLOCKS, 2, 0xa2));
+
+        let stele = inscription(layers);
+
+        let mut plan = Plan {
+            position: read_position(&stele.position).unwrap(),
+            sequence: stele.sequence,
+            epochs: select_epochs(&stele).unwrap(),
+            state: select_state(&stele).unwrap().tip,
+            state_dumps: BTreeMap::new(),
+            skipped_epochs: 0,
+            skipped_unknown: Vec::new(),
+        };
+
+        // Epochs 0 and 1 are each larger than any volume; epoch 2 and the tip
+        // keep their hundred bytes. So the whole plan cannot fit anywhere, and
+        // what is left once the first two are committed fits everywhere.
+        for epoch in plan.epochs.iter_mut().take(2) {
+            epoch.blocks.as_mut().unwrap().uncompressed_size = u64::MAX / 4;
+        }
+
+        let blocks_of = |epochs: std::ops::Range<usize>| {
+            let mut progress = RestoreProgress::new(Digest::from_bytes([0xdd; 32]));
+
+            for epoch in &plan.epochs[epochs] {
+                progress.record(epoch.blocks.as_ref().unwrap().diff_id);
+            }
+
+            Resume::from_progress(Some(&progress))
+        };
+
+        let tip = crate::state_layer_count() as u64;
+
+        // An empty resume asks for exactly what it asked for before there was
+        // a resume at all.
+        assert_eq!(
+            plan.remaining_uncompressed_size(&Resume::none()),
+            plan.uncompressed_size()
+        );
+
+        let err = plan
+            .preflight(temp.path(), &Resume::none(), None)
+            .unwrap_err();
+        assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+
+        // Both impossible epochs committed: what is left is epoch 2 and the
+        // tip, and the run proceeds on a volume that could never have held the
+        // whole stele.
+        let resume = blocks_of(0..2);
+        assert_eq!(
+            plan.remaining_uncompressed_size(&resume),
+            (tip + 1) * 100,
+            "the tip is always redone and is always charged"
+        );
+        plan.preflight(temp.path(), &resume, None).unwrap();
+
+        // One of them committed: the other is still ahead of this run, and it
+        // is still refused. Subtracting too much is the dangerous direction.
+        let err = plan
+            .preflight(temp.path(), &blocks_of(0..1), None)
+            .unwrap_err();
+        assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+
+        // Every epoch committed leaves the tip, which no resume ever skips.
+        assert_eq!(
+            plan.remaining_uncompressed_size(&blocks_of(0..3)),
+            tip * 100
+        );
     }
 
     /// The staging half: a scratch volume that cannot hold the largest layer
@@ -2150,6 +2284,7 @@ mod tests {
         let staging = |largest_layer, unsized_layers| {
             plan.preflight(
                 temp.path(),
+                &Resume::none(),
                 Some(Staging {
                     dir: &scratch,
                     largest_layer,

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -99,9 +99,8 @@
 //! so a redone `blocks` layer leaves the superseded bodies in the segment file
 //! with nothing pointing at them. Reads go through the table, so the node is
 //! correct; the dead space is bounded by one layer and is the price of not
-//! starting over. [`Plan::preflight`] carries no addend for it: free space is
-//! read at check time, so an interrupted attempt's dead bytes are already out
-//! of what the check compares against.
+//! starting over. The preflight carries no addend for it; the reason is on
+//! [`Plan::remaining_uncompressed_size`].
 //!
 //! ## Memory
 //!

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -122,7 +122,7 @@ fn restore_into<B: ToyStores>(
     let plan = restore::plan(&stele, magic, None)?;
     // A directory stele stages nothing — its blobs are read where they are —
     // so the only volume this restore has a need on is the destination.
-    plan.preflight(root, None)?;
+    plan.preflight(root, &stelae::Resume::none(), None)?;
 
     let index = stele.blob_index()?;
 


### PR DESCRIPTION
Plan: `plans/dolos-stelae-resumed-restore-destination-need.md` — residue of the
preflight slice (#1192), where CodeRabbit named this asymmetry and it was left
because narrowing it was a decision that plan had not made. Ruled by the owner
on 2026-09-03: no slack.

## The problem

The restore preflight sizes two needs on different terms. The staging need is
resume-aware — the largest layer the run will *actually* pull, from `Remaining`,
which drops what the checkpoint records as done. The destination need is not:
`Plan::uncompressed_size()` counts every selected layer, including the ones a
resumed run will skip.

So a resumed restore is measured against free space its own committed layers
already consumed, then charged for those layers a second time. A run that would
finish gets refused — and there is no override flag to escape with, by design
(the operability umbrella ruled overrides out: only what is actually measured
may refuse).

## What changed

- `Plan::remaining_layers(&Resume)` — one definition of "what is left", now
  shared by the compressed bytes `Plan::remaining` reports and the uncompressed
  room the preflight demands. Two filters saying the same thing is two places
  for the resume rule to drift.
- `Plan::remaining_uncompressed_size(&Resume)` — the immutable layers the resume
  has not recorded, plus every tip layer, which is always redone.
- `Plan::preflight` takes the `Resume` and sizes the destination on it.
  `restore_stele` passes `checkpoint.resume()`, which it already held for the
  staging half — the preflight was already below the checkpoint for exactly this
  kind of question, so nothing moved.

The staging need is untouched. So is the refuse/warn policy in
`crate::preflight` — since the repo split a re-export of
`stelae_driver::preflight`. This is arithmetic upstream of it, and nothing in
`txpipe/stelae` moves: `Resume::is_done` and `LayerDescriptor.uncompressed_size`
are already exposed.

### No addend

A redone layer is rewritten, not appended — every write path is keyed — with one
exception: the redb archive appends block bodies, so an interrupted `blocks`
layer leaves superseded bodies as dead space in its segment file. That is past
spend, not future spend. `preflight::check` reads free space at check time, so
those bytes are already out of what it compares against, and the layer that left
them is not recorded as done, so its full uncompressed size is charged again.
Nothing the resume still has to write is understated. A cushion on top would
claim a precision this check disclaims everywhere else — it is an underestimate
for every backend by design, a catch for the obviously-doomed run and not a
prediction of store footprint.

## Verification

Two-sided, because both directions are failures — charging for committed layers
refuses a run that would finish, and charging for none of them would pass a run
that dies at hour eight. `the_preflight_charges_a_resume_only_for_what_is_left`
builds a plan whose first two epochs are each larger than any volume, then:

- an empty resume asks for exactly `Plan::uncompressed_size()`, and is refused;
- both impossible epochs committed → the need is epoch 2 plus the tip, and the
  run proceeds on a volume that could never have held the whole stele;
- one of them committed → still refused;
- every epoch committed → the tip, which no resume ever skips.

Full check set on this branch:

- `cargo +nightly fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all green (`crates/snapshot` lib 26 passed, `stelae_restore`
  9 passed, no failures anywhere)

One pre-existing finding, untouched and unrelated: `cargo doc` with
`-D rustdoc::broken_intra_doc_links` reports two unresolved links already on
`main` (`Publishing::storage_path` and `drain`). Not in the repo's check set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxyzBAjayXLrR7LgvaKgvT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resuming a restore now checks disk space based only on the data still needing to be written.
  - Restore preflight validation now accounts for the current resume state, preventing unnecessary space requirements for already-completed layers.

- **Tests**
  - Added coverage for disk-space calculations during resumed restores.
  - Updated restore tests to validate preflight behavior with explicit resume state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->