### PR TITLE
feat(config)!: remove the non-live redb state and index backends

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -273,21 +273,12 @@ impl FjallStateConfig {
     }
 }
 
-/// The message a configuration selecting the removed `redb` state backend
-/// fails with.
-pub const REMOVED_REDB_STATE_BACKEND: &str =
-    "the `redb` state backend was removed; the supported state backend is `fjall`, \
-     and an existing redb state directory has to be re-bootstrapped (a stelae restore \
-     is the shortest path)";
-
 /// State store configuration.
 ///
-/// The supported persistent state backend is `fjall`. The `redb` backend was
-/// removed: a configuration still naming it fails to load with
-/// [`REMOVED_REDB_STATE_BACKEND`] rather than serde's unknown-variant error.
+/// The supported persistent state backend is `fjall`; the `redb` backend was
+/// removed.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
-#[serde(try_from = "StateStoreConfigRepr")]
 pub enum StateStoreConfig {
     /// Builtin in-memory backend: serves the whole state contract, ephemeral
     /// by design and sized for devnets, tooling and tests rather than for a
@@ -295,29 +286,6 @@ pub enum StateStoreConfig {
     #[serde(rename = "in_memory")]
     InMemory,
     Fjall(FjallStateConfig),
-}
-
-/// Deserialization shape for [`StateStoreConfig`]: it still accepts the
-/// removed `redb` backend so the load fails with a migration message.
-#[derive(Deserialize)]
-#[serde(tag = "backend", rename_all = "lowercase")]
-enum StateStoreConfigRepr {
-    Redb {},
-    #[serde(rename = "in_memory")]
-    InMemory,
-    Fjall(FjallStateConfig),
-}
-
-impl TryFrom<StateStoreConfigRepr> for StateStoreConfig {
-    type Error = &'static str;
-
-    fn try_from(value: StateStoreConfigRepr) -> Result<Self, Self::Error> {
-        match value {
-            StateStoreConfigRepr::Redb {} => Err(REMOVED_REDB_STATE_BACKEND),
-            StateStoreConfigRepr::InMemory => Ok(Self::InMemory),
-            StateStoreConfigRepr::Fjall(cfg) => Ok(Self::Fjall(cfg)),
-        }
-    }
 }
 
 impl Default for StateStoreConfig {
@@ -531,21 +499,12 @@ impl FjallIndexConfig {
     }
 }
 
-/// The message a configuration selecting the removed `redb` index backend
-/// fails with.
-pub const REMOVED_REDB_INDEX_BACKEND: &str =
-    "the `redb` index backend was removed; the supported index backend is `fjall`, \
-     and an existing redb index directory has to be rebuilt (a stelae restore \
-     is the shortest path)";
-
 /// Index store configuration.
 ///
-/// The supported persistent index backend is `fjall`. The `redb` backend was
-/// removed: a configuration still naming it fails to load with
-/// [`REMOVED_REDB_INDEX_BACKEND`] rather than serde's unknown-variant error.
+/// The supported persistent index backend is `fjall`; the `redb` backend was
+/// removed.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
-#[serde(try_from = "IndexStoreConfigRepr")]
 pub enum IndexStoreConfig {
     /// Builtin in-memory backend: serves the whole index contract, ephemeral
     /// by design and sized for devnets, tooling and tests rather than for a
@@ -557,32 +516,6 @@ pub enum IndexStoreConfig {
     /// explicit opt-out of the index layer.
     #[serde(rename = "no_op", alias = "noop")]
     NoOp,
-}
-
-/// Deserialization shape for [`IndexStoreConfig`]: it still accepts the
-/// removed `redb` backend so the load fails with a migration message.
-#[derive(Deserialize)]
-#[serde(tag = "backend", rename_all = "lowercase")]
-enum IndexStoreConfigRepr {
-    Redb {},
-    #[serde(rename = "in_memory")]
-    InMemory,
-    Fjall(FjallIndexConfig),
-    #[serde(rename = "no_op", alias = "noop")]
-    NoOp,
-}
-
-impl TryFrom<IndexStoreConfigRepr> for IndexStoreConfig {
-    type Error = &'static str;
-
-    fn try_from(value: IndexStoreConfigRepr) -> Result<Self, Self::Error> {
-        match value {
-            IndexStoreConfigRepr::Redb {} => Err(REMOVED_REDB_INDEX_BACKEND),
-            IndexStoreConfigRepr::InMemory => Ok(Self::InMemory),
-            IndexStoreConfigRepr::Fjall(cfg) => Ok(Self::Fjall(cfg)),
-            IndexStoreConfigRepr::NoOp => Ok(Self::NoOp),
-        }
-    }
 }
 
 impl Default for IndexStoreConfig {
@@ -1434,31 +1367,5 @@ mod tests {
 
         let json = serde_json::to_value(IndexStoreConfig::NoOp).unwrap();
         assert_eq!(json["backend"], "no_op");
-    }
-
-    /// A configuration still naming the removed `redb` state or index backend
-    /// must fail with the migration message, not with serde's unknown-variant
-    /// error, so an operator upgrading reads what to do instead.
-    #[test]
-    fn the_removed_redb_backends_fail_with_a_migration_message() {
-        use serde_json::json;
-
-        let error = serde_json::from_value::<StateStoreConfig>(
-            json!({ "backend": "redb", "path": "state", "cache": 500 }),
-        )
-        .unwrap_err()
-        .to_string();
-
-        assert!(error.contains("redb"), "must name the removed backend");
-        assert!(error.contains("fjall"), "must name the supported backend");
-
-        let error = serde_json::from_value::<IndexStoreConfig>(
-            json!({ "backend": "redb", "path": "index" }),
-        )
-        .unwrap_err()
-        .to_string();
-
-        assert!(error.contains("redb"), "must name the removed backend");
-        assert!(error.contains("fjall"), "must name the supported backend");
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -273,17 +273,22 @@ impl FjallStateConfig {
     }
 }
 
+/// The message a configuration selecting the removed `redb` state backend
+/// fails with.
+pub const REMOVED_REDB_STATE_BACKEND: &str =
+    "the `redb` state backend was removed; the supported state backend is `fjall`, \
+     and an existing redb state directory has to be re-bootstrapped (a stelae restore \
+     is the shortest path)";
+
 /// State store configuration.
 ///
-/// The supported persistent state backend is `fjall`. The `redb` variant is
-/// deprecated in its favor: it is kept only so existing configuration files
-/// still deserialize, and is refused when the node opens its stores.
+/// The supported persistent state backend is `fjall`. The `redb` backend was
+/// removed: a configuration still naming it fails to load with
+/// [`REMOVED_REDB_STATE_BACKEND`] rather than serde's unknown-variant error.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
-#[allow(deprecated)]
+#[serde(try_from = "StateStoreConfigRepr")]
 pub enum StateStoreConfig {
-    #[deprecated(note = "deprecated in favor of the supported `fjall` state backend")]
-    Redb(RedbStateConfig),
     /// Builtin in-memory backend: serves the whole state contract, ephemeral
     /// by design and sized for devnets, tooling and tests rather than for a
     /// node following a public network.
@@ -292,17 +297,38 @@ pub enum StateStoreConfig {
     Fjall(FjallStateConfig),
 }
 
+/// Deserialization shape for [`StateStoreConfig`]: it still accepts the
+/// removed `redb` backend so the load fails with a migration message.
+#[derive(Deserialize)]
+#[serde(tag = "backend", rename_all = "lowercase")]
+enum StateStoreConfigRepr {
+    Redb {},
+    #[serde(rename = "in_memory")]
+    InMemory,
+    Fjall(FjallStateConfig),
+}
+
+impl TryFrom<StateStoreConfigRepr> for StateStoreConfig {
+    type Error = &'static str;
+
+    fn try_from(value: StateStoreConfigRepr) -> Result<Self, Self::Error> {
+        match value {
+            StateStoreConfigRepr::Redb {} => Err(REMOVED_REDB_STATE_BACKEND),
+            StateStoreConfigRepr::InMemory => Ok(Self::InMemory),
+            StateStoreConfigRepr::Fjall(cfg) => Ok(Self::Fjall(cfg)),
+        }
+    }
+}
+
 impl Default for StateStoreConfig {
     fn default() -> Self {
         Self::Fjall(FjallStateConfig::default())
     }
 }
 
-#[allow(deprecated)]
 impl StateStoreConfig {
     pub fn path(&self) -> Option<&PathBuf> {
         match self {
-            Self::Redb(cfg) => cfg.path.as_ref(),
             Self::Fjall(cfg) => cfg.path.as_ref(),
             Self::InMemory => None,
         }
@@ -310,7 +336,6 @@ impl StateStoreConfig {
 
     pub fn max_history(&self) -> Option<u64> {
         match self {
-            Self::Redb(cfg) => cfg.max_history,
             Self::Fjall(cfg) => cfg.max_history,
             Self::InMemory => None,
         }
@@ -322,7 +347,7 @@ impl StateStoreConfig {
     pub fn is_default(&self) -> bool {
         match self {
             Self::Fjall(cfg) => cfg.is_default(),
-            Self::Redb(_) | Self::InMemory => false,
+            Self::InMemory => false,
         }
     }
 }
@@ -506,17 +531,22 @@ impl FjallIndexConfig {
     }
 }
 
+/// The message a configuration selecting the removed `redb` index backend
+/// fails with.
+pub const REMOVED_REDB_INDEX_BACKEND: &str =
+    "the `redb` index backend was removed; the supported index backend is `fjall`, \
+     and an existing redb index directory has to be rebuilt (a stelae restore \
+     is the shortest path)";
+
 /// Index store configuration.
 ///
-/// The supported persistent index backend is `fjall`. The `redb` variant is
-/// deprecated in its favor: it is kept only so existing configuration files
-/// still deserialize, and is refused when the node opens its stores.
+/// The supported persistent index backend is `fjall`. The `redb` backend was
+/// removed: a configuration still naming it fails to load with
+/// [`REMOVED_REDB_INDEX_BACKEND`] rather than serde's unknown-variant error.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "backend", rename_all = "lowercase")]
-#[allow(deprecated)]
+#[serde(try_from = "IndexStoreConfigRepr")]
 pub enum IndexStoreConfig {
-    #[deprecated(note = "deprecated in favor of the supported `fjall` index backend")]
-    Redb(RedbIndexConfig),
     /// Builtin in-memory backend: serves the whole index contract, ephemeral
     /// by design and sized for devnets, tooling and tests rather than for a
     /// node following a public network.
@@ -529,17 +559,41 @@ pub enum IndexStoreConfig {
     NoOp,
 }
 
+/// Deserialization shape for [`IndexStoreConfig`]: it still accepts the
+/// removed `redb` backend so the load fails with a migration message.
+#[derive(Deserialize)]
+#[serde(tag = "backend", rename_all = "lowercase")]
+enum IndexStoreConfigRepr {
+    Redb {},
+    #[serde(rename = "in_memory")]
+    InMemory,
+    Fjall(FjallIndexConfig),
+    #[serde(rename = "no_op", alias = "noop")]
+    NoOp,
+}
+
+impl TryFrom<IndexStoreConfigRepr> for IndexStoreConfig {
+    type Error = &'static str;
+
+    fn try_from(value: IndexStoreConfigRepr) -> Result<Self, Self::Error> {
+        match value {
+            IndexStoreConfigRepr::Redb {} => Err(REMOVED_REDB_INDEX_BACKEND),
+            IndexStoreConfigRepr::InMemory => Ok(Self::InMemory),
+            IndexStoreConfigRepr::Fjall(cfg) => Ok(Self::Fjall(cfg)),
+            IndexStoreConfigRepr::NoOp => Ok(Self::NoOp),
+        }
+    }
+}
+
 impl Default for IndexStoreConfig {
     fn default() -> Self {
         Self::Fjall(FjallIndexConfig::default())
     }
 }
 
-#[allow(deprecated)]
 impl IndexStoreConfig {
     pub fn path(&self) -> Option<&PathBuf> {
         match self {
-            Self::Redb(cfg) => cfg.path.as_ref(),
             Self::Fjall(cfg) => cfg.path.as_ref(),
             Self::InMemory | Self::NoOp => None,
         }
@@ -551,7 +605,7 @@ impl IndexStoreConfig {
     pub fn is_default(&self) -> bool {
         match self {
             Self::Fjall(cfg) => cfg.is_default(),
-            Self::Redb(_) | Self::InMemory | Self::NoOp => false,
+            Self::InMemory | Self::NoOp => false,
         }
     }
 }
@@ -660,13 +714,9 @@ impl StorageConfig {
 
     /// Get the resolved path for the state store.
     /// Returns `None` for in-memory backends.
-    #[allow(deprecated)]
     pub fn state_path(&self) -> Option<PathBuf> {
         match &self.state {
             StateStoreConfig::InMemory => None,
-            StateStoreConfig::Redb(cfg) => {
-                Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "state"))
-            }
             StateStoreConfig::Fjall(cfg) => {
                 Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "state"))
             }
@@ -689,13 +739,9 @@ impl StorageConfig {
 
     /// Get the resolved path for the index store.
     /// Returns `None` for in-memory or no-op backends.
-    #[allow(deprecated)]
     pub fn index_path(&self) -> Option<PathBuf> {
         match &self.index {
             IndexStoreConfig::InMemory | IndexStoreConfig::NoOp => None,
-            IndexStoreConfig::Redb(cfg) => {
-                Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "index"))
-            }
             IndexStoreConfig::Fjall(cfg) => {
                 Some(self.resolve_store_path_with_default(cfg.path.as_ref(), "index"))
             }
@@ -1388,5 +1434,31 @@ mod tests {
 
         let json = serde_json::to_value(IndexStoreConfig::NoOp).unwrap();
         assert_eq!(json["backend"], "no_op");
+    }
+
+    /// A configuration still naming the removed `redb` state or index backend
+    /// must fail with the migration message, not with serde's unknown-variant
+    /// error, so an operator upgrading reads what to do instead.
+    #[test]
+    fn the_removed_redb_backends_fail_with_a_migration_message() {
+        use serde_json::json;
+
+        let error = serde_json::from_value::<StateStoreConfig>(
+            json!({ "backend": "redb", "path": "state", "cache": 500 }),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("redb"), "must name the removed backend");
+        assert!(error.contains("fjall"), "must name the supported backend");
+
+        let error = serde_json::from_value::<IndexStoreConfig>(
+            json!({ "backend": "redb", "path": "index" }),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("redb"), "must name the removed backend");
+        assert!(error.contains("fjall"), "must name the supported backend");
     }
 }

--- a/docs/content/architecture/data-layer.mdx
+++ b/docs/content/architecture/data-layer.mdx
@@ -32,7 +32,7 @@ Each store is defined as a trait in `dolos-core` — `WalStore`, `StateStore`, `
 
 Available backends:
 
-- **redb** (`dolos-redb3`) — an embedded ACID B+tree store. It backs the WAL (the only WAL implementation) and remains a supported archive backend via explicit configuration; its state and index implementations are deprecated and refused at startup.
+- **redb** (`dolos-redb3`) — an embedded ACID B+tree store. It backs the WAL (the only WAL implementation) and remains a supported archive backend via explicit configuration; its state and index config variants were removed in v1.7, so a configuration naming them fails to load.
 - **fjall** (`dolos-fjall`) — an LSM-tree engine tuned for write-heavy workloads with many hot keys. The default backend for the state, index, and archive stores. Both archive backends share the same flat block segment files; only the index format differs.
 - **no-op** — a store that silently discards writes, used to *disable* the archive and/or index stores.
 - **in-memory** — non-persistent stores for testing and ephemeral nodes. State and indexes have builtin implementations in `dolos-core` backed by ordered maps, which serve their traits in full; the WAL, archive, and mempool use redb's memory backend instead.

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -148,7 +148,7 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 | worker_threads    | integer | 4       |
 | memtable_size_mb  | integer | 64      |
 
-- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` keeps the whole state in process memory: it is ephemeral — everything is lost on restart — and it holds the UTxO set and all entities in RAM, so it suits devnets, tooling and tests rather than a node following a public network. The `redb` value was removed in v1.7: a configuration still naming it fails to load with a message pointing at `fjall`, and an existing redb state directory has to be re-bootstrapped (a stelae restore is the shortest path).
+- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` keeps the whole state in process memory: it is ephemeral — everything is lost on restart — and it holds the UTxO set and all entities in RAM, so it suits devnets, tooling and tests rather than a node following a public network. The `redb` value was removed in v1.7: a configuration still naming it fails to load, and an existing redb state directory has to be re-bootstrapped (a stelae restore is the shortest path).
 - `path`: optional override for the state path (defaults to `<storage.path>/state`).
 - `cache`: size (MB) of the state cache.
 - `max_history`: maximum number of slots to keep before pruning.
@@ -187,7 +187,7 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 | worker_threads   | integer | 8       |
 | memtable_size_mb | integer | 128     |
 
-- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` keeps the whole index in process memory: ephemeral — everything is lost on restart — and RAM-resident, so it suits devnets, tooling and tests rather than a node following a public network. `no_op` disables the index layer entirely. The `redb` value was removed in v1.7: a configuration still naming it fails to load with a message pointing at `fjall`, and an existing redb index directory has to be rebuilt (a stelae restore is the shortest path).
+- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` keeps the whole index in process memory: ephemeral — everything is lost on restart — and RAM-resident, so it suits devnets, tooling and tests rather than a node following a public network. `no_op` disables the index layer entirely. The `redb` value was removed in v1.7: a configuration still naming it fails to load, and an existing redb index directory has to be rebuilt (a stelae restore is the shortest path).
 - `path`: optional override for the index path (defaults to `<storage.path>/index`).
 - `cache`: size (MB) of the index cache.
 - `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -148,7 +148,7 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 | worker_threads    | integer | 4       |
 | memtable_size_mb  | integer | 64      |
 
-- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` keeps the whole state in process memory: it is ephemeral — everything is lost on restart — and it holds the UTxO set and all entities in RAM, so it suits devnets, tooling and tests rather than a node following a public network. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
+- `backend`: `fjall` or `in_memory` (defaults to `fjall`). `in_memory` keeps the whole state in process memory: it is ephemeral — everything is lost on restart — and it holds the UTxO set and all entities in RAM, so it suits devnets, tooling and tests rather than a node following a public network. The `redb` value was removed in v1.7: a configuration still naming it fails to load with a message pointing at `fjall`, and an existing redb state directory has to be re-bootstrapped (a stelae restore is the shortest path).
 - `path`: optional override for the state path (defaults to `<storage.path>/state`).
 - `cache`: size (MB) of the state cache.
 - `max_history`: maximum number of slots to keep before pruning.
@@ -187,7 +187,7 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 | worker_threads   | integer | 8       |
 | memtable_size_mb | integer | 128     |
 
-- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` keeps the whole index in process memory: ephemeral — everything is lost on restart — and RAM-resident, so it suits devnets, tooling and tests rather than a node following a public network. `no_op` disables the index layer entirely. The `redb` value is deprecated in favor of `fjall`: it still parses but is refused at startup.
+- `backend`: `fjall`, `in_memory`, or `no_op` (defaults to `fjall`). `in_memory` keeps the whole index in process memory: ephemeral — everything is lost on restart — and RAM-resident, so it suits devnets, tooling and tests rather than a node following a public network. `no_op` disables the index layer entirely. The `redb` value was removed in v1.7: a configuration still naming it fails to load with a message pointing at `fjall`, and an existing redb index directory has to be rebuilt (a stelae restore is the shortest path).
 - `path`: optional override for the index path (defaults to `<storage.path>/index`).
 - `cache`: size (MB) of the index cache.
 - `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -148,41 +148,6 @@ fn check_storage_version(config: &RootConfig) -> Result<(), Error> {
     Ok(())
 }
 
-/// Refuse a deprecated state backend at the point where the backend is
-/// chosen, so a stale configuration fails immediately with an actionable
-/// error instead of surfacing later at runtime.
-///
-/// `in_memory` is not refused: it is a builtin store that serves the whole
-/// contract, ephemeral by design rather than by incapacity.
-#[allow(deprecated)]
-fn check_state_backend(config: &StateStoreConfig) -> Result<(), Error> {
-    let selected = match config {
-        StateStoreConfig::Fjall(_) | StateStoreConfig::InMemory => return Ok(()),
-        StateStoreConfig::Redb(_) => "redb",
-    };
-
-    Err(Error::StorageError(format!(
-        "state backend `{selected}` is deprecated; the supported state backend is `fjall`"
-    )))
-}
-
-/// Refuse a deprecated index backend, same rationale as
-/// [`check_state_backend`]. `in_memory` is a builtin store that serves the
-/// whole contract, and `no_op` is an explicit opt-out of the index layer.
-#[allow(deprecated)]
-fn check_index_backend(config: &IndexStoreConfig) -> Result<(), Error> {
-    let selected = match config {
-        IndexStoreConfig::Fjall(_) | IndexStoreConfig::InMemory | IndexStoreConfig::NoOp => {
-            return Ok(())
-        }
-        IndexStoreConfig::Redb(_) => "redb",
-    };
-
-    Err(Error::StorageError(format!(
-        "index backend `{selected}` is deprecated; the supported index backend is `fjall`"
-    )))
-}
-
 /// Ensure directory exists for a store path.
 fn ensure_store_path(path: &Path) -> Result<(), Error> {
     if let Some(parent) = path.parent() {
@@ -211,14 +176,12 @@ pub fn open_archive_store(config: &RootConfig) -> Result<ArchiveStoreBackend, Er
 }
 
 pub fn open_index_store(config: &RootConfig) -> Result<IndexStoreBackend, Error> {
-    check_index_backend(&config.storage.index)?;
     let path = config.storage.index_path().unwrap_or_default();
     ensure_store_path(&path)?;
     Ok(IndexStoreBackend::open(&path, &config.storage.index)?)
 }
 
 pub fn open_state_store(config: &RootConfig) -> Result<StateStoreBackend, Error> {
-    check_state_backend(&config.storage.state)?;
     let path = config.storage.state_path().unwrap_or_default();
     ensure_store_path(&path)?;
     Ok(StateStoreBackend::open(
@@ -492,14 +455,12 @@ impl StateStoreBackend {
     ///
     /// For persistent backends, the caller must provide the resolved path.
     /// For `InMemory`, the path is ignored and an in-memory store is created.
-    #[allow(deprecated)]
     pub fn open(
         path: impl AsRef<Path>,
-        schema: StateSchema,
+        _schema: StateSchema,
         config: &StateStoreConfig,
     ) -> Result<Self, StateError> {
         match config {
-            StateStoreConfig::Redb(cfg) => Self::open_redb(path, schema, cfg),
             StateStoreConfig::Fjall(cfg) => Self::open_fjall(path, cfg),
             StateStoreConfig::InMemory => Self::in_memory(),
         }
@@ -1116,10 +1077,8 @@ impl IndexStoreBackend {
     /// For persistent backends, the caller must provide the resolved path.
     /// For `InMemory`, the path is ignored and an in-memory store is created.
     /// For `NoOp`, the path is ignored.
-    #[allow(deprecated)]
     pub fn open(path: impl AsRef<Path>, config: &IndexStoreConfig) -> Result<Self, IndexError> {
         match config {
-            IndexStoreConfig::Redb(cfg) => Self::open_redb(path, cfg),
             IndexStoreConfig::Fjall(cfg) => Self::open_fjall(path, cfg),
             IndexStoreConfig::InMemory => Self::in_memory(),
             IndexStoreConfig::NoOp => Ok(Self::noop()),
@@ -1524,31 +1483,8 @@ impl MempoolStore for MempoolBackend {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
-
-    fn refusal(result: Result<(), Error>) -> String {
-        match result {
-            Err(Error::StorageError(message)) => message,
-            other => panic!("expected a storage refusal, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn accepted_backends_pass_validation() {
-        check_state_backend(&StateStoreConfig::Fjall(FjallStateConfig::default())).unwrap();
-        check_index_backend(&IndexStoreConfig::Fjall(FjallIndexConfig::default())).unwrap();
-
-        // in_memory stays accepted: a builtin store that serves the whole
-        // contract, ephemeral by design rather than by incapacity.
-        check_state_backend(&StateStoreConfig::InMemory).unwrap();
-        check_index_backend(&IndexStoreConfig::InMemory).unwrap();
-
-        // no_op stays accepted too: it is an explicit opt-out of the index
-        // layer.
-        check_index_backend(&IndexStoreConfig::NoOp).unwrap();
-    }
 
     /// `in_memory` has to reach the builtin stores, not a memory-mode disk
     /// backend: that was the old wiring, and it was the reason the variant
@@ -1578,40 +1514,6 @@ mod tests {
             .expect("start_writer failed")
             .append_prehashed([])
             .expect("append_prehashed must be supported");
-    }
-
-    #[test]
-    fn deprecated_state_backends_are_refused() {
-        let message = refusal(check_state_backend(&StateStoreConfig::Redb(
-            RedbStateConfig::default(),
-        )));
-
-        assert!(message.contains("redb"), "refusal must name the backend");
-        assert!(
-            message.contains("deprecated"),
-            "refusal must say the backend is deprecated"
-        );
-        assert!(
-            message.contains("fjall"),
-            "refusal must name the supported backend"
-        );
-    }
-
-    #[test]
-    fn deprecated_index_backends_are_refused() {
-        let message = refusal(check_index_backend(&IndexStoreConfig::Redb(
-            RedbIndexConfig::default(),
-        )));
-
-        assert!(message.contains("redb"), "refusal must name the backend");
-        assert!(
-            message.contains("deprecated"),
-            "refusal must say the backend is deprecated"
-        );
-        assert!(
-            message.contains("fjall"),
-            "refusal must name the supported backend"
-        );
     }
 }
 

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -384,27 +384,6 @@ mod tests {
 
     use super::*;
 
-    /// The migration message for a removed backend has to survive the
-    /// configuration loader, not just serde: an operator upgrading reads what
-    /// the loader prints, and a message the `config` crate replaced with its
-    /// own unknown-variant text would tell them nothing.
-    #[test]
-    fn a_removed_backend_reports_the_migration_message_through_the_loader() {
-        let error = ::config::Config::builder()
-            .add_source(::config::File::from_str(
-                "path = \"data\"\n[state]\nbackend = \"redb\"\npath = \"state\"\n",
-                ::config::FileFormat::Toml,
-            ))
-            .build()
-            .expect("the source builds")
-            .try_deserialize::<dolos_core::config::StorageConfig>()
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("redb"), "must name the removed backend");
-        assert!(error.contains("fjall"), "must name the supported backend");
-    }
-
     /// The environment reaches `[stelae.registry]` by the same route as every
     /// other setting, and *this* is the assertion that says so.
     ///

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -384,6 +384,27 @@ mod tests {
 
     use super::*;
 
+    /// The migration message for a removed backend has to survive the
+    /// configuration loader, not just serde: an operator upgrading reads what
+    /// the loader prints, and a message the `config` crate replaced with its
+    /// own unknown-variant text would tell them nothing.
+    #[test]
+    fn a_removed_backend_reports_the_migration_message_through_the_loader() {
+        let error = ::config::Config::builder()
+            .add_source(::config::File::from_str(
+                "path = \"data\"\n[state]\nbackend = \"redb\"\npath = \"state\"\n",
+                ::config::FileFormat::Toml,
+            ))
+            .build()
+            .expect("the source builds")
+            .try_deserialize::<dolos_core::config::StorageConfig>()
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("redb"), "must name the removed backend");
+        assert!(error.contains("fjall"), "must name the supported backend");
+    }
+
     /// The environment reaches `[stelae.registry]` by the same route as every
     /// other setting, and *this* is the assertion that says so.
     ///


### PR DESCRIPTION
Plan: `plans/dolos-remove-nonlive-backend-config.md` (Brain/txpipe).

## What changed

The live persistent backend for the state and index stores is `fjall`. The `redb` variants of `StateStoreConfig` and `IndexStoreConfig` were `#[deprecated]` and refused at store-open, kept only so an old configuration file still deserialized into a readable error. They are gone, along with their `#[allow(deprecated)]` escorts.

- `crates/core/src/config.rs` — the two `Redb` variants removed. A configuration naming them now fails on deserialization, so the refusal moves from store-open to config load.
- `src/adapters/storage.rs` — `check_state_backend` / `check_index_backend` and their call sites are gone (unrepresentable now), along with the `Redb` config match arms in `StateStoreBackend::open`, `IndexStoreBackend::open`, and the backend-name helpers.
- Docs — `docs/content/configuration/schema.mdx` (state and index sections) and `docs/content/architecture/data-layer.mdx` now say the variants were removed in v1.7 and what to do instead.

**Breaking:** `backend = "redb"` under `[storage.state]` or `[storage.index]` no longer loads. Operators on a redb state or index directory re-bootstrap; a stelae restore is the shortest path. The changelog entry comes from this commit's `!` marker.

## Out of scope

- The **redb archive** backend is untouched: it retires separately in the same release, per [decision 0039](https://github.com/txpipe/dolos/) via the index-store-dissolution plan.
- `in_memory` and `no_op` stay — a builtin live ephemeral backend and the index layer's off-switch, neither a removal candidate.
- `crates/redb3/src/{state,indexes}/` and the `StateStoreBackend::Redb` / `IndexStoreBackend::Redb` adapter arms stay: `redb3` state and indexes are still the oracles for `tests/memory.rs` and `tests/index_roundtrip.rs`, and `crates/redb3/src/indexes/` opens the archive's tag tables, so it goes with the archive removal.

## Review follow-up (53208a86)

Per review, the custom migration message is gone: no repr enums, no `TryFrom` impls, no `REMOVED_REDB_*_BACKEND` constants, and no tests asserting the message text. Both enums derive `Deserialize` plainly, and an old `backend = "redb"` fails on deserialization with serde's own unknown-variant error.

## Verification

- `cargo test -p dolos-core --lib` and `cargo test --bin dolos` — green after the follow-up (90 + 39 tests, 0 failures); the full `cargo test --workspace --all-targets` run on the first commit was 38 binaries, all green.
- `cargo clippy --workspace --all-targets` — no new warnings (pre-existing ones elsewhere in the tree unchanged).
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4eS1ecP2KK34SSpY3RdF7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed support for selecting the `redb` state and index storage backends through configuration.
  - Configurations that specify `redb` now fail to load with an unknown-variant error instead of a migration-specific message.

- **Documentation**
  - Updated storage architecture and configuration guidance to reflect that `redb` configurations fail to load.
  - Existing re-bootstrap and rebuild guidance remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->