### PR TITLE
refactor(archive)!: host the archive tags and exact lookups in the archive store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,10 @@ Dolos uses four distinct storage backends, each serving a specific purpose:
 - **Database**: `<storage.path>/wal`
 
 ### IndexStore
-- **Purpose**: Cross-cutting indexes for fast historical lookups
-- **Contents**: Archive indexes — historical queries (by block hash, tx hash, slots with address/asset/etc.)
-- **Not here**: the live-UTxO tags (by address, payment, stake, policy, asset, script ref) are a projection of the UTxO set and live in the `StateStore` (`StateStore::utxos_by_tag`, written through `StateWriter::apply_utxo_tags` in the same batch as the set)
-- **Traits**: `IndexStore` (reads) + `IndexWriter` (batched writes)
+- **Purpose**: the index cursor, and nothing else any more
+- **Not here**: the live-UTxO tags (by address, payment, stake, policy, asset, script ref) are a projection of the UTxO set and live in the `StateStore` (`StateStore::utxos_by_tag`, written through `StateWriter::apply_utxo_tags` in the same batch as the set); the archive tags and the exact lookups (by block hash, block number, tx hash) are a projection of the block history and live in the `ArchiveStore` (`ArchiveStore::slots_by_tag` / `slot_by_*`, written through `ArchiveWriter::apply_index` in the same batch as the blocks)
+- **Traits**: `IndexStore` (cursor read) + `IndexWriter` (cursor write)
 - **Database**: `<storage.path>/index` (isolated from other stores)
-- **Design Note**: Returns primitive values (slots, UTxO refs) not block data. Use `QueryHelpers` to join with archive for full data.
 
 ### Database File Organization
 
@@ -111,10 +109,12 @@ The project follows a modular workspace architecture with clear separation of co
     - **`state-utxos`**: UTxO set storage with `[tx_hash:32][index:4]` keys
     - **`state-entities`**: All entity types with `[ns_hash:8][entity_key:32]` keys
     - **`state-tags`**: Live-UTxO tags with `[dim_hash:8][lookup_key:var][txo_ref:36]` keys
-  - `index`: `IndexStore` implementation with three-keyspace design:
-    - **`index-cursor`**: Chain position tracking
+  - `archive`: `ArchiveStore` implementation with four-keyspace design:
+    - **`archive-blocks`**: Slot -> packed block locations in the flat segment files
+    - **`archive-logs`**: All log namespaces with `[ns_hash:8][log_key:40]` keys
+    - **`archive-tags`**: Tag-based prefix scans for block tags with `[dim_hash:8][key_hash:8][slot:8]` keys
     - **`index-exact`**: Exact-match lookups with `[dim_hash:8][key_data:var]` -> `[slot:8]`
-    - **`archive-tags`**: Tag-based prefix scans for block tags
+  - `index`: `IndexStore` implementation, reduced to the **`index-cursor`** keyspace
   - `keys`: Shared key encoding utilities
 - **Key Advantages**:
   - Reduced segment files compared to per-entity keyspaces

--- a/crates/cardano/src/indexes/delta.rs
+++ b/crates/cardano/src/indexes/delta.rs
@@ -3,11 +3,11 @@
 //! This module provides `CardanoIndexDeltaBuilder` for constructing the two
 //! index halves from Cardano block data: the live-UTxO tags
 //! (`UtxoIndexDelta`, written through the state store) and the archive
-//! entries (`IndexDelta`, written through the index store).
+//! entries (one `ArchiveIndexDelta` per block, written through the archive
+//! store).
 
 use dolos_core::{
-    ArchiveIndexDelta, BlockSlot, ChainPoint, EraCbor, IndexDelta, Tag, TxoRef, UtxoIndexDelta,
-    UtxoMap, UtxoSetDelta,
+    ArchiveIndexDelta, BlockSlot, EraCbor, Tag, TxoRef, UtxoIndexDelta, UtxoMap, UtxoSetDelta,
 };
 use pallas::{
     codec::minicbor,
@@ -25,12 +25,14 @@ use crate::pallas_extras;
 ///
 /// This builder accumulates index tags as blocks are processed and produces
 /// the live-UTxO half (a `UtxoIndexDelta`, for `StateWriter::apply_utxo_tags`)
-/// and the archive half (an `IndexDelta`, for `IndexWriter::apply`).
+/// and the archive half (the `ArchiveIndexDelta`s, for
+/// `ArchiveWriter::apply_index`). Where the cursor lands is the committing
+/// writer's business, not the builder's.
 ///
 /// # Example
 ///
 /// ```ignore
-/// let mut builder = CardanoIndexDeltaBuilder::new(cursor_point);
+/// let mut builder = CardanoIndexDeltaBuilder::new();
 ///
 /// // Start processing a block
 /// builder.start_block(slot, block_hash, Some(block_number));
@@ -43,21 +45,15 @@ use crate::pallas_extras;
 /// // Take both halves
 /// let (utxo_tags, archive) = builder.into_parts();
 /// ```
+#[derive(Default)]
 pub struct CardanoIndexDeltaBuilder {
     utxo: UtxoIndexDelta,
-    delta: IndexDelta,
+    archive: Vec<ArchiveIndexDelta>,
 }
 
 impl CardanoIndexDeltaBuilder {
-    /// Create a new builder with the given cursor position.
-    pub fn new(cursor: ChainPoint) -> Self {
-        Self {
-            utxo: UtxoIndexDelta::default(),
-            delta: IndexDelta {
-                cursor,
-                ..Default::default()
-            },
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     // ============ UTxO Operations ============
@@ -131,7 +127,7 @@ impl CardanoIndexDeltaBuilder {
     ///
     /// Must be called before adding block-level tags.
     pub fn start_block(&mut self, slot: BlockSlot, block_hash: Vec<u8>, number: Option<u64>) {
-        self.delta.archive.push(ArchiveIndexDelta {
+        self.archive.push(ArchiveIndexDelta {
             slot,
             block_hash,
             block_number: number,
@@ -142,8 +138,7 @@ impl CardanoIndexDeltaBuilder {
 
     /// Get mutable reference to the current block delta.
     fn current_block(&mut self) -> &mut ArchiveIndexDelta {
-        self.delta
-            .archive
+        self.archive
             .last_mut()
             .expect("must call start_block before adding tags")
     }
@@ -378,17 +373,17 @@ impl CardanoIndexDeltaBuilder {
         }
     }
 
-    /// Build the archive half: the `IndexDelta` with its cursor.
+    /// Build the archive half: one delta per block started.
     ///
     /// Any live-UTxO tags added to the builder are dropped; a caller that
     /// wants both halves takes them with [`Self::into_parts`].
-    pub fn build(self) -> IndexDelta {
-        self.delta
+    pub fn build(self) -> Vec<ArchiveIndexDelta> {
+        self.archive
     }
 
-    /// Take both halves: the live-UTxO tags and the archive delta.
-    pub fn into_parts(self) -> (UtxoIndexDelta, IndexDelta) {
-        (self.utxo, self.delta)
+    /// Take both halves: the live-UTxO tags and the archive deltas.
+    pub fn into_parts(self) -> (UtxoIndexDelta, Vec<ArchiveIndexDelta>) {
+        (self.utxo, self.archive)
     }
 
     /// Get a reference to the UTxO delta (for inspection/testing).
@@ -398,7 +393,7 @@ impl CardanoIndexDeltaBuilder {
 
     /// Get a reference to the archive deltas (for inspection/testing).
     pub fn archive_deltas(&self) -> &[ArchiveIndexDelta] {
-        &self.delta.archive
+        &self.archive
     }
 
     // ============ Batch UTxO Operations (for genesis/import) ============
@@ -450,7 +445,7 @@ impl CardanoIndexDeltaBuilder {
 /// projection of the set. Used by genesis, WAL replay, the epoch-boundary
 /// AVVM deletion and the stele restore.
 pub fn utxo_index_delta_from_utxo_delta(utxo_delta: &UtxoSetDelta) -> UtxoIndexDelta {
-    let mut builder = CardanoIndexDeltaBuilder::new(ChainPoint::Origin);
+    let mut builder = CardanoIndexDeltaBuilder::new();
     builder.add_utxo_tags_from_delta(utxo_delta);
     builder.into_parts().0
 }
@@ -458,7 +453,6 @@ pub fn utxo_index_delta_from_utxo_delta(utxo_delta: &UtxoSetDelta) -> UtxoIndexD
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dolos_core::ChainPoint;
     use pallas::crypto::hash::Hash;
     use pallas::ledger::addresses::{
         Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart,
@@ -475,22 +469,20 @@ mod tests {
 
     #[test]
     fn test_builder_basic() {
-        let cursor = ChainPoint::Specific(100, Hash::new([0; 32]));
-        let mut builder = CardanoIndexDeltaBuilder::new(cursor.clone());
+        let mut builder = CardanoIndexDeltaBuilder::new();
 
         builder.start_block(100, vec![0; 32], Some(50));
         builder.add_tx_hash(vec![1; 32]);
         builder.add_address(&test_shelley_address());
 
-        let delta = builder.build();
+        let archive = builder.build();
 
-        assert_eq!(delta.cursor, cursor);
-        assert_eq!(delta.archive.len(), 1);
-        assert_eq!(delta.archive[0].slot, 100);
-        assert_eq!(delta.archive[0].block_number, Some(50));
-        assert_eq!(delta.archive[0].tx_hashes.len(), 1);
+        assert_eq!(archive.len(), 1);
+        assert_eq!(archive[0].slot, 100);
+        assert_eq!(archive[0].block_number, Some(50));
+        assert_eq!(archive[0].tx_hashes.len(), 1);
         // Shelley address produces 3 tags: full, payment, stake
-        assert_eq!(delta.archive[0].tags.len(), 3);
+        assert_eq!(archive[0].tags.len(), 3);
     }
 
     /// An output that carries a reference script gets a `script_ref` tag whose
@@ -605,14 +597,12 @@ mod tests {
     /// still pass, which is the same blind spot one step removed.
     #[test]
     fn every_produced_dimension_is_registered() {
-        let mut builder =
-            CardanoIndexDeltaBuilder::new(ChainPoint::Specific(100, Hash::new([0; 32])));
+        let mut builder = CardanoIndexDeltaBuilder::new();
         tag_every_dimension(&mut builder);
 
-        let delta = builder.build();
+        let archive = builder.build();
 
-        let produced: BTreeSet<&str> = delta
-            .archive
+        let produced: BTreeSet<&str> = archive
             .iter()
             .flat_map(|block| block.tags.iter())
             .map(|tag| tag.dimension)

--- a/crates/cardano/src/indexes/dimensions.rs
+++ b/crates/cardano/src/indexes/dimensions.rs
@@ -34,7 +34,7 @@ pub mod utxo {
 ///
 /// Index stores keep a *hash* of the dimension name rather than the name, so
 /// the set of dimensions is not discoverable from disk: any bulk traversal of
-/// archive tags (`IndexStore::iter_archive_tags`) has to be driven by `ALL`,
+/// archive tags (`ArchiveStore::iter_archive_tags`) has to be driven by `ALL`,
 /// and a dimension missing from it silently stops being exported.
 ///
 /// Writing the two out separately made that a comment's job. Here a constant

--- a/crates/cardano/src/indexes/ext.rs
+++ b/crates/cardano/src/indexes/ext.rs
@@ -1,10 +1,10 @@
 //! Cardano-specific store extension traits.
 //!
 //! This module provides `CardanoStateIndexExt`, which adds the live-UTxO
-//! lookups to any `StateStore`, and `CardanoIndexExt`, which adds the archive
-//! lookups to any `IndexStore`.
+//! lookups to any `StateStore`, and `CardanoArchiveIndexExt`, which adds the
+//! history lookups to any `ArchiveStore`.
 
-use dolos_core::{BlockSlot, IndexError, IndexStore, StateError, StateStore, UtxoSet};
+use dolos_core::{ArchiveError, ArchiveStore, BlockSlot, StateError, StateStore, UtxoSet};
 
 use super::dimensions::{archive, utxo};
 
@@ -60,18 +60,18 @@ impl<T: StateStore> CardanoStateIndexExt for T {}
 /// Extension trait providing Cardano-specific archive index queries.
 ///
 /// This trait is automatically implemented for all types implementing
-/// `IndexStore`. It provides convenient methods that map Cardano concepts to
-/// generic tag lookups.
+/// `ArchiveStore`. It provides convenient methods that map Cardano concepts
+/// to generic tag lookups.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use dolos_cardano::indexes::CardanoIndexExt;
+/// use dolos_cardano::indexes::CardanoArchiveIndexExt;
 ///
-/// // domain.indexes() returns an IndexStore implementation
-/// let slots = domain.indexes().slots_by_address(&address_bytes, start, end)?;
+/// // domain.archive() returns an ArchiveStore implementation
+/// let slots = domain.archive().slots_by_address(&address_bytes, start, end)?;
 /// ```
-pub trait CardanoIndexExt: IndexStore {
+pub trait CardanoArchiveIndexExt: ArchiveStore {
     // ============ Archive Slot Queries ============
 
     /// Iterate over slots of blocks containing transactions involving an
@@ -81,7 +81,7 @@ pub trait CardanoIndexExt: IndexStore {
         address: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::ADDRESS, address, start, end)
     }
 
@@ -92,7 +92,7 @@ pub trait CardanoIndexExt: IndexStore {
         payment: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::PAYMENT, payment, start, end)
     }
 
@@ -103,7 +103,7 @@ pub trait CardanoIndexExt: IndexStore {
         stake: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::STAKE, stake, start, end)
     }
 
@@ -113,7 +113,7 @@ pub trait CardanoIndexExt: IndexStore {
         asset: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::ASSET, asset, start, end)
     }
 
@@ -124,7 +124,7 @@ pub trait CardanoIndexExt: IndexStore {
         policy: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::POLICY, policy, start, end)
     }
 
@@ -134,7 +134,7 @@ pub trait CardanoIndexExt: IndexStore {
         datum: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::DATUM, datum, start, end)
     }
 
@@ -144,7 +144,7 @@ pub trait CardanoIndexExt: IndexStore {
         txo: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::SPENT_TXO, txo, start, end)
     }
 
@@ -154,7 +154,7 @@ pub trait CardanoIndexExt: IndexStore {
         account: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::ACCOUNT_CERTS, account, start, end)
     }
 
@@ -164,7 +164,7 @@ pub trait CardanoIndexExt: IndexStore {
         pool: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::POOL_CERTS, pool, start, end)
     }
 
@@ -174,7 +174,7 @@ pub trait CardanoIndexExt: IndexStore {
         account: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::ACCOUNT_WITHDRAWALS, account, start, end)
     }
 
@@ -185,7 +185,7 @@ pub trait CardanoIndexExt: IndexStore {
         label: u64,
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.slots_by_tag(archive::METADATA, &label.to_be_bytes(), start, end)
     }
 
@@ -194,9 +194,9 @@ pub trait CardanoIndexExt: IndexStore {
     /// Iterate every archive tag record in `slots`, across every Cardano
     /// archive dimension.
     ///
-    /// [`IndexStore::iter_archive_tags`] takes the dimension list because the
-    /// storage layer is chain-agnostic and cannot know it — stores keep a hash
-    /// of the dimension name, not the name. That makes `archive::ALL` the
+    /// [`ArchiveStore::iter_archive_tags`] takes the dimension list because
+    /// the storage layer is chain-agnostic and cannot know it — stores keep a
+    /// hash of the dimension name, not the name. That makes `archive::ALL` the
     /// caller's to supply, and every export call site a place the list can
     /// drift out of.
     ///
@@ -205,10 +205,10 @@ pub trait CardanoIndexExt: IndexStore {
     fn iter_all_archive_tags(
         &self,
         slots: std::ops::Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
+    ) -> Result<Self::TagIter, ArchiveError> {
         self.iter_archive_tags(&archive::ALL, slots)
     }
 }
 
-// Blanket implementation for all IndexStore implementations
-impl<T: IndexStore> CardanoIndexExt for T {}
+// Blanket implementation for all ArchiveStore implementations
+impl<T: ArchiveStore> CardanoArchiveIndexExt for T {}

--- a/crates/cardano/src/indexes/ext.rs
+++ b/crates/cardano/src/indexes/ext.rs
@@ -210,5 +210,4 @@ pub trait CardanoArchiveIndexExt: ArchiveStore {
     }
 }
 
-// Blanket implementation for all ArchiveStore implementations
 impl<T: ArchiveStore> CardanoArchiveIndexExt for T {}

--- a/crates/cardano/src/indexes/mod.rs
+++ b/crates/cardano/src/indexes/mod.rs
@@ -1,7 +1,7 @@
 //! Cardano-specific index support.
 //!
-//! This module provides Cardano-specific extensions to the generic index store
-//! defined in `dolos-core`. It includes:
+//! This module provides Cardano-specific extensions to the generic index
+//! types defined in `dolos-core`. It includes:
 //!
 //! - Dimension constants for UTxO filter and archive indexes
 //! - Extension traits for convenient Cardano-specific index queries
@@ -14,5 +14,5 @@ mod query;
 
 pub use delta::{utxo_index_delta_from_utxo_delta, CardanoIndexDeltaBuilder};
 pub use dimensions::{archive as archive_dimensions, utxo as utxo_dimensions};
-pub use ext::{CardanoIndexExt, CardanoStateIndexExt};
+pub use ext::{CardanoArchiveIndexExt, CardanoStateIndexExt};
 pub use query::{AsyncCardanoQueryExt, ScriptData, ScriptLanguage, SlotOrder};

--- a/crates/cardano/src/indexes/query.rs
+++ b/crates/cardano/src/indexes/query.rs
@@ -11,7 +11,7 @@ use pallas::{
 
 use dolos_core::{
     archive::ArchiveStore, AsyncQueryFacade, BlockBody, BlockSlot, ChainError, Domain, DomainError,
-    EntityKey, IndexStore, StateStore as _, TagDimension, TxHash, TxoRef,
+    EntityKey, StateStore as _, TagDimension, TxHash, TxoRef,
 };
 
 use crate::indexes::dimensions::archive;
@@ -677,7 +677,7 @@ where
         let slots: Vec<BlockSlot> = facade
             .run_blocking(move |domain| {
                 Ok(domain
-                    .indexes()
+                    .archive()
                     .slots_by_tag(dimension, &key_clone, chunk_start, end_slot)?
                     .take(SLOT_CHUNK_SIZE)
                     .collect::<Result<Vec<_>, _>>()?)
@@ -733,7 +733,7 @@ where
                     let key = key.clone();
                     move |domain| {
                         let iter = domain
-                            .indexes()
+                            .archive()
                             .slots_by_tag(dimension, &key, start_slot, end_slot)?;
 
                         let slots = match order {

--- a/crates/cardano/src/lib.rs
+++ b/crates/cardano/src/lib.rs
@@ -486,7 +486,7 @@ impl dolos_core::ChainLogic for CardanoLogic {
     fn compute_undo(
         block: &dolos_core::Cbor,
         inputs: &std::collections::HashMap<dolos_core::TxoRef, Arc<EraCbor>>,
-        point: ChainPoint,
+        _point: ChainPoint,
     ) -> Result<dolos_core::UndoBlockData, ChainError> {
         let block_arc = Arc::new(block.clone());
         let blockd = OwnedMultiEraBlock::decode(block_arc)?;
@@ -506,17 +506,22 @@ impl dolos_core::ChainLogic for CardanoLogic {
         // The tags the block put in and took out, as it did them: the undo
         // delta names them inverted (undone = what the block produced,
         // recovered = what it consumed), and `undo_utxo_tags` inverts again.
-        let mut builder = crate::indexes::CardanoIndexDeltaBuilder::new(point);
+        let mut builder = crate::indexes::CardanoIndexDeltaBuilder::new();
         builder.add_produced_utxos(&utxo_delta.undone_utxo);
         builder.add_consumed_utxos(&utxo_delta.recovered_stxi);
-        let (utxo_index_delta, index_delta) = builder.into_parts();
+
+        // The archive entries the block wrote, rebuilt the way the apply path
+        // built them, so `undo_index` removes exactly what `apply_index` added.
+        builder.index_block(blockv, &decoded_inputs);
+
+        let (utxo_index_delta, archive_index_deltas) = builder.into_parts();
 
         let tx_hashes = blockv.txs().iter().map(|tx| tx.hash()).collect();
 
         Ok(dolos_core::UndoBlockData {
             utxo_delta,
             utxo_index_delta,
-            index_delta,
+            archive_index_deltas,
             tx_hashes,
         })
     }
@@ -524,7 +529,7 @@ impl dolos_core::ChainLogic for CardanoLogic {
     fn compute_catchup(
         block: &dolos_core::Cbor,
         inputs: &std::collections::HashMap<dolos_core::TxoRef, Arc<EraCbor>>,
-        point: ChainPoint,
+        _point: ChainPoint,
     ) -> Result<dolos_core::CatchUpBlockData, ChainError> {
         let block_arc = Arc::new(block.clone());
         let blockd = OwnedMultiEraBlock::decode(block_arc)?;
@@ -541,7 +546,7 @@ impl dolos_core::ChainLogic for CardanoLogic {
         let utxo_delta = crate::utxoset::compute_apply_delta(blockv, &decoded_inputs)
             .map_err(ChainError::from)?;
 
-        let mut builder = crate::indexes::CardanoIndexDeltaBuilder::new(point);
+        let mut builder = crate::indexes::CardanoIndexDeltaBuilder::new();
 
         // UTxO filter changes
         builder.add_utxo_tags_from_delta(&utxo_delta);
@@ -549,14 +554,14 @@ impl dolos_core::ChainLogic for CardanoLogic {
         // Archive indexes (shared logic)
         builder.index_block(blockv, &decoded_inputs);
 
-        let (utxo_index_delta, index_delta) = builder.into_parts();
+        let (utxo_index_delta, archive_index_deltas) = builder.into_parts();
 
         let tx_hashes = blockv.txs().iter().map(|tx| tx.hash()).collect();
 
         Ok(dolos_core::CatchUpBlockData {
             utxo_delta,
             utxo_index_delta,
-            index_delta,
+            archive_index_deltas,
             tx_hashes,
         })
     }

--- a/crates/cardano/src/roll/batch.rs
+++ b/crates/cardano/src/roll/batch.rs
@@ -124,7 +124,8 @@ pub struct WorkBatch {
     entities: EntityMap<CardanoEntity>,
 
     // index halves, built once by `build_index_deltas` and committed by
-    // `commit_state` (tags) and `commit_indexes` (archive)
+    // `commit_state` (live-UTxO tags) and `commit_archive` (archive tags and
+    // exact lookups)
     utxo_index_delta: Option<UtxoIndexDelta>,
     archive_index_deltas: Option<Vec<ArchiveIndexDelta>>,
 
@@ -375,6 +376,8 @@ impl WorkBatch {
         Ok(())
     }
 
+    /// Write the batch's blocks and, in the same commit, the index entries
+    /// they project: the archive tags and the exact lookups.
     pub fn commit_archive<D>(&mut self, domain: &D) -> Result<(), DomainError>
     where
         D: Domain<Chain = CardanoLogic>,
@@ -388,6 +391,13 @@ impl WorkBatch {
             writer.apply(&point, &raw)?;
         }
 
+        self.build_index_deltas();
+        let archive_index_deltas = self
+            .archive_index_deltas
+            .take()
+            .expect("build_index_deltas fills the archive half");
+        writer.apply_index(&archive_index_deltas)?;
+
         writer.commit()?;
 
         Ok(())
@@ -397,14 +407,14 @@ impl WorkBatch {
     ///
     /// The live-UTxO tags follow each block's `utxo_delta`; the archive
     /// entries come from the already decoded block. Idempotent: the halves are
-    /// cached on the batch for `commit_state` and `commit_indexes`, whichever
+    /// cached on the batch for `commit_state` and `commit_archive`, whichever
     /// runs first.
     fn build_index_deltas(&mut self) {
         if self.utxo_index_delta.is_some() {
             return;
         }
 
-        let mut builder = CardanoIndexDeltaBuilder::new(self.last_point());
+        let mut builder = CardanoIndexDeltaBuilder::new();
 
         for work_block in self.blocks.iter() {
             if let Some(utxo_delta) = &work_block.utxo_delta {
@@ -418,21 +428,16 @@ impl WorkBatch {
         let (utxo, archive) = builder.into_parts();
 
         self.utxo_index_delta = Some(utxo);
-        self.archive_index_deltas = Some(archive.archive);
+        self.archive_index_deltas = Some(archive);
     }
 
+    /// Place the index store's cursor at the batch's last point.
     pub fn commit_indexes<D>(&mut self, domain: &D) -> Result<(), DomainError>
     where
         D: Domain<Chain = CardanoLogic>,
     {
-        self.build_index_deltas();
-
         let delta = IndexDelta {
             cursor: self.last_point(),
-            archive: self
-                .archive_index_deltas
-                .take()
-                .expect("build_index_deltas fills the archive half"),
         };
 
         let writer = domain.indexes().start_writer()?;

--- a/crates/core/src/archive.rs
+++ b/crates/core/src/archive.rs
@@ -374,8 +374,6 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
 
     fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError>;
 
-    // ============ Index Queries (Exact Lookups) ============
-
     /// Get the slot for a block by its hash (exact lookup).
     fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError>;
 
@@ -384,8 +382,6 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
 
     /// Get the slot containing a transaction by its hash (exact lookup).
     fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError>;
-
-    // ============ Index Queries (Tag-Based Range Queries) ============
 
     /// Query slots by tag dimension and key within a slot range.
     ///
@@ -405,8 +401,6 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
         start: BlockSlot,
         end: BlockSlot,
     ) -> Result<Self::SlotIter, ArchiveError>;
-
-    // ============ Record Traversal (Bulk Export) ============
 
     /// Iterate every archive tag record whose slot falls in `slots`.
     ///

--- a/crates/core/src/archive.rs
+++ b/crates/core/src/archive.rs
@@ -3,8 +3,10 @@ use std::{marker::PhantomData, ops::Range};
 use thiserror::Error;
 
 use crate::{
-    state::KEY_SIZE, BlockBody, BlockSlot, BrokenInvariant, ChainPoint, Entity, EntityKey,
-    EntityValue, Namespace, RawBlock,
+    indexes::{ArchiveIndexDelta, ExactRecord, IndexRecord, TagDimension, TagRecord},
+    state::KEY_SIZE,
+    BlockBody, BlockSlot, BrokenInvariant, ChainPoint, Entity, EntityKey, EntityValue, Namespace,
+    RawBlock,
 };
 
 const TEMPORAL_KEY_SIZE: usize = 8;
@@ -169,10 +171,77 @@ pub enum ArchiveError {
 
     #[error("namespace {0} not found")]
     NamespaceNotFound(Namespace),
+
+    /// The operation is part of the trait but the concrete backend does not
+    /// implement it.
+    ///
+    /// The no-op archive answers the index record traversals and the
+    /// pre-hashed append with this, so a restore into a store that discards
+    /// records fails instead of reporting success.
+    #[error("{0} is not supported on this storage backend")]
+    Unsupported(&'static str),
 }
+
+/// Iterator used by backends that do not implement
+/// [`ArchiveStore::iter_archive_tags`].
+///
+/// Never constructed — those backends return [`ArchiveError::Unsupported`],
+/// so the alias only exists to satisfy the associated type.
+pub type EmptyTagIter = std::iter::Empty<Result<TagRecord, ArchiveError>>;
+
+/// Iterator used by backends that do not implement
+/// [`ArchiveStore::iter_exact_records`].
+///
+/// Never constructed — those backends return [`ArchiveError::Unsupported`],
+/// so the alias only exists to satisfy the associated type.
+pub type EmptyExactIter = std::iter::Empty<Result<ExactRecord, ArchiveError>>;
 
 pub trait ArchiveWriter: Send + Sync + 'static {
     fn apply(&self, point: &ChainPoint, block: &RawBlock) -> Result<(), ArchiveError>;
+
+    /// Write the index entries the blocks of this batch project: their tags
+    /// and their exact lookups.
+    ///
+    /// Separate from [`ArchiveWriter::apply`] on purpose. A restore writes
+    /// the `blocks` layer without deltas (the entries arrive pre-hashed in
+    /// the `indexes` layer, see [`ArchiveWriter::append_prehashed`]), while
+    /// the sync pipeline and the WAL catch-up derive the deltas from the
+    /// blocks they are about to write and land both in the same commit.
+    fn apply_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError>;
+
+    /// Remove the index entries [`ArchiveWriter::apply_index`] wrote for
+    /// these blocks (rollback).
+    fn undo_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError>;
+
+    /// Append archive records that already carry their stored key form.
+    ///
+    /// This is the write mirror of [`ArchiveStore::iter_archive_tags`] and
+    /// [`ArchiveStore::iter_exact_records`]: records that came out of one
+    /// store go into another byte-for-byte, with no logical key in between
+    /// (there is none to recover — see [`crate::indexes::KeyHash`]).
+    ///
+    /// Records must arrive sorted, since the backing stores are append
+    /// oriented.
+    ///
+    /// ## Chunking
+    ///
+    /// The argument is an iterator so a restore can pipe its wire decoder
+    /// straight in, rather than materializing a slice beside the write
+    /// batch's own encoded copy. It is consumed lazily and fully; a backend
+    /// never collects it.
+    ///
+    /// This call is *not* the batch boundary — the writer accumulates until
+    /// [`ArchiveWriter::commit`], so an unbounded iterator builds an
+    /// unbounded batch. Chunking is the caller's: feed one writer a run of
+    /// records, commit it, start the next. The sort order has to hold across
+    /// the whole restore, not merely within a chunk.
+    ///
+    /// Backends that do not implement this return
+    /// [`ArchiveError::Unsupported`].
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), ArchiveError>;
 
     fn write_log(
         &self,
@@ -212,6 +281,15 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
     type Writer: ArchiveWriter;
     type LogIter: Iterator<Item = Result<(LogKey, EntityValue), ArchiveError>>;
     type EntityValueIter: Iterator<Item = Result<EntityValue, ArchiveError>>;
+
+    /// Iterator type for sparse slot queries.
+    type SlotIter: Iterator<Item = Result<BlockSlot, ArchiveError>> + DoubleEndedIterator;
+
+    /// Iterator type for archive tag record traversal.
+    type TagIter: Iterator<Item = Result<TagRecord, ArchiveError>>;
+
+    /// Iterator type for exact-match record traversal.
+    type ExactIter: Iterator<Item = Result<ExactRecord, ArchiveError>>;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError>;
 
@@ -295,4 +373,92 @@ pub trait ArchiveStore: Clone + Send + Sync + 'static {
     fn prune_history(&self, max_slots: u64, max_prune: Option<u64>) -> Result<bool, ArchiveError>;
 
     fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError>;
+
+    // ============ Index Queries (Exact Lookups) ============
+
+    /// Get the slot for a block by its hash (exact lookup).
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError>;
+
+    /// Get the slot for a block by its number/height (exact lookup).
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError>;
+
+    /// Get the slot containing a transaction by its hash (exact lookup).
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError>;
+
+    // ============ Index Queries (Tag-Based Range Queries) ============
+
+    /// Query slots by tag dimension and key within a slot range.
+    ///
+    /// This method returns a lazy iterator over the slots that contain data
+    /// with the given dimension and key. Forward iteration gives the slots
+    /// in ascending order. Reverse iteration gives the slots in descending
+    /// order.
+    ///
+    /// Both `start` and `end` are **inclusive** — unlike the record traversal
+    /// methods below, which take a half-open [`Range`]. Reusing one `(start,
+    /// end)` pair across both conventions drops or double-counts the record at
+    /// `end`.
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError>;
+
+    // ============ Record Traversal (Bulk Export) ============
+
+    /// Iterate every archive tag record whose slot falls in `slots`.
+    ///
+    /// `slots` is **half-open** (`start..end`), unlike
+    /// [`ArchiveStore::slots_by_tag`], whose bounds are both inclusive.
+    ///
+    /// `dimensions` is the closed list of dimensions to traverse. It has to be
+    /// supplied by the caller: stores keep a hash of the dimension name, not
+    /// the name, so the set of dimensions is not discoverable from disk.
+    /// Duplicates are ignored.
+    ///
+    /// **Order is part of the contract.** Records come out sorted by
+    /// `(dimension, key_hash, slot)` — `dimension` compared as a string,
+    /// independently of the order `dimensions` was given in. Consumers of this
+    /// iteration (snapshot layers) make that order their content, so an
+    /// unordered iterator is a wrong one.
+    ///
+    /// **Errors are terminal.** A malformed on-disk entry or a read failure is
+    /// yielded as `Err` and the iterator is fused from then on: it never
+    /// resumes past a fault, so a consumer that collects into
+    /// `Result<Vec<_>, _>` cannot receive a silently truncated record set.
+    ///
+    /// The iterator must be lazy in the size of the store. Each call opens its
+    /// own point-in-time view: records from separate calls (or from
+    /// [`ArchiveStore::iter_exact_records`]) are only mutually consistent if
+    /// the store is quiescent across the calls.
+    ///
+    /// Backends that do not implement this return
+    /// [`ArchiveError::Unsupported`].
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError>;
+
+    /// Iterate every exact-match record whose slot falls in `slots`.
+    ///
+    /// `slots` is **half-open** (`start..end`), unlike
+    /// [`ArchiveStore::slots_by_tag`], whose bounds are both inclusive.
+    ///
+    /// **Order is part of the contract**: records come out sorted by
+    /// `(kind, key)`, kinds in ascending [`crate::indexes::ExactKind::as_str`]
+    /// order.
+    ///
+    /// **Errors are terminal** — same policy as
+    /// [`ArchiveStore::iter_archive_tags`].
+    ///
+    /// Note that the slot is the stored *value* of an exact entry, not part of
+    /// its key, so a slot-bounded traversal is a scan of every exact entry in
+    /// the store rather than a seek. The iterator is still lazy in memory.
+    ///
+    /// Backends that do not implement this return
+    /// [`ArchiveError::Unsupported`].
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, ArchiveError>;
 }

--- a/crates/core/src/async_query.rs
+++ b/crates/core/src/async_query.rs
@@ -5,9 +5,8 @@ use tokio::sync::Semaphore;
 use pallas::ledger::traverse::MultiEraBlock;
 
 use crate::{
-    archive::ArchiveStore, indexes::IndexStore, ArchiveError, BlockBody, BlockHash, BlockHeight,
-    BlockSlot, ChainError, ChainPoint, Domain, DomainError, EraCbor, IndexError, TagDimension,
-    TxHash, TxOrder,
+    archive::ArchiveStore, ArchiveError, BlockBody, BlockHash, BlockHeight, BlockSlot, ChainError,
+    ChainPoint, Domain, DomainError, EraCbor, TagDimension, TxHash, TxOrder,
 };
 
 /// Lightweight block metadata for a transaction, extracted via a single decode.
@@ -110,7 +109,7 @@ where
 
     pub async fn block_by_hash(&self, hash: Vec<u8>) -> Result<Option<BlockBody>, DomainError> {
         self.run_blocking(move |domain| {
-            let slot = domain.indexes().slot_by_block_hash(&hash)?;
+            let slot = domain.archive().slot_by_block_hash(&hash)?;
             match slot {
                 Some(slot) => {
                     let candidates = domain.archive().get_blocks_by_slot(&slot)?;
@@ -124,7 +123,7 @@ where
 
     pub async fn block_by_number(&self, number: u64) -> Result<Option<BlockBody>, DomainError> {
         self.run_blocking(move |domain| {
-            let slot = domain.indexes().slot_by_block_number(number)?;
+            let slot = domain.archive().slot_by_block_number(number)?;
             match slot {
                 Some(slot) => Ok(domain.archive().get_block_by_slot(&slot)?),
                 None => Ok(None),
@@ -134,7 +133,7 @@ where
     }
 
     pub async fn slot_by_number(&self, number: u64) -> Result<Option<BlockSlot>, DomainError> {
-        self.run_blocking(move |domain| Ok(domain.indexes().slot_by_block_number(number)?))
+        self.run_blocking(move |domain| Ok(domain.archive().slot_by_block_number(number)?))
             .await
     }
 
@@ -145,7 +144,7 @@ where
         let tx_hash_lookup = tx_hash.clone();
         let Some(raw) = self
             .run_blocking(move |domain| {
-                let slot = domain.indexes().slot_by_tx_hash(&tx_hash_lookup)?;
+                let slot = domain.archive().slot_by_tx_hash(&tx_hash_lookup)?;
                 let Some(slot) = slot else {
                     return Ok(None);
                 };
@@ -181,7 +180,7 @@ where
         tx_hash: Vec<u8>,
     ) -> Result<Option<BlockRefMeta>, DomainError> {
         self.run_blocking(move |domain| {
-            let Some(slot) = domain.indexes().slot_by_tx_hash(&tx_hash)? else {
+            let Some(slot) = domain.archive().slot_by_tx_hash(&tx_hash)? else {
                 return Ok(None);
             };
             let Some(raw) = domain.archive().get_block_by_slot(&slot)? else {
@@ -212,7 +211,7 @@ where
         let tx_hash_lookup = tx_hash.clone();
         let Some(raw) = self
             .run_blocking(move |domain| {
-                let slot = domain.indexes().slot_by_tx_hash(&tx_hash_lookup)?;
+                let slot = domain.archive().slot_by_tx_hash(&tx_hash_lookup)?;
                 let Some(slot) = slot else {
                     return Ok(None);
                 };
@@ -242,9 +241,9 @@ where
     ) -> Result<Vec<BlockSlot>, DomainError> {
         self.run_blocking(move |domain| {
             let slots = domain
-                .indexes()
+                .archive()
                 .slots_by_tag(dimension, &key, start_slot, end_slot)?
-                .collect::<Result<Vec<_>, IndexError>>()?;
+                .collect::<Result<Vec<_>, ArchiveError>>()?;
             Ok(slots)
         })
         .await

--- a/crates/core/src/bootstrap.rs
+++ b/crates/core/src/bootstrap.rs
@@ -4,11 +4,14 @@
 //! It ensures storage consistency and drains any pending initialization work
 //! using the full sync lifecycle (WAL + tip notifications).
 
+use std::sync::Arc;
+
 use tracing::{error, info, warn};
 
 use crate::{
     sync::drain_pending_work, ArchiveStore, ArchiveWriter as _, ChainLogic, ChainPoint, Domain,
-    DomainError, EntityMap, IndexStore, IndexWriter as _, StateStore, StateWriter as _, WalStore,
+    DomainError, EntityMap, IndexDelta, IndexStore, IndexWriter as _, StateStore, StateWriter as _,
+    WalStore,
 };
 
 /// Extension trait for domain bootstrapping operations.
@@ -194,8 +197,8 @@ fn verify_caught_up(
 /// The WAL commits first in the work-unit lifecycle, so after a crash it is
 /// the most advanced store. Every other store reconciles forward to the WAL
 /// tip: state first (covering a crash between `commit_wal` and
-/// `commit_state`), then archive and indexes (covering a crash between the
-/// state commit and the archive/index commits).
+/// `commit_state`), then the archive with its index entries, then the index
+/// cursor (covering a crash between the state commit and the later commits).
 fn catch_up_stores<D: Domain>(domain: &D) -> Result<(), DomainError> {
     let target = match domain.wal().find_tip()? {
         // nothing to catch up
@@ -295,7 +298,13 @@ fn catch_up_state<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), Doma
     )
 }
 
-/// Catch up archive store by replaying WAL blocks.
+/// Catch up the archive store by replaying WAL entries.
+///
+/// A crash between `commit_state` and `commit_archive` leaves the WAL (and
+/// the state) holding blocks the archive never saw. Each entry carries the
+/// block and its resolved inputs, so the archive's index entries — the tags
+/// and the exact lookups the block projects — are re-derived here and land in
+/// the same commit as the block, as they do on the sync path.
 fn catch_up_archive<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), DomainError> {
     let archive_tip = domain.archive().get_tip()?.map(|(slot, _)| slot);
     let target_slot = target.slot();
@@ -311,23 +320,26 @@ fn catch_up_archive<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), Do
         None => None,
     };
 
-    let blocks = domain.wal().iter_blocks(start, Some(target.clone()))?;
+    let logs = domain.wal().iter_logs(start, Some(target.clone()))?;
 
     let writer = domain.archive().start_writer()?;
     let mut count = 0u64;
 
-    for (point, block) in blocks {
+    for (point, log) in logs {
         // Skip the start point itself (already in archive) and anything at or before it
         if Some(point.slot()) <= archive_tip {
             continue;
         }
 
         // Skip synthetic entries (from reset_to) — they carry no block
-        if block.is_empty() {
+        if log.block.is_empty() {
             continue;
         }
 
-        writer.apply(&point, &block)?;
+        let catchup = D::Chain::compute_catchup(&log.block, &log.inputs, point.clone())?;
+
+        writer.apply(&point, &Arc::new(log.block))?;
+        writer.apply_index(&catchup.archive_index_deltas)?;
         count += 1;
     }
 
@@ -344,7 +356,12 @@ fn catch_up_archive<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), Do
     verify_caught_up("archive", archive_tip, target, CatchUpSeverity::Lenient)
 }
 
-/// Catch up index store by replaying WAL log entries.
+/// Catch up the index store's cursor by replaying WAL entries.
+///
+/// The index entries themselves ride the state and archive commits, so what
+/// a crash between `commit_archive` and `commit_indexes` leaves behind is a
+/// cursor: it is walked forward over the same entries the other stores
+/// replayed.
 fn catch_up_indexes<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), DomainError> {
     let index_cursor = domain.indexes().cursor()?;
 
@@ -376,9 +393,7 @@ fn catch_up_indexes<D: Domain>(domain: &D, target: &ChainPoint) -> Result<(), Do
             continue;
         }
 
-        let catchup = D::Chain::compute_catchup(&log.block, &log.inputs, point)?;
-
-        writer.apply(&catchup.index_delta)?;
+        writer.apply(&IndexDelta { cursor: point })?;
         count += 1;
     }
 

--- a/crates/core/src/builtin/memory/archive.rs
+++ b/crates/core/src/builtin/memory/archive.rs
@@ -12,7 +12,21 @@
 //!   main block arrives second;
 //! - logs live in one map keyed `(namespace, log_key)`, which makes a
 //!   namespaced range scan a plain [`BTreeMap::range`] — the same shape fjall
-//!   gets from its `[ns_hash:8][log_key:40]` prefix.
+//!   gets from its `[ns_hash:8][log_key:40]` prefix;
+//! - the archive tags live in one set keyed on the traversal contract's own
+//!   sort key `(dimension, key_hash, slot)`, and the exact lookups in one map
+//!   keyed `(kind, key)`. The disk backend encodes `[dim_hash][key][slot]`
+//!   triples into a flat keyspace and can only reach the contract's order by
+//!   walking a caller-supplied dimension list in name order; keyed on the
+//!   triple, that order is the map's own and holds by construction.
+//!
+//! ## Stored key form
+//!
+//! Tags are stored under [`key_hash`], not under their logical key, exactly as
+//! the disk backend stores them. Keeping the logical key would be a
+//! divergence, not an improvement: [`ArchiveWriter::append_prehashed`]
+//! delivers records that carry only the stored form, so a store that indexed
+//! anything else could not answer a logical-key query about a restored record.
 //!
 //! ## Ephemeral by design
 //!
@@ -23,16 +37,47 @@
 //! variant, the test harness's store, and the oracle the disk backend's
 //! conformance suite is checked against.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::{Bound, Range};
 use std::sync::{Arc, Mutex, RwLock};
 
 use pallas::ledger::traverse::MultiEraBlock;
 
 use crate::archive::{ArchiveError, ArchiveStore, ArchiveWriter, LogKey, Skippable};
+use crate::indexes::{
+    key_hash, ArchiveIndexDelta, ExactKind, ExactRecord, IndexRecord, KeyHash, TagDimension,
+    TagRecord, MAX_EXACT_KEY_LEN,
+};
 use crate::{
     BlockBody, BlockSlot, ChainPoint, EntityValue, Namespace, RawBlock, StateSchema, TemporalKey,
 };
+
+/// A stored archive tag: the traversal contract's sort key, used as the key.
+type ArchiveTag = (Cow<'static, str>, KeyHash, BlockSlot);
+
+/// An exact key, zero-padded to the widest kind — the same inline shape
+/// [`ExactRecord`] carries, so a record goes in and comes back out without a
+/// heap allocation on either side.
+type ExactKey = [u8; MAX_EXACT_KEY_LEN];
+
+/// A key's stored form, or `None` unless it is exactly the width its kind
+/// requires.
+///
+/// Refusing rather than padding or truncating to fit: a key adjusted to fit
+/// aliases with the key it was adjusted into, so a 33-byte block hash and the
+/// 32-byte hash that is its prefix would answer each other's lookups.
+/// `ArchiveIndexDelta` holds its hashes as `Vec<u8>`, so nothing upstream
+/// enforces the width.
+fn exact_key(kind: ExactKind, key: &[u8]) -> Option<ExactKey> {
+    if key.len() != kind.key_len() {
+        return None;
+    }
+
+    let mut buf = [0u8; MAX_EXACT_KEY_LEN];
+    buf[..key.len()].copy_from_slice(key);
+    Some(buf)
+}
 
 /// The store's whole contents, guarded as one unit so a commit is atomic.
 #[derive(Default)]
@@ -42,6 +87,10 @@ struct Tables {
     /// always real chain positions.
     blocks: BTreeMap<BlockSlot, Vec<BlockBody>>,
     logs: BTreeMap<(Namespace, LogKey), EntityValue>,
+    archive_tags: BTreeSet<ArchiveTag>,
+    /// Keyed on the record's own inline key rather than a `Vec`, so
+    /// `iter_exact_records` copies rather than allocates per record.
+    exact: BTreeMap<(ExactKind, ExactKey), BlockSlot>,
 }
 
 /// A single mutation, recorded by a writer and replayed at commit.
@@ -53,6 +102,10 @@ enum Op {
     Apply(ChainPoint, RawBlock),
     WriteLog(Namespace, LogKey, EntityValue),
     Undo(ChainPoint),
+    InsertArchiveTag(ArchiveTag),
+    RemoveArchiveTag(ArchiveTag),
+    InsertExact(ExactKind, ExactKey, BlockSlot),
+    RemoveExact(ExactKind, ExactKey),
 }
 
 fn poisoned() -> ArchiveError {
@@ -122,11 +175,123 @@ impl MemoryArchiveWriter {
         self.ops.lock().map_err(|_| poisoned())?.push(op);
         Ok(())
     }
+
+    fn archive_tags_of(block: &ArchiveIndexDelta) -> impl Iterator<Item = ArchiveTag> + '_ {
+        block.tags.iter().filter_map(|tag| {
+            key_hash(tag.dimension, &tag.key)
+                .map(|hash| (Cow::Borrowed(tag.dimension), hash, block.slot))
+        })
+    }
+
+    /// The exact entries a block delta writes.
+    ///
+    /// Every key is width-checked here, because the delta path is *not*
+    /// type-enforced: `ArchiveIndexDelta` holds its block and transaction
+    /// hashes as `Vec<u8>`. A wrong-width hash is a malformed block, and
+    /// refusing the batch beats dropping the entry — a block whose hash did not
+    /// land is a block no hash lookup can reach, and an index that quietly
+    /// omits it looks complete.
+    fn exact_keys_of(
+        block: &ArchiveIndexDelta,
+    ) -> impl Iterator<Item = Result<(ExactKind, ExactKey), ArchiveError>> + '_ {
+        let hash = (!block.block_hash.is_empty())
+            .then_some((ExactKind::BlockHash, block.block_hash.as_slice()));
+
+        let number = block.block_number.map(|n| (ExactKind::BlockNumber, n));
+
+        let txs = block
+            .tx_hashes
+            .iter()
+            .map(|hash| (ExactKind::TxHash, hash.as_slice()));
+
+        let hashes = hash.into_iter().chain(txs).map(|(kind, key)| {
+            exact_key(kind, key).map(|key| (kind, key)).ok_or_else(|| {
+                ArchiveError::InternalError(format!(
+                    "exact entry of kind {kind} has a {}-byte key, expected {}",
+                    key.len(),
+                    kind.key_len(),
+                ))
+            })
+        });
+
+        // A block number is type-enforced eight bytes, so it cannot be
+        // malformed the way a hash can.
+        let number = number.map(|(kind, n)| {
+            Ok((
+                kind,
+                exact_key(kind, &n.to_be_bytes()).expect("a u64 is the block-number key width"),
+            ))
+        });
+
+        hashes.chain(number)
+    }
 }
 
 impl ArchiveWriter for MemoryArchiveWriter {
     fn apply(&self, point: &ChainPoint, block: &RawBlock) -> Result<(), ArchiveError> {
         self.push(Op::Apply(point.clone(), block.clone()))
+    }
+
+    fn apply_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for block in deltas {
+            for entry in Self::exact_keys_of(block) {
+                let (kind, key) = entry?;
+                ops.push(Op::InsertExact(kind, key, block.slot));
+            }
+
+            for tag in Self::archive_tags_of(block) {
+                ops.push(Op::InsertArchiveTag(tag));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The exact inverse of [`Self::apply_index`], blocks walked
+    /// back-to-front.
+    fn undo_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for block in deltas.iter().rev() {
+            for entry in Self::exact_keys_of(block) {
+                let (kind, key) = entry?;
+                ops.push(Op::RemoveExact(kind, key));
+            }
+
+            for tag in Self::archive_tags_of(block) {
+                ops.push(Op::RemoveArchiveTag(tag));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), ArchiveError> {
+        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
+
+        for record in records {
+            match record {
+                IndexRecord::Tag(tag) => ops.push(Op::InsertArchiveTag((
+                    tag.dimension,
+                    tag.key_hash,
+                    tag.slot,
+                ))),
+                // The width is already checked: `ExactRecord` cannot be
+                // constructed with a key that does not match its kind.
+                IndexRecord::Exact(exact) => ops.push(Op::InsertExact(
+                    exact.kind,
+                    exact_key(exact.kind, exact.key()).expect("a record's key is its kind's width"),
+                    exact.slot,
+                )),
+            }
+        }
+
+        Ok(())
     }
 
     fn write_log(
@@ -182,11 +347,69 @@ impl ArchiveWriter for MemoryArchiveWriter {
                         }
                     }
                 }
+                Op::InsertArchiveTag(tag) => {
+                    tables.archive_tags.insert(tag);
+                }
+                Op::RemoveArchiveTag(tag) => {
+                    tables.archive_tags.remove(&tag);
+                }
+                Op::InsertExact(kind, key, slot) => {
+                    tables.exact.insert((kind, key), slot);
+                }
+                Op::RemoveExact(kind, key) => {
+                    tables.exact.remove(&(kind, key));
+                }
             }
         }
 
         Ok(())
     }
+}
+
+/// Slot iterator over a materialized range.
+pub struct MemorySlotIter(std::vec::IntoIter<BlockSlot>);
+
+impl Iterator for MemorySlotIter {
+    type Item = Result<BlockSlot, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+impl DoubleEndedIterator for MemorySlotIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(Ok)
+    }
+}
+
+/// Archive tag iterator over a materialized range.
+pub struct MemoryTagIter(std::vec::IntoIter<TagRecord>);
+
+impl Iterator for MemoryTagIter {
+    type Item = Result<TagRecord, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// Exact-match record iterator over a materialized range.
+pub struct MemoryExactIter(std::vec::IntoIter<ExactRecord>);
+
+impl Iterator for MemoryExactIter {
+    type Item = Result<ExactRecord, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// Every tag stored under `dimension`, whatever its key hash or slot.
+fn dimension_span(dimension: TagDimension) -> std::ops::RangeInclusive<ArchiveTag> {
+    let low = (Cow::Borrowed(dimension), [u8::MIN; 8], BlockSlot::MIN);
+    let high = (Cow::Borrowed(dimension), [u8::MAX; 8], BlockSlot::MAX);
+    low..=high
 }
 
 /// Block iterator over a materialized range.
@@ -246,6 +469,9 @@ impl ArchiveStore for MemoryArchiveStore {
     type Writer = MemoryArchiveWriter;
     type LogIter = MemoryLogIter;
     type EntityValueIter = std::iter::Empty<Result<EntityValue, ArchiveError>>;
+    type SlotIter = MemorySlotIter;
+    type TagIter = MemoryTagIter;
+    type ExactIter = MemoryExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         Ok(MemoryArchiveWriter {
@@ -418,5 +644,113 @@ impl ArchiveStore for MemoryArchiveStore {
         tables.logs.retain(|(_, key), _| *key < cutoff);
 
         Ok(())
+    }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        // A key that could not have been stored cannot be found, so a
+        // wrong-width query is a miss rather than an error.
+        let Some(key) = exact_key(ExactKind::BlockHash, hash) else {
+            return Ok(None);
+        };
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables.exact.get(&(ExactKind::BlockHash, key)).copied())
+    }
+
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
+        // A block number is type-enforced eight bytes, so this cannot fail.
+        let key = exact_key(ExactKind::BlockNumber, &number.to_be_bytes())
+            .expect("a u64 is the block-number key width");
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables.exact.get(&(ExactKind::BlockNumber, key)).copied())
+    }
+
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        // A key that could not have been stored cannot be found, so a
+        // wrong-width query is a miss rather than an error.
+        let Some(key) = exact_key(ExactKind::TxHash, hash) else {
+            return Ok(None);
+        };
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+        Ok(tables.exact.get(&(ExactKind::TxHash, key)).copied())
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError> {
+        let Some(hash) = key_hash(dimension, key) else {
+            return Err(ArchiveError::InternalError(format!(
+                "{dimension} key must be 8 bytes, got {}",
+                key.len(),
+            )));
+        };
+
+        if start > end {
+            return Ok(MemorySlotIter(Vec::new().into_iter()));
+        }
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let low = (Cow::Borrowed(dimension), hash, start);
+        let high = (Cow::Borrowed(dimension), hash, end);
+
+        let slots: Vec<BlockSlot> = tables
+            .archive_tags
+            .range(low..=high)
+            .map(|(_, _, slot)| *slot)
+            .collect();
+
+        Ok(MemorySlotIter(slots.into_iter()))
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError> {
+        // Sorted and deduplicated here rather than trusted from the caller, so
+        // the ordering contract holds whatever order the list arrived in.
+        let mut dimensions = dimensions.to_vec();
+        dimensions.sort_unstable();
+        dimensions.dedup();
+
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        let records: Vec<TagRecord> = dimensions
+            .into_iter()
+            .flat_map(|dimension| {
+                tables
+                    .archive_tags
+                    .range(dimension_span(dimension))
+                    .filter(|(_, _, slot)| slots.contains(slot))
+                    .map(move |(_, hash, slot)| TagRecord::new(dimension, *hash, *slot))
+            })
+            .collect();
+
+        Ok(MemoryTagIter(records.into_iter()))
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, ArchiveError> {
+        let tables = self.tables.read().map_err(|_| poisoned())?;
+
+        // `ExactKind`'s ordering is its name ordering, so the map's own order
+        // is the `(kind, key)` contract.
+        let records: Vec<ExactRecord> = tables
+            .exact
+            .iter()
+            .filter(|(_, slot)| slots.contains(slot))
+            .map(|((kind, key), slot)| {
+                ExactRecord::new(*kind, &key[..kind.key_len()], *slot)
+                    .map_err(|e| ArchiveError::InternalError(e.to_string()))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(MemoryExactIter(records.into_iter()))
     }
 }

--- a/crates/core/src/builtin/memory/index.rs
+++ b/crates/core/src/builtin/memory/index.rs
@@ -1,86 +1,14 @@
-//! In-memory index store backed by ordered maps.
+//! In-memory index store: a cursor behind a lock.
 //!
-//! Same idea as the state store beside it: the disk backends encode
-//! `[dim_hash][key][slot]` triples into one flat keyspace, and an ordered map
-//! keyed on the triple itself is that keyspace without the encoding.
-//!
-//! The payoff is sharpest for archive tags. Their traversal contract is
-//! "sorted by `(dimension, key_hash, slot)`, dimension compared as a string",
-//! which the disk stores can only reach by walking a caller-supplied dimension
-//! list in name order — on disk the leading component is a *hash* of the
-//! dimension, whose order is unrelated. Keyed on the triple, that contract is
-//! the map's own ordering and holds by construction.
-//!
-//! ## Stored key form
-//!
-//! Tags are stored under [`key_hash`], not under their logical key, exactly as
-//! the disk backends store them. Keeping the logical key would be a divergence,
-//! not an improvement: [`IndexWriter::append_prehashed`] delivers records that
-//! carry only the stored form, so a store that indexed anything else could not
-//! answer a logical-key query about a restored record.
-//!
-//! ## Ephemeral by design
-//!
-//! Nothing persists, and the record iterators materialize their range into an
-//! owned buffer rather than streaming it. See the state store's module docs for
-//! what that costs and why it is the right trade here.
+//! The archive tags and the exact lookups this store used to hold moved to
+//! the memory archive beside the blocks they project (see `memory/archive.rs`);
+//! the live-UTxO tags had already moved to the memory state store. What is
+//! left is the cursor the bootstrap catch-up still reads.
 
-use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Range;
 use std::sync::{Arc, Mutex, RwLock};
 
-use crate::indexes::{
-    key_hash, ArchiveIndexDelta, ExactKind, ExactRecord, IndexDelta, IndexError, IndexRecord,
-    IndexStore, IndexWriter, KeyHash, TagDimension, TagRecord, MAX_EXACT_KEY_LEN,
-};
-use crate::{BlockSlot, ChainPoint};
-
-/// A stored archive tag: the traversal contract's sort key, used as the key.
-type ArchiveTag = (Cow<'static, str>, KeyHash, BlockSlot);
-
-/// An exact key, zero-padded to the widest kind — the same inline shape
-/// [`ExactRecord`] carries, so a record goes in and comes back out without a
-/// heap allocation on either side.
-type ExactKey = [u8; MAX_EXACT_KEY_LEN];
-
-/// A key's stored form, or `None` unless it is exactly the width its kind
-/// requires.
-///
-/// Refusing rather than padding or truncating to fit: a key adjusted to fit
-/// aliases with the key it was adjusted into, so a 33-byte block hash and the
-/// 32-byte hash that is its prefix would answer each other's lookups.
-/// `ArchiveIndexDelta` holds its hashes as `Vec<u8>`, so nothing upstream
-/// enforces the width.
-fn exact_key(kind: ExactKind, key: &[u8]) -> Option<ExactKey> {
-    if key.len() != kind.key_len() {
-        return None;
-    }
-
-    let mut buf = [0u8; MAX_EXACT_KEY_LEN];
-    buf[..key.len()].copy_from_slice(key);
-    Some(buf)
-}
-
-/// The store's whole contents, guarded as one unit so a commit is atomic.
-#[derive(Default, Clone)]
-struct Tables {
-    cursor: Option<ChainPoint>,
-    archive_tags: BTreeSet<ArchiveTag>,
-    /// Keyed on the record's own inline key rather than a `Vec`, so
-    /// `iter_exact_records` copies rather than allocates per record.
-    exact: BTreeMap<(ExactKind, ExactKey), BlockSlot>,
-}
-
-/// A single mutation, recorded by a writer and replayed at commit. See the
-/// state store's `Op` for why the writer keeps an ordered log.
-enum Op {
-    SetCursor(ChainPoint),
-    InsertArchiveTag(ArchiveTag),
-    RemoveArchiveTag(ArchiveTag),
-    InsertExact(ExactKind, ExactKey, BlockSlot),
-    RemoveExact(ExactKind, ExactKey),
-}
+use crate::indexes::{IndexDelta, IndexError, IndexStore, IndexWriter};
+use crate::ChainPoint;
 
 fn poisoned() -> IndexError {
     IndexError::DbError("index store lock poisoned".into())
@@ -88,11 +16,11 @@ fn poisoned() -> IndexError {
 
 /// Index store held entirely in memory.
 ///
-/// Cloning shares the underlying tables — a clone is another handle on the same
-/// store, not a copy of it.
+/// Cloning shares the underlying cursor — a clone is another handle on the
+/// same store, not a copy of it.
 #[derive(Clone, Default)]
 pub struct MemoryIndexStore {
-    tables: Arc<RwLock<Tables>>,
+    cursor: Arc<RwLock<Option<ChainPoint>>>,
 }
 
 impl MemoryIndexStore {
@@ -106,214 +34,38 @@ impl MemoryIndexStore {
     }
 }
 
-/// Writer that accumulates its mutations privately and merges them under a
-/// single write lock at [`IndexWriter::commit`].
+/// Writer that holds the cursor it was asked to place until
+/// [`IndexWriter::commit`].
 pub struct MemoryIndexWriter {
     store: MemoryIndexStore,
-    ops: Mutex<Vec<Op>>,
-}
-
-impl MemoryIndexWriter {
-    fn archive_tags_of(block: &ArchiveIndexDelta) -> impl Iterator<Item = ArchiveTag> + '_ {
-        block.tags.iter().filter_map(|tag| {
-            key_hash(tag.dimension, &tag.key)
-                .map(|hash| (Cow::Borrowed(tag.dimension), hash, block.slot))
-        })
-    }
-
-    /// The exact entries a block delta writes.
-    ///
-    /// Every key is width-checked here, because the delta path is *not*
-    /// type-enforced: `ArchiveIndexDelta` holds its block and transaction
-    /// hashes as `Vec<u8>`. A wrong-width hash is a malformed block, and
-    /// refusing the batch beats dropping the entry — a block whose hash did not
-    /// land is a block no hash lookup can reach, and an index that quietly
-    /// omits it looks complete.
-    fn exact_keys_of(
-        block: &ArchiveIndexDelta,
-    ) -> impl Iterator<Item = Result<(ExactKind, ExactKey), IndexError>> + '_ {
-        let hash = (!block.block_hash.is_empty())
-            .then_some((ExactKind::BlockHash, block.block_hash.as_slice()));
-
-        let number = block.block_number.map(|n| (ExactKind::BlockNumber, n));
-
-        let txs = block
-            .tx_hashes
-            .iter()
-            .map(|hash| (ExactKind::TxHash, hash.as_slice()));
-
-        let hashes = hash.into_iter().chain(txs).map(|(kind, key)| {
-            exact_key(kind, key).map(|key| (kind, key)).ok_or_else(|| {
-                IndexError::CodecError(format!(
-                    "exact entry of kind {kind} has a {}-byte key, expected {}",
-                    key.len(),
-                    kind.key_len(),
-                ))
-            })
-        });
-
-        // A block number is type-enforced eight bytes, so it cannot be
-        // malformed the way a hash can.
-        let number = number.map(|(kind, n)| {
-            Ok((
-                kind,
-                exact_key(kind, &n.to_be_bytes()).expect("a u64 is the block-number key width"),
-            ))
-        });
-
-        hashes.chain(number)
-    }
+    cursor: Mutex<Option<ChainPoint>>,
 }
 
 impl IndexWriter for MemoryIndexWriter {
     fn apply(&self, delta: &IndexDelta) -> Result<(), IndexError> {
-        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
-
-        for block in &delta.archive {
-            for entry in Self::exact_keys_of(block) {
-                let (kind, key) = entry?;
-                ops.push(Op::InsertExact(kind, key, block.slot));
-            }
-
-            for tag in Self::archive_tags_of(block) {
-                ops.push(Op::InsertArchiveTag(tag));
-            }
-        }
-
-        ops.push(Op::SetCursor(delta.cursor.clone()));
-
-        Ok(())
-    }
-
-    /// The exact inverse of [`Self::apply`], blocks walked back-to-front. The
-    /// cursor is deliberately untouched: an undo reverses index content, and
-    /// where the chain now sits is the caller's to declare.
-    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError> {
-        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
-
-        for block in delta.archive.iter().rev() {
-            for entry in Self::exact_keys_of(block) {
-                let (kind, key) = entry?;
-                ops.push(Op::RemoveExact(kind, key));
-            }
-
-            for tag in Self::archive_tags_of(block) {
-                ops.push(Op::RemoveArchiveTag(tag));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn append_prehashed(
-        &self,
-        records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError> {
-        let mut ops = self.ops.lock().map_err(|_| poisoned())?;
-
-        for record in records {
-            match record {
-                IndexRecord::Tag(tag) => ops.push(Op::InsertArchiveTag((
-                    tag.dimension,
-                    tag.key_hash,
-                    tag.slot,
-                ))),
-                // The width is already checked: `ExactRecord` cannot be
-                // constructed with a key that does not match its kind.
-                IndexRecord::Exact(exact) => ops.push(Op::InsertExact(
-                    exact.kind,
-                    exact_key(exact.kind, exact.key()).expect("a record's key is its kind's width"),
-                    exact.slot,
-                )),
-            }
-        }
+        *self.cursor.lock().map_err(|_| poisoned())? = Some(delta.cursor.clone());
 
         Ok(())
     }
 
     fn commit(self) -> Result<(), IndexError> {
-        let ops = self.ops.into_inner().map_err(|_| poisoned())?;
+        let cursor = self.cursor.into_inner().map_err(|_| poisoned())?;
 
-        let mut tables = self.store.tables.write().map_err(|_| poisoned())?;
-
-        for op in ops {
-            match op {
-                Op::SetCursor(cursor) => tables.cursor = Some(cursor),
-                Op::InsertArchiveTag(tag) => {
-                    tables.archive_tags.insert(tag);
-                }
-                Op::RemoveArchiveTag(tag) => {
-                    tables.archive_tags.remove(&tag);
-                }
-                Op::InsertExact(kind, key, slot) => {
-                    tables.exact.insert((kind, key), slot);
-                }
-                Op::RemoveExact(kind, key) => {
-                    tables.exact.remove(&(kind, key));
-                }
-            }
+        if let Some(cursor) = cursor {
+            *self.store.cursor.write().map_err(|_| poisoned())? = Some(cursor);
         }
 
         Ok(())
     }
 }
 
-/// Slot iterator over a materialized range.
-pub struct MemorySlotIter(std::vec::IntoIter<BlockSlot>);
-
-impl Iterator for MemorySlotIter {
-    type Item = Result<BlockSlot, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Ok)
-    }
-}
-
-impl DoubleEndedIterator for MemorySlotIter {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(Ok)
-    }
-}
-
-/// Archive tag iterator over a materialized range.
-pub struct MemoryTagIter(std::vec::IntoIter<TagRecord>);
-
-impl Iterator for MemoryTagIter {
-    type Item = Result<TagRecord, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Ok)
-    }
-}
-
-/// Exact-match record iterator over a materialized range.
-pub struct MemoryExactIter(std::vec::IntoIter<ExactRecord>);
-
-impl Iterator for MemoryExactIter {
-    type Item = Result<ExactRecord, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Ok)
-    }
-}
-
-/// Every tag stored under `dimension`, whatever its key hash or slot.
-fn dimension_span(dimension: TagDimension) -> std::ops::RangeInclusive<ArchiveTag> {
-    let low = (Cow::Borrowed(dimension), [u8::MIN; 8], BlockSlot::MIN);
-    let high = (Cow::Borrowed(dimension), [u8::MAX; 8], BlockSlot::MAX);
-    low..=high
-}
-
 impl IndexStore for MemoryIndexStore {
     type Writer = MemoryIndexWriter;
-    type SlotIter = MemorySlotIter;
-    type TagIter = MemoryTagIter;
-    type ExactIter = MemoryExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         Ok(MemoryIndexWriter {
             store: self.clone(),
-            ops: Mutex::new(Vec::new()),
+            cursor: Mutex::new(None),
         })
     }
 
@@ -326,127 +78,16 @@ impl IndexStore for MemoryIndexStore {
     fn copy(&self, target: &Self) -> Result<(), IndexError> {
         // Cloned and released before touching the target, so copying a store
         // onto itself is a no-op rather than a deadlock.
-        let source = self.tables.read().map_err(|_| poisoned())?.clone();
+        let source = self.cursor.read().map_err(|_| poisoned())?.clone();
 
-        let mut target = target.tables.write().map_err(|_| poisoned())?;
-
-        if let Some(cursor) = source.cursor {
-            target.cursor = Some(cursor);
+        if let Some(cursor) = source {
+            *target.cursor.write().map_err(|_| poisoned())? = Some(cursor);
         }
-
-        target.archive_tags.extend(source.archive_tags);
-        target.exact.extend(source.exact);
 
         Ok(())
     }
 
     fn cursor(&self) -> Result<Option<ChainPoint>, IndexError> {
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-        Ok(tables.cursor.clone())
-    }
-
-    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        // A key that could not have been stored cannot be found, so a
-        // wrong-width query is a miss rather than an error.
-        let Some(key) = exact_key(ExactKind::BlockHash, hash) else {
-            return Ok(None);
-        };
-
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-        Ok(tables.exact.get(&(ExactKind::BlockHash, key)).copied())
-    }
-
-    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError> {
-        // A block number is type-enforced eight bytes, so this cannot fail.
-        let key = exact_key(ExactKind::BlockNumber, &number.to_be_bytes())
-            .expect("a u64 is the block-number key width");
-
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-        Ok(tables.exact.get(&(ExactKind::BlockNumber, key)).copied())
-    }
-
-    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        // A key that could not have been stored cannot be found, so a
-        // wrong-width query is a miss rather than an error.
-        let Some(key) = exact_key(ExactKind::TxHash, hash) else {
-            return Ok(None);
-        };
-
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-        Ok(tables.exact.get(&(ExactKind::TxHash, key)).copied())
-    }
-
-    fn slots_by_tag(
-        &self,
-        dimension: TagDimension,
-        key: &[u8],
-        start: BlockSlot,
-        end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
-        let Some(hash) = key_hash(dimension, key) else {
-            return Err(IndexError::CodecError(format!(
-                "{dimension} key must be 8 bytes, got {}",
-                key.len(),
-            )));
-        };
-
-        if start > end {
-            return Ok(MemorySlotIter(Vec::new().into_iter()));
-        }
-
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-
-        let low = (Cow::Borrowed(dimension), hash, start);
-        let high = (Cow::Borrowed(dimension), hash, end);
-
-        let slots: Vec<BlockSlot> = tables
-            .archive_tags
-            .range(low..=high)
-            .map(|(_, _, slot)| *slot)
-            .collect();
-
-        Ok(MemorySlotIter(slots.into_iter()))
-    }
-
-    fn iter_archive_tags(
-        &self,
-        dimensions: &[TagDimension],
-        slots: Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
-        // Sorted and deduplicated here rather than trusted from the caller, so
-        // the ordering contract holds whatever order the list arrived in.
-        let mut dimensions = dimensions.to_vec();
-        dimensions.sort_unstable();
-        dimensions.dedup();
-
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-
-        let records: Vec<TagRecord> = dimensions
-            .into_iter()
-            .flat_map(|dimension| {
-                tables
-                    .archive_tags
-                    .range(dimension_span(dimension))
-                    .filter(|(_, _, slot)| slots.contains(slot))
-                    .map(move |(_, hash, slot)| TagRecord::new(dimension, *hash, *slot))
-            })
-            .collect();
-
-        Ok(MemoryTagIter(records.into_iter()))
-    }
-
-    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
-        let tables = self.tables.read().map_err(|_| poisoned())?;
-
-        // `ExactKind`'s ordering is its name ordering, so the map's own order
-        // is the `(kind, key)` contract.
-        let records: Vec<ExactRecord> = tables
-            .exact
-            .iter()
-            .filter(|(_, slot)| slots.contains(slot))
-            .map(|((kind, key), slot)| ExactRecord::new(*kind, &key[..kind.key_len()], *slot))
-            .collect::<Result<_, _>>()?;
-
-        Ok(MemoryExactIter(records.into_iter()))
+        Ok(self.cursor.read().map_err(|_| poisoned())?.clone())
     }
 }

--- a/crates/core/src/builtin/memory/mod.rs
+++ b/crates/core/src/builtin/memory/mod.rs
@@ -16,8 +16,9 @@ mod archive;
 mod index;
 mod state;
 
-pub use archive::{MemoryArchiveStore, MemoryArchiveWriter, MemoryBlockIter, MemoryLogIter};
-pub use index::{
-    MemoryExactIter, MemoryIndexStore, MemoryIndexWriter, MemorySlotIter, MemoryTagIter,
+pub use archive::{
+    MemoryArchiveStore, MemoryArchiveWriter, MemoryBlockIter, MemoryExactIter, MemoryLogIter,
+    MemorySlotIter, MemoryTagIter,
 };
+pub use index::{MemoryIndexStore, MemoryIndexWriter};
 pub use state::{MemoryEntityIter, MemoryStateStore, MemoryStateWriter, MemoryUtxoIter};

--- a/crates/core/src/builtin/noop.rs
+++ b/crates/core/src/builtin/noop.rs
@@ -7,12 +7,9 @@
 use std::ops::Range;
 
 use crate::{
-    archive::{ArchiveError, ArchiveStore, ArchiveWriter, LogKey},
-    indexes::{
-        EmptyExactIter, EmptyTagIter, IndexDelta, IndexError, IndexRecord, IndexStore, IndexWriter,
-        TagDimension,
-    },
-    BlockBody, BlockSlot, ChainPoint, EntityValue, Namespace, RawBlock,
+    archive::{ArchiveError, ArchiveStore, ArchiveWriter, EmptyExactIter, EmptyTagIter, LogKey},
+    indexes::{ArchiveIndexDelta, IndexDelta, IndexError, IndexRecord, IndexStore, IndexWriter},
+    BlockBody, BlockSlot, ChainPoint, EntityValue, Namespace, RawBlock, TagDimension,
 };
 
 // ============================================================================
@@ -26,21 +23,6 @@ pub struct NoOpIndexWriter;
 impl IndexWriter for NoOpIndexWriter {
     fn apply(&self, _delta: &IndexDelta) -> Result<(), IndexError> {
         Ok(())
-    }
-
-    fn undo(&self, _delta: &IndexDelta) -> Result<(), IndexError> {
-        Ok(())
-    }
-
-    /// A restore against a store that discards every record must fail, not
-    /// report success: `Ok` here would let a snapshot restore complete
-    /// "cleanly" having written nothing. See
-    /// [`NoOpIndexStore::iter_archive_tags`] for the read-side twin.
-    fn append_prehashed(
-        &self,
-        _records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError> {
-        Err(IndexError::Unsupported("append_prehashed"))
     }
 
     fn commit(self) -> Result<(), IndexError> {
@@ -62,28 +44,8 @@ impl NoOpIndexStore {
     }
 }
 
-/// Empty iterator for slot queries.
-pub struct EmptySlotIter;
-
-impl Iterator for EmptySlotIter {
-    type Item = Result<BlockSlot, IndexError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-impl DoubleEndedIterator for EmptySlotIter {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
 impl IndexStore for NoOpIndexStore {
     type Writer = NoOpIndexWriter;
-    type SlotIter = EmptySlotIter;
-    type TagIter = EmptyTagIter;
-    type ExactIter = EmptyExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         Ok(NoOpIndexWriter)
@@ -99,46 +61,6 @@ impl IndexStore for NoOpIndexStore {
 
     fn cursor(&self) -> Result<Option<ChainPoint>, IndexError> {
         Ok(None)
-    }
-
-    fn slot_by_block_hash(&self, _hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        Ok(None)
-    }
-
-    fn slot_by_block_number(&self, _number: u64) -> Result<Option<BlockSlot>, IndexError> {
-        Ok(None)
-    }
-
-    fn slot_by_tx_hash(&self, _hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        Ok(None)
-    }
-
-    fn slots_by_tag(
-        &self,
-        _dimension: TagDimension,
-        _key: &[u8],
-        _start: BlockSlot,
-        _end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
-        Ok(EmptySlotIter)
-    }
-
-    /// Errors rather than yielding an empty iteration: this seam's callers
-    /// publish the iterated records as a signed snapshot layer, and a
-    /// well-formed *empty* layer from an index-less node is indistinguishable
-    /// from a genuinely tag-free epoch. Matches redb3 and the loud-failure
-    /// precedent of `data stats` / `data export` on noop backends.
-    fn iter_archive_tags(
-        &self,
-        _dimensions: &[TagDimension],
-        _slots: Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
-        Err(IndexError::Unsupported("iter_archive_tags"))
-    }
-
-    /// See [`NoOpIndexStore::iter_archive_tags`].
-    fn iter_exact_records(&self, _slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
-        Err(IndexError::Unsupported("iter_exact_records"))
     }
 }
 
@@ -168,6 +90,25 @@ impl ArchiveWriter for NoOpArchiveWriter {
         Ok(())
     }
 
+    fn apply_index(&self, _deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        Ok(())
+    }
+
+    fn undo_index(&self, _deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        Ok(())
+    }
+
+    /// A restore against a store that discards every record must fail, not
+    /// report success: `Ok` here would let a snapshot restore complete
+    /// "cleanly" having written nothing. See
+    /// [`NoOpArchiveStore::iter_archive_tags`] for the read-side twin.
+    fn append_prehashed(
+        &self,
+        _records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), ArchiveError> {
+        Err(ArchiveError::Unsupported("append_prehashed"))
+    }
+
     fn commit(self) -> Result<(), ArchiveError> {
         Ok(())
     }
@@ -184,6 +125,23 @@ impl NoOpArchiveStore {
 
     pub fn shutdown(&self) -> Result<(), ArchiveError> {
         Ok(())
+    }
+}
+
+/// Empty iterator for slot queries.
+pub struct EmptySlotIter;
+
+impl Iterator for EmptySlotIter {
+    type Item = Result<BlockSlot, ArchiveError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+impl DoubleEndedIterator for EmptySlotIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        None
     }
 }
 
@@ -236,6 +194,9 @@ impl ArchiveStore for NoOpArchiveStore {
     type Writer = NoOpArchiveWriter;
     type LogIter = EmptyLogIter;
     type EntityValueIter = EmptyEntityValueIter;
+    type SlotIter = EmptySlotIter;
+    type TagIter = EmptyTagIter;
+    type ExactIter = EmptyExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         Ok(NoOpArchiveWriter)
@@ -291,5 +252,48 @@ impl ArchiveStore for NoOpArchiveStore {
 
     fn truncate_front(&self, _after: &ChainPoint) -> Result<(), ArchiveError> {
         Ok(())
+    }
+
+    fn slot_by_block_hash(&self, _hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        Ok(None)
+    }
+
+    fn slot_by_block_number(&self, _number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
+        Ok(None)
+    }
+
+    fn slot_by_tx_hash(&self, _hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        Ok(None)
+    }
+
+    fn slots_by_tag(
+        &self,
+        _dimension: TagDimension,
+        _key: &[u8],
+        _start: BlockSlot,
+        _end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError> {
+        Ok(EmptySlotIter)
+    }
+
+    /// Errors rather than yielding an empty iteration: this seam's callers
+    /// publish the iterated records as a signed snapshot layer, and a
+    /// well-formed *empty* layer from an index-less node is indistinguishable
+    /// from a genuinely tag-free epoch. Matches the loud-failure precedent of
+    /// `data stats` / `data export` on noop backends.
+    fn iter_archive_tags(
+        &self,
+        _dimensions: &[TagDimension],
+        _slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError> {
+        Err(ArchiveError::Unsupported("iter_archive_tags"))
+    }
+
+    /// See [`NoOpArchiveStore::iter_archive_tags`].
+    fn iter_exact_records(
+        &self,
+        _slots: Range<BlockSlot>,
+    ) -> Result<Self::ExactIter, ArchiveError> {
+        Err(ArchiveError::Unsupported("iter_exact_records"))
     }
 }

--- a/crates/core/src/indexes.rs
+++ b/crates/core/src/indexes.rs
@@ -1,19 +1,24 @@
-//! Index store trait for cross-cutting indexes.
-//!
-//! The `IndexStore` provides lookups that return primitive index values (slots)
-//! rather than full block data. To get block data, use `AsyncQueryFacade` from
-//! the `async_query` module which combines index lookups with archive fetches.
-//!
-//! The live-UTxO tags are a projection of the UTxO set and live beside it in
-//! the state store (`StateStore::utxos_by_tag`, written through
-//! `StateWriter::apply_utxo_tags`); this store keeps the archive half.
+//! The chain-agnostic index types, and the index store that keeps a cursor.
 //!
 //! This module defines a chain-agnostic indexing system based on "tags" -
 //! associations between entities (blocks, transactions, UTxOs) and dimension
 //! keys. Chain-specific code (e.g., Cardano) defines the dimensions and
 //! provides extension traits for convenient access.
+//!
+//! The indexes themselves are projections of the stores they live beside:
+//!
+//! - the live-UTxO tags project the UTxO set and live in the state store
+//!   (`StateStore::utxos_by_tag`, written through
+//!   `StateWriter::apply_utxo_tags`);
+//! - the archive tags and the exact lookups project the block history and live
+//!   in the archive store (`ArchiveStore::slots_by_tag`,
+//!   `ArchiveStore::slot_by_*`, written through `ArchiveWriter::apply_index`),
+//!   where the `indexes` stele layer is produced from and restored into.
+//!
+//! What is left of the `IndexStore` is its cursor, which the bootstrap
+//! catch-up and `dolos data check` still read; its removal is the next step.
 
-use std::{borrow::Cow, ops::Range};
+use std::borrow::Cow;
 
 use thiserror::Error;
 
@@ -64,7 +69,8 @@ pub struct UtxoIndexDelta {
 ///
 /// Archive indexes track which slots contain data matching various tags.
 /// They enable historical queries like "find all blocks with transactions
-/// involving this address".
+/// involving this address". One per block; written through
+/// `ArchiveWriter::apply_index` in the same batch as the block it projects.
 #[derive(Debug, Clone, Default)]
 pub struct ArchiveIndexDelta {
     pub slot: BlockSlot,
@@ -74,23 +80,22 @@ pub struct ArchiveIndexDelta {
     pub tags: Vec<Tag>,
 }
 
-/// Archive index delta for a batch of operations.
+/// What an index store commit carries: the cursor to leave behind.
 ///
-/// This structure contains the archive index entries for a batch of blocks
-/// and the cursor to leave behind them.
+/// The index entries themselves moved to the stores they project; this is the
+/// shape the cursor write kept, so the callers that place a cursor
+/// (`commit_indexes`, the WAL catch-up, a rollback, a stele restore) did not
+/// change.
 #[derive(Debug, Clone)]
 pub struct IndexDelta {
     /// Cursor position after applying this delta.
     pub cursor: ChainPoint,
-    /// Archive index changes (one per block in batch).
-    pub archive: Vec<ArchiveIndexDelta>,
 }
 
 impl Default for IndexDelta {
     fn default() -> Self {
         Self {
             cursor: ChainPoint::Origin,
-            archive: Vec::new(),
         }
     }
 }
@@ -112,9 +117,8 @@ pub enum IndexError {
     /// The operation is part of the trait but the concrete backend does not
     /// implement it.
     ///
-    /// Used by backends outside the live set (see the record iteration and
-    /// pre-hashed append below) so that a caller reaching for an unimplemented
-    /// capability gets an error it can handle instead of a panic.
+    /// A caller reaching for an unimplemented capability gets an error it can
+    /// handle instead of a panic.
     #[error("{0} is not supported on this storage backend")]
     Unsupported(&'static str),
 }
@@ -161,9 +165,9 @@ pub fn key_hash(dimension: &str, key: &[u8]) -> Option<KeyHash> {
 /// One archive tag entry, carrying the stored key hash instead of the logical
 /// key.
 ///
-/// The logical key is not recoverable from the index store — only its hash is
-/// kept on disk — so this is the most a reader can produce and the least a
-/// writer needs.
+/// The logical key is not recoverable from the store — only its hash is kept
+/// on disk — so this is the most a reader can produce and the least a writer
+/// needs.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TagRecord {
     /// The logical dimension name. Borrowed when read from a store (the
@@ -191,7 +195,7 @@ impl TagRecord {
     }
 }
 
-/// The kinds of exact-match archive lookup an index store keeps.
+/// The kinds of exact-match archive lookup the archive store keeps.
 ///
 /// This is a closed set: the store hashes the kind name into the key, so it
 /// cannot be recovered from disk and traversal has to be driven by the known
@@ -326,7 +330,7 @@ impl std::fmt::Debug for ExactRecord {
 }
 
 /// Either archive record, as consumed by
-/// [`IndexWriter::append_prehashed`].
+/// `ArchiveWriter::append_prehashed`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IndexRecord {
     Tag(TagRecord),
@@ -345,97 +349,28 @@ impl From<ExactRecord> for IndexRecord {
     }
 }
 
-/// Iterator used by backends that do not implement
-/// [`IndexStore::iter_archive_tags`].
-///
-/// Never constructed — those backends return [`IndexError::Unsupported`], so
-/// the alias only exists to satisfy the associated type.
-pub type EmptyTagIter = std::iter::Empty<Result<TagRecord, IndexError>>;
-
-/// Iterator used by backends that do not implement
-/// [`IndexStore::iter_exact_records`].
-///
-/// Never constructed — those backends return [`IndexError::Unsupported`], so
-/// the alias only exists to satisfy the associated type.
-pub type EmptyExactIter = std::iter::Empty<Result<ExactRecord, IndexError>>;
-
 /// Writer for batched index operations.
 ///
-/// This trait provides transactional write operations for indexes. Multiple
-/// operations can be batched together and committed atomically.
+/// The one write left is the cursor. It is still a writer with a commit so the
+/// callers that place a cursor kept their shape, and so the memory and fjall
+/// stores keep one code path for it.
 pub trait IndexWriter: Send + Sync + 'static {
-    /// Apply index changes from a delta.
-    ///
-    /// This applies the archive index entries contained in the delta. The
-    /// cursor is set internally from `delta.cursor`.
+    /// Set the cursor from `delta.cursor`.
     fn apply(&self, delta: &IndexDelta) -> Result<(), IndexError>;
-
-    /// Undo index changes from a delta (rollback).
-    ///
-    /// This reverses the changes made by `apply()`: the archive index entries
-    /// are removed. The cursor is left alone.
-    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError>;
-
-    /// Append archive records that already carry their stored key form.
-    ///
-    /// This is the write mirror of [`IndexStore::iter_archive_tags`] and
-    /// [`IndexStore::iter_exact_records`]: records that came out of one store
-    /// go into another byte-for-byte, with no logical key in between (there is
-    /// none to recover — see [`KeyHash`]).
-    ///
-    /// Records must arrive sorted, since the backing stores are append
-    /// oriented. The cursor is *not* touched: a restore owns cursor placement,
-    /// and places it with an otherwise-empty delta once the records are in:
-    /// `writer.apply(&IndexDelta { cursor, ..Default::default() })`. A restore
-    /// that skips this leaves `cursor()` at `None` and bootstrap will treat the
-    /// store as never indexed.
-    ///
-    /// ## Chunking
-    ///
-    /// The argument is an iterator so a restore can pipe its wire decoder
-    /// straight in, rather than materializing a slice beside the write batch's
-    /// own encoded copy. It is consumed lazily and fully; a backend never
-    /// collects it.
-    ///
-    /// This call is *not* the batch boundary — the writer accumulates until
-    /// [`IndexWriter::commit`], so an unbounded iterator builds an unbounded
-    /// batch. Chunking is the caller's: feed one writer a run of records,
-    /// commit it, start the next. The sort order has to hold across the whole
-    /// restore, not merely within a chunk.
-    ///
-    /// Backends that do not implement this return
-    /// [`IndexError::Unsupported`].
-    fn append_prehashed(
-        &self,
-        records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError>;
 
     /// Commit the batched operations.
     fn commit(self) -> Result<(), IndexError>;
 }
 
-/// Index store trait for cross-cutting indexes.
+/// The index store: a cursor, and the writer that places it.
 ///
-/// This trait provides pure index lookups that return primitive values like
-/// `BlockSlot` rather than full block data. For high-level queries
-/// that also fetch block data, use `AsyncQueryFacade`.
-///
-/// The trait is chain-agnostic, using dimension strings to identify index
-/// types. Chain-specific code should provide extension traits with convenient
-/// methods.
+/// The lookups this trait used to answer live on the stores that hold what
+/// they project — see the module docs — and this is what the removal of the
+/// store still has to take out.
 #[trait_variant::make(Send)]
 pub trait IndexStore: Clone + Send + Sync + 'static {
     /// Writer type for batched write operations.
     type Writer: IndexWriter;
-
-    /// Iterator type for sparse slot queries.
-    type SlotIter: Iterator<Item = Result<BlockSlot, IndexError>> + DoubleEndedIterator;
-
-    /// Iterator type for archive tag record traversal.
-    type TagIter: Iterator<Item = Result<TagRecord, IndexError>>;
-
-    /// Iterator type for exact-match record traversal.
-    type ExactIter: Iterator<Item = Result<ExactRecord, IndexError>>;
 
     /// Start a new writer for batched operations.
     fn start_writer(&self) -> Result<Self::Writer, IndexError>;
@@ -452,93 +387,6 @@ pub trait IndexStore: Clone + Send + Sync + 'static {
     /// have been applied yet. This is used for synchronization verification
     /// with other stores (state, archive).
     fn cursor(&self) -> Result<Option<ChainPoint>, IndexError>;
-
-    // ============ Archive Queries (Exact Lookups) ============
-
-    /// Get the slot for a block by its hash (exact lookup).
-    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError>;
-
-    /// Get the slot for a block by its number/height (exact lookup).
-    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError>;
-
-    /// Get the slot containing a transaction by its hash (exact lookup).
-    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError>;
-
-    // ============ Archive Queries (Tag-Based Range Queries) ============
-
-    /// Query slots by tag dimension and key within a slot range.
-    ///
-    /// This method returns a lazy iterator over the slots that contain data
-    /// with the given dimension and key. Forward iteration gives the slots
-    /// in ascending order. Reverse iteration gives the slots in descending
-    /// order.
-    ///
-    /// Both `start` and `end` are **inclusive** — unlike the record traversal
-    /// methods below, which take a half-open [`Range`]. Reusing one `(start,
-    /// end)` pair across both conventions drops or double-counts the record at
-    /// `end`.
-    fn slots_by_tag(
-        &self,
-        dimension: TagDimension,
-        key: &[u8],
-        start: BlockSlot,
-        end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError>;
-
-    // ============ Record Traversal (Bulk Export) ============
-
-    /// Iterate every archive tag record whose slot falls in `slots`.
-    ///
-    /// `slots` is **half-open** (`start..end`), unlike
-    /// [`IndexStore::slots_by_tag`], whose bounds are both inclusive.
-    ///
-    /// `dimensions` is the closed list of dimensions to traverse. It has to be
-    /// supplied by the caller: stores keep a hash of the dimension name, not
-    /// the name, so the set of dimensions is not discoverable from disk.
-    /// Duplicates are ignored.
-    ///
-    /// **Order is part of the contract.** Records come out sorted by
-    /// `(dimension, key_hash, slot)` — `dimension` compared as a string,
-    /// independently of the order `dimensions` was given in. Consumers of this
-    /// iteration (snapshot layers) make that order their content, so an
-    /// unordered iterator is a wrong one.
-    ///
-    /// **Errors are terminal.** A malformed on-disk entry or a read failure is
-    /// yielded as `Err` and the iterator is fused from then on: it never
-    /// resumes past a fault, so a consumer that collects into
-    /// `Result<Vec<_>, _>` cannot receive a silently truncated record set.
-    ///
-    /// The iterator must be lazy in the size of the store. Each call opens its
-    /// own point-in-time view: records from separate calls (or from
-    /// [`IndexStore::iter_exact_records`]) are only mutually consistent if the
-    /// store is quiescent across the calls.
-    ///
-    /// Backends that do not implement this return
-    /// [`IndexError::Unsupported`].
-    fn iter_archive_tags(
-        &self,
-        dimensions: &[TagDimension],
-        slots: Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError>;
-
-    /// Iterate every exact-match record whose slot falls in `slots`.
-    ///
-    /// `slots` is **half-open** (`start..end`), unlike
-    /// [`IndexStore::slots_by_tag`], whose bounds are both inclusive.
-    ///
-    /// **Order is part of the contract**: records come out sorted by
-    /// `(kind, key)`, kinds in ascending [`ExactKind::as_str`] order.
-    ///
-    /// **Errors are terminal** — same policy as
-    /// [`IndexStore::iter_archive_tags`].
-    ///
-    /// Note that the slot is the stored *value* of an exact entry, not part of
-    /// its key, so a slot-bounded traversal is a scan of every exact entry in
-    /// the store rather than a seek. The iterator is still lazy in memory.
-    ///
-    /// Backends that do not implement this return
-    /// [`IndexError::Unsupported`].
-    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -83,7 +83,9 @@ pub struct UndoBlockData {
     /// The tags the block's outputs and inputs carried, for
     /// `StateWriter::undo_utxo_tags` to take back out beside `utxo_delta`.
     pub utxo_index_delta: UtxoIndexDelta,
-    pub index_delta: IndexDelta,
+    /// The archive tags and exact entries the block wrote, for
+    /// `ArchiveWriter::undo_index` to take back out beside the block.
+    pub archive_index_deltas: Vec<ArchiveIndexDelta>,
     pub tx_hashes: Vec<TxHash>,
 }
 
@@ -97,7 +99,9 @@ pub struct CatchUpBlockData {
     /// The tag changes `utxo_delta` implies, applied beside it through the
     /// state writer.
     pub utxo_index_delta: UtxoIndexDelta,
-    pub index_delta: IndexDelta,
+    /// The archive tags and exact entries the block projects, applied beside
+    /// it through the archive writer.
+    pub archive_index_deltas: Vec<ArchiveIndexDelta>,
     pub tx_hashes: Vec<TxHash>,
 }
 

--- a/crates/core/src/sync.rs
+++ b/crates/core/src/sync.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    ArchiveStore as _, BlockSlot, ChainLogic, ChainPoint, Domain, DomainError, EntityMap,
-    IndexStore as _, IndexWriter as _, MempoolStore, RawBlock, StateStore, StateWriter as _,
-    TipEvent, WalStore, WorkUnit,
+    ArchiveStore as _, ArchiveWriter as _, BlockSlot, ChainLogic, ChainPoint, Domain, DomainError,
+    EntityMap, IndexStore as _, IndexWriter as _, MempoolStore, RawBlock, StateStore,
+    StateWriter as _, TipEvent, WalStore, WorkUnit,
 };
 
 const MEMPOOL_FINALIZE_THRESHOLD: u32 = 6;
@@ -44,8 +44,9 @@ pub trait SyncExt: Domain {
     /// Roll back the chain to a previous point.
     ///
     /// Iterates WAL entries after the target point in reverse order,
-    /// undoing each block's effects on state, UTxOs (tags included), and
-    /// indexes.
+    /// undoing each block's effects on state, UTxOs (tags included), and the
+    /// archive's index entries; the archive's blocks and logs are then cut
+    /// with `truncate_front`.
     fn rollback(&self, to: &ChainPoint) -> Result<(), DomainError>;
 }
 
@@ -70,6 +71,7 @@ impl<D: Domain> SyncExt for D {
         let undo_blocks = self.wal().iter_logs(Some(to.clone()), None)?;
 
         let writer = self.state().start_writer()?;
+        let archive_writer = self.archive().start_writer()?;
         let index_writer = self.indexes().start_writer()?;
 
         // Entities accumulate across all undone entries so consecutive blocks
@@ -79,12 +81,10 @@ impl<D: Domain> SyncExt for D {
 
         for (point, log) in undo_blocks.rev() {
             if point == *to {
-                // Final cursor update - build an empty delta with just the cursor
-                let empty_delta = crate::IndexDelta {
+                // Final cursor update
+                index_writer.apply(&crate::IndexDelta {
                     cursor: point.clone(),
-                    ..Default::default()
-                };
-                index_writer.apply(&empty_delta)?;
+                })?;
                 writer.set_cursor(point.clone())?;
                 break;
             }
@@ -98,7 +98,10 @@ impl<D: Domain> SyncExt for D {
             writer.apply_utxoset(&undo_data.utxo_delta)?;
             writer.undo_utxo_tags(&undo_data.utxo_index_delta)?;
 
-            index_writer.undo(&undo_data.index_delta)?;
+            // The block's index entries go with the block: `truncate_front`
+            // below takes the block bodies and the logs, this takes the tags
+            // and the exact lookups that pointed at them.
+            archive_writer.undo_index(&undo_data.archive_index_deltas)?;
 
             // TODO: we should differ notifications until we commit the writers
             self.notify_tip(TipEvent::Undo(point.clone(), block));
@@ -121,6 +124,7 @@ impl<D: Domain> SyncExt for D {
         crate::state::save_entities::<Self>(&writer, &entities)?;
 
         writer.commit()?;
+        archive_writer.commit()?;
         index_writer.commit()?;
 
         self.archive().truncate_front(to)?;

--- a/crates/fjall/src/archive/exact.rs
+++ b/crates/fjall/src/archive/exact.rs
@@ -1,8 +1,9 @@
-//! Exact-match index operations for the `index-exact` keyspace
-//! (chain-agnostic).
+//! Exact-match index operations for the `index-exact` keyspace of the
+//! archive store (chain-agnostic).
 //!
 //! This module handles key encoding, batch writes (apply/undo), and read
-//! queries for the `index-exact` keyspace:
+//! queries for the `index-exact` keyspace, written in the same batch as the
+//! block locations its entries resolve to:
 //! - Block hash -> slot
 //! - Transaction hash -> slot
 //! - Block number -> slot
@@ -20,11 +21,11 @@
 use std::ops::Range;
 
 use dolos_core::{
-    ArchiveIndexDelta, BlockSlot, ExactKind, ExactRecord, IndexDelta, IndexError, MAX_EXACT_KEY_LEN,
+    ArchiveError, ArchiveIndexDelta, BlockSlot, ExactKind, ExactRecord, MAX_EXACT_KEY_LEN,
 };
 use fjall::{Keyspace, OwnedWriteBatch, Readable, Snapshot};
 
-use crate::index::scan::{DimensionScan, ScanTarget};
+use crate::archive::scan::{DimensionScan, ScanTarget};
 use crate::keys::{decode_slot, dim_prefix, encode_slot, hash_dimension, DIM_HASH_SIZE, SLOT_SIZE};
 use crate::Error;
 
@@ -178,25 +179,25 @@ fn undo_block(
     Ok(())
 }
 
-/// Apply exact indexes from an IndexDelta
+/// Apply exact indexes for a batch of block deltas
 pub fn apply(
     batch: &mut OwnedWriteBatch,
     exact_keyspace: &Keyspace,
-    delta: &IndexDelta,
+    deltas: &[ArchiveIndexDelta],
 ) -> Result<(), Error> {
-    for block in &delta.archive {
+    for block in deltas {
         apply_block(batch, exact_keyspace, block)?;
     }
     Ok(())
 }
 
-/// Undo exact indexes from an IndexDelta (rollback)
+/// Undo exact indexes for a batch of block deltas (rollback)
 pub fn undo(
     batch: &mut OwnedWriteBatch,
     exact_keyspace: &Keyspace,
-    delta: &IndexDelta,
+    deltas: &[ArchiveIndexDelta],
 ) -> Result<(), Error> {
-    for block in delta.archive.iter().rev() {
+    for block in deltas.iter().rev() {
         undo_block(batch, exact_keyspace, block)?;
     }
     Ok(())
@@ -320,7 +321,7 @@ pub fn get_by_tx_hash<R: Readable>(
 ///
 /// Same contract as `TagRecordIterator`: the held MVCC snapshot pins fjall's
 /// GC watermark for the iterator's lifetime, and errors are terminal per the
-/// policy in [`crate::index::scan`].
+/// policy in [`crate::archive::scan`].
 pub struct ExactRecordIterator(DimensionScan<ExactScan, std::array::IntoIter<ExactKind, 3>>);
 
 /// The exact-match half of the shared prefix walk.
@@ -340,16 +341,17 @@ impl ScanTarget for ExactScan {
         kind: ExactKind,
         guard: fjall::Guard,
         slots: &Range<BlockSlot>,
-    ) -> Result<Option<ExactRecord>, IndexError> {
+    ) -> Result<Option<ExactRecord>, ArchiveError> {
         let (key, value) = guard.into_inner().map_err(Error::Fjall)?;
 
         if key.len() <= DIM_HASH_SIZE || value.len() < SLOT_SIZE {
-            return Err(IndexError::CodecError(format!(
+            return Err(Error::Codec(format!(
                 "malformed exact index entry of kind {kind}: \
                  key {} bytes, value {} bytes",
                 key.len(),
                 value.len(),
-            )));
+            ))
+            .into());
         }
 
         let slot = decode_slot_value(&value);
@@ -361,7 +363,9 @@ impl ScanTarget for ExactScan {
         // A stored key of the wrong width for its kind is a malformed entry,
         // and `ExactRecord::new` is where that is decided. `Err` fuses the
         // scan, which is the policy for a malformed entry either way.
-        ExactRecord::new(kind, &key[DIM_HASH_SIZE..], slot).map(Some)
+        ExactRecord::new(kind, &key[DIM_HASH_SIZE..], slot)
+            .map(Some)
+            .map_err(|e| Error::Codec(e.to_string()).into())
     }
 }
 
@@ -380,7 +384,7 @@ impl ExactRecordIterator {
 }
 
 impl Iterator for ExactRecordIterator {
-    type Item = Result<ExactRecord, IndexError>;
+    type Item = Result<ExactRecord, ArchiveError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -1,12 +1,13 @@
 //! Fjall-based archive store implementation for Dolos.
 //!
 //! The archive keeps block bodies in flat segment files ([`dolos_flatfiles`],
-//! shared byte for byte with the redb backend) and holds two kinds of index
-//! rows — a blocks location table and the derived-log namespaces — in an LSM
-//! tree. Behavior is pinned to the redb archive by the shared conformance
-//! suite (`tests/archive_conformance.rs`).
+//! shared byte for byte with the redb backend) and holds the rows that point
+//! into the history — a blocks location table, the derived-log namespaces,
+//! and the two index projections of the blocks — in an LSM tree. Behavior is
+//! pinned by the shared conformance suite (`tests/archive_conformance.rs`),
+//! with the builtin memory archive as the oracle.
 //!
-//! ## Two Keyspace Design
+//! ## Four Keyspace Design
 //!
 //! 1. **`archive-blocks`**: slot → packed 16-byte [`BlockLocation`]s, newest
 //!    first. Key is the 8-byte big-endian slot; the value encoding is
@@ -20,19 +21,34 @@
 //!    per-namespace LSM trees blow the file-descriptor limit during heavy
 //!    compaction.
 //!
+//! 3. **`archive-tags`**: block tag queries (append-only). Key:
+//!    `[dim_hash:8][key_hash:8][slot:8]` → empty. See [`tags`].
+//!
+//! 4. **`index-exact`**: exact-match lookups (block hash, block number, tx hash
+//!    → slot). Key: `[dim_hash:8][key_data:var]` → `[slot:8]`. See [`exact`].
+//!
+//! The two index keyspaces are projections of the blocks and are written in
+//! the same batch as the block locations, so the history and its lookups
+//! commit together. They keep the compaction settings the standalone index
+//! store gave them, and neither `prune_history` nor `truncate_front` touches
+//! them: a rollback removes its entries through
+//! [`CoreArchiveWriter::undo_index`], and pruning them is not done yet.
+//!
 //! Unlike the redb writer, log batches are not reordered before insertion:
 //! shuffling exists to work around redb's half-split of ascending B-tree
 //! leaves, and an LSM memtable sorts its batch regardless of arrival order.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::ops::{Bound, Range};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
-    config::FjallArchiveConfig, ArchiveError, ArchiveStore as CoreArchiveStore,
-    ArchiveWriter as CoreArchiveWriter, BlockBody, BlockSlot, ChainPoint, EntityValue, LogKey,
-    Namespace, RawBlock, StateSchema,
+    config::FjallArchiveConfig, key_hash, ArchiveError, ArchiveIndexDelta,
+    ArchiveStore as CoreArchiveStore, ArchiveWriter as CoreArchiveWriter, BlockBody, BlockSlot,
+    ChainPoint, EntityValue, ExactKind, IndexRecord, LogKey, Namespace, RawBlock, StateSchema,
+    TagDimension, KEY_HASH_SIZE,
 };
 use fjall::{
     compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
@@ -42,17 +58,30 @@ use pallas::ledger::traverse::MultiEraBlock;
 
 use dolos_flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
 
+use crate::keys::{dim_prefix, hash_dimension, DIM_HASH_SIZE};
 use crate::Error;
 
+pub mod exact;
 pub mod log_keys;
+pub mod scan;
+pub mod tags;
 
 use log_keys::{
     build_log_key, build_temporal_bound, decode_log_key, namespace_end, namespace_start,
     PREFIXED_LOG_KEY_SIZE,
 };
 
+pub use exact::ExactRecordIterator as ExactIter;
+pub use tags::{SlotIterator as SlotIter, TagRecordIterator as TagIter};
+
 /// Default cache size in MB
 const DEFAULT_CACHE_SIZE_MB: usize = 500;
+
+/// Compaction settings of the two index keyspaces: what the standalone index
+/// store applied to them before they moved here, kept so their behavior does
+/// not change.
+const INDEX_L0_THRESHOLD: u8 = 8;
+const INDEX_MEMTABLE_SIZE_MB: usize = 128;
 
 /// Keyspace names for the archive store
 mod keyspace_names {
@@ -60,6 +89,10 @@ mod keyspace_names {
     pub const BLOCKS: &str = "archive-blocks";
     /// Unified log namespaces keyspace
     pub const LOGS: &str = "archive-logs";
+    /// Archive tags keyspace (append-only)
+    pub const TAGS: &str = "archive-tags";
+    /// Exact-match keyspace (block hash, tx hash, block number -> slot)
+    pub const EXACT: &str = "index-exact";
 }
 
 fn io_err(e: std::io::Error) -> ArchiveError {
@@ -73,13 +106,15 @@ fn fjall_err(e: fjall::Error) -> ArchiveError {
 /// Fjall-based archive store.
 ///
 /// Block bodies live in flat segment files (shared, byte-identical layout
-/// with the redb backend); only the location table and the log namespaces
-/// live in the LSM tree.
+/// with the redb backend); the location table, the log namespaces and the
+/// two index keyspaces live in the LSM tree.
 #[derive(Clone)]
 pub struct ArchiveStore {
     db: Database,
     blocks: Keyspace,
     logs: Keyspace,
+    tags: Keyspace,
+    exact: Keyspace,
     flatfiles: Arc<FlatFileStore>,
     schema: Arc<StateSchema>,
     flush_on_commit: bool,
@@ -178,10 +213,22 @@ impl ArchiveStore {
         let blocks = db.keyspace(keyspace_names::BLOCKS, build_opts)?;
         let logs = db.keyspace(keyspace_names::LOGS, build_opts)?;
 
+        let index_opts = || {
+            KeyspaceCreateOptions::default()
+                .compaction_strategy(Arc::new(
+                    Leveled::default().with_l0_threshold(INDEX_L0_THRESHOLD),
+                ))
+                .max_memtable_size((INDEX_MEMTABLE_SIZE_MB as u64) * 1024 * 1024)
+        };
+        let tags = db.keyspace(keyspace_names::TAGS, index_opts)?;
+        let exact = db.keyspace(keyspace_names::EXACT, index_opts)?;
+
         Ok(Self {
             db,
             blocks,
             logs,
+            tags,
+            exact,
             flatfiles: Arc::new(flatfiles),
             schema: Arc::new(schema),
             flush_on_commit,
@@ -196,21 +243,17 @@ impl ArchiveStore {
 
     /// Per-keyspace disk footprint: `(name, bytes, path)`.
     pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
-        vec![
-            (
-                keyspace_names::BLOCKS,
-                self.blocks.disk_space(),
-                self.blocks.path().to_path_buf(),
-            ),
-            (
-                keyspace_names::LOGS,
-                self.logs.disk_space(),
-                self.logs.path().to_path_buf(),
-            ),
+        [
+            (keyspace_names::BLOCKS, &self.blocks),
+            (keyspace_names::LOGS, &self.logs),
+            (keyspace_names::TAGS, &self.tags),
+            (keyspace_names::EXACT, &self.exact),
         ]
+        .map(|(name, ks)| (name, ks.disk_space(), ks.path().to_path_buf()))
+        .to_vec()
     }
 
-    /// Fully compact both keyspaces and sync the result to disk.
+    /// Fully compact every keyspace and sync the result to disk.
     ///
     /// The export path runs this as its sanitization step — the LSM analogue
     /// of redb's pre-export compaction — so an exported database directory
@@ -218,6 +261,8 @@ impl ArchiveStore {
     pub fn compact(&self) -> Result<(), Error> {
         self.blocks.major_compact()?;
         self.logs.major_compact()?;
+        self.tags.major_compact()?;
+        self.exact.major_compact()?;
         self.db.persist(PersistMode::SyncAll)?;
 
         Ok(())
@@ -280,14 +325,14 @@ impl ArchiveStore {
 
 /// Writer for batched archive operations.
 ///
-/// Log writes go straight into the shared write batch: fjall applies a
-/// batch's items to the memtable in order, and the memtable replaces on an
-/// identical key, so the last write to a key within one batch is the one
-/// that survives — the same end state redb's writer reaches by collapsing
-/// each batch to its last writes. Blocks are buffered until `commit` so
-/// their bodies can be appended to the segment files (and fsynced) before
-/// any index entry that points at them is committed, the same crash window
-/// the redb writer keeps.
+/// Log writes and index entries go straight into the shared write batch:
+/// fjall applies a batch's items to the memtable in order, and the memtable
+/// replaces on an identical key, so the last write to a key within one batch
+/// is the one that survives — the same end state redb's writer reaches by
+/// collapsing each batch to its last writes. Blocks are buffered until
+/// `commit` so their bodies can be appended to the segment files (and
+/// fsynced) before any entry that points at them is committed, the same
+/// crash window the redb writer keeps.
 ///
 /// `overlay` is the writer-local view of every blocks-table slot this
 /// writer has touched. The write batch is invisible to reads until commit,
@@ -382,10 +427,73 @@ impl CoreArchiveWriter for ArchiveWriter {
         Ok(())
     }
 
+    fn apply_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        let mut batch = self.batch.lock().unwrap();
+
+        exact::apply(&mut batch, &self.store.exact, deltas)?;
+        tags::apply(&mut batch, &self.store.tags, deltas)?;
+
+        Ok(())
+    }
+
+    fn undo_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        let mut batch = self.batch.lock().unwrap();
+
+        exact::undo(&mut batch, &self.store.exact, deltas)?;
+        tags::undo(&mut batch, &self.store.tags, deltas)?;
+
+        Ok(())
+    }
+
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), ArchiveError> {
+        let mut batch = self.batch.lock().unwrap();
+
+        // Records arrive sorted, hence grouped by dimension/kind: hash each
+        // group's dimension once instead of once per record. The cached
+        // dimension is owned because a record no longer outlives its own
+        // iteration step — the clone is one per group, not one per record.
+        let mut tag_dim: Option<(Cow<'static, str>, [u8; DIM_HASH_SIZE])> = None;
+        let mut exact_dim: Option<(ExactKind, [u8; DIM_HASH_SIZE])> = None;
+
+        for record in records {
+            match record {
+                IndexRecord::Tag(tag) => {
+                    let dim_hash = match &tag_dim {
+                        Some((cached, hash)) if cached == &tag.dimension => *hash,
+                        _ => {
+                            let hash = hash_dimension(dim_prefix::BLOCK, tag.dimension());
+                            tag_dim = Some((tag.dimension.clone(), hash));
+                            hash
+                        }
+                    };
+
+                    tags::insert_prehashed(&mut batch, &self.store.tags, &tag, dim_hash);
+                }
+                IndexRecord::Exact(exact) => {
+                    let dim_hash = match exact_dim {
+                        Some((cached, hash)) if cached == exact.kind => hash,
+                        _ => {
+                            let hash = hash_dimension(dim_prefix::EXACT, exact.kind.as_str());
+                            exact_dim = Some((exact.kind, hash));
+                            hash
+                        }
+                    };
+
+                    exact::insert_prehashed(&mut batch, &self.store.exact, &exact, dim_hash);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn commit(self) -> Result<(), ArchiveError> {
         // 1. Batch-append all pending blocks to flat files (fsync inside).
-        // 2. Insert all index entries into the write batch.
-        // 3. Commit the batch (log rows are already in it).
+        // 2. Insert all location entries into the write batch.
+        // 3. Commit the batch (log rows and index entries are already in it).
         let pending = self.pending_blocks.into_inner().unwrap();
         let mut overlay = self.overlay.into_inner().unwrap();
         let mut batch = self.batch.into_inner().unwrap();
@@ -642,6 +750,9 @@ impl CoreArchiveStore for ArchiveStore {
     type Writer = ArchiveWriter;
     type LogIter = LogIter;
     type EntityValueIter = EmptyEntityValueIter;
+    type SlotIter = SlotIter;
+    type TagIter = TagIter;
+    type ExactIter = ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         Ok(ArchiveWriter {
@@ -924,5 +1035,65 @@ impl CoreArchiveStore for ArchiveStore {
         batch.commit().map_err(fjall_err)?;
 
         Ok(())
+    }
+
+    fn slot_by_block_hash(&self, block_hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        exact::get_by_block_hash(&snapshot, &self.exact, block_hash).map_err(ArchiveError::from)
+    }
+
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        exact::get_by_block_number(&snapshot, &self.exact, number).map_err(ArchiveError::from)
+    }
+
+    fn slot_by_tx_hash(&self, tx_hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        let snapshot = self.db.snapshot();
+        exact::get_by_tx_hash(&snapshot, &self.exact, tx_hash).map_err(ArchiveError::from)
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError> {
+        // The stored key form is the write path's, not this method's: the same
+        // `key_hash` an insert used, so a query cannot look under bytes an
+        // insert would not have written. `None` is a key with no valid stored
+        // form — today only a `metadata` label that is not eight bytes wide —
+        // which is a malformed query rather than an empty result.
+        let Some(hash) = key_hash(dimension, key) else {
+            return Err(Error::Codec(format!(
+                "{dimension} key must be {KEY_HASH_SIZE} bytes, got {}",
+                key.len(),
+            ))
+            .into());
+        };
+
+        let snapshot = self.db.snapshot();
+
+        SlotIter::new(&snapshot, &self.tags, dimension, hash, start, end)
+            .map_err(ArchiveError::from)
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError> {
+        // One snapshot for the whole traversal: every dimension prefix is read
+        // from the same MVCC view, so the record set is consistent even under
+        // concurrent writes.
+        let snapshot = self.db.snapshot();
+
+        Ok(TagIter::new(snapshot, &self.tags, dimensions, slots))
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, ArchiveError> {
+        let snapshot = self.db.snapshot();
+
+        Ok(ExactIter::new(snapshot, &self.exact, slots))
     }
 }

--- a/crates/fjall/src/archive/scan.rs
+++ b/crates/fjall/src/archive/scan.rs
@@ -27,7 +27,7 @@
 
 use std::ops::Range;
 
-use dolos_core::{BlockSlot, IndexError};
+use dolos_core::{ArchiveError, BlockSlot};
 use fjall::{Guard, Keyspace, Readable, Snapshot};
 
 use crate::keys::DIM_HASH_SIZE;
@@ -61,7 +61,7 @@ pub trait ScanTarget {
         label: Self::Label,
         guard: Guard,
         slots: &Range<BlockSlot>,
-    ) -> Result<Option<Self::Record>, IndexError>;
+    ) -> Result<Option<Self::Record>, ArchiveError>;
 }
 
 /// A lazy walk over the entries of a label list's prefixes, in list order.
@@ -112,7 +112,7 @@ impl<T: ScanTarget, L: Iterator<Item = T::Label>> DimensionScan<T, L> {
 }
 
 impl<T: ScanTarget, L: Iterator<Item = T::Label>> Iterator for DimensionScan<T, L> {
-    type Item = Result<T::Record, IndexError>;
+    type Item = Result<T::Record, ArchiveError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {

--- a/crates/fjall/src/archive/tags.rs
+++ b/crates/fjall/src/archive/tags.rs
@@ -1,9 +1,10 @@
-//! Archive tag index operations for the `archive-tags` keyspace
-//! (chain-agnostic).
+//! Archive tag index operations for the `archive-tags` keyspace of the
+//! archive store (chain-agnostic).
 //!
 //! This module handles key encoding, batch writes (apply/undo), read queries,
 //! and the `SlotIterator` for the `archive-tags` keyspace. Block tags are
-//! append-only entries that record which blocks contain specific data.
+//! append-only entries that record which blocks contain specific data; they
+//! are written in the same batch as the block locations they point at.
 //!
 //! ## Key Format
 //!
@@ -21,12 +22,11 @@ use std::borrow::Cow;
 use std::ops::Range;
 
 use dolos_core::{
-    key_hash, ArchiveIndexDelta, BlockSlot, IndexDelta, IndexError, KeyHash, Tag, TagDimension,
-    TagRecord,
+    key_hash, ArchiveError, ArchiveIndexDelta, BlockSlot, KeyHash, Tag, TagDimension, TagRecord,
 };
 use fjall::{Keyspace, OwnedWriteBatch, Readable, Snapshot};
 
-use crate::index::scan::{DimensionScan, ScanTarget};
+use crate::archive::scan::{DimensionScan, ScanTarget};
 use crate::keys::{
     decode_slot, dim_prefix, hash_dimension, DIM_HASH_SIZE, HASH_KEY_SIZE, SLOT_SIZE,
 };
@@ -170,25 +170,25 @@ fn undo_block(
     Ok(())
 }
 
-/// Apply archive tag indexes from an IndexDelta
+/// Apply archive tag indexes for a batch of block deltas
 pub fn apply(
     batch: &mut OwnedWriteBatch,
     keyspace: &Keyspace,
-    delta: &IndexDelta,
+    deltas: &[ArchiveIndexDelta],
 ) -> Result<(), Error> {
-    for block in &delta.archive {
+    for block in deltas {
         apply_block(batch, keyspace, block)?;
     }
     Ok(())
 }
 
-/// Undo archive tag indexes from an IndexDelta (rollback)
+/// Undo archive tag indexes for a batch of block deltas (rollback)
 pub fn undo(
     batch: &mut OwnedWriteBatch,
     keyspace: &Keyspace,
-    delta: &IndexDelta,
+    deltas: &[ArchiveIndexDelta],
 ) -> Result<(), Error> {
-    for block in delta.archive.iter().rev() {
+    for block in deltas.iter().rev() {
         undo_block(batch, keyspace, block)?;
     }
     Ok(())
@@ -252,7 +252,7 @@ impl SlotIterator {
 }
 
 impl Iterator for SlotIterator {
-    type Item = Result<BlockSlot, IndexError>;
+    type Item = Result<BlockSlot, ArchiveError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.front < self.back {
@@ -310,7 +310,7 @@ impl DoubleEndedIterator for SlotIterator {
 ///
 /// ## Errors
 ///
-/// Terminal, per the policy in [`crate::index::scan`] — the one place it is
+/// Terminal, per the policy in [`crate::archive::scan`] — the one place it is
 /// defined.
 pub struct TagRecordIterator(DimensionScan<TagScan, std::vec::IntoIter<TagDimension>>);
 
@@ -332,15 +332,16 @@ impl ScanTarget for TagScan {
         dimension: TagDimension,
         guard: fjall::Guard,
         slots: &Range<BlockSlot>,
-    ) -> Result<Option<TagRecord>, IndexError> {
+    ) -> Result<Option<TagRecord>, ArchiveError> {
         let key = guard.key().map_err(Error::Fjall)?;
 
         if key.len() < BLOCK_TAG_KEY_SIZE {
-            return Err(IndexError::CodecError(format!(
+            return Err(Error::Codec(format!(
                 "malformed archive tag key in dimension {dimension}: \
                  {} bytes, expected {BLOCK_TAG_KEY_SIZE}",
                 key.len(),
-            )));
+            ))
+            .into());
         }
 
         let slot = decode_block_tag_slot(&key);
@@ -383,7 +384,7 @@ impl TagRecordIterator {
 }
 
 impl Iterator for TagRecordIterator {
-    type Item = Result<TagRecord, IndexError>;
+    type Item = Result<TagRecord, ArchiveError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()

--- a/crates/fjall/src/index/README.md
+++ b/crates/fjall/src/index/README.md
@@ -1,101 +1,35 @@
 # Fjall Index Store
 
-This module implements the `IndexStore` trait using [Fjall](https://github.com/fjall-rs/fjall), an LSM-tree based embedded database optimized for write-heavy workloads.
+This module implements the `IndexStore` trait using [Fjall](https://github.com/fjall-rs/fjall). What is left of it is the cursor.
 
-## Design Philosophy
+## Where the indexes went
 
-The index store is organized into **3 keyspaces** based on workload class. Each keyspace maps to its own physical LSM-tree, which means it gets independent compaction, memtables, and I/O pipelines.
+The index store used to hold three keyspaces. Each was a projection of data another store owns, and each now lives beside what it projects, written in the same atomic batch:
 
-### Why separate keyspaces by workload?
+| Former keyspace | Now in | Module | Why |
+|---|---|---|---|
+| `state-tags` (live-UTxO tags) | state store | `../state/tags.rs` | a projection of the UTxO set; mutable, high churn |
+| `archive-tags` (block tags) | archive store | `../archive/tags.rs` | a projection of the block history; append-only |
+| `index-exact` (hash/number → slot) | archive store | `../archive/exact.rs` | a projection of the block history; append-only |
 
-Tag indexes come in two fundamentally different write patterns:
-
-- **State tags** (UTxO tags) are mutable. Entries are inserted when a UTxO is produced and deleted when it's consumed. This creates high churn with many tombstones that need compaction cleanup. They are a projection of the UTxO set, so they live in the state store's database (`state-tags`, see `../state/tags.rs`) and commit in the same batch as the set — in their own keyspace there, for the reasons below.
-- **Archive tags** (block tags) are append-only. Entries are written once during block indexing and never deleted. They grow monotonically with chain height.
-
-Mixing these in a single LSM-tree causes problems:
-
-1. **Write amplification** - When L0 SSTs are compacted into deeper levels, a flush triggered by high-volume state tag writes forces rewriting co-located archive tag entries (and vice versa). Separating them means each tree only compacts its own data.
-
-2. **Compaction strategy mismatch** - State tags need aggressive leveled compaction to reclaim space from tombstones. Archive tags could use larger memtables and less aggressive compaction since there are no deletions. Separate keyspaces allow independent tuning.
-
-3. **I/O contention** - A single large keyspace creates a single compaction pipeline that can bottleneck. With separate keyspaces, compaction runs independently per tree, which benefits SSD workloads that handle concurrent I/O well.
-
-4. **Read amplification** - Prefix scans for UTxO lookups no longer traverse SSTs containing unrelated archive data, and vice versa.
-
-### Chain-agnostic storage
-
-The storage layer has **no knowledge of blockchain-specific concepts** like "address", "policy", or "stake". Instead:
-
-1. **Dimension strings are hashed** - Any dimension string (e.g., "address", "policy") is hashed using xxh3 to produce an 8-byte prefix.
-
-2. **Internal prefixes distinguish types** - To prevent collisions between different index types with the same dimension name, internal prefixes are prepended before hashing:
-   - `"utxo:"` for state tag dimensions
-   - `"block:"` for archive tag dimensions
-   - `"exact:"` for exact lookup dimensions
-
-3. **Example**: `hash("utxo:address")` != `hash("block:address")` - no collisions even with same dimension name.
-
-This allows the chain logic layer (dolos-cardano) to define any dimensions it needs without requiring changes to the storage layer.
+The keyspaces kept their names, key encodings, dimension hashing and compaction settings; what changed is which database journal and write batch they live under. The `indexes` stele layer — the sorted output of `ArchiveStore::iter_archive_tags` then `iter_exact_records`, and the input of `ArchiveWriter::append_prehashed` — is byte-identical whichever store produced it. See `../archive/mod.rs` for the read and write surface, and `../archive/scan.rs` for the prefix walk both traversals share.
 
 ## Keyspace Layout
 
-| Keyspace | Name | Purpose | Access Pattern | Mutability |
-|----------|------|---------|----------------|------------|
-| 1 | `index-cursor` | Chain position tracking | Single key read/write | Overwrite |
-| 2 | `index-exact` | Hash/number -> slot lookups | Point queries | Append-only |
-| 3 | `archive-tags` | Block tag indexes (historical lookups) | Prefix scans | Append-only |
-
-All three keyspaces participate in a single atomic write batch per block, so cross-keyspace consistency is guaranteed by Fjall's `OwnedWriteBatch`.
-
-The live-UTxO tags (`state-tags`, keyed `[dim_hash:8][lookup_key:var][txo_ref:36]`) are a projection of the UTxO set and live in the state store's database, written in the same batch as the set — see `state/tags.rs`.
-
-## Key Schemas
-
-### Cursor Keyspace (`index-cursor`)
-
-Single entry storing the current chain position:
+| Keyspace | Name | Purpose | Access Pattern |
+|----------|------|---------|----------------|
+| 1 | `index-cursor` | Chain position tracking | Single key read/write |
 
 ```
 Key:   [0x00]
 Value: bincode-serialized ChainPoint
 ```
 
-### Exact Keyspace (`index-exact`)
-
-Point lookups for block/transaction identification:
-
-```
-Key:   [dim_hash:8][key_data:var]
-Value: [slot:8]
-```
-
-Where `dim_hash = xxh3("exact:" + dimension)`.
-
-| Dimension | Qualified Name | Key Data |
-|-----------|---------------|----------|
-| Block Hash | `exact:block_hash` | 32-byte hash |
-| Block Number | `exact:block_num` | 8-byte big-endian u64 |
-| Tx Hash | `exact:tx_hash` | 32-byte hash |
-
-### Archive Tags Keyspace (`archive-tags`)
-
-Historical indexes for finding blocks containing specific data:
-
-```
-Key:   [dim_hash:8][xxh3(tag_key):8][slot:8]
-Value: (empty)
-```
-
-Where `dim_hash = xxh3("block:" + dimension)`.
-
-The `xxh3(tag_key)` is an 8-byte hash of the original key data, providing approximate matching with compact keys. The `slot` is 8-byte big-endian for correct lexicographic ordering.
-
-Entries are append-only and never deleted.
+The cursor is placed by `IndexWriter::apply(&IndexDelta { cursor })` and read by the bootstrap catch-up and `dolos data check`. Removing it, and the store with it, is the next step of the dissolution.
 
 ## Dimension Hashing
 
-The `hash_dimension()` function in `keys.rs` computes dimension hashes:
+`hash_dimension()` in `keys.rs` computes the dimension hashes every index keyspace uses:
 
 ```rust
 pub fn hash_dimension(prefix: &str, dim: &str) -> [u8; 8] {
@@ -109,112 +43,7 @@ pub fn hash_dimension(prefix: &str, dim: &str) -> [u8; 8] {
 
 Internal prefix constants:
 - `dim_prefix::UTXO = "utxo"` - for the live-UTxO tag dimensions (state store)
-- `dim_prefix::BLOCK = "block"` - for archive tag dimensions
-- `dim_prefix::EXACT = "exact"` - for exact lookup dimensions
+- `dim_prefix::BLOCK = "block"` - for archive tag dimensions (archive store)
+- `dim_prefix::EXACT = "exact"` - for exact lookup dimensions (archive store)
 
-## Module Structure
-
-```
-index/
-├── mod.rs              # IndexStore, keyspace management, trait impls
-├── exact.rs            # index-exact keyspace (key encoding + operations + queries)
-├── archive_tags.rs     # archive-tags keyspace (key encoding + operations + SlotIterator)
-└── README.md
-```
-
-## Encoding Conventions
-
-- **All integers are big-endian** for correct lexicographic ordering in LSM-tree scans
-- **Dimension hashes are 8 bytes** (xxh3 truncated to big-endian u64)
-- **Variable-length keys** are concatenated directly (no length prefixes needed since we scan by prefix)
-- **Empty values** for tag entries - presence of key is sufficient
-
-## Query Patterns
-
-### Point Lookups (Exact Keyspace)
-
-```rust
-// Find slot by block hash
-let slot = store.slot_by_block_hash(&hash)?;
-
-// Find slot by tx hash
-let slot = store.slot_by_tx_hash(&tx_hash)?;
-
-// Find slot by block number
-let slot = store.slot_by_block_number(12345)?;
-```
-
-### UTxO Queries (State Tags Keyspace)
-
-```rust
-// Find all UTxOs for an address (dimension string passed directly)
-let utxos = store.utxos_by_tag("address", &addr_bytes)?;
-
-// Find all UTxOs for a policy
-let utxos = store.utxos_by_tag("policy", &policy_id)?;
-```
-
-### Historical Queries (Archive Tags Keyspace)
-
-```rust
-// Find slots where address appeared (within range)
-let slots = store.slots_by_tag("address", &addr_bytes, start_slot, end_slot)?;
-
-// Find slots with specific metadata label
-let slots = store.slots_by_tag("metadata", &label_bytes, start_slot, end_slot)?;
-```
-
-### Bulk Record Traversal (Export) and Pre-Hashed Append (Restore)
-
-```rust
-// Every archive tag record in a slot range, sorted by (dimension, key_hash, slot)
-let tags = store.iter_archive_tags(&archive_dimensions::ALL, epoch_start..epoch_end)?;
-
-// Every exact record in a slot range, sorted by (kind, key)
-let exacts = store.iter_exact_records(epoch_start..epoch_end)?;
-
-// ...and back into another store, byte for byte
-let writer = target.start_writer()?;
-writer.append_prehashed(&records)?;
-writer.commit()?;
-```
-
-Three things about this pair:
-
-- **Records carry the stored key form, not the logical key.** The logical key is
-  not on disk — only its hash is — so this is the most a reader can produce.
-  Consumers must copy those 8 bytes through unchanged: for every dimension but
-  `metadata` they are `xxh3_64(key)` big-endian, while `metadata` keys are u64
-  labels that the store keeps verbatim rather than hashing.
-
-- **The traversal is driven by a caller-supplied list.** Dimension and kind
-  names are hashed into keys, so neither is discoverable from disk. The
-  canonical archive list is `dolos_cardano::indexes::archive_dimensions::ALL`.
-
-- **Order is part of the contract**, because these records become snapshot
-  layers and the layer *is* a sorted sequence. On-disk order is by dimension
-  *hash*, so the traversal walks the dimension list in name order and relies on
-  lexicographic order within each prefix.
-
-## Performance Considerations
-
-1. **Snapshot reads** - All read operations use MVCC snapshots to avoid blocking concurrent writes.
-
-2. **Batched writes** - The `IndexWriter` accumulates changes and commits atomically across all four keyspaces.
-
-3. **Independent compaction** - State tags and archive tags compact on their own schedules, preventing one workload from stalling the other.
-
-4. **Flush on commit** - Configurable journal flushing prevents unbounded memory growth during bulk imports.
-
-5. **Graceful shutdown** - Call `shutdown()` before dropping to ensure all background work completes.
-
-6. **A slot range is not a seek** - Slot is the *last* component of an archive
-   tag key and is not part of an exact key at all (it is the value), so
-   `iter_archive_tags` and `iter_exact_records` both scan and filter: the cost
-   of slicing one epoch is O(store), not O(epoch). Measured on a synthetic
-   mainnet-shaped store (648k tag + 108k exact records per epoch): ~0.13 s per
-   epoch of stored history, i.e. ~0.25 s at 2 epochs of depth, ~0.87 s at 8 and
-   ~3.1 s at 24. `tests/index_roundtrip.rs` carries the measurement
-   (`measure_one_epoch_iteration_cost`, `--ignored`). A backfill over deep
-   history wants a single pass bucketing records by epoch rather than one slice
-   per epoch.
+`hash("utxo:address") != hash("block:address")`, so a dimension name can be used by more than one index type without a collision.

--- a/crates/fjall/src/index/mod.rs
+++ b/crates/fjall/src/index/mod.rs
@@ -1,58 +1,32 @@
 //! Fjall-based index store implementation for Dolos (chain-agnostic).
 //!
-//! This module provides an implementation of the `IndexStore` trait using
-//! fjall, an LSM-tree based embedded database. This is optimized for
-//! write-heavy workloads with many keys, which is ideal for blockchain index
-//! data.
+//! What is left of the index store is its cursor: one keyspace, one key.
 //!
-//! ## Three Keyspace Design
+//! The indexes it used to hold moved to the stores they project. The
+//! live-UTxO tags (mutable, high-churn) live in the state store's `state-tags`
+//! keyspace beside the UTxO set (see `crate::state::tags`); the archive tags
+//! and the exact lookups live in the archive store's `archive-tags` and
+//! `index-exact` keyspaces beside the block locations (see
+//! `crate::archive::{tags, exact}`), written in the same batch as the blocks.
 //!
-//! Indexes are organized into three keyspaces based on access patterns:
+//! ## Keyspace
 //!
-//! 1. **`index-cursor`**: Chain position tracking (separate for different
-//!    access pattern)
-//!
-//! 2. **`index-exact`**: Exact-match lookups (point queries) Key format:
-//!    `[dim_hash:8][key_data:var]` -> `[slot:8]`
-//!
-//! 3. **`archive-tags`**: Block tag queries (append-only, never deleted) Key
-//!    format: `[dim_hash:8][xxh3(tag_key):8][slot:8]` -> empty
-//!
-//! The `dim_hash` is computed as `xxh3(prefix + ":" + dimension)` where prefix
-//! is "exact" or "block". This makes the storage layer fully chain-agnostic.
-//!
-//! The live-UTxO tags (mutable, high-churn) live in the state store's
-//! `state-tags` keyspace, beside the UTxO set they project (see
-//! `crate::state::tags`).
-//!
-//! All multi-byte integers are big-endian encoded for correct lexicographic
-//! ordering.
+//! - **`index-cursor`**: chain position tracking. Key `[0x00]`, value a
+//!   bincode-serialized `ChainPoint`.
 
-use std::borrow::Cow;
-use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
-    config::FjallIndexConfig, key_hash, BlockSlot, ChainPoint, ExactKind, IndexDelta, IndexError,
-    IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter, TagDimension,
-    KEY_HASH_SIZE,
+    config::FjallIndexConfig, ChainPoint, IndexDelta, IndexError, IndexStore as CoreIndexStore,
+    IndexWriter as CoreIndexWriter,
 };
 use fjall::{
     compaction::Leveled, Database, Keyspace, KeyspaceCreateOptions, OwnedWriteBatch, PersistMode,
     Readable,
 };
 
-pub mod archive_tags;
-pub mod exact;
-pub mod scan;
-
-use crate::keys::{dim_prefix, hash_dimension, DIM_HASH_SIZE};
 use crate::Error;
-
-// Re-export the iterator types
-pub use archive_tags::{SlotIterator as SlotIter, TagRecordIterator as TagIter};
-pub use exact::ExactRecordIterator as ExactIter;
 
 /// Default cache size in MB
 const DEFAULT_CACHE_SIZE_MB: usize = 500;
@@ -67,33 +41,18 @@ const DEFAULT_MEMTABLE_SIZE_MB: usize = 128;
 
 /// Keyspace names for index store
 mod keyspace_names {
-    /// Cursor keyspace (separate for different access pattern)
+    /// Cursor keyspace
     pub const CURSOR: &str = "index-cursor";
-    /// Exact-match keyspace (block hash, tx hash, block number -> slot)
-    pub const EXACT: &str = "index-exact";
-    /// Archive tags keyspace (append-only, never deleted)
-    pub const BLOCK_TAGS: &str = "archive-tags";
 }
 
 /// Key for the cursor entry
 const CURSOR_KEY: &[u8] = &[0u8];
 
-/// Fjall-based index store implementation with three keyspaces.
-///
-/// Uses 3 keyspaces split by workload class:
-/// - `cursor`: Chain position tracking
-/// - `exact`: Exact-match lookups (block/tx hash, block number)
-/// - `block_tags`: Block tags (append-only, can use relaxed compaction)
+/// Fjall-based index store: the cursor keyspace.
 #[derive(Clone)]
 pub struct IndexStore {
     db: Database,
-    /// Cursor keyspace (separate due to different access pattern)
     cursor: Keyspace,
-    /// Exact-match keyspace for point lookups
-    exact: Keyspace,
-    /// Block tags keyspace (append-only, never deleted)
-    block_tags: Keyspace,
-    /// Configuration
     flush_on_commit: bool,
 }
 
@@ -153,14 +112,10 @@ impl IndexStore {
         };
 
         let cursor = db.keyspace(keyspace_names::CURSOR, build_opts)?;
-        let exact = db.keyspace(keyspace_names::EXACT, build_opts)?;
-        let block_tags = db.keyspace(keyspace_names::BLOCK_TAGS, build_opts)?;
 
         Ok(Self {
             db,
             cursor,
-            exact,
-            block_tags,
             flush_on_commit,
         })
     }
@@ -170,25 +125,13 @@ impl IndexStore {
         &self.db
     }
 
-    /// Get a reference to the exact-match keyspace
-    pub fn exact_keyspace(&self) -> &Keyspace {
-        &self.exact
-    }
-
-    /// Get a reference to the block tags keyspace
-    pub fn block_tags_keyspace(&self) -> &Keyspace {
-        &self.block_tags
-    }
-
     /// Per-keyspace disk footprint: `(name, bytes, path)`.
     pub fn disk_usage(&self) -> Vec<(&'static str, u64, std::path::PathBuf)> {
-        [
-            (keyspace_names::CURSOR, &self.cursor),
-            (keyspace_names::EXACT, &self.exact),
-            (keyspace_names::BLOCK_TAGS, &self.block_tags),
-        ]
-        .map(|(name, ks)| (name, ks.disk_space(), ks.path().to_path_buf()))
-        .to_vec()
+        vec![(
+            keyspace_names::CURSOR,
+            self.cursor.disk_space(),
+            self.cursor.path().to_path_buf(),
+        )]
     }
 
     /// Gracefully shutdown the index store.
@@ -247,78 +190,9 @@ impl CoreIndexWriter for IndexStoreWriter {
     fn apply(&self, delta: &IndexDelta) -> Result<(), IndexError> {
         let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
 
-        // Apply exact index changes to index-exact keyspace
-        exact::apply(&mut batch, &self.store.exact, delta).map_err(IndexError::from)?;
-
-        // Apply archive tag changes to archive-tags keyspace
-        archive_tags::apply(&mut batch, &self.store.block_tags, delta).map_err(IndexError::from)?;
-
-        // Set cursor
         let cursor_bytes =
             bincode::serialize(&delta.cursor).map_err(|e| Error::Codec(e.to_string()))?;
         batch.insert(&self.store.cursor, CURSOR_KEY, cursor_bytes);
-
-        Ok(())
-    }
-
-    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError> {
-        let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
-
-        // Undo exact index changes
-        exact::undo(&mut batch, &self.store.exact, delta).map_err(IndexError::from)?;
-
-        // Undo archive tag changes
-        archive_tags::undo(&mut batch, &self.store.block_tags, delta).map_err(IndexError::from)?;
-
-        Ok(())
-    }
-
-    fn append_prehashed(
-        &self,
-        records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError> {
-        let mut batch = self.batch.lock().map_err(|_| Error::LockPoisoned)?;
-
-        // Records arrive sorted, hence grouped by dimension/kind: hash each
-        // group's dimension once instead of once per record. The cached
-        // dimension is owned because a record no longer outlives its own
-        // iteration step — the clone is one per group, not one per record.
-        let mut tag_dim: Option<(Cow<'static, str>, [u8; DIM_HASH_SIZE])> = None;
-        let mut exact_dim: Option<(ExactKind, [u8; DIM_HASH_SIZE])> = None;
-
-        for record in records {
-            match record {
-                IndexRecord::Tag(tag) => {
-                    let dim_hash = match &tag_dim {
-                        Some((cached, hash)) if cached == &tag.dimension => *hash,
-                        _ => {
-                            let hash = hash_dimension(dim_prefix::BLOCK, tag.dimension());
-                            tag_dim = Some((tag.dimension.clone(), hash));
-                            hash
-                        }
-                    };
-
-                    archive_tags::insert_prehashed(
-                        &mut batch,
-                        &self.store.block_tags,
-                        &tag,
-                        dim_hash,
-                    );
-                }
-                IndexRecord::Exact(exact) => {
-                    let dim_hash = match exact_dim {
-                        Some((cached, hash)) if cached == exact.kind => hash,
-                        _ => {
-                            let hash = hash_dimension(dim_prefix::EXACT, exact.kind.as_str());
-                            exact_dim = Some((exact.kind, hash));
-                            hash
-                        }
-                    };
-
-                    exact::insert_prehashed(&mut batch, &self.store.exact, &exact, dim_hash);
-                }
-            }
-        }
 
         Ok(())
     }
@@ -346,9 +220,6 @@ impl CoreIndexWriter for IndexStoreWriter {
 
 impl CoreIndexStore for IndexStore {
     type Writer = IndexStoreWriter;
-    type SlotIter = SlotIter;
-    type TagIter = TagIter;
-    type ExactIter = ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         let batch = self.db.batch();
@@ -386,69 +257,5 @@ impl CoreIndexStore for IndexStore {
             }
             None => Ok(None),
         }
-    }
-
-    fn slot_by_block_hash(&self, block_hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
-        let snapshot = self.db.snapshot();
-        exact::get_by_block_hash(&snapshot, &self.exact, block_hash).map_err(IndexError::from)
-    }
-
-    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError> {
-        // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
-        let snapshot = self.db.snapshot();
-        exact::get_by_block_number(&snapshot, &self.exact, number).map_err(IndexError::from)
-    }
-
-    fn slot_by_tx_hash(&self, tx_hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
-        let snapshot = self.db.snapshot();
-        exact::get_by_tx_hash(&snapshot, &self.exact, tx_hash).map_err(IndexError::from)
-    }
-
-    fn slots_by_tag(
-        &self,
-        dimension: TagDimension,
-        key: &[u8],
-        start: BlockSlot,
-        end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
-        // The stored key form is the write path's, not this method's: the same
-        // `key_hash` an insert used, so a query cannot look under bytes an
-        // insert would not have written. `None` is a key with no valid stored
-        // form — today only a `metadata` label that is not eight bytes wide —
-        // which is a malformed query rather than an empty result.
-        let Some(hash) = key_hash(dimension, key) else {
-            return Err(IndexError::CodecError(format!(
-                "{dimension} key must be {KEY_HASH_SIZE} bytes, got {}",
-                key.len(),
-            )));
-        };
-
-        // Use snapshot for MVCC reads to avoid deadlocks with concurrent writes
-        let snapshot = self.db.snapshot();
-
-        // Pass dimension string directly - chain-agnostic
-        SlotIter::new(&snapshot, &self.block_tags, dimension, hash, start, end)
-            .map_err(IndexError::from)
-    }
-
-    fn iter_archive_tags(
-        &self,
-        dimensions: &[TagDimension],
-        slots: Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
-        // One snapshot for the whole traversal: every dimension prefix is read
-        // from the same MVCC view, so the record set is consistent even under
-        // concurrent writes.
-        let snapshot = self.db.snapshot();
-
-        Ok(TagIter::new(snapshot, &self.block_tags, dimensions, slots))
-    }
-
-    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
-        let snapshot = self.db.snapshot();
-
-        Ok(ExactIter::new(snapshot, &self.exact, slots))
     }
 }

--- a/crates/fjall/src/keys.rs
+++ b/crates/fjall/src/keys.rs
@@ -3,12 +3,12 @@
 //! All multi-byte integers are encoded as big-endian to ensure correct
 //! lexicographic ordering in the LSM tree.
 //!
-//! ## Index Store Keys
+//! ## Index Keys
 //!
 //! All index keys use dimension hashing for chain-agnostic storage:
-//! - **UTxO tag**: `[dim_hash:8][lookup_key:var][txo_ref:36]`
-//! - **Block tag**: `[dim_hash:8][xxh3(tag_key):8][slot:8]`
-//! - **Exact lookup**: `[dim_hash:8][key_data:var]`
+//! - **UTxO tag** (state store): `[dim_hash:8][lookup_key:var][txo_ref:36]`
+//! - **Block tag** (archive store): `[dim_hash:8][xxh3(tag_key):8][slot:8]`
+//! - **Exact lookup** (archive store): `[dim_hash:8][key_data:var]`
 //!
 //! ## State Store Keys
 //!
@@ -39,7 +39,7 @@ pub const DIM_HASH_SIZE: usize = 8;
 // Dimension Hashing (Chain-Agnostic Index Keys)
 // ============================================================================
 
-/// Internal dimension prefix constants for index store.
+/// Internal dimension prefix constants for the index keyspaces.
 ///
 /// These prefixes are combined with dimension strings to create unique
 /// hashes that distinguish between different index types (UTxO tags,

--- a/crates/fjall/src/lib.rs
+++ b/crates/fjall/src/lib.rs
@@ -1,17 +1,18 @@
 //! Fjall-based storage implementations for Dolos.
 //!
-//! This crate provides implementations of the `IndexStore` and `StateStore`
-//! traits using fjall, an LSM-tree based embedded database. Fjall is optimized
-//! for write-heavy workloads with many keys, which is ideal for blockchain
-//! data.
+//! This crate provides implementations of the `StateStore`, `ArchiveStore`
+//! and `IndexStore` traits using fjall, an LSM-tree based embedded database.
+//! Fjall is optimized for write-heavy workloads with many keys, which is ideal
+//! for blockchain data.
 //!
 //! ## Modules
 //!
-//! - [`index`]: Index store implementation for cross-cutting indexes
 //! - [`state`]: State store implementation for ledger state (UTxOs, entities,
-//!   datums)
+//!   datums) and the live-UTxO tags that project the UTxO set
 //! - [`archive`]: Archive store implementation (block bodies stay in the shared
-//!   flat segment files from `dolos-flatfiles`)
+//!   flat segment files from `dolos-flatfiles`), hosting the archive tags and
+//!   the exact lookups that project the blocks
+//! - [`index`]: Index store implementation, reduced to its cursor
 //! - [`keys`]: Shared key encoding utilities
 
 use dolos_core::{ArchiveError, IndexError, StateError};
@@ -22,7 +23,7 @@ pub mod keys;
 pub mod state;
 
 // Re-export main types for convenience
-pub use index::{IndexStore, IndexStoreWriter, SlotIter};
+pub use index::{IndexStore, IndexStoreWriter};
 pub use state::{StateStore, StateWriter};
 
 /// Error type for fjall storage operations

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -1665,7 +1665,7 @@ mod tests {
 
     #[tokio::test]
     async fn accounts_by_stake_addresses_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/addresses");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -1787,7 +1787,7 @@ mod tests {
 
     #[tokio::test]
     async fn accounts_by_stake_delegations_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/delegations");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -1926,7 +1926,7 @@ mod tests {
 
     #[tokio::test]
     async fn accounts_by_stake_registrations_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/registrations");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -2358,7 +2358,7 @@ mod tests {
 
     #[tokio::test]
     async fn accounts_by_stake_withdrawals_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/withdrawals");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -2478,7 +2478,7 @@ mod tests {
 
     #[tokio::test]
     async fn accounts_by_stake_transactions_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/transactions");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -883,7 +883,7 @@ mod tests {
 
     #[tokio::test]
     async fn addresses_total_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let address = app.vectors().address.as_str();
         let path = format!("/addresses/{address}/total");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[tokio::test]
     async fn addresses_transactions_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let address = app.vectors().address.as_str();
         let path = format!("/addresses/{address}/transactions");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -1121,7 +1121,7 @@ mod tests {
 
     #[tokio::test]
     async fn addresses_utxos_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let address = app.vectors().address.as_str();
         let path = format!("/addresses/{address}/utxos");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -21,7 +21,7 @@ use dolos_cardano::{
     model::AssetState,
     ChainSummary,
 };
-use dolos_core::{BlockSlot, Domain, EraCbor, IndexStore as _, StateStore as _};
+use dolos_core::{ArchiveStore as _, BlockSlot, Domain, EraCbor, StateStore as _};
 use futures_util::StreamExt;
 use itertools::Itertools;
 use pallas::{
@@ -564,7 +564,7 @@ where
     for (txoref, eracbor) in utxos {
         let sort = (
             domain
-                .indexes()
+                .archive()
                 .slot_by_tx_hash(txoref.0.as_slice())
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
                 .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
@@ -1107,7 +1107,7 @@ mod tests {
 
     #[tokio::test]
     async fn assets_by_subject_transactions_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let asset = app.vectors().asset_unit.as_str();
         let path = format!("/assets/{asset}/transactions");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -1236,7 +1236,7 @@ mod tests {
 
     #[tokio::test]
     async fn assets_by_subject_txs_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let asset = app.vectors().asset_unit.as_str();
         let path = format!("/assets/{asset}/txs");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/crates/minibf/src/routes/metadata.rs
+++ b/crates/minibf/src/routes/metadata.rs
@@ -357,7 +357,7 @@ mod tests {
 
     #[tokio::test]
     async fn metadata_label_json_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let label = app.vectors().metadata_label.as_str();
         let path = format!("/metadata/txs/labels/{label}");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -473,7 +473,7 @@ mod tests {
 
     #[tokio::test]
     async fn metadata_label_cbor_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let label = app.vectors().metadata_label.as_str();
         let path = format!("/metadata/txs/labels/{label}/cbor");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/crates/minibf/src/routes/txs.rs
+++ b/crates/minibf/src/routes/txs.rs
@@ -381,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -420,7 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_cbor_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/cbor");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -459,7 +459,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_utxos_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/utxos");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -498,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_metadata_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/metadata");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -537,7 +537,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_metadata_cbor_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/metadata/cbor");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -576,7 +576,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_redeemers_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/redeemers");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -615,7 +615,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_delegations_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/delegations");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -654,7 +654,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_mirs_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/mirs");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -693,7 +693,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_pool_retires_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/pool_retires");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -732,7 +732,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_pool_updates_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/pool_updates");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -771,7 +771,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_stakes_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/stakes");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -814,7 +814,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_required_signers_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/required_signers");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
@@ -853,7 +853,7 @@ mod tests {
 
     #[tokio::test]
     async fn txs_by_hash_withdrawals_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let tx_hash = app.vectors().tx_hash.as_str();
         let path = format!("/txs/{tx_hash}/withdrawals");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/crates/minikupo/src/routes/matches.rs
+++ b/crates/minikupo/src/routes/matches.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use dolos_cardano::{indexes::CardanoStateIndexExt, network_from_genesis, pallas_extras};
 use dolos_core::{
-    async_query::BlockRefMeta, Domain, EraCbor, IndexStore as _, StateStore as _, TxoRef, UtxoSet,
+    async_query::BlockRefMeta, ArchiveStore as _, Domain, EraCbor, StateStore as _, TxoRef, UtxoSet,
 };
 use pallas::codec::minicbor;
 use pallas::ledger::{
@@ -682,7 +682,7 @@ fn parse_slot_or_point<D: Domain>(value: &str, facade: &Facade<D>) -> Result<u64
             return Err(MatchError::BadRequest(slot_range_hint()));
         }
         let found_slot = facade
-            .indexes()
+            .archive()
             .slot_by_block_hash(&bytes)
             .map_err(|_| MatchError::Internal)?
             .ok_or_else(|| MatchError::BadRequest(slot_range_hint()))?;
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[tokio::test]
     async fn matches_internal_error() {
-        let app = TestApp::new_with_fault(Some(TestFault::IndexStoreError));
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let path = format!("/matches/{}", app.vectors().address);
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }

--- a/crates/snapshot/PROFILE.md
+++ b/crates/snapshot/PROFILE.md
@@ -58,7 +58,7 @@ Content records per kind (Dolos profile):
 | Kind | Record | Order | Restore write path |
 |---|---|---|---|
 | `blocks` (per epoch) | `[slot, hash: bytes(32), body: bytes]`, body = raw wire CBOR verbatim | ascending slot, stream order for same-slot (Byron EBB) | `ArchiveWriter::apply` |
-| `indexes` (per epoch) | tags: `[0, dimension: tstr, key_hash: bytes(8), slot]` with `key_hash = xxh3_64(key)` BE — except dimension `metadata`, see below; exact: `[1, kind: tstr, key: bytes, slot]` for block-hash/block-number/tx | sorted, deduped | new `IndexWriter::append_prehashed` |
+| `indexes` (per epoch) | tags: `[0, dimension: tstr, key_hash: bytes(8), slot]` with `key_hash = xxh3_64(key)` BE — except dimension `metadata`, see below; exact: `[1, kind: tstr, key: bytes, slot]` for block-hash/block-number/tx | sorted, deduped | new `ArchiveWriter::append_prehashed` |
 | `log-{ns}` (per epoch, per log namespace, omitted when empty) | `[log_key: bytes(40), value: bytes]`, value = stored EntityValue verbatim | `log_key` | `ArchiveWriter::write_log` into the namespace the kind names |
 | `state-{ns}` (tip or retained dump, per state namespace, `scope.shard` = 0..`parameters.shards[ns]`-1) | `[key: bytes, value: bytes]` | `key`; shard = first nibble of `key[0]` for a 16-way namespace, 0 for a single blob | dispatch on the kind: `state-utxos` → chunked `StateWriter::apply_utxoset`, else `write_entity` into the namespace the kind names |
 | `digests` (tip, optional) | `[immutable_number, chunk: bytes(32), primary: bytes(32), secondary: bytes(32)]`, each sha256 over the raw file bytes | ascending `immutable_number` | none — verification metadata, not written to stores |

--- a/crates/snapshot/src/backfill.rs
+++ b/crates/snapshot/src/backfill.rs
@@ -230,13 +230,7 @@ pub trait Publish<D: Domain> {
 
     /// Publish the plan. Retried in place by the daemon, so it must be safe to
     /// simply run again.
-    fn publish(
-        &self,
-        plan: &Plan,
-        archive: &D::Archive,
-        state: &D::State,
-        indexes: &D::Indexes,
-    ) -> Result<(), Error>;
+    fn publish(&self, plan: &Plan, archive: &D::Archive, state: &D::State) -> Result<(), Error>;
 }
 
 /// How a run ended, for a caller that has something to say about it.
@@ -652,10 +646,7 @@ impl<D: Domain> Driver<'_, D> {
         retry::transient(
             "publishing the pending sequence",
             &|| self.aborted(),
-            || {
-                self.publish
-                    .publish(&plan, &stores.archive, &stores.state, &stores.indexes)
-            },
+            || self.publish.publish(&plan, &stores.archive, &stores.state),
         )?;
 
         if self.until_epoch.is_some_and(|until| plan.sequence >= until) {

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -66,8 +66,8 @@ use dolos_cardano::{
     eras::ChainSummary, indexes::archive_dimensions, pallas::ledger::traverse::MultiEraBlock,
 };
 use dolos_core::{
-    ArchiveStore, BlockSlot, ChainPoint, EntityKey, IndexRecord, IndexStore, LogKey, Namespace,
-    StateStore, TemporalKey,
+    ArchiveStore, BlockSlot, ChainPoint, EntityKey, IndexRecord, LogKey, Namespace, StateStore,
+    TemporalKey,
 };
 use stelae::{
     inscription::{HistoryEntry, Inscription, LayerDescriptor},
@@ -148,7 +148,7 @@ impl IndexBand {
     ///
     /// A zstd compression context at level 9 and the framing around it.
     /// Measured at **10.3 MiB** by `measure_layer_sink_residency` in the root
-    /// package's `tests/index_roundtrip.rs` — thirty-two sinks opened against a
+    /// package's `tests/archive_index_roundtrip.rs` — thirty-two sinks opened against a
     /// real stele and each given records to compress, since a context that has
     /// never compressed anything has not yet allocated its window. Pinned above
     /// the measurement rather than at it, so a zstd whose level-9 parameters
@@ -701,13 +701,11 @@ pub use stelae_driver::Standing;
 /// through here, because the two halves of what an operator wants to see live
 /// in two places — this loop knows which layer of how many, and only the
 /// transport knows how much of it has moved.
-#[allow(clippy::too_many_arguments)]
-pub fn export<W, A, S, I>(
+pub fn export<W, A, S>(
     stele: &W,
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     previous: &dyn Predecessor,
     observer: &Observer,
@@ -716,7 +714,6 @@ where
     W: SteleWriter + Sync,
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     stele.observe(observer.clone());
 
@@ -759,7 +756,7 @@ where
     // the jobs around it.
     for band in plan.epochs.chunks(plan.band.epochs()) {
         jobs.push(Job::band(move || {
-            write_indexes(stele, plan, indexes, band, previous, cursor)
+            write_indexes(stele, plan, archive, band, previous, cursor)
         }));
     }
 
@@ -829,19 +826,17 @@ where
 /// crate. Refuses a directory that already holds an inscription: republishing
 /// over a stele in place would leave its old blobs behind, indistinguishable
 /// from the new ones.
-pub fn publish<A, S, I>(
+pub fn publish<A, S>(
     root: impl Into<std::path::PathBuf>,
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     observer: &Observer,
 ) -> Result<Inscription, Error>
 where
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     let stele = stelae::dir::SteleDir::create(root)?;
 
@@ -850,7 +845,6 @@ where
         plan,
         archive,
         state,
-        indexes,
         digest_records,
         &First,
         observer,
@@ -873,18 +867,16 @@ where
 /// the same stores chained differently are different digests. Pass
 /// [`First`] for a stele that starts a chain and [`Following`] for one that
 /// extends a predecessor's.
-pub fn reproduce<A, S, I>(
+pub fn reproduce<A, S>(
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     previous: &dyn Predecessor,
 ) -> Result<Inscription, Error>
 where
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     // Silent, and not for want of a caller to thread one through: a
     // reproduction stores nothing and moves nothing, so the only thing it could
@@ -896,7 +888,6 @@ where
         plan,
         archive,
         state,
-        indexes,
         digest_records,
         previous,
         &Observer::silent(),
@@ -928,19 +919,17 @@ pub struct Document {
 /// `previous` is the chain this reproduction is told to follow. It is an input
 /// and not an inference — `history` rides inside the canonical document, so the
 /// same stores chained differently are two different digests, deliberately.
-pub fn digest_document<A, S, I>(
+pub fn digest_document<A, S>(
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     previous: &dyn Predecessor,
 ) -> Result<Document, Error>
 where
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
-    let inscription = reproduce(plan, archive, state, indexes, None, previous)?;
+    let inscription = reproduce(plan, archive, state, None, previous)?;
 
     Ok(Document {
         canonical: inscription.canonicalize()?,
@@ -974,18 +963,16 @@ where
 /// [`Attested`] takes the published history verbatim and so — unlike
 /// [`Following::new`] — checks nothing about it; this is where that check
 /// lands.
-pub fn verify_reproduction<A, S, I>(
+pub fn verify_reproduction<A, S>(
     published: &Inscription,
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
 ) -> Result<Inscription, Error>
 where
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     if plan.sequence != published.sequence {
         return Err(Error::ReproductionMismatch {
@@ -1008,7 +995,6 @@ where
         plan,
         archive,
         state,
-        indexes,
         digest_records,
         &Attested::of(published),
         &Observer::silent(),
@@ -1623,10 +1609,10 @@ fn log_key_range(slots: &Range<BlockSlot>) -> Range<LogKey> {
 /// index layers rather than the ones before the dying epoch. There is nothing
 /// to save there — resuming into the middle of a band would have to re-traverse
 /// the store for the rest of it anyway.
-fn write_indexes<W: SteleWriter, I: IndexStore>(
+fn write_indexes<W: SteleWriter, A: ArchiveStore>(
     stele: &W,
     plan: &Plan,
-    store: &I,
+    store: &A,
     band: &[EpochWindow],
     previous: &dyn Predecessor,
     cursor: &Cursor<'_>,

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -112,7 +112,7 @@ impl EpochWindow {
     }
 }
 
-/// How many `indexes` layers one traversal of the index store fills.
+/// How many `indexes` layers one traversal of the archive store fills.
 ///
 /// ## Why a publish needs a band at all
 ///
@@ -278,11 +278,11 @@ pub struct Plan {
     /// derived from `summary` — which epochs are worth a dump is operational
     /// (decision 0026).
     pub retained: RetainedEpochs,
-    /// How many `indexes` layers one traversal of the index store fills.
+    /// How many `indexes` layers one traversal of the archive store fills.
     ///
     /// Execution rather than geometry: it changes neither which layers this
     /// publish writes nor a byte of what is in them, only how many passes over
-    /// the index store it takes to fill them. It rides on the plan because
+    /// the archive store it takes to fill them. It rides on the plan because
     /// every driver that walks these stores — [`export`], [`reproduce`],
     /// [`verify_reproduction`] — pays the same cost and should take the same
     /// band without each call site spelling it. See [`IndexBand`].
@@ -1576,9 +1576,9 @@ fn log_key_range(slots: &Range<BlockSlot>) -> Range<LogKey> {
 /// ## This is a scan, not a seek, which is why it is banded
 ///
 /// Neither traversal can seek to a slot, so a pass here costs a walk of the
-/// whole index store however few epochs it fills, and one epoch per pass makes
-/// a first publish O(N²). [`IndexBand`] states why the store cannot seek, what
-/// turns that into ⌈N/K⌉ passes, and the measurement K is sized on.
+/// whole archive store however few epochs it fills, and one epoch per pass
+/// makes a first publish O(N²). [`IndexBand`] states why the store cannot seek,
+/// what turns that into ⌈N/K⌉ passes, and the measurement K is sized on.
 ///
 /// ## Positions are handed out before anything is written
 ///
@@ -1712,7 +1712,7 @@ struct Building<K> {
 /// Send one index record to the layer whose epoch its slot falls in.
 ///
 /// A binary search rather than a walk of the band: this runs once per record,
-/// and a mainnet index store holds hundreds of millions of them.
+/// and a mainnet archive store holds hundreds of millions of them.
 ///
 /// A record that lands in no layer is **dropped on purpose** — see
 /// [`write_indexes`] for the two ways the band's span can cover a slot no layer

--- a/crates/snapshot/src/export.rs
+++ b/crates/snapshot/src/export.rs
@@ -148,11 +148,11 @@ impl IndexBand {
     ///
     /// A zstd compression context at level 9 and the framing around it.
     /// Measured at **10.3 MiB** by `measure_layer_sink_residency` in the root
-    /// package's `tests/archive_index_roundtrip.rs` — thirty-two sinks opened against a
-    /// real stele and each given records to compress, since a context that has
-    /// never compressed anything has not yet allocated its window. Pinned above
-    /// the measurement rather than at it, so a zstd whose level-9 parameters
-    /// grow does not silently overrun the ceiling.
+    /// package's `tests/archive_index_roundtrip.rs` — thirty-two sinks opened
+    /// against a real stele and each given records to compress, since a
+    /// context that has never compressed anything has not yet allocated its
+    /// window. Pinned above the measurement rather than at it, so a zstd
+    /// whose level-9 parameters grow does not silently overrun the ceiling.
     ///
     /// A constant because [`DEFAULT`](IndexBand::DEFAULT) is arithmetic over it
     /// rather than a number someone liked.

--- a/crates/snapshot/src/layers/indexes.rs
+++ b/crates/snapshot/src/layers/indexes.rs
@@ -25,8 +25,8 @@
 //! and `(kind, key)` — and a leading discriminant that sorts `0` before `1`.
 //! The layer therefore carries every tag record first, then every exact record,
 //! which is also the shape the two source iterators hand over
-//! ([`dolos_core::IndexStore::iter_archive_tags`] then
-//! [`dolos_core::IndexStore::iter_exact_records`]). Both runs are strictly
+//! ([`dolos_core::ArchiveStore::iter_archive_tags`] then
+//! [`dolos_core::ArchiveStore::iter_exact_records`]). Both runs are strictly
 //! ascending, so "sorted, deduped" is one rule rather than two.
 //!
 //! Exact records dedupe on `(kind, key)` and not on the slot behind it: a block

--- a/crates/snapshot/src/layers/mod.rs
+++ b/crates/snapshot/src/layers/mod.rs
@@ -15,8 +15,8 @@
 //!
 //! The ordering rules are ADR-004's, and three of the five are exactly the
 //! iteration order the source stores already promise
-//! ([`dolos_core::IndexStore::iter_archive_tags`],
-//! [`dolos_core::IndexStore::iter_exact_records`]). The validator is not a
+//! ([`dolos_core::ArchiveStore::iter_archive_tags`],
+//! [`dolos_core::ArchiveStore::iter_exact_records`]). The validator is not a
 //! substitute for that promise; it is what catches a driver that merges,
 //! chunks or parallelizes those iterators and loses it.
 //!

--- a/crates/snapshot/src/publisher.rs
+++ b/crates/snapshot/src/publisher.rs
@@ -17,7 +17,7 @@
 
 use std::path::PathBuf;
 
-use dolos_core::{config::RootConfig, ArchiveStore, IndexStore, StateStore};
+use dolos_core::{config::RootConfig, ArchiveStore, StateStore};
 use stelae::progress::Observer;
 use stelae_driver::Standing;
 
@@ -200,28 +200,18 @@ impl Publisher {
     }
 
     /// Publish, chained to whatever is already in the repository.
-    pub fn publish<A, S, I>(
+    pub fn publish<A, S>(
         &self,
         plan: &Plan,
         archive: &A,
         state: &S,
-        indexes: &I,
         observer: &Observer,
     ) -> Result<Published, Error>
     where
         A: ArchiveStore,
         S: StateStore,
-        I: IndexStore,
     {
-        registry::publish(
-            self.publishing(),
-            plan,
-            archive,
-            state,
-            indexes,
-            None,
-            observer,
-        )
+        registry::publish(self.publishing(), plan, archive, state, None, observer)
     }
 
     fn publishing(&self) -> Publishing<'_> {

--- a/crates/snapshot/src/registry.rs
+++ b/crates/snapshot/src/registry.rs
@@ -560,19 +560,17 @@ pub use stelae_driver::publish::{preflight, staging_peak, StagingPeak};
 ///
 /// `observer` is who hears about it while it runs, and [`Observer::silent`] is
 /// what a caller with nothing to render passes.
-pub fn publish<A, S, I>(
+pub fn publish<A, S>(
     publishing: Publishing<'_>,
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     observer: &Observer,
 ) -> Result<Published, Error>
 where
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     publish_into(
         publishing.registry,
@@ -580,7 +578,6 @@ where
         plan,
         archive,
         state,
-        indexes,
         digest_records,
         observer,
     )
@@ -598,14 +595,12 @@ where
 /// from what that transport is carrying, so a writer that puts the layers
 /// somewhere else would seal a manifest with holes in it. A decorator over the
 /// registry is the shape this takes; anything else is a caller misusing it.
-#[allow(clippy::too_many_arguments)]
-pub fn publish_into<W, A, S, I>(
+pub fn publish_into<W, A, S>(
     stele: &W,
     publishing: Publishing<'_>,
     plan: &Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     digest_records: Option<&[digests::ImmutableDigests]>,
     observer: &Observer,
 ) -> Result<Published, Error>
@@ -613,7 +608,6 @@ where
     W: SteleWriter + Sync,
     A: ArchiveStore,
     S: StateStore,
-    I: IndexStore,
 {
     let registry = publishing.registry;
     let latest = registry.latest(&DolosProfile)?;
@@ -628,7 +622,6 @@ where
         plan,
         archive,
         state,
-        indexes,
         digest_records,
         &previous,
         observer,

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -19,7 +19,7 @@
 //!    the protocol, so nothing but this crate can read an epoch out of one.
 //! 3. [`dolos_core::IndexStore::initialize_schema`].
 //! 4. Per epoch: `blocks`, then the `log-{ns}` layers the epoch carries, then
-//!    `indexes`.
+//!    `indexes` — all three into the archive store.
 //! 5. The state tip — every shard of every `state-{ns}` kind.
 //! 6. Rebuild the live-UTxO tags from the restored UTxO set, into the state
 //!    store beside it. They are never shipped — ADR-004's Amendment 2 — so this
@@ -999,7 +999,7 @@ where
             let at = cursor.open(INDEXES, &descriptor.scope);
 
             let (count, outcome) =
-                checkpoint.fetch(descriptor, || restore_indexes(&reader, descriptor, indexes))?;
+                checkpoint.fetch(descriptor, || restore_indexes(&reader, descriptor, archive))?;
 
             cursor.close(at, INDEXES, outcome);
             summary.count(outcome);
@@ -1031,13 +1031,12 @@ where
 
     rebuild_utxo_tags(state, budget)?;
 
-    // Align the index cursor, which `IndexWriter::append_prehashed`
-    // deliberately never touches: bootstrap still reads it, and without it the
-    // index store reads as never indexed.
+    // Align the index cursor, which nothing above wrote: the index records
+    // went into the archive, and bootstrap still reads this cursor — without
+    // it the index store reads as never indexed.
     let writer = indexes.start_writer()?;
     writer.apply(&IndexDelta {
         cursor: plan.position.point.clone(),
-        ..Default::default()
     })?;
     writer.commit()?;
 
@@ -1323,17 +1322,20 @@ fn restore_logs<R: SteleReader, A: ArchiveStore>(
 /// is this caller's, which is what the trait says, and the sort order the
 /// backends want holds across the whole layer because that is what the codec's
 /// `OrderCheck` made the exporter prove.
-fn restore_indexes<R: SteleReader, I: IndexStore>(
+///
+/// The records go into the archive, beside the blocks they project — the same
+/// store `restore_blocks` wrote the epoch's `blocks` layer into.
+fn restore_indexes<R: SteleReader, A: ArchiveStore>(
     reader: &Reader<'_, R>,
     descriptor: &LayerDescriptor,
-    indexes: &I,
+    archive: &A,
 ) -> Result<u64, Error> {
     reader.drain(
         descriptor,
         indexes::decode,
         |_| std::mem::size_of::<IndexRecord>(),
         |chunk| {
-            let writer = indexes.start_writer()?;
+            let writer = archive.start_writer()?;
 
             writer.append_prehashed(chunk)?;
             writer.commit()?;

--- a/crates/snapshot/tests/export.rs
+++ b/crates/snapshot/tests/export.rs
@@ -43,9 +43,9 @@ use dolos_cardano::{
     pallas::ledger::traverse::MultiEraBlock, EraBoundary,
 };
 use dolos_core::{
-    builtin::{MemoryArchiveStore, MemoryIndexStore, MemoryStateStore},
-    ArchiveStore, ArchiveWriter as _, BlockSlot, ChainPoint, Domain, EntityKey, ExactRecord,
-    IndexRecord, IndexStore, IndexWriter as _, LogKey, Namespace, StateStore, StateWriter as _,
+    builtin::{MemoryArchiveStore, MemoryStateStore},
+    ArchiveError, ArchiveStore, ArchiveWriter as _, BlockBody, BlockSlot, ChainPoint, Domain,
+    EntityKey, ExactRecord, IndexRecord, LogKey, Namespace, StateStore, StateWriter as _,
     TagRecord, TemporalKey,
 };
 use dolos_snapshot::{
@@ -104,8 +104,8 @@ fn skeleton_point() -> ChainPoint {
     ChainPoint::Specific(SKELETON_SLOT, dolos_core::BlockHash::new([0x0b; 32]))
 }
 
-/// An archive, state and index store holding nothing but a cursor.
-fn empty_stores() -> (MemoryArchiveStore, MemoryStateStore, MemoryIndexStore) {
+/// An archive and a state store holding nothing but a cursor.
+fn empty_stores() -> (MemoryArchiveStore, MemoryStateStore) {
     let archive = MemoryArchiveStore::new(dolos_cardano::model::build_schema());
 
     let state = MemoryStateStore::new();
@@ -113,7 +113,7 @@ fn empty_stores() -> (MemoryArchiveStore, MemoryStateStore, MemoryIndexStore) {
     writer.set_cursor(skeleton_point()).unwrap();
     writer.commit().unwrap();
 
-    (archive, state, MemoryIndexStore::new())
+    (archive, state)
 }
 
 /// Done criterion 4.
@@ -128,7 +128,7 @@ fn an_empty_store_set_exports_the_pinned_skeleton() {
     let temp = tempfile::tempdir().unwrap();
     let stele = SteleDir::create(temp.path()).unwrap();
 
-    let (archive, state, index) = empty_stores();
+    let (archive, state) = empty_stores();
 
     let plan = Plan::new(
         &skeleton_summary(),
@@ -143,7 +143,6 @@ fn an_empty_store_set_exports_the_pinned_skeleton() {
         &plan,
         &archive,
         &state,
-        &index,
         None,
         &export::First,
         &Observer::silent(),
@@ -189,7 +188,7 @@ fn a_log_under_an_uncovered_namespace_fails_the_export() {
     let temp = tempfile::tempdir().unwrap();
     let stele = SteleDir::create(temp.path()).unwrap();
 
-    let (archive, state, index) = empty_stores();
+    let (archive, state) = empty_stores();
 
     let stray = NAMESPACES
         .into_iter()
@@ -215,7 +214,6 @@ fn a_log_under_an_uncovered_namespace_fails_the_export() {
         &plan,
         &archive,
         &state,
-        &index,
         None,
         &export::First,
         &Observer::silent(),
@@ -528,7 +526,7 @@ fn expected_indexes<B: ToyStores>(domain: &ToyDomain<B>, window: &EpochWindow) -
     let slots = window.slots();
 
     let mut tags: Vec<TagRecord> = domain
-        .indexes()
+        .archive()
         .iter_archive_tags(&archive_dimensions::ALL, slots.clone())
         .unwrap()
         .map(Result::unwrap)
@@ -537,7 +535,7 @@ fn expected_indexes<B: ToyStores>(domain: &ToyDomain<B>, window: &EpochWindow) -
     tags.sort();
 
     let mut exact: Vec<ExactRecord> = domain
-        .indexes()
+        .archive()
         .iter_exact_records(slots)
         .unwrap()
         .map(Result::unwrap)
@@ -834,7 +832,6 @@ fn a_failing_producer_fails_the_pooled_export() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::First,
         &Observer::silent(),
@@ -1073,15 +1070,9 @@ fn a_reproduction_rebuilds_the_dump_it_cuts_and_trusts_the_ones_it_inherits() {
     let temp = tempfile::tempdir().unwrap();
     let cut = export_plan(temp.path(), &domain, &cutting);
 
-    let reproduced = export::verify_reproduction(
-        &cut,
-        &cutting,
-        domain.archive(),
-        domain.state(),
-        domain.indexes(),
-        None,
-    )
-    .unwrap();
+    let reproduced =
+        export::verify_reproduction(&cut, &cutting, domain.archive(), domain.state(), None)
+            .unwrap();
 
     assert_eq!(reproduced, cut);
     assert_eq!(dumps_in(&reproduced)[&1].len(), state_layer_count());
@@ -1092,7 +1083,6 @@ fn a_reproduction_rebuilds_the_dump_it_cuts_and_trusts_the_ones_it_inherits() {
         &cutting,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::First,
     )
@@ -1109,7 +1099,6 @@ fn a_reproduction_rebuilds_the_dump_it_cuts_and_trusts_the_ones_it_inherits() {
         &following_plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::Following::read(&canonical, &following_plan).unwrap(),
     )
@@ -1125,7 +1114,6 @@ fn a_reproduction_rebuilds_the_dump_it_cuts_and_trusts_the_ones_it_inherits() {
         &following_plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
     )
     .unwrap();
@@ -1260,7 +1248,6 @@ fn a_discarding_export_reproduces_what_a_publish_stores() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::First,
         &Observer::silent(),
@@ -1315,7 +1302,6 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &Observer::silent(),
     )
@@ -1326,7 +1312,6 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::First,
         &Observer::silent(),
@@ -1349,7 +1334,6 @@ fn a_restricted_reproduction_matches_the_same_restricted_publish() {
         &plan_for(&domain),
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &export::First,
         &Observer::silent(),
@@ -1395,7 +1379,6 @@ fn a_directory_publish_reports_every_layer_and_record() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &watcher.observer(),
     )
@@ -1460,7 +1443,6 @@ fn a_silent_publish_writes_exactly_what_a_watched_one_does() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &watcher.observer(),
     )
@@ -1471,7 +1453,6 @@ fn a_silent_publish_writes_exactly_what_a_watched_one_does() {
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &Observer::silent(),
     )
@@ -1499,7 +1480,7 @@ struct Counted<S> {
     exacts: Arc<AtomicUsize>,
 }
 
-impl<S: IndexStore> Counted<S> {
+impl<S: ArchiveStore> Counted<S> {
     fn new(inner: S) -> Self {
         Self {
             inner,
@@ -1518,40 +1499,76 @@ impl<S: IndexStore> Counted<S> {
     }
 }
 
-impl<S: IndexStore> IndexStore for Counted<S> {
+impl<S: ArchiveStore> ArchiveStore for Counted<S> {
+    type BlockIter<'a> = S::BlockIter<'a>;
     type Writer = S::Writer;
+    type LogIter = S::LogIter;
+    type EntityValueIter = S::EntityValueIter;
     type SlotIter = S::SlotIter;
     type TagIter = S::TagIter;
     type ExactIter = S::ExactIter;
 
-    fn start_writer(&self) -> Result<Self::Writer, dolos_core::IndexError> {
+    fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         self.inner.start_writer()
     }
 
-    fn initialize_schema(&self) -> Result<(), dolos_core::IndexError> {
-        self.inner.initialize_schema()
+    fn read_logs(
+        &self,
+        ns: Namespace,
+        keys: &[&LogKey],
+    ) -> Result<Vec<Option<dolos_core::EntityValue>>, ArchiveError> {
+        self.inner.read_logs(ns, keys)
     }
 
-    fn copy(&self, target: &Self) -> Result<(), dolos_core::IndexError> {
-        self.inner.copy(&target.inner)
+    fn iter_logs(
+        &self,
+        ns: Namespace,
+        range: std::ops::Range<LogKey>,
+    ) -> Result<Self::LogIter, ArchiveError> {
+        self.inner.iter_logs(ns, range)
     }
 
-    fn cursor(&self) -> Result<Option<ChainPoint>, dolos_core::IndexError> {
-        self.inner.cursor()
+    fn get_block_by_slot(&self, slot: &BlockSlot) -> Result<Option<BlockBody>, ArchiveError> {
+        self.inner.get_block_by_slot(slot)
     }
 
-    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+    fn get_blocks_by_slot(&self, slot: &BlockSlot) -> Result<Vec<BlockBody>, ArchiveError> {
+        self.inner.get_blocks_by_slot(slot)
+    }
+
+    fn get_range<'a>(
+        &self,
+        from: Option<BlockSlot>,
+        to: Option<BlockSlot>,
+    ) -> Result<Self::BlockIter<'a>, ArchiveError> {
+        self.inner.get_range(from, to)
+    }
+
+    fn find_intersect(&self, intersect: &[ChainPoint]) -> Result<Option<ChainPoint>, ArchiveError> {
+        self.inner.find_intersect(intersect)
+    }
+
+    fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
+        self.inner.get_tip()
+    }
+
+    fn prune_history(&self, max_slots: u64, max_prune: Option<u64>) -> Result<bool, ArchiveError> {
+        self.inner.prune_history(max_slots, max_prune)
+    }
+
+    fn truncate_front(&self, after: &ChainPoint) -> Result<(), ArchiveError> {
+        self.inner.truncate_front(after)
+    }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
         self.inner.slot_by_block_hash(hash)
     }
 
-    fn slot_by_block_number(
-        &self,
-        number: u64,
-    ) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
         self.inner.slot_by_block_number(number)
     }
 
-    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, dolos_core::IndexError> {
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
         self.inner.slot_by_tx_hash(hash)
     }
 
@@ -1561,7 +1578,7 @@ impl<S: IndexStore> IndexStore for Counted<S> {
         key: &[u8],
         start: BlockSlot,
         end: BlockSlot,
-    ) -> Result<Self::SlotIter, dolos_core::IndexError> {
+    ) -> Result<Self::SlotIter, ArchiveError> {
         self.inner.slots_by_tag(dimension, key, start, end)
     }
 
@@ -1569,7 +1586,7 @@ impl<S: IndexStore> IndexStore for Counted<S> {
         &self,
         dimensions: &[dolos_core::TagDimension],
         slots: std::ops::Range<BlockSlot>,
-    ) -> Result<Self::TagIter, dolos_core::IndexError> {
+    ) -> Result<Self::TagIter, ArchiveError> {
         self.tags.fetch_add(1, Ordering::Relaxed);
 
         self.inner.iter_archive_tags(dimensions, slots)
@@ -1578,7 +1595,7 @@ impl<S: IndexStore> IndexStore for Counted<S> {
     fn iter_exact_records(
         &self,
         slots: std::ops::Range<BlockSlot>,
-    ) -> Result<Self::ExactIter, dolos_core::IndexError> {
+    ) -> Result<Self::ExactIter, ArchiveError> {
         self.exacts.fetch_add(1, Ordering::Relaxed);
 
         self.inner.iter_exact_records(slots)
@@ -1591,8 +1608,8 @@ impl<S: IndexStore> IndexStore for Counted<S> {
 /// Two blocks per epoch, each carrying tags in every dimension and the three
 /// exact kinds a block produces. Nothing here has to be a real ledger: what the
 /// banded pass does with a record is decided by its slot alone.
-fn index_across_the_skeleton() -> MemoryIndexStore {
-    let store = MemoryIndexStore::new();
+fn index_across_the_skeleton() -> MemoryArchiveStore {
+    let store = MemoryArchiveStore::new(dolos_cardano::model::build_schema());
     let writer = store.start_writer().unwrap();
 
     let mut archive = Vec::new();
@@ -1614,12 +1631,8 @@ fn index_across_the_skeleton() -> MemoryIndexStore {
         }
     }
 
-    writer
-        .apply(&dolos_core::IndexDelta {
-            cursor: ChainPoint::Slot(SKELETON_SLOT),
-            archive,
-        })
-        .unwrap();
+    writer.apply_index(&archive).unwrap();
+    writer.commit().unwrap();
 
     store
 }
@@ -1630,8 +1643,8 @@ fn export_banded(band: usize) -> (usize, usize, usize, Vec<u8>) {
     let temp = tempfile::tempdir().unwrap();
     let stele = SteleDir::create(temp.path()).unwrap();
 
-    let (archive, state, _) = empty_stores();
-    let indexes = Counted::new(index_across_the_skeleton());
+    let (_, state) = empty_stores();
+    let archive = Counted::new(index_across_the_skeleton());
 
     let plan = Plan::new(
         &skeleton_summary(),
@@ -1649,7 +1662,6 @@ fn export_banded(band: usize) -> (usize, usize, usize, Vec<u8>) {
         &plan,
         &archive,
         &state,
-        &indexes,
         None,
         &export::First,
         &watcher.observer(),
@@ -1658,7 +1670,7 @@ fn export_banded(band: usize) -> (usize, usize, usize, Vec<u8>) {
 
     watcher.assert_well_formed(inscription.layers.len());
 
-    let (tags, exacts) = indexes.traversals();
+    let (tags, exacts) = archive.traversals();
 
     (
         tags,

--- a/crates/snapshot/tests/node/mod.rs
+++ b/crates/snapshot/tests/node/mod.rs
@@ -219,7 +219,6 @@ mod registry_node {
                 plan,
                 self.domain.archive(),
                 self.domain.state(),
-                self.domain.indexes(),
                 None,
                 observer,
             )
@@ -239,7 +238,6 @@ mod registry_node {
                 plan,
                 self.domain.archive(),
                 self.domain.state(),
-                self.domain.indexes(),
                 None,
                 &Observer::silent(),
             )
@@ -331,7 +329,6 @@ pub fn export_plan<B: ToyStores>(
         plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &First,
         &Observer::silent(),

--- a/crates/snapshot/tests/publish.rs
+++ b/crates/snapshot/tests/publish.rs
@@ -833,7 +833,6 @@ fn a_stele_published_with_reuse_is_reproduced_from_the_stores() {
         &node.second,
         node.domain.archive(),
         node.domain.state(),
-        node.domain.indexes(),
         None,
         &following,
     )
@@ -860,7 +859,6 @@ fn a_stele_published_with_reuse_is_reproduced_from_the_stores() {
         &node.second,
         node.domain.archive(),
         node.domain.state(),
-        node.domain.indexes(),
         None,
         &export::First,
     )

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -537,7 +537,6 @@ fn roundtrip<B: ToyStores>() {
             &plan,
             &blank.archive,
             blank.state(),
-            blank.indexes(),
             None,
             &dolos_snapshot::export::First,
             &Observer::silent(),
@@ -597,7 +596,12 @@ fn a_restored_node_matches_a_replayed_one_on_fjall() {
 fn assert_stores_match<B: ToyStores>(restored: &Blank<B>, original: &ToyDomain<B>) {
     assert_state_matches(restored.state(), original.state());
     assert_archive_matches(&restored.archive, original.archive());
-    assert_indexes_match(restored.indexes(), original.indexes());
+    assert_indexes_match(&restored.archive, original.archive());
+    assert_eq!(
+        restored.indexes().cursor().unwrap(),
+        original.indexes().cursor().unwrap(),
+        "index cursor"
+    );
     assert_utxo_tags_match(restored.state(), original.state());
 }
 
@@ -661,14 +665,8 @@ fn assert_archive_matches<A: ArchiveStore>(restored: &A, original: &A) {
     assert!(any, "the fixture wrote no logs, so this proves nothing");
 }
 
-/// The archive half of the index store: the records the layers carry.
-fn assert_indexes_match<I: IndexStore>(restored: &I, original: &I) {
-    assert_eq!(
-        restored.cursor().unwrap(),
-        original.cursor().unwrap(),
-        "cursor"
-    );
-
+/// The index half of the archive: the records the `indexes` layers carry.
+fn assert_indexes_match<A: ArchiveStore>(restored: &A, original: &A) {
     let tags = tags_of(original);
     assert!(!tags.is_empty(), "the fixture produced no archive tags");
     assert_eq!(tags_of(restored), tags, "archive tags");
@@ -743,7 +741,7 @@ fn logs_of<A: ArchiveStore>(store: &A, ns: &'static str) -> Vec<(LogKey, Vec<u8>
         .collect()
 }
 
-fn tags_of<I: IndexStore>(store: &I) -> Vec<TagRecord> {
+fn tags_of<A: ArchiveStore>(store: &A) -> Vec<TagRecord> {
     let mut found: Vec<TagRecord> = store
         .iter_archive_tags(&archive_dimensions::ALL, 0..u64::MAX)
         .unwrap()
@@ -754,7 +752,7 @@ fn tags_of<I: IndexStore>(store: &I) -> Vec<TagRecord> {
     found
 }
 
-fn exact_of<I: IndexStore>(store: &I) -> Vec<ExactRecord> {
+fn exact_of<A: ArchiveStore>(store: &A) -> Vec<ExactRecord> {
     let mut found: Vec<ExactRecord> = store
         .iter_exact_records(0..u64::MAX)
         .unwrap()
@@ -1282,7 +1280,12 @@ fn a_newer_inscription_keeps_the_epoch_layers_and_redoes_the_tip() {
 
     assert_state_matches(blank.state(), reference.state());
     assert_archive_matches(&blank.archive, &reference.archive);
-    assert_indexes_match(blank.indexes(), reference.indexes());
+    assert_indexes_match(&blank.archive, &reference.archive);
+    assert_eq!(
+        blank.indexes().cursor().unwrap(),
+        reference.indexes().cursor().unwrap(),
+        "index cursor"
+    );
     assert_utxo_tags_match(blank.state(), reference.state());
 }
 
@@ -1326,7 +1329,6 @@ fn export_standing_at<B: ToyStores>(
         &plan,
         domain.archive(),
         domain.state(),
-        domain.indexes(),
         None,
         &dolos_snapshot::export::First,
         &Observer::silent(),

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -139,7 +139,6 @@ impl Node {
             plan,
             self.domain.archive(),
             self.domain.state(),
-            self.domain.indexes(),
             None,
             &Observer::silent(),
         )
@@ -242,7 +241,6 @@ fn a_registry_restore_is_a_directory_restore() {
             &node.first,
             node.domain.archive(),
             node.domain.state(),
-            node.domain.indexes(),
             None,
             &dolos_snapshot::export::First,
             &Observer::silent(),
@@ -688,7 +686,12 @@ impl SteleReader for Interrupted<'_> {
 fn assert_stores_match<B: ToyStores>(left: &Blank<B>, right: &Blank<B>) {
     assert_state_matches(left.state(), right.state());
     assert_archive_matches(&left.archive, &right.archive);
-    assert_indexes_match(left.indexes(), right.indexes());
+    assert_indexes_match(&left.archive, &right.archive);
+    assert_eq!(
+        left.indexes().cursor().unwrap(),
+        right.indexes().cursor().unwrap(),
+        "index cursor"
+    );
     assert_utxo_tags_match(left.state(), right.state());
 }
 
@@ -749,10 +752,8 @@ fn assert_archive_matches<A: ArchiveStore>(left: &A, right: &A) {
     assert!(any, "the fixture wrote no logs, so this proves nothing");
 }
 
-/// The archive half of the index store: the records the layers carry.
-fn assert_indexes_match<I: IndexStore>(left: &I, right: &I) {
-    assert_eq!(left.cursor().unwrap(), right.cursor().unwrap(), "cursor");
-
+/// The index half of the archive: the records the `indexes` layers carry.
+fn assert_indexes_match<A: ArchiveStore>(left: &A, right: &A) {
     let tags = tags_of(right);
     assert!(!tags.is_empty(), "the fixture produced no archive tags");
     assert_eq!(tags_of(left), tags, "archive tags");
@@ -821,7 +822,7 @@ fn logs_of<A: ArchiveStore>(store: &A, ns: &'static str) -> Vec<(LogKey, Vec<u8>
         .collect()
 }
 
-fn tags_of<I: IndexStore>(store: &I) -> Vec<TagRecord> {
+fn tags_of<A: ArchiveStore>(store: &A) -> Vec<TagRecord> {
     let mut found: Vec<TagRecord> = store
         .iter_archive_tags(&archive_dimensions::ALL, 0..u64::MAX)
         .unwrap()
@@ -832,7 +833,7 @@ fn tags_of<I: IndexStore>(store: &I) -> Vec<TagRecord> {
     found
 }
 
-fn exact_of<I: IndexStore>(store: &I) -> Vec<ExactRecord> {
+fn exact_of<A: ArchiveStore>(store: &A) -> Vec<ExactRecord> {
     let mut found: Vec<ExactRecord> = store
         .iter_exact_records(0..u64::MAX)
         .unwrap()

--- a/crates/snapshot/tests/snapshot_verify.rs
+++ b/crates/snapshot/tests/snapshot_verify.rs
@@ -262,7 +262,6 @@ fn a_reproduction_passes_at_the_published_epoch_and_fails_at_another() {
         &node.second,
         node.domain.archive(),
         node.domain.state(),
-        node.domain.indexes(),
         None,
     )
     .unwrap();
@@ -274,7 +273,6 @@ fn a_reproduction_passes_at_the_published_epoch_and_fails_at_another() {
         &node.first,
         node.domain.archive(),
         node.domain.state(),
-        node.domain.indexes(),
         None,
     )
     .unwrap_err();
@@ -350,7 +348,6 @@ fn an_inspection_reports_the_manifest_and_its_json_chains_a_digest() {
         &node.second,
         node.domain.archive(),
         node.domain.state(),
-        node.domain.indexes(),
         None,
         &following,
     )

--- a/crates/testing/src/faults.rs
+++ b/crates/testing/src/faults.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use dolos_core::{
     builtin::{MemoryArchiveStore, MemoryIndexStore, MemoryStateStore},
     ArchiveError, ArchiveStore, BlockBody, BlockSlot, ChainPoint, Domain, DomainError, IndexDelta,
-    IndexError, IndexRecord, IndexStore, IndexWriter, LogEntry, LogKey, LogValue, Namespace,
-    StateError, StateStore, StateWriter, TagDimension, TipEvent, UtxoIndexDelta, WalError,
-    WalStore,
+    IndexError, IndexStore, IndexWriter, LogEntry, LogKey, LogValue, Namespace, StateError,
+    StateStore, StateWriter, TagDimension, TipEvent, UtxoIndexDelta, WalError, WalStore,
 };
 
 use crate::toy_domain::{Mempool, TipSubscription, ToyDomain};
@@ -240,6 +239,9 @@ impl ArchiveStore for FaultyArchiveStore {
     type Writer = <MemoryArchiveStore as ArchiveStore>::Writer;
     type LogIter = <MemoryArchiveStore as ArchiveStore>::LogIter;
     type EntityValueIter = <MemoryArchiveStore as ArchiveStore>::EntityValueIter;
+    type SlotIter = <MemoryArchiveStore as ArchiveStore>::SlotIter;
+    type TagIter = <MemoryArchiveStore as ArchiveStore>::TagIter;
+    type ExactIter = <MemoryArchiveStore as ArchiveStore>::ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         if self.should_fault() {
@@ -322,6 +324,61 @@ impl ArchiveStore for FaultyArchiveStore {
         }
         self.inner.truncate_front(after)
     }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.slot_by_block_hash(hash)
+    }
+
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.slot_by_block_number(number)
+    }
+
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.slot_by_tx_hash(hash)
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.slots_by_tag(dimension, key, start, end)
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.iter_archive_tags(dimensions, slots)
+    }
+
+    fn iter_exact_records(
+        &self,
+        slots: std::ops::Range<BlockSlot>,
+    ) -> Result<Self::ExactIter, ArchiveError> {
+        if self.should_fault() {
+            return Err(self.fault_err());
+        }
+        self.inner.iter_exact_records(slots)
+    }
 }
 
 #[derive(Clone)]
@@ -346,9 +403,6 @@ impl FaultyIndexStore {
 
 impl IndexStore for FaultyIndexStore {
     type Writer = FaultyIndexWriter;
-    type SlotIter = <MemoryIndexStore as IndexStore>::SlotIter;
-    type TagIter = <MemoryIndexStore as IndexStore>::TagIter;
-    type ExactIter = <MemoryIndexStore as IndexStore>::ExactIter;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         if self.should_fault() {
@@ -379,61 +433,6 @@ impl IndexStore for FaultyIndexStore {
         }
         self.inner.cursor()
     }
-
-    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.slot_by_block_hash(hash)
-    }
-
-    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.slot_by_block_number(number)
-    }
-
-    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.slot_by_tx_hash(hash)
-    }
-
-    fn slots_by_tag(
-        &self,
-        dimension: TagDimension,
-        key: &[u8],
-        start: BlockSlot,
-        end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.slots_by_tag(dimension, key, start, end)
-    }
-
-    fn iter_archive_tags(
-        &self,
-        dimensions: &[TagDimension],
-        slots: std::ops::Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.iter_archive_tags(dimensions, slots)
-    }
-
-    fn iter_exact_records(
-        &self,
-        slots: std::ops::Range<BlockSlot>,
-    ) -> Result<Self::ExactIter, IndexError> {
-        if self.should_fault() {
-            return Err(self.fault_err());
-        }
-        self.inner.iter_exact_records(slots)
-    }
 }
 
 pub struct FaultyIndexWriter {
@@ -443,17 +442,6 @@ pub struct FaultyIndexWriter {
 impl IndexWriter for FaultyIndexWriter {
     fn apply(&self, delta: &IndexDelta) -> Result<(), IndexError> {
         self.inner.apply(delta)
-    }
-
-    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError> {
-        self.inner.undo(delta)
-    }
-
-    fn append_prehashed(
-        &self,
-        records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError> {
-        self.inner.append_prehashed(records)
     }
 
     fn commit(self) -> Result<(), IndexError> {

--- a/docs/content/architecture/data-layer.mdx
+++ b/docs/content/architecture/data-layer.mdx
@@ -57,6 +57,12 @@ A few concepts recur across the stores:
 - **`EntityDelta` (apply / undo).** Every state change is expressed as a delta that carries enough of the previous value to reverse itself. Applying deltas rolls the ledger forward; undoing them (from the WAL) rolls it back. This is the mechanism that makes rollbacks exact — see the [Sync Pipeline](./sync-pipeline).
 - **`EpochValue` snapshot window.** Cardano staking reads state as it was several epochs ago. State entities that participate in staking are stored as a rotating window of snapshots (live / mark / set / go / next). The details are covered in the [Ledger Model](./ledger-model).
 - **Archive dual storage.** Block bodies are written to append-only flatfile segments (one segment per Cardano epoch), while a compact index maps each slot to its `(segment, offset, length)` location. Historical entity changes are stored as `(slot, entity-key) → value` logs, enabling range queries over time.
-- **Index dimensions.** Tag multimaps keyed by address, payment credential, stake credential, policy id, and asset id. The live ones point at the matching UTxOs and live in the state store's `state-tags` keyspace, written in the same batch as the UTxO set; the historical ones point at slots and live in the index store.
+- **Index dimensions.** Tag multimaps keyed by address, payment credential, stake credential, policy id, and asset id. The live ones point at the matching UTxOs and live in the state store's `state-tags` keyspace, written in the same batch as the UTxO set; the historical ones point at slots and live in the archive store's `archive-tags` keyspace, beside the `index-exact` keyspace that resolves a block hash, block number or transaction hash to its slot — both written in the same batch as the blocks they project. The index store keeps only its cursor.
+
+| Store | Keyspaces |
+|---|---|
+| state | `state-cursor`, `state-utxos`, `state-entities`, `state-tags` |
+| archive | `archive-blocks`, `archive-logs`, `archive-tags`, `index-exact` |
+| index | `index-cursor` |
 
 Source: `crates/core/src/{state,archive,wal,indexes,mempool}.rs`, `crates/redb3/src/*`, `crates/fjall/src/*`, and storage configuration in `crates/core/src/config.rs`.

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -7,7 +7,6 @@ use dolos_cardano::CardanoLogic;
 use dolos_core::{
     archive::ArchiveStore as _,
     config::{StorageConfig, SyncConfig},
-    indexes::IndexStore as _,
     *,
 };
 use pallas::ledger::traverse::MultiEraBlock;
@@ -173,7 +172,7 @@ impl pallas::interop::utxorpc::LedgerContext for DomainAdapter {
         }
 
         for (tx_hash_bytes, txo_refs) in by_tx {
-            let Ok(Some(slot)) = self.indexes().slot_by_tx_hash(&tx_hash_bytes) else {
+            let Ok(Some(slot)) = self.archive().slot_by_tx_hash(&tx_hash_bytes) else {
                 continue;
             };
             let Ok(Some(block_bytes)) = self.archive().get_block_by_slot(&slot) else {

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -25,12 +25,12 @@ use dolos_core::{
         MempoolStoreConfig, RedbStateConfig, RedbWalConfig, RootConfig, StateStoreConfig,
         StorageVersion, WalStoreConfig,
     },
-    BlockBody, BlockSlot, ChainPoint, EntityDelta, EntityKey, EntityValue, ExactRecord, IndexDelta,
-    IndexError, IndexRecord, IndexStore as CoreIndexStore, IndexWriter as CoreIndexWriter,
-    LogEntry, LogValue, MempoolError, MempoolEvent, MempoolStore, MempoolTx, Namespace, RawBlock,
-    StateError, StateSchema, StateStore as CoreStateStore, StateWriter as CoreStateWriter,
-    TagDimension, TagRecord, TxHash, TxStatus, TxoRef, UtxoEntry, UtxoIndexDelta, UtxoMap, UtxoSet,
-    UtxoSetDelta, WalError, WalStore,
+    ArchiveIndexDelta, BlockBody, BlockSlot, ChainPoint, EntityDelta, EntityKey, EntityValue,
+    ExactRecord, IndexDelta, IndexError, IndexRecord, IndexStore as CoreIndexStore,
+    IndexWriter as CoreIndexWriter, LogEntry, LogValue, MempoolError, MempoolEvent, MempoolStore,
+    MempoolTx, Namespace, RawBlock, StateError, StateSchema, StateStore as CoreStateStore,
+    StateWriter as CoreStateWriter, TagDimension, TagRecord, TxHash, TxStatus, TxoRef, UtxoEntry,
+    UtxoIndexDelta, UtxoMap, UtxoSet, UtxoSetDelta, WalError, WalStore,
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -790,7 +790,8 @@ impl ArchiveStoreBackend {
 
 pub enum ArchiveWriterBackend {
     Memory(Box<<MemoryArchiveStore as CoreArchiveStore>::Writer>),
-    /// Delegates `write_log` and `commit`; discards `apply` and `undo`.
+    /// Delegates `write_log` and `commit`; discards `apply`, `undo` and the
+    /// index writes, which project the blocks the gate refuses.
     LogsOnly(Box<ArchiveWriterBackend>),
     Fjall(Box<<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::Writer>),
     NoOp(NoOpArchiveWriter),
@@ -826,6 +827,36 @@ impl CoreArchiveWriter for ArchiveWriterBackend {
             Self::LogsOnly(_) => Ok(()),
             Self::Fjall(w) => w.undo(point),
             Self::NoOp(w) => w.undo(point),
+        }
+    }
+
+    fn apply_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        match self {
+            Self::Memory(w) => w.apply_index(deltas),
+            Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.apply_index(deltas),
+            Self::NoOp(w) => w.apply_index(deltas),
+        }
+    }
+
+    fn undo_index(&self, deltas: &[ArchiveIndexDelta]) -> Result<(), ArchiveError> {
+        match self {
+            Self::Memory(w) => w.undo_index(deltas),
+            Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.undo_index(deltas),
+            Self::NoOp(w) => w.undo_index(deltas),
+        }
+    }
+
+    fn append_prehashed(
+        &self,
+        records: impl IntoIterator<Item = IndexRecord>,
+    ) -> Result<(), ArchiveError> {
+        match self {
+            Self::Memory(w) => w.append_prehashed(records),
+            Self::LogsOnly(_) => Ok(()),
+            Self::Fjall(w) => w.append_prehashed(records),
+            Self::NoOp(w) => w.append_prehashed(records),
         }
     }
 
@@ -918,11 +949,75 @@ impl Iterator for ArchiveEntityValueIterBackend {
     }
 }
 
+pub enum ArchiveSlotIterBackend {
+    Memory(<MemoryArchiveStore as CoreArchiveStore>::SlotIter),
+    Fjall(<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::SlotIter),
+    NoOp(EmptySlotIter),
+}
+
+impl Iterator for ArchiveSlotIterBackend {
+    type Item = Result<BlockSlot, ArchiveError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Memory(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+            Self::NoOp(iter) => iter.next(),
+        }
+    }
+}
+
+impl DoubleEndedIterator for ArchiveSlotIterBackend {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Memory(iter) => iter.next_back(),
+            Self::Fjall(iter) => iter.next_back(),
+            Self::NoOp(iter) => iter.next_back(),
+        }
+    }
+}
+
+pub enum ArchiveTagIterBackend {
+    Memory(<MemoryArchiveStore as CoreArchiveStore>::TagIter),
+    Fjall(<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::TagIter),
+    NoOp(<NoOpArchiveStore as CoreArchiveStore>::TagIter),
+}
+
+impl Iterator for ArchiveTagIterBackend {
+    type Item = Result<TagRecord, ArchiveError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Memory(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+            Self::NoOp(iter) => iter.next(),
+        }
+    }
+}
+
+pub enum ArchiveExactIterBackend {
+    Memory(<MemoryArchiveStore as CoreArchiveStore>::ExactIter),
+    Fjall(<dolos_fjall::archive::ArchiveStore as CoreArchiveStore>::ExactIter),
+    NoOp(<NoOpArchiveStore as CoreArchiveStore>::ExactIter),
+}
+
+impl Iterator for ArchiveExactIterBackend {
+    type Item = Result<ExactRecord, ArchiveError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Memory(iter) => iter.next(),
+            Self::Fjall(iter) => iter.next(),
+            Self::NoOp(iter) => iter.next(),
+        }
+    }
+}
+
 impl CoreArchiveStore for ArchiveStoreBackend {
     type BlockIter<'a> = ArchiveBlockIterBackend;
     type Writer = ArchiveWriterBackend;
     type LogIter = ArchiveLogIterBackend;
     type EntityValueIter = ArchiveEntityValueIterBackend;
+    type SlotIter = ArchiveSlotIterBackend;
+    type TagIter = ArchiveTagIterBackend;
+    type ExactIter = ArchiveExactIterBackend;
 
     fn start_writer(&self) -> Result<Self::Writer, ArchiveError> {
         match self {
@@ -1038,6 +1133,86 @@ impl CoreArchiveStore for ArchiveStoreBackend {
             Self::NoOp(s) => CoreArchiveStore::truncate_front(s, after),
         }
     }
+
+    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        match self {
+            Self::Memory(s) => CoreArchiveStore::slot_by_block_hash(s, hash),
+            Self::LogsOnly(inner) => CoreArchiveStore::slot_by_block_hash(inner.as_ref(), hash),
+            Self::Fjall(s) => CoreArchiveStore::slot_by_block_hash(s, hash),
+            Self::NoOp(s) => CoreArchiveStore::slot_by_block_hash(s, hash),
+        }
+    }
+
+    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, ArchiveError> {
+        match self {
+            Self::Memory(s) => CoreArchiveStore::slot_by_block_number(s, number),
+            Self::LogsOnly(inner) => CoreArchiveStore::slot_by_block_number(inner.as_ref(), number),
+            Self::Fjall(s) => CoreArchiveStore::slot_by_block_number(s, number),
+            Self::NoOp(s) => CoreArchiveStore::slot_by_block_number(s, number),
+        }
+    }
+
+    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, ArchiveError> {
+        match self {
+            Self::Memory(s) => CoreArchiveStore::slot_by_tx_hash(s, hash),
+            Self::LogsOnly(inner) => CoreArchiveStore::slot_by_tx_hash(inner.as_ref(), hash),
+            Self::Fjall(s) => CoreArchiveStore::slot_by_tx_hash(s, hash),
+            Self::NoOp(s) => CoreArchiveStore::slot_by_tx_hash(s, hash),
+        }
+    }
+
+    fn slots_by_tag(
+        &self,
+        dimension: TagDimension,
+        key: &[u8],
+        start: BlockSlot,
+        end: BlockSlot,
+    ) -> Result<Self::SlotIter, ArchiveError> {
+        match self {
+            Self::Memory(s) => CoreArchiveStore::slots_by_tag(s, dimension, key, start, end)
+                .map(ArchiveSlotIterBackend::Memory),
+            Self::LogsOnly(inner) => {
+                CoreArchiveStore::slots_by_tag(inner.as_ref(), dimension, key, start, end)
+            }
+            Self::Fjall(s) => CoreArchiveStore::slots_by_tag(s, dimension, key, start, end)
+                .map(ArchiveSlotIterBackend::Fjall),
+            Self::NoOp(s) => CoreArchiveStore::slots_by_tag(s, dimension, key, start, end)
+                .map(ArchiveSlotIterBackend::NoOp),
+        }
+    }
+
+    fn iter_archive_tags(
+        &self,
+        dimensions: &[TagDimension],
+        slots: Range<BlockSlot>,
+    ) -> Result<Self::TagIter, ArchiveError> {
+        match self {
+            Self::Memory(s) => CoreArchiveStore::iter_archive_tags(s, dimensions, slots)
+                .map(ArchiveTagIterBackend::Memory),
+            Self::LogsOnly(inner) => {
+                CoreArchiveStore::iter_archive_tags(inner.as_ref(), dimensions, slots)
+            }
+            Self::Fjall(s) => CoreArchiveStore::iter_archive_tags(s, dimensions, slots)
+                .map(ArchiveTagIterBackend::Fjall),
+            Self::NoOp(s) => CoreArchiveStore::iter_archive_tags(s, dimensions, slots)
+                .map(ArchiveTagIterBackend::NoOp),
+        }
+    }
+
+    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, ArchiveError> {
+        match self {
+            Self::Memory(s) => {
+                CoreArchiveStore::iter_exact_records(s, slots).map(ArchiveExactIterBackend::Memory)
+            }
+            Self::LogsOnly(inner) => CoreArchiveStore::iter_exact_records(inner.as_ref(), slots),
+            Self::Fjall(s) => {
+                CoreArchiveStore::iter_exact_records(s, slots).map(ArchiveExactIterBackend::Fjall)
+            }
+            Self::NoOp(s) => {
+                CoreArchiveStore::iter_exact_records(s, slots).map(ArchiveExactIterBackend::NoOp)
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -1108,25 +1283,6 @@ impl CoreIndexWriter for IndexWriterBackend {
         }
     }
 
-    fn undo(&self, delta: &IndexDelta) -> Result<(), IndexError> {
-        match self {
-            Self::Fjall(w) => w.undo(delta),
-            Self::Memory(w) => w.undo(delta),
-            Self::NoOp(w) => w.undo(delta),
-        }
-    }
-
-    fn append_prehashed(
-        &self,
-        records: impl IntoIterator<Item = IndexRecord>,
-    ) -> Result<(), IndexError> {
-        match self {
-            Self::Fjall(w) => w.append_prehashed(records),
-            Self::Memory(w) => w.append_prehashed(records),
-            Self::NoOp(w) => w.append_prehashed(records),
-        }
-    }
-
     fn commit(self) -> Result<(), IndexError> {
         match self {
             Self::Fjall(w) => w.commit(),
@@ -1136,72 +1292,8 @@ impl CoreIndexWriter for IndexWriterBackend {
     }
 }
 
-pub enum IndexSlotIterBackend {
-    Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::SlotIter),
-    Memory(<MemoryIndexStore as CoreIndexStore>::SlotIter),
-    NoOp(EmptySlotIter),
-}
-
-impl Iterator for IndexSlotIterBackend {
-    type Item = Result<BlockSlot, IndexError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Fjall(iter) => iter.next(),
-            Self::Memory(iter) => iter.next(),
-            Self::NoOp(iter) => iter.next(),
-        }
-    }
-}
-
-impl DoubleEndedIterator for IndexSlotIterBackend {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Fjall(iter) => iter.next_back(),
-            Self::Memory(iter) => iter.next_back(),
-            Self::NoOp(iter) => iter.next_back(),
-        }
-    }
-}
-
-pub enum IndexTagIterBackend {
-    Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::TagIter),
-    Memory(<MemoryIndexStore as CoreIndexStore>::TagIter),
-    NoOp(<NoOpIndexStore as CoreIndexStore>::TagIter),
-}
-
-impl Iterator for IndexTagIterBackend {
-    type Item = Result<TagRecord, IndexError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Fjall(iter) => iter.next(),
-            Self::Memory(iter) => iter.next(),
-            Self::NoOp(iter) => iter.next(),
-        }
-    }
-}
-
-pub enum IndexExactIterBackend {
-    Fjall(<dolos_fjall::IndexStore as CoreIndexStore>::ExactIter),
-    Memory(<MemoryIndexStore as CoreIndexStore>::ExactIter),
-    NoOp(<NoOpIndexStore as CoreIndexStore>::ExactIter),
-}
-
-impl Iterator for IndexExactIterBackend {
-    type Item = Result<ExactRecord, IndexError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Fjall(iter) => iter.next(),
-            Self::Memory(iter) => iter.next(),
-            Self::NoOp(iter) => iter.next(),
-        }
-    }
-}
-
 impl CoreIndexStore for IndexStoreBackend {
     type Writer = IndexWriterBackend;
-    type SlotIter = IndexSlotIterBackend;
-    type TagIter = IndexTagIterBackend;
-    type ExactIter = IndexExactIterBackend;
 
     fn start_writer(&self) -> Result<Self::Writer, IndexError> {
         match self {
@@ -1235,80 +1327,6 @@ impl CoreIndexStore for IndexStoreBackend {
             Self::Fjall(s) => s.cursor(),
             Self::Memory(s) => s.cursor(),
             Self::NoOp(s) => s.cursor(),
-        }
-    }
-
-    fn slot_by_block_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        match self {
-            Self::Fjall(s) => s.slot_by_block_hash(hash),
-            Self::Memory(s) => s.slot_by_block_hash(hash),
-            Self::NoOp(s) => s.slot_by_block_hash(hash),
-        }
-    }
-
-    fn slot_by_block_number(&self, number: u64) -> Result<Option<BlockSlot>, IndexError> {
-        match self {
-            Self::Fjall(s) => s.slot_by_block_number(number),
-            Self::Memory(s) => s.slot_by_block_number(number),
-            Self::NoOp(s) => s.slot_by_block_number(number),
-        }
-    }
-
-    fn slot_by_tx_hash(&self, hash: &[u8]) -> Result<Option<BlockSlot>, IndexError> {
-        match self {
-            Self::Fjall(s) => s.slot_by_tx_hash(hash),
-            Self::Memory(s) => s.slot_by_tx_hash(hash),
-            Self::NoOp(s) => s.slot_by_tx_hash(hash),
-        }
-    }
-
-    fn slots_by_tag(
-        &self,
-        dimension: TagDimension,
-        key: &[u8],
-        start: BlockSlot,
-        end: BlockSlot,
-    ) -> Result<Self::SlotIter, IndexError> {
-        match self {
-            Self::Fjall(s) => s
-                .slots_by_tag(dimension, key, start, end)
-                .map(IndexSlotIterBackend::Fjall),
-            Self::Memory(s) => s
-                .slots_by_tag(dimension, key, start, end)
-                .map(IndexSlotIterBackend::Memory),
-            Self::NoOp(s) => s
-                .slots_by_tag(dimension, key, start, end)
-                .map(IndexSlotIterBackend::NoOp),
-        }
-    }
-
-    fn iter_archive_tags(
-        &self,
-        dimensions: &[TagDimension],
-        slots: Range<BlockSlot>,
-    ) -> Result<Self::TagIter, IndexError> {
-        match self {
-            Self::Fjall(s) => s
-                .iter_archive_tags(dimensions, slots)
-                .map(IndexTagIterBackend::Fjall),
-            Self::Memory(s) => s
-                .iter_archive_tags(dimensions, slots)
-                .map(IndexTagIterBackend::Memory),
-            Self::NoOp(s) => s
-                .iter_archive_tags(dimensions, slots)
-                .map(IndexTagIterBackend::NoOp),
-        }
-    }
-
-    fn iter_exact_records(&self, slots: Range<BlockSlot>) -> Result<Self::ExactIter, IndexError> {
-        match self {
-            Self::Fjall(s) => s
-                .iter_exact_records(slots)
-                .map(IndexExactIterBackend::Fjall),
-            Self::Memory(s) => s
-                .iter_exact_records(slots)
-                .map(IndexExactIterBackend::Memory),
-            Self::NoOp(s) => s.iter_exact_records(slots).map(IndexExactIterBackend::NoOp),
         }
     }
 }
@@ -1465,12 +1483,18 @@ mod tests {
 
         assert!(matches!(indexes, IndexStoreBackend::Memory(_)));
 
+        let archive =
+            ArchiveStoreBackend::open(path, StateSchema::default(), &ArchiveStoreConfig::InMemory)
+                .expect("in_memory archive store should open without touching the path");
+
+        assert!(matches!(archive, ArchiveStoreBackend::Memory(_)));
+
         // And the seam the old wiring could not serve now answers.
         state.iter_utxos().expect("iter_utxos must be supported");
-        indexes
+        archive
             .iter_archive_tags(&[], 0..1)
             .expect("iter_archive_tags must be supported");
-        indexes
+        archive
             .start_writer()
             .expect("start_writer failed")
             .append_prehashed([])

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -23,7 +23,7 @@ use miette::{bail, Context as _, IntoDiagnostic as _};
 use tokio_util::sync::CancellationToken;
 
 use crate::feedback::Feedback;
-use dolos::adapters::{ArchiveStoreBackend, DomainAdapter, IndexStoreBackend, StateStoreBackend};
+use dolos::adapters::{ArchiveStoreBackend, DomainAdapter, StateStoreBackend};
 
 /// Where the mithril window lands when the operator names nowhere: beside the
 /// stores, so the bytes stay on the data mount.
@@ -179,7 +179,6 @@ impl backfill::Publish<DomainAdapter> for RepositoryArm<'_> {
         plan: &Plan,
         archive: &ArchiveStoreBackend,
         state: &StateStoreBackend,
-        indexes: &IndexStoreBackend,
     ) -> Result<(), backfill::Error> {
         super::publish::to_repository(
             self.config,
@@ -187,7 +186,6 @@ impl backfill::Publish<DomainAdapter> for RepositoryArm<'_> {
             plan,
             archive,
             state,
-            indexes,
             self.feedback,
         )
         .map_err(backfill::Error::caller)

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -61,7 +61,7 @@ pub struct Args {
     #[arg(long, value_name = "RANGE")]
     epochs: Option<EpochRange>,
 
-    /// epochs whose index layers one traversal of the index store fills; a
+    /// epochs whose index layers one traversal of the archive store fills; a
     /// larger band trades resident memory for fewer traversals, and changes
     /// nothing about the stele it produces. Defaults to the measured value
     /// that keeps the index pass inside 1 GiB

--- a/src/bin/dolos/snapshot/digest.rs
+++ b/src/bin/dolos/snapshot/digest.rs
@@ -120,15 +120,9 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         None => eprintln!("history:  none; this reproduction starts a chain"),
     }
 
-    let document = export::digest_document(
-        &plan,
-        &stores.archive,
-        &stores.state,
-        &stores.indexes,
-        predecessor,
-    )
-    .into_diagnostic()
-    .context("reproducing the stele")?;
+    let document = export::digest_document(&plan, &stores.archive, &stores.state, predecessor)
+        .into_diagnostic()
+        .context("reproducing the stele")?;
 
     eprintln!("layers:   {}", document.layers);
     eprintln!(

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -57,7 +57,7 @@ pub struct Args {
     #[arg(long, value_name = "DIR", conflicts_with = "output_dir")]
     scratch_dir: Option<PathBuf>,
 
-    /// epochs whose index layers one traversal of the index store fills; a
+    /// epochs whose index layers one traversal of the archive store fills; a
     /// larger band trades resident memory for fewer traversals, and changes
     /// nothing about the stele it produces. Defaults to the measured value
     /// that keeps the index pass inside 1 GiB

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use dolos_core::config::RootConfig;
-use dolos_core::{ArchiveStore, IndexStore, StateStore};
+use dolos_core::{ArchiveStore, StateStore};
 use miette::{Context as _, IntoDiagnostic as _};
 
 use dolos_snapshot::{
@@ -134,7 +134,6 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
                 &plan,
                 &stores.archive,
                 &stores.state,
-                &stores.indexes,
                 feedback,
             )
         }
@@ -166,7 +165,6 @@ fn to_directory(
         plan,
         &stores.archive,
         &stores.state,
-        &stores.indexes,
         None,
         &progress.observer(),
     )
@@ -196,13 +194,12 @@ fn to_directory(
 /// than trust: how much of this stele was inherited rather than built, and how
 /// much of it moved. Both are numbers the code counted, not an inference from a
 /// duration.
-pub(super) fn to_repository<A: ArchiveStore, S: StateStore, I: IndexStore>(
+pub(super) fn to_repository<A: ArchiveStore, S: StateStore>(
     config: &RootConfig,
     publish: &RepositoryPublish,
     plan: &export::Plan,
     archive: &A,
     state: &S,
-    indexes: &I,
     feedback: &Feedback,
 ) -> miette::Result<()> {
     let repo = publish.repo;
@@ -257,7 +254,7 @@ pub(super) fn to_repository<A: ArchiveStore, S: StateStore, I: IndexStore>(
     let progress = SteleProgress::publishing(feedback);
 
     let published = publisher
-        .publish(plan, archive, state, indexes, &progress.observer())
+        .publish(plan, archive, state, &progress.observer())
         .into_diagnostic()
         .context("publishing the stele")?;
 

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -66,7 +66,7 @@ pub struct Args {
     #[arg(long, action)]
     reproduce: bool,
 
-    /// epochs whose index layers one traversal of the index store fills; a
+    /// epochs whose index layers one traversal of the archive store fills; a
     /// larger band trades resident memory for fewer traversals, and changes
     /// nothing about the stele it produces. Defaults to the measured value
     /// that keeps the index pass inside 1 GiB

--- a/src/bin/dolos/snapshot/verify.rs
+++ b/src/bin/dolos/snapshot/verify.rs
@@ -156,7 +156,6 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
         &plan,
         &stores.archive,
         &stores.state,
-        &stores.indexes,
         None,
     )
     .into_diagnostic()

--- a/src/serve/grpc/v1alpha/sync.rs
+++ b/src/serve/grpc/v1alpha/sync.rs
@@ -202,7 +202,7 @@ where
             if !br.hash.is_empty() {
                 slot = self
                     .domain
-                    .indexes()
+                    .archive()
                     .slot_by_block_hash(&br.hash)
                     .map_err(|_| Status::internal("Failed to query chain service."))?;
             }
@@ -210,7 +210,7 @@ where
             if slot.is_none() && br.height != 0 {
                 slot = self
                     .domain
-                    .indexes()
+                    .archive()
                     .slot_by_block_number(br.height)
                     .map_err(|_| Status::internal("Failed to query chain service."))?;
             }

--- a/src/serve/grpc/v1beta/sync.rs
+++ b/src/serve/grpc/v1beta/sync.rs
@@ -202,7 +202,7 @@ where
             if !br.hash.is_empty() {
                 slot = self
                     .domain
-                    .indexes()
+                    .archive()
                     .slot_by_block_hash(&br.hash)
                     .map_err(|_| Status::internal("Failed to query chain service."))?;
             }
@@ -210,7 +210,7 @@ where
             if slot.is_none() && br.height != 0 {
                 slot = self
                     .domain
-                    .indexes()
+                    .archive()
                     .slot_by_block_number(br.height)
                     .map_err(|_| Status::internal("Failed to query chain service."))?;
             }

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -5,8 +5,11 @@
 //! bottom, so the builtin memory archive — small enough to read as a
 //! specification — pins the semantics the shipping fjall backend must match:
 //! block reads and walks (including the Byron boundary slot family), undo's
-//! segment truncation, prune and truncate boundaries, and the log
-//! namespaces' write/read/range behavior.
+//! segment truncation, prune and truncate boundaries, the log namespaces'
+//! write/read/range behavior, and the index entries a block projects (the
+//! exact lookups and the archive tags, written in the block's own commit).
+//! The index half's export/restore contract has its own suite,
+//! `archive_index_roundtrip`.
 //!
 //! The suite was written against the retired redb archive, whose block tests
 //! it ports; the memory archive took over as the oracle when redb retired
@@ -14,9 +17,11 @@
 
 use std::sync::Arc;
 
+use dolos_cardano::indexes::archive_dimensions;
 use dolos_core::{
-    builtin::MemoryArchiveStore, ArchiveStore as CoreArchiveStore, ArchiveWriter as _, BlockSlot,
-    ChainPoint, EntityKey, LogKey, NamespaceType, RawBlock, StateSchema, TemporalKey,
+    builtin::MemoryArchiveStore, ArchiveIndexDelta, ArchiveStore as CoreArchiveStore,
+    ArchiveWriter as _, BlockSlot, ChainPoint, EntityKey, LogKey, NamespaceType, RawBlock,
+    StateSchema, Tag, TemporalKey,
 };
 
 use dolos_testing::blocks::{byron_ebb_slot, make_byron_ebb, make_conway_block_with_prev};
@@ -1031,6 +1036,131 @@ fn logs_and_blocks_share_one_writer_commit<B: Backend>() {
 }
 
 // ---------------------------------------------------------------------------
+// Index entries: the archive's projection of its blocks
+// ---------------------------------------------------------------------------
+
+/// The index entries one block projects: its hash, its number, one
+/// transaction and one address tag, all derived from `seed` so two deltas
+/// never share an entry.
+fn index_delta(slot: u64, seed: u8) -> ArchiveIndexDelta {
+    ArchiveIndexDelta {
+        slot,
+        block_hash: vec![seed; 32],
+        block_number: Some(slot),
+        tx_hashes: vec![vec![0x80 | seed; 32]],
+        tags: vec![Tag::new(archive_dimensions::ADDRESS, vec![seed; 28])],
+    }
+}
+
+fn tagged_slots<S: CoreArchiveStore>(store: &S, key: &[u8], start: u64, end: u64) -> Vec<u64> {
+    store
+        .slots_by_tag(archive_dimensions::ADDRESS, key, start, end)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+/// A block and the entries that resolve to it land in one commit, and every
+/// exact lookup then answers with the block's slot.
+fn apply_index_then_slot_by_tx_hash_resolves<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let delta = index_delta(100, 0x01);
+
+    let writer = store.start_writer().unwrap();
+    writer
+        .apply(&point(100), &Arc::new(fake_block(100)))
+        .unwrap();
+    writer.apply_index(std::slice::from_ref(&delta)).unwrap();
+
+    // Nothing is visible before the commit: the entries ride the block's
+    // batch rather than landing ahead of it.
+    assert_eq!(store.slot_by_tx_hash(&delta.tx_hashes[0]).unwrap(), None);
+
+    writer.commit().unwrap();
+
+    assert_eq!(
+        store.slot_by_tx_hash(&delta.tx_hashes[0]).unwrap(),
+        Some(100)
+    );
+    assert_eq!(
+        store.slot_by_block_hash(&delta.block_hash).unwrap(),
+        Some(100)
+    );
+    assert_eq!(store.slot_by_block_number(100).unwrap(), Some(100));
+    assert_eq!(tagged_slots(&store, &delta.tags[0].key, 0, u64::MAX), [100]);
+
+    assert_eq!(
+        store.get_block_by_slot(&100).unwrap(),
+        Some(fake_block(100)),
+        "the block the entries point at is there too"
+    );
+}
+
+/// A rollback takes back exactly the undone block's entries, and nothing of
+/// the block before it.
+fn undo_index_removes_exactly_what_apply_index_added<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let kept = index_delta(100, 0x01);
+    let undone = index_delta(200, 0x02);
+
+    let writer = store.start_writer().unwrap();
+    writer.apply_index(&[kept.clone(), undone.clone()]).unwrap();
+    writer.commit().unwrap();
+
+    let writer = store.start_writer().unwrap();
+    writer.undo_index(std::slice::from_ref(&undone)).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(store.slot_by_tx_hash(&undone.tx_hashes[0]).unwrap(), None);
+    assert_eq!(store.slot_by_block_hash(&undone.block_hash).unwrap(), None);
+    assert_eq!(store.slot_by_block_number(200).unwrap(), None);
+    assert!(tagged_slots(&store, &undone.tags[0].key, 0, u64::MAX).is_empty());
+
+    assert_eq!(
+        store.slot_by_tx_hash(&kept.tx_hashes[0]).unwrap(),
+        Some(100)
+    );
+    assert_eq!(
+        store.slot_by_block_hash(&kept.block_hash).unwrap(),
+        Some(100)
+    );
+    assert_eq!(store.slot_by_block_number(100).unwrap(), Some(100));
+    assert_eq!(tagged_slots(&store, &kept.tags[0].key, 0, u64::MAX), [100]);
+}
+
+/// `slots_by_tag` takes both bounds inclusive — unlike the record traversals,
+/// whose range is half-open — so the slot at `end` is an answer.
+fn slots_by_tag_bounds_are_inclusive<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let key = vec![0xAA; 28];
+
+    let deltas: Vec<_> = [10u64, 20, 30]
+        .into_iter()
+        .map(|slot| ArchiveIndexDelta {
+            slot,
+            block_hash: vec![slot as u8; 32],
+            block_number: Some(slot),
+            tx_hashes: Vec::new(),
+            tags: vec![Tag::new(archive_dimensions::ADDRESS, key.clone())],
+        })
+        .collect();
+
+    let writer = store.start_writer().unwrap();
+    writer.apply_index(&deltas).unwrap();
+    writer.commit().unwrap();
+
+    assert_eq!(tagged_slots(&store, &key, 10, 30), [10, 20, 30]);
+    assert_eq!(tagged_slots(&store, &key, 10, 20), [10, 20]);
+    assert_eq!(tagged_slots(&store, &key, 20, 30), [20, 30]);
+    assert_eq!(tagged_slots(&store, &key, 20, 20), [20]);
+    assert_eq!(tagged_slots(&store, &key, 11, 29), [20]);
+    assert!(tagged_slots(&store, &key, 21, 29).is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // Cross-backend agreement: both backends walk identical data identically
 // ---------------------------------------------------------------------------
 
@@ -1147,6 +1277,9 @@ macro_rules! full_suite {
                 prune_keeps_logs_at_the_cutoff_slot,
                 truncate_front_drops_logs_at_the_cut_slot,
                 logs_and_blocks_share_one_writer_commit,
+                apply_index_then_slot_by_tx_hash_resolves,
+                undo_index_removes_exactly_what_apply_index_added,
+                slots_by_tag_bounds_are_inclusive,
             ]
         );
     };

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1035,9 +1035,7 @@ fn logs_and_blocks_share_one_writer_commit<B: Backend>() {
     );
 }
 
-// ---------------------------------------------------------------------------
 // Index entries: the archive's projection of its blocks
-// ---------------------------------------------------------------------------
 
 /// The index entries one block projects: its hash, its number, one
 /// transaction and one address tag, all derived from `seed` so two deltas

--- a/tests/archive_index_roundtrip.rs
+++ b/tests/archive_index_roundtrip.rs
@@ -1,10 +1,10 @@
 //! Export/restore conformance for the pre-hashed archive index seam.
 //!
-//! `IndexStore::iter_archive_tags` / `iter_exact_records` and
-//! `IndexWriter::append_prehashed` are the two halves of one thing: a snapshot
-//! layer is exactly what iteration yields, and a restore is exactly what the
-//! writer takes back. Two properties make that work, and neither is visible
-//! from a single-store unit test:
+//! `ArchiveStore::iter_archive_tags` / `iter_exact_records` and
+//! `ArchiveWriter::append_prehashed` are the two halves of one thing: a
+//! snapshot layer is exactly what iteration yields, and a restore is exactly
+//! what the writer takes back. Two properties make that work, and neither is
+//! visible from a single-store unit test:
 //!
 //! 1. **The round trip is exact.** Records carry the stored key form, not a
 //!    logical key, because the logical key is not on disk. A store rebuilt from
@@ -15,20 +15,26 @@
 //!    sequences, so an iterator that yields the right records in the wrong
 //!    order is wrong, not slow.
 //!
-//! The suite is written once against the [`IndexStore`] trait and run against
-//! every live backend: fjall, the persistent one, and the builtin memory store.
-//! One suite defining the semantics is the point — a backend that passed its
-//! own private tests could still disagree with its peers, and records really do
-//! cross between backends (see [`records_cross_between_backends`]).
+//! The suite is written once against the [`ArchiveStore`] trait's index half
+//! and run against every live backend: fjall, the persistent one, and the
+//! builtin memory archive. One suite defining the semantics is the point — a
+//! backend that passed its own private tests could still disagree with its
+//! peers, and records really do cross between backends (see
+//! [`records_cross_between_backends`]).
+//!
+//! Only the index half of the archive is exercised here: the deltas name
+//! blocks the store never holds. The block side has its own suite
+//! (`archive_conformance`), which also pins that a block and its index
+//! entries share one commit.
 
 use std::collections::BTreeSet;
 use std::ops::Range;
 
-use dolos_cardano::indexes::{archive_dimensions, CardanoIndexExt};
+use dolos_cardano::indexes::{archive_dimensions, CardanoArchiveIndexExt};
 use dolos_core::{
-    builtin::MemoryIndexStore, config::FjallIndexConfig, ArchiveIndexDelta, BlockSlot, ChainPoint,
-    ExactKind, ExactRecord, IndexDelta, IndexRecord, IndexStore as CoreIndexStore,
-    IndexWriter as CoreIndexWriter, Tag, TagDimension, TagRecord,
+    builtin::MemoryArchiveStore, ArchiveIndexDelta, ArchiveStore as CoreArchiveStore,
+    ArchiveWriter as CoreArchiveWriter, BlockSlot, ExactKind, ExactRecord, IndexRecord,
+    StateSchema, Tag, TagDimension, TagRecord,
 };
 
 const EPOCH_LEN: BlockSlot = 432_000;
@@ -166,7 +172,7 @@ fn seed_tag(spec: &SeedSpec, block: u64, t: u64) -> Tag {
 /// Deltas are streamed rather than returned so the cost measurement can seed
 /// millions of records without holding them; callers that want them all keep
 /// them in the sink (see [`Seeded::absorb`]).
-fn seed_deltas(spec: &SeedSpec, sink: &mut impl FnMut(IndexDelta)) -> SeedCounts {
+fn seed_deltas(spec: &SeedSpec, sink: &mut impl FnMut(Vec<ArchiveIndexDelta>)) -> SeedCounts {
     spec.check();
 
     let mut counts = SeedCounts {
@@ -207,8 +213,7 @@ fn seed_deltas(spec: &SeedSpec, sink: &mut impl FnMut(IndexDelta)) -> SeedCounts
                 });
             }
 
-            let cursor = ChainPoint::Slot(archive.last().unwrap().slot);
-            sink(IndexDelta { cursor, archive });
+            sink(archive);
 
             block = batch_end;
         }
@@ -241,13 +246,12 @@ const CONFORMANCE: SeedSpec = SeedSpec {
     blocks_per_batch: 40,
 };
 
-/// One index backend under test.
+/// One archive backend under test.
 ///
 /// The guard carries whatever the backend needs kept alive for the store to
-/// stay usable — a temp directory for the on-disk one, nothing for the
-/// in-memory one.
+/// stay usable; both stores here hold their own, so it is nothing.
 trait Backend {
-    type Store: CoreIndexStore;
+    type Store: CoreArchiveStore;
     type Guard;
 
     /// A fresh, empty store.
@@ -257,36 +261,27 @@ trait Backend {
 struct Fjall;
 
 impl Backend for Fjall {
-    type Store = dolos_fjall::IndexStore;
-    type Guard = tempfile::TempDir;
+    type Store = dolos_fjall::archive::ArchiveStore;
+    type Guard = ();
 
     fn open() -> (Self::Store, Self::Guard) {
-        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        // The store carries its temp directory and removes it with the last
+        // clone.
+        let store = dolos_fjall::archive::ArchiveStore::for_tempdir(StateSchema::default())
+            .expect("failed to open fjall archive store");
 
-        // Only the fields this suite cares about; the rest are the backend's
-        // own defaults rather than a re-listing of them that can go stale.
-        let config = FjallIndexConfig {
-            cache: Some(16),
-            flush_on_commit: Some(false),
-            worker_threads: Some(1),
-            ..Default::default()
-        };
-
-        let store = dolos_fjall::IndexStore::open(dir.path(), &config)
-            .expect("failed to open fjall index store");
-
-        (store, dir)
+        (store, ())
     }
 }
 
 struct Memory;
 
 impl Backend for Memory {
-    type Store = MemoryIndexStore;
+    type Store = MemoryArchiveStore;
     type Guard = ();
 
     fn open() -> (Self::Store, Self::Guard) {
-        (MemoryIndexStore::new(), ())
+        (MemoryArchiveStore::new(StateSchema::default()), ())
     }
 }
 
@@ -379,8 +374,8 @@ impl Seeded {
     /// The seeder streams deltas rather than describing what it wrote in a
     /// second structure, so this reads it back off them — one definition of
     /// what a delta contains instead of two that can disagree.
-    fn absorb(&mut self, delta: &IndexDelta) {
-        for block in &delta.archive {
+    fn absorb(&mut self, deltas: &[ArchiveIndexDelta]) {
+        for block in deltas {
             self.blocks.push((
                 block.block_hash.clone(),
                 block.block_number.unwrap(),
@@ -400,7 +395,7 @@ impl Seeded {
 
 /// The conformance seed's deltas, built independently of any store so two
 /// backends can be handed byte-identical input.
-fn conformance_deltas() -> (Vec<IndexDelta>, Seeded) {
+fn conformance_deltas() -> (Vec<Vec<ArchiveIndexDelta>>, Seeded) {
     let mut seeded = Seeded::default();
     let mut deltas = Vec::new();
 
@@ -412,10 +407,10 @@ fn conformance_deltas() -> (Vec<IndexDelta>, Seeded) {
     (deltas, seeded)
 }
 
-/// Apply one delta through the regular write path.
-fn apply<S: CoreIndexStore>(store: &S, delta: &IndexDelta) {
+/// Apply one batch of block deltas through the regular write path.
+fn apply<S: CoreArchiveStore>(store: &S, deltas: &[ArchiveIndexDelta]) {
     let writer = store.start_writer().expect("start_writer failed");
-    writer.apply(delta).expect("apply failed");
+    writer.apply_index(deltas).expect("apply_index failed");
     writer.commit().expect("commit failed");
 }
 
@@ -423,7 +418,7 @@ fn slots_by_tag_are_ordered_in_both_directions<B: Backend>() {
     let (store, _guard) = B::open();
     let policy = vec![0xAA; 28];
     let slots = [30, 10, 20];
-    let archive = slots
+    let archive: Vec<_> = slots
         .into_iter()
         .map(|slot| ArchiveIndexDelta {
             slot,
@@ -434,13 +429,7 @@ fn slots_by_tag_are_ordered_in_both_directions<B: Backend>() {
         })
         .collect();
 
-    apply(
-        &store,
-        &IndexDelta {
-            cursor: ChainPoint::Slot(30),
-            archive,
-        },
-    );
+    apply(&store, &archive);
 
     let forward = store
         .slots_by_tag(archive_dimensions::POLICY, &policy, 0, 40)
@@ -461,7 +450,7 @@ fn slots_by_tag_are_ordered_in_both_directions<B: Backend>() {
 /// Populate a store through the regular delta path, the same one the sync
 /// pipeline uses. Nothing here knows about pre-hashed records: the export side
 /// has to cope with whatever normal indexing produced.
-fn seed<S: CoreIndexStore>(store: &S) -> Seeded {
+fn seed<S: CoreArchiveStore>(store: &S) -> Seeded {
     let mut seeded = Seeded::default();
 
     seed_deltas(&CONFORMANCE, &mut |delta| {
@@ -472,7 +461,7 @@ fn seed<S: CoreIndexStore>(store: &S) -> Seeded {
     seeded
 }
 
-fn collect_tags<S: CoreIndexStore>(
+fn collect_tags<S: CoreArchiveStore>(
     store: &S,
     dimensions: &[TagDimension],
     slots: Range<BlockSlot>,
@@ -487,7 +476,7 @@ fn collect_tags<S: CoreIndexStore>(
 /// Every dimension's tag records, the way an export call site asks for them:
 /// through the wrapper, so `archive_dimensions::ALL` is named in one place
 /// rather than at each call.
-fn collect_all_tags<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<TagRecord> {
+fn collect_all_tags<S: CoreArchiveStore>(store: &S, slots: Range<BlockSlot>) -> Vec<TagRecord> {
     store
         .iter_all_archive_tags(slots)
         .expect("iter_all_archive_tags failed")
@@ -495,7 +484,7 @@ fn collect_all_tags<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Ve
         .expect("tag iteration failed")
 }
 
-fn collect_exacts<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
+fn collect_exacts<S: CoreArchiveStore>(store: &S, slots: Range<BlockSlot>) -> Vec<ExactRecord> {
     store
         .iter_exact_records(slots)
         .expect("iter_exact_records failed")
@@ -503,7 +492,7 @@ fn collect_exacts<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<
         .expect("exact iteration failed")
 }
 
-fn slots_for_tag<S: CoreIndexStore>(
+fn slots_for_tag<S: CoreArchiveStore>(
     store: &S,
     dimension: TagDimension,
     key: &[u8],
@@ -518,7 +507,7 @@ fn slots_for_tag<S: CoreIndexStore>(
 
 /// The epoch slice a publisher would export: every tag and exact record whose
 /// slot falls in the epoch, in traversal order.
-fn export_slice<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<IndexRecord> {
+fn export_slice<S: CoreArchiveStore>(store: &S, slots: Range<BlockSlot>) -> Vec<IndexRecord> {
     let mut records: Vec<IndexRecord> = Vec::new();
 
     records.extend(
@@ -538,7 +527,7 @@ fn export_slice<S: CoreIndexStore>(store: &S, slots: Range<BlockSlot>) -> Vec<In
 
 /// Restore in one batch, the way a driver would restore one chunk: the writer
 /// takes the records as an iterator and accumulates them until `commit`.
-fn restore<S: CoreIndexStore>(store: &S, records: impl IntoIterator<Item = IndexRecord>) {
+fn restore<S: CoreArchiveStore>(store: &S, records: impl IntoIterator<Item = IndexRecord>) {
     let writer = store.start_writer().expect("start_writer failed");
     writer
         .append_prehashed(records)
@@ -824,7 +813,7 @@ fn undo_removes_exactly_what_apply_added<B: Backend>() {
 
     for delta in second.iter().rev() {
         let writer = store.start_writer().expect("start_writer failed");
-        writer.undo(delta).expect("undo failed");
+        writer.undo_index(delta).expect("undo_index failed");
         writer.commit().expect("commit failed");
     }
 
@@ -997,7 +986,8 @@ fn cost_spec(epochs: u64) -> SeedSpec {
 /// orchestration, not here.
 ///
 /// Run with:
-/// `cargo test --release --test index_roundtrip -- --ignored --nocapture`
+/// `cargo test --release --test archive_index_roundtrip -- --ignored
+/// --nocapture`
 #[test]
 #[ignore = "measurement, not an assertion"]
 fn measure_one_epoch_iteration_cost() {
@@ -1102,8 +1092,8 @@ fn mib(bytes: u64) -> f64 {
 /// window — a measurement taken before that would say a sink is nearly free.
 ///
 /// Run with:
-/// `cargo test --release --test index_roundtrip -- --ignored --nocapture
-/// measure_layer_sink_residency`
+/// `cargo test --release --test archive_index_roundtrip -- --ignored
+/// --nocapture measure_layer_sink_residency`
 #[cfg(unix)]
 #[test]
 #[ignore = "measurement, not an assertion"]
@@ -1182,9 +1172,9 @@ fn measure_layer_sink_residency() {
 /// assumed — a speed-up that moved the bytes would not be one.
 ///
 /// Run with:
-/// `cargo test --release --test index_roundtrip -- --ignored --nocapture
-/// measure_banded_publish_cost`, and `DOLOS_INDEX_COST_EPOCHS=32` for the
-/// deeper store [`measure_one_epoch_iteration_cost`] also reports.
+/// `cargo test --release --test archive_index_roundtrip -- --ignored
+/// --nocapture measure_banded_publish_cost`, and `DOLOS_INDEX_COST_EPOCHS=32`
+/// for the deeper store [`measure_one_epoch_iteration_cost`] also reports.
 #[cfg(unix)]
 #[test]
 #[ignore = "measurement, not an assertion"]
@@ -1249,24 +1239,21 @@ fn measure_banded_publish_cost() {
     );
 }
 
-/// Publish the seeded index store at `band`, into a directory that lives as
-/// long as the returned guard.
+/// Publish the seeded archive at `band`, into a directory that lives as long
+/// as the returned guard.
 #[cfg(unix)]
-fn publish_at_band<S: CoreIndexStore>(
+fn publish_at_band<S: CoreArchiveStore>(
     store: &S,
     epochs: u64,
     band: usize,
 ) -> (dolos_snapshot::inscription::Inscription, tempfile::TempDir) {
-    use dolos_core::{StateStore as _, StateWriter as _};
+    use dolos_core::{ChainPoint, StateStore as _, StateWriter as _};
     use dolos_snapshot::{
         export::{IndexBand, Plan},
         Network,
     };
 
     let temp = tempfile::tempdir().expect("tempdir");
-
-    let archive =
-        dolos_core::builtin::MemoryArchiveStore::new(dolos_cardano::model::build_schema());
 
     let state = dolos_core::builtin::MemoryStateStore::new();
 
@@ -1295,9 +1282,8 @@ fn publish_at_band<S: CoreIndexStore>(
     let inscription = dolos_snapshot::export::publish(
         temp.path().join("stele"),
         &plan,
-        &archive,
-        &state,
         store,
+        &state,
         None,
         &dolos_snapshot::progress::Observer::silent(),
     )
@@ -1349,19 +1335,16 @@ fn malformed_exact_keys_are_refused<B: Backend>() {
     for (label, width) in widths {
         let (store, _guard) = B::open();
 
-        let delta = IndexDelta {
-            cursor: ChainPoint::Slot(100),
-            archive: vec![ArchiveIndexDelta {
-                slot: 100,
-                block_hash: vec![0xAB; width],
-                block_number: Some(1),
-                tx_hashes: vec![vec![0xCD; 32]],
-                tags: Vec::new(),
-            }],
-        };
+        let delta = vec![ArchiveIndexDelta {
+            slot: 100,
+            block_hash: vec![0xAB; width],
+            block_number: Some(1),
+            tx_hashes: vec![vec![0xCD; 32]],
+            tags: Vec::new(),
+        }];
 
         let writer = store.start_writer().expect("start_writer failed");
-        let applied = writer.apply(&delta);
+        let applied = writer.apply_index(&delta);
 
         if width == 0 {
             // An empty hash is "no block hash", not a malformed one — the
@@ -1389,20 +1372,17 @@ fn malformed_exact_keys_are_refused<B: Backend>() {
     for (label, width) in [("short", 31usize), ("over-wide", 33)] {
         let (store, _guard) = B::open();
 
-        let delta = IndexDelta {
-            cursor: ChainPoint::Slot(100),
-            archive: vec![ArchiveIndexDelta {
-                slot: 100,
-                block_hash: vec![0x01; 32],
-                block_number: Some(1),
-                tx_hashes: vec![vec![0xEF; width]],
-                tags: Vec::new(),
-            }],
-        };
+        let delta = vec![ArchiveIndexDelta {
+            slot: 100,
+            block_hash: vec![0x01; 32],
+            block_number: Some(1),
+            tx_hashes: vec![vec![0xEF; width]],
+            tags: Vec::new(),
+        }];
 
         let writer = store.start_writer().expect("start_writer failed");
         assert!(
-            writer.apply(&delta).is_err(),
+            writer.apply_index(&delta).is_err(),
             "a {label} ({width}-byte) tx hash should be refused, not stored"
         );
         writer.commit().expect("commit failed");

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -238,13 +238,14 @@ fn test_catchup_recovers_archive_and_indexes() {
     );
 
     // Verify index content: look up a synthetic tx hash to confirm
-    // compute_catchup produced the correct index delta.
+    // compute_catchup produced the correct index delta, and that it landed in
+    // the archive beside the block.
     let tx_hash_hex = &vectors.blocks[0].tx_hashes[0];
     let tx_hash_bytes = hex::decode(tx_hash_hex).unwrap();
-    let slot = domain.indexes().slot_by_tx_hash(&tx_hash_bytes).unwrap();
+    let slot = domain.archive().slot_by_tx_hash(&tx_hash_bytes).unwrap();
     assert!(
         slot.is_some(),
-        "tx hash {} should be found in index after catch-up",
+        "tx hash {} should be found in the archive after catch-up",
         tx_hash_hex
     );
 
@@ -413,13 +414,13 @@ fn test_catchup_recovers_indexes_when_archive_ahead() {
         "index cursor should be at the WAL tip after catch-up"
     );
 
-    // Verify index content came through the replay.
+    // The index entries rode the archive commit, so they were never behind.
     let tx_hash_hex = &vectors.blocks[0].tx_hashes[0];
     let tx_hash_bytes = hex::decode(tx_hash_hex).unwrap();
-    let slot = domain.indexes().slot_by_tx_hash(&tx_hash_bytes).unwrap();
+    let slot = domain.archive().slot_by_tx_hash(&tx_hash_bytes).unwrap();
     assert!(
         slot.is_some(),
-        "tx hash {} should be found in index after catch-up",
+        "tx hash {} should be found in the archive",
         tx_hash_hex
     );
 }
@@ -445,10 +446,14 @@ fn test_catchup_recovers_indexes_when_archive_ahead() {
 /// byte-identical to its snapshot at the rollback target. Before the fix,
 /// rollback undid entities in memory but never saved them, leaving entity
 /// state reflecting the undone blocks.
+///
+/// And it verifies that the archive's index entries go with the blocks: a
+/// rolled-back block's transaction hash no longer resolves, while the
+/// target's still does.
 #[test]
 fn test_rollback_after_full_sync_lifecycle() {
     let cfg = SyntheticBlockConfig::default();
-    let (blocks, _vectors, cardano_config) = build_synthetic_blocks(cfg);
+    let (blocks, vectors, cardano_config) = build_synthetic_blocks(cfg);
     assert!(
         blocks.len() >= 2,
         "synthetic config must produce at least 2 blocks for the rollback target to differ from the tip",
@@ -479,6 +484,17 @@ fn test_rollback_after_full_sync_lifecycle() {
     }
 
     let tags_at_tip = live_tag_keys(&domain);
+
+    let kept_tx = hex::decode(&vectors.blocks[0].tx_hashes[0]).unwrap();
+    let undone_tx = hex::decode(&vectors.blocks[1].tx_hashes[0]).unwrap();
+    assert!(
+        domain
+            .archive()
+            .slot_by_tx_hash(&undone_tx)
+            .unwrap()
+            .is_some(),
+        "the block about to be undone should resolve before the rollback"
+    );
 
     let tip_before_rollback = domain.state().read_cursor().unwrap();
     assert_ne!(
@@ -525,6 +541,22 @@ fn test_rollback_after_full_sync_lifecycle() {
         "no tag key was unique to the undone blocks, so the stale-key probe proves nothing"
     );
     assert_no_stale_tags(&domain, &tags_at_tip);
+
+    // The archive's index entries followed the blocks back: the undone
+    // block's transaction is gone, the target's is still there.
+    assert_eq!(
+        domain.archive().slot_by_tx_hash(&undone_tx).unwrap(),
+        None,
+        "a rolled-back block's tx hash should no longer resolve"
+    );
+    assert!(
+        domain
+            .archive()
+            .slot_by_tx_hash(&kept_tx)
+            .unwrap()
+            .is_some(),
+        "the rollback target's tx hash should still resolve"
+    );
 }
 
 /// Collect all raw (key, value) pairs in a state namespace.

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use dolos_cardano::indexes::archive_dimensions;
 use dolos_core::{
-    config::{FjallIndexConfig, FjallStateConfig},
-    ArchiveIndexDelta, ChainPoint, EntityKey, EraCbor, IndexDelta, IndexStore as CoreIndexStore,
-    IndexWriter as CoreIndexWriter, NamespaceType, StateSchema, StateStore as CoreStateStore,
+    config::{FjallArchiveConfig, FjallStateConfig},
+    ArchiveIndexDelta, ArchiveStore as CoreArchiveStore, ArchiveWriter as CoreArchiveWriter,
+    EntityKey, EraCbor, NamespaceType, StateSchema, StateStore as CoreStateStore,
     StateWriter as CoreStateWriter, Tag, TagRecord, TxoRef, UtxoSetDelta,
 };
 
@@ -342,7 +342,7 @@ const TAGS_PER_BLOCK: u64 = 20;
 const TAG_RECORD_COUNT: u64 = TAG_BLOCK_COUNT * TAGS_PER_BLOCK;
 const TAG_BLOCKS_PER_BATCH: u64 = 500;
 
-fn seed_archive_tags<S: CoreIndexStore>(store: &S) {
+fn seed_archive_tags<S: CoreArchiveStore>(store: &S) {
     let mut block = 0u64;
 
     while block < TAG_BLOCK_COUNT {
@@ -381,18 +381,15 @@ fn seed_archive_tags<S: CoreIndexStore>(store: &S) {
             });
         }
 
-        let cursor = ChainPoint::Slot(archive.last().unwrap().slot);
-        let delta = IndexDelta { cursor, archive };
-
         let writer = store.start_writer().expect("start_writer failed");
-        writer.apply(&delta).expect("apply failed");
+        writer.apply_index(&archive).expect("apply_index failed");
         writer.commit().expect("commit failed");
 
         block = batch_end;
     }
 }
 
-fn assert_lazy_archive_tag_iter<S: CoreIndexStore>(store: &S) {
+fn assert_lazy_archive_tag_iter<S: CoreArchiveStore>(store: &S) {
     seed_archive_tags(store);
 
     let threshold = LAZY_BUDGET;
@@ -455,7 +452,7 @@ fn assert_lazy_archive_tag_iter<S: CoreIndexStore>(store: &S) {
 #[serial]
 fn test_fjall_lazy_archive_tag_iter() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
-    let config = FjallIndexConfig {
+    let config = FjallArchiveConfig {
         // Small on purpose: cached blocks are live heap, and the measurement is
         // the iterator's footprint, not the engine's cache budget.
         cache: Some(1),
@@ -463,8 +460,9 @@ fn test_fjall_lazy_archive_tag_iter() {
         worker_threads: Some(1),
         ..Default::default()
     };
-    let store = dolos_fjall::IndexStore::open(tmpdir.path(), &config)
-        .expect("failed to open fjall index store");
+    let store =
+        dolos_fjall::archive::ArchiveStore::open(StateSchema::default(), tmpdir.path(), &config)
+            .expect("failed to open fjall archive store");
 
     assert_lazy_archive_tag_iter(&store);
 }


### PR DESCRIPTION
Piece 3 of the index store dissolution: the `archive-tags` and `index-exact` keyspaces are projections of the block history, so they move into the archive store and commit in the same batch as the blocks they project. The `indexes` stele layer is produced from and restored into the archive from here on, byte for byte the same. The index store is left holding only its cursor, for the removal step to delete.

Plan: `plans/dolos-index-store-dissolution-archive-index.md` in the txpipe domain (awaits #1302 and #1303, both merged).

## What moves

- **Traits.** `ArchiveWriter` gains `apply_index`, `undo_index` and `append_prehashed`; `ArchiveStore` gains `slot_by_block_hash`, `slot_by_block_number`, `slot_by_tx_hash`, `slots_by_tag`, `iter_archive_tags`, `iter_exact_records` and the three iterator types, errors typed `ArchiveError` (plus `ArchiveError::Unsupported` for the no-op store). `IndexDelta` is `{ cursor }`; `IndexWriter` keeps `apply` and `commit` for it. `UndoBlockData` and `CatchUpBlockData` carry `archive_index_deltas`.
- **Builder.** `CardanoIndexDeltaBuilder::new()` takes no cursor; `into_parts` returns `(UtxoIndexDelta, Vec<ArchiveIndexDelta>)`. `compute_undo` now runs `index_block`, so a rollback has the entries to remove.
- **Writers.** `commit_archive` applies the archive half beside the blocks, same writer, same commit. `rollback` opens an archive writer beside the state writer and `undo_index`es each undone block, committed after the state writer and before `truncate_front`. `catch_up_archive` replays WAL *entries* now (it needs the inputs) and applies the index deltas beside each block; `catch_up_indexes` walks the cursor only. `restore_indexes` drains into the archive writer.
- **Readers.** `CardanoArchiveIndexExt: ArchiveStore` replaces `CardanoIndexExt`. The facade's seven methods, the two `query.rs` helpers and the six direct sites (`LedgerContext::get_utxos`, the two gRPC `dump_history`, minikupo's `parse_slot_or_point`, minibf's asset addresses) read `.archive()`.
- **Snapshot.** `export`, `publish`, `reproduce`, `digest_document`, `verify_reproduction`, `registry::{publish, publish_into}`, `Publisher::publish` and `backfill::Publish::publish` drop their index-store parameter; `write_indexes` reads the archive. `Target` and the restore functions **keep** theirs: the restore still writes the index cursor explicitly, because bootstrap and `data check` read it until the removal step (the plan's step 5 says both "drop `I`" and "keep the cursor write"; the cursor write wins, since dropping it would leave every restored node booting with a lenient catch-up error).
- **fjall.** `index/{archive_tags,exact,scan}.rs` move to `archive/{tags,exact,scan}.rs`; `apply`/`undo` take `&[ArchiveIndexDelta]`; the archive database gains `archive-tags` and `index-exact` with the standalone store's settings (L0 threshold 8, memtable 128 MB); `disk_usage` and `compact` cover them; `prune_history` and `truncate_front` leave them alone. The index database holds `index-cursor` only.
- **Memory, no-op, adapters.** The tag set and exact map move from `memory/index.rs` to `memory/archive.rs` with their iterators. The no-op archive answers `None`/empty for lookups and `Unsupported` for the traversals and the pre-hashed append. `ArchiveStoreBackend` gains the fan-out and three iterator enums; `LogsOnly` discards the index writes as it discards `apply`, and forwards reads.
- **Docs.** The keyspace table in `data-layer.mdx`, the fjall index README, and the two `AGENTS.md` sections that named the old layout.

Layout change: an existing node re-bootstraps (its archive database lacks the two keyspaces, its index database still carries them). The store-version gate is a separate plan.

## Verification

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets`: 1339 passed, 0 failed, 48 ignored across 38 binaries.
- `tests/archive_index_roundtrip.rs` (was `index_roundtrip`) runs the export/restore conformance against both archive backends; `records_cross_between_backends` and `backends_agree_on_exported_records` pin the stored key form; the golden inscriptions in `crates/snapshot/tests/goldens.rs` and `export.rs` are unchanged.
- `tests/archive_conformance.rs` gains `apply_index_then_slot_by_tx_hash_resolves`, `undo_index_removes_exactly_what_apply_index_added` and `slots_by_tag_bounds_are_inclusive`, on fjall and memory.
- `tests/bootstrap.rs` asserts `archive().slot_by_tx_hash` after the archive catch-up, and that after a rollback the undone block's tx hash no longer resolves while the target's still does.
- The 25 minibf and minikupo `*_internal_error` route tests inject `TestFault::ArchiveStoreError` now, since the lookups they exercise moved.

## Stelae acceptance

No preprod stele is published (`oci.stelae.store/cardano/preprod` answers manifest unknown; only mainnet is), so the plan's "existing published preprod stele" step ran against local data instead, which also gives the stronger comparison: a stele produced by the **split** layout, restored and reproduced by the **dissolved** one.

1. `dolos snapshot publish --output-dir …` with a `main` (b84d8230) debug binary from a preprod node synced from genesis to slot 95020 under the old layout (archive tags and exact lookups in the index store). 88 layers, 5 epochs (0..=4), identity `sha256:21ebd3f3a17ba57437b826e3a59503abe4611e5f68dbecd756b73d25ef546d2f`; the five `indexes` layers carry 981 records.
2. `dolos bootstrap stelae --source file://…` with this PR's binary into a fresh node: restored 478 blocks, 4 logs, 981 index records, 14 entities, 11 utxos.
3. `dolos data stats` on the restored node: archive keyspaces `archive-blocks`, `archive-logs`, `archive-tags`, `index-exact`; index keyspace `index-cursor` only.
4. `dolos data check` on the restored node: `cursors`, `archive-continuity`, `account-epochs`, `epoch-log` clean; `totals` reports the pots 1,500,000,000 lovelace under the genesis supply — the same finding, to the lovelace, that `main`'s binary reports on the split-layout source node with `dolos data check`, so it predates this PR and lives in the Byron-era state, not in the archive or its indexes.
5. `dolos snapshot digest` on the restored node with this PR's binary: 88 layers, identity `sha256:21ebd3f3a17ba57437b826e3a59503abe4611e5f68dbecd756b73d25ef546d2f` — byte-identical to the stele the split layout published, `indexes` layers included.

Instance and stele left in place for QA under `/Volumes/Santi HDD/dolos-work/archive-index-verify/` (the split-layout source node is `/Volumes/Santi HDD/dolos-work/state-tags-verify/old`).

Not done here: the preprod replay comparison of the dissolved layout against the split one (the plan's write-path gate, PR #1257's method) needs two full preprod syncs and this machine has neither the SSD headroom nor the hours in this session. It is a merge gate for QA or the founder to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EDRw39A4EoGyFaJ7nZeMx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archive storage now provides block, transaction, tag, and exact-match lookups.
  * Archive indexes are committed and rolled back together with archive data.
  * Snapshot export, publishing, and restoration no longer require a separate index store.

* **Bug Fixes**
  * Catch-up and rollback flows now preserve archive index state correctly.
  * Lookup-based endpoints consistently resolve data through archive storage.

* **Documentation**
  * Updated storage architecture and keyspace documentation to reflect these responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->