### PR TITLE
ci: lint PR titles for conventional commits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,10 @@ name: PR checks
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+  # `main` merges through a queue, and a required check that never reports on
+  # the merge group stalls it. The title was validated on the PR before it was
+  # enqueued and is fixed from then on, so here the job only has to report.
+  merge_group:
 
 permissions:
   pull-requests: read
@@ -17,6 +21,7 @@ jobs:
       # changelog entry. `pull_request_target` so fork PRs get the token; the
       # job never checks out the branch, so that grant is safe.
       - uses: amannn/action-semantic-pull-request@v6
+        if: github.event_name != 'merge_group'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,40 @@
+name: PR checks
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title:
+    name: title is a conventional commit
+    runs-on: ubuntu-latest
+    steps:
+      # Squash merges take the PR title as the commit subject, and cliff.toml
+      # drops unconventional subjects from the changelog, so the title is the
+      # changelog entry. `pull_request_target` so fork PRs get the token; the
+      # job never checks out the branch, so that grant is safe.
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The types cliff.toml's commit_parsers group, plus `release`.
+          types: |
+            feat
+            fix
+            docs
+            ci
+            perf
+            refactor
+            style
+            test
+            chore
+            revert
+            release
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" starts with a capital letter. Keep it lowercase;
+            the changelog generator capitalises it on render.


### PR DESCRIPTION
## Why

The repo squash-merges with the PR title as the commit subject, and `cliff.toml` runs with `filter_unconventional = true`, so a PR whose title is not a conventional commit silently drops out of the changelog. Nothing enforces the shape today; the last ~200 titles conform by discipline alone.

## What

Adds `.github/workflows/pr.yml` (`PR checks`) with one job, `title is a conventional commit`, running [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) on `pull_request_target` for opened/edited/reopened/synchronize.

- Allowed types: the ones `cliff.toml`'s `commit_parsers` group, plus `release`.
- Scope optional; the `!` breaking marker is accepted.
- Subjects starting with a capital letter fail (cliff capitalises on render).
- Read-only permissions, no checkout, so the `pull_request_target` grant is safe for fork PRs.

The workflow name is generic so future PR-level checks join it as sibling jobs.

## Follow-up (repo setting, not in this PR)

Once this check has run once, make it required on `main`:

```
gh api -X PATCH repos/txpipe/dolos/branches/main/protection/required_status_checks \
  -f strict=true -f 'contexts[]=title is a conventional commit'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request title validation.
  * Pull request titles must follow conventional commit formatting, use an approved type, and begin the subject in lowercase.
  * Validation runs when pull requests are opened, edited, reopened, or updated.
  * Checks also run during merge queue processing, while title-specific validation is skipped for those merge events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->