### PR TITLE
feat(archive): prune the archive index entries with the blocks

### DIFF
--- a/crates/core/src/builtin/memory/archive.rs
+++ b/crates/core/src/builtin/memory/archive.rs
@@ -625,6 +625,14 @@ impl ArchiveStore for MemoryArchiveStore {
         tables.blocks.retain(|slot, _| *slot >= prune_before);
         tables.logs.retain(|(_, key), _| *key >= cutoff);
 
+        // The index entries of a pruned block go with it. The disk backend
+        // amortizes this across rounds; here a walk of the maps is the cost
+        // of a retain, so every round does it.
+        tables
+            .archive_tags
+            .retain(|(_, _, slot)| *slot >= prune_before);
+        tables.exact.retain(|_, slot| *slot >= prune_before);
+
         Ok(done)
     }
 

--- a/crates/fjall/src/archive/exact.rs
+++ b/crates/fjall/src/archive/exact.rs
@@ -122,6 +122,23 @@ fn decode_slot_value(value: &[u8]) -> u64 {
     decode_slot(value)
 }
 
+/// The slot a stored exact entry resolves to, read from its value.
+///
+/// The prune sweep's view of an entry: the slot is the value, so the key is
+/// not consulted. A value too short to carry one is a malformed entry,
+/// refused rather than skipped for the same reason the record scan fuses on
+/// it.
+pub fn slot_of_entry(value: &[u8]) -> Result<BlockSlot, Error> {
+    if value.len() < SLOT_SIZE {
+        return Err(Error::Codec(format!(
+            "malformed exact index value: {} bytes, expected {SLOT_SIZE}",
+            value.len(),
+        )));
+    }
+
+    Ok(decode_slot_value(value))
+}
+
 // ============================================================================
 // Block Processing
 // ============================================================================

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -30,9 +30,20 @@
 //! The two index keyspaces are projections of the blocks and are written in
 //! the same batch as the block locations, so the history and its lookups
 //! commit together. They keep the compaction settings the standalone index
-//! store gave them, and neither `prune_history` nor `truncate_front` touches
-//! them: a rollback removes its entries through
-//! [`CoreArchiveWriter::undo_index`], and pruning them is not done yet.
+//! store gave them. A rollback removes its entries through
+//! [`CoreArchiveWriter::undo_index`]; `truncate_front` does not touch them.
+//!
+//! ## Pruning the index keyspaces
+//!
+//! The slot is the *last* key component of a tag entry and the *value* of an
+//! exact entry, so neither keyspace can be range-deleted by slot the way the
+//! blocks and logs are. `prune_history` instead sweeps them: a full walk of
+//! both keyspaces removing every entry below the cutoff. Under sliding
+//! history the retained entry set is one window wide once the sweep has run,
+//! so a walk costs the window, not the chain — and the sweep is amortized
+//! across housekeeping rounds, running only when the cutoff has advanced by
+//! a sixteenth of the window since the last one. A node restored from a
+//! full-history stele pays one whole-keyspace scan on its first sweep.
 //!
 //! Unlike the redb writer, log batches are not reordered before insertion:
 //! shuffling exists to work around redb's half-split of ascending B-tree
@@ -42,6 +53,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::ops::{Bound, Range};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use dolos_core::{
@@ -83,6 +95,15 @@ const DEFAULT_CACHE_SIZE_MB: usize = 500;
 const INDEX_L0_THRESHOLD: u8 = 8;
 const INDEX_MEMTABLE_SIZE_MB: usize = 128;
 
+/// The index keyspaces are swept once the prune cutoff has advanced by this
+/// fraction of the retained window since the last sweep.
+const INDEX_SWEEP_WINDOW_DIVISOR: u64 = 16;
+
+/// Most removals one sweep batch carries before it is committed and a new
+/// one started, so the first sweep after a full-history restore — tens of
+/// millions of entries — never builds one memory-resident batch.
+const INDEX_SWEEP_BATCH_KEYS: usize = 100_000;
+
 /// Keyspace names for the archive store
 mod keyspace_names {
     /// Blocks location table (slot → packed BlockLocations)
@@ -118,6 +139,9 @@ pub struct ArchiveStore {
     flatfiles: Arc<FlatFileStore>,
     schema: Arc<StateSchema>,
     flush_on_commit: bool,
+    /// The prune cutoff the index keyspaces were last swept up to; zero
+    /// until the first sweep after open, which is why that one always runs.
+    last_index_sweep: Arc<AtomicU64>,
     _tempdir: Option<Arc<tempfile::TempDir>>,
 }
 
@@ -232,6 +256,7 @@ impl ArchiveStore {
             flatfiles: Arc::new(flatfiles),
             schema: Arc::new(schema),
             flush_on_commit,
+            last_index_sweep: Arc::new(AtomicU64::new(0)),
             _tempdir: tempdir,
         })
     }
@@ -320,6 +345,94 @@ impl ArchiveStore {
             Some(bytes) => Ok(decode_locations(&bytes).collect()),
             None => Ok(vec![]),
         }
+    }
+
+    /// Remove every index entry below `prune_before` if the cutoff has moved
+    /// far enough since the last sweep to be worth a walk of both keyspaces.
+    ///
+    /// The threshold is a sixteenth of the retained window (at least one
+    /// slot), so a sliding node walks its window-sized index about sixteen
+    /// times per window of chain instead of once per housekeeping round. The
+    /// first prune after open always sweeps.
+    fn sweep_indexes(
+        &self,
+        snapshot: &Snapshot,
+        prune_before: BlockSlot,
+        max_slots: u64,
+    ) -> Result<(), ArchiveError> {
+        let last = self.last_index_sweep.load(Ordering::Acquire);
+        let threshold = (max_slots / INDEX_SWEEP_WINDOW_DIVISOR).max(1);
+
+        if last != 0 && prune_before.saturating_sub(last) < threshold {
+            tracing::debug!(
+                cutoff_slot = prune_before,
+                last_sweep = last,
+                threshold,
+                "index sweep deferred"
+            );
+            return Ok(());
+        }
+
+        let tags = self.sweep_below(snapshot, &self.tags, prune_before, |key, _| {
+            tags::slot_of_entry(key)
+        })?;
+        let exact = self.sweep_below(snapshot, &self.exact, prune_before, |_, value| {
+            exact::slot_of_entry(value)
+        })?;
+
+        self.last_index_sweep.store(prune_before, Ordering::Release);
+
+        tracing::info!(
+            cutoff_slot = prune_before,
+            tags,
+            exact,
+            "swept archive index entries below cutoff"
+        );
+
+        Ok(())
+    }
+
+    /// Walk `keyspace` under `snapshot` and remove every entry whose slot,
+    /// as `slot_of` reads it from the entry, is below `prune_before`.
+    ///
+    /// Removals are committed in batches of at most
+    /// [`INDEX_SWEEP_BATCH_KEYS`], in sequence. Returns the number removed.
+    fn sweep_below(
+        &self,
+        snapshot: &Snapshot,
+        keyspace: &Keyspace,
+        prune_before: BlockSlot,
+        slot_of: impl Fn(&[u8], &[u8]) -> Result<BlockSlot, Error>,
+    ) -> Result<u64, ArchiveError> {
+        let mut removed = 0u64;
+        let mut batch = self.db.batch();
+
+        for guard in snapshot.iter(keyspace) {
+            let (key, value) = guard.into_inner().map_err(fjall_err)?;
+
+            if slot_of(&key, &value)? >= prune_before {
+                continue;
+            }
+
+            batch.remove(keyspace, key);
+            removed += 1;
+
+            if batch.len() >= INDEX_SWEEP_BATCH_KEYS {
+                let full = std::mem::replace(&mut batch, self.db.batch());
+                full.durability(Some(PersistMode::Buffer))
+                    .commit()
+                    .map_err(fjall_err)?;
+            }
+        }
+
+        if !batch.is_empty() {
+            batch
+                .durability(Some(PersistMode::Buffer))
+                .commit()
+                .map_err(fjall_err)?;
+        }
+
+        Ok(removed)
     }
 }
 
@@ -968,6 +1081,10 @@ impl CoreArchiveStore for ArchiveStore {
 
         let batch = batch.durability(Some(PersistMode::Buffer));
         batch.commit().map_err(fjall_err)?;
+
+        // The index keyspaces cannot be range-deleted by slot; they are swept
+        // under the same snapshot, after the rows that point at the blocks.
+        self.sweep_indexes(&snapshot, prune_before, max_slots)?;
 
         Ok(done)
     }

--- a/crates/fjall/src/archive/tags.rs
+++ b/crates/fjall/src/archive/tags.rs
@@ -82,6 +82,23 @@ fn decode_block_tag_slot(key: &[u8]) -> u64 {
     decode_slot(&key[start..])
 }
 
+/// The slot a stored tag entry belongs to, read from its key.
+///
+/// The prune sweep's view of an entry: the slot is the key's last component,
+/// so nothing but the key is needed. A key too short to carry one is a
+/// malformed entry, refused rather than skipped for the same reason the
+/// record scan fuses on it.
+pub fn slot_of_entry(key: &[u8]) -> Result<BlockSlot, Error> {
+    if key.len() < BLOCK_TAG_KEY_SIZE {
+        return Err(Error::Codec(format!(
+            "malformed archive tag key: {} bytes, expected {BLOCK_TAG_KEY_SIZE}",
+            key.len(),
+        )));
+    }
+
+    Ok(decode_block_tag_slot(key))
+}
+
 /// Decode the stored tag key hash from a block tag key (bytes 8..16)
 fn decode_block_tag_key_hash(key: &[u8]) -> KeyHash {
     debug_assert!(key.len() >= BLOCK_TAG_KEY_SIZE);

--- a/docs/content/architecture/data-layer.mdx
+++ b/docs/content/architecture/data-layer.mdx
@@ -49,7 +49,7 @@ The three storage modes exposed in configuration are really combinations of back
 
 `archive.backend = "no_op"` is the ledger-only switch, and it drops the historical lookups with the archive that hosts them. The live-UTxO tags are not affected: they project the UTxO set, so they stay in the state store in every mode (about 3.5 GB on mainnet).
 
-Pruning is driven by `prune_history()` on the WAL and archive stores. See the [configuration schema](../configuration/schema#storage-section) for the exact keys.
+Pruning is driven by `prune_history()` on the WAL and archive stores. In the archive it covers the block bodies, the logs, and the `archive-tags` and `index-exact` keyspaces, so a sliding-history node's index footprint is window-sized too. See the [configuration schema](../configuration/schema#storage-section) for the exact keys.
 
 ## Data model primitives
 

--- a/docs/content/operations/performance.mdx
+++ b/docs/content/operations/performance.mdx
@@ -72,7 +72,7 @@ Dolos includes a write-ahead log and bounded rollback history to support restart
 The most relevant configuration knobs are in the [`[sync]`](../configuration/schema#sync-section) section:
 
 - `max_rollback` controls how much rollback history Dolos keeps available for rollback handling.
-- `max_history` controls how much recent archive history remains before pruning.
+- `max_history` controls how much recent archive history remains before pruning. The window bounds the archive's block bodies, its logs, and its two index keyspaces (`archive-tags` and `index-exact`) alike: housekeeping removes the index entries of pruned blocks in a sweep of both keyspaces, run once the prune cutoff has advanced by a sixteenth of the window since the last sweep rather than every round. A sliding-history node restored from a full-history stele pays one whole-keyspace scan on its first sweep, then only window-sized ones.
 
 Bootstrap commands also provide flags such as `--continue` and `--skip-if-data` to help operators resume or safely avoid repeating work when data already exists. See the [bootstrap overview](../bootstrap).
 

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -1159,9 +1159,7 @@ fn slots_by_tag_bounds_are_inclusive<B: Backend>() {
     assert!(tagged_slots(&store, &key, 21, 29).is_empty());
 }
 
-// ---------------------------------------------------------------------------
 // Index entries: prune
-// ---------------------------------------------------------------------------
 
 /// The one tag key every block of a prune test carries, so `slots_by_tag`
 /// on it lists whatever blocks the store still holds.

--- a/tests/archive_conformance.rs
+++ b/tests/archive_conformance.rs
@@ -7,7 +7,8 @@
 //! block reads and walks (including the Byron boundary slot family), undo's
 //! segment truncation, prune and truncate boundaries, the log namespaces'
 //! write/read/range behavior, and the index entries a block projects (the
-//! exact lookups and the archive tags, written in the block's own commit).
+//! exact lookups and the archive tags, written in the block's own commit
+//! and pruned with it).
 //! The index half's export/restore contract has its own suite,
 //! `archive_index_roundtrip`.
 //!
@@ -1159,6 +1160,192 @@ fn slots_by_tag_bounds_are_inclusive<B: Backend>() {
 }
 
 // ---------------------------------------------------------------------------
+// Index entries: prune
+// ---------------------------------------------------------------------------
+
+/// The one tag key every block of a prune test carries, so `slots_by_tag`
+/// on it lists whatever blocks the store still holds.
+const SHARED_TAG_KEY: [u8; 28] = [0xAA; 28];
+
+/// The index entries of a block at `slot`, derived from the slot alone so a
+/// test can probe any block it wrote without keeping the deltas around: the
+/// block number is the slot, the hashes carry the slot in their leading
+/// bytes.
+fn slot_delta(slot: u64) -> ArchiveIndexDelta {
+    let mut block_hash = vec![0u8; 32];
+    block_hash[..8].copy_from_slice(&slot.to_be_bytes());
+
+    let mut tx_hash = vec![0xFFu8; 32];
+    tx_hash[8..16].copy_from_slice(&slot.to_be_bytes());
+
+    ArchiveIndexDelta {
+        slot,
+        block_hash,
+        block_number: Some(slot),
+        tx_hashes: vec![tx_hash],
+        tags: vec![Tag::new(
+            archive_dimensions::ADDRESS,
+            SHARED_TAG_KEY.to_vec(),
+        )],
+    }
+}
+
+/// Write a block and its [`slot_delta`] entries at every slot, one commit.
+fn write_indexed_blocks<S: CoreArchiveStore>(store: &S, slots: &[u64]) {
+    let writer = store.start_writer().unwrap();
+    for &slot in slots {
+        writer
+            .apply(&point(slot), &Arc::new(fake_block(slot)))
+            .unwrap();
+        writer.apply_index(&[slot_delta(slot)]).unwrap();
+    }
+    writer.commit().unwrap();
+}
+
+/// Whether every exact lookup of the block at `slot` still resolves.
+///
+/// The three answer together or not at all: a block's entries are pruned
+/// as one, so a split answer is a defect this helper would hide.
+fn exact_entries_present<S: CoreArchiveStore>(store: &S, slot: u64) -> bool {
+    let delta = slot_delta(slot);
+    let answers = [
+        store.slot_by_block_hash(&delta.block_hash).unwrap(),
+        store.slot_by_tx_hash(&delta.tx_hashes[0]).unwrap(),
+        store.slot_by_block_number(slot).unwrap(),
+    ];
+
+    match answers {
+        [Some(a), Some(b), Some(c)] if a == slot && b == slot && c == slot => true,
+        [None, None, None] => false,
+        other => panic!("the exact entries of slot {slot} disagree: {other:?}"),
+    }
+}
+
+/// Pruning the blocks below the cutoff prunes their index entries with
+/// them: no exact lookup resolves a pruned block and no tag names it, while
+/// every block still held keeps every entry.
+fn prune_history_drops_tags_and_exact_below_the_cutoff<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let slots: Vec<u64> = (0..=1_000).step_by(100).collect();
+    write_indexed_blocks(&store, &slots);
+
+    // Start 0, tip 1000, window 500: prune before slot 500.
+    let done = store.prune_history(500, None).unwrap();
+    assert!(done);
+
+    for &slot in &slots {
+        let retained = slot >= 500;
+        assert_eq!(
+            store.get_block_by_slot(&slot).unwrap().is_some(),
+            retained,
+            "block at {slot}"
+        );
+        assert_eq!(
+            exact_entries_present(&store, slot),
+            retained,
+            "exact entries of {slot}"
+        );
+    }
+
+    assert_eq!(
+        tagged_slots(&store, &SHARED_TAG_KEY, 0, u64::MAX),
+        [500, 600, 700, 800, 900, 1_000]
+    );
+}
+
+/// The cutoff is exclusive for index entries exactly as it is for blocks and
+/// logs: the entries of the block at the cutoff slot survive, the entries of
+/// the block one slot before it go.
+fn prune_keeps_index_entries_at_the_cutoff_slot<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    write_indexed_blocks(&store, &[0, 499, 500, 501, 1_000]);
+
+    // Start 0, tip 1000, window 500: prune before slot 500.
+    let done = store.prune_history(500, None).unwrap();
+    assert!(done);
+
+    assert!(!exact_entries_present(&store, 0));
+    assert!(!exact_entries_present(&store, 499));
+    assert!(exact_entries_present(&store, 500));
+    assert!(exact_entries_present(&store, 501));
+    assert!(exact_entries_present(&store, 1_000));
+
+    assert_eq!(
+        tagged_slots(&store, &SHARED_TAG_KEY, 0, u64::MAX),
+        [500, 501, 1_000]
+    );
+}
+
+/// A tag query whose range straddles the cutoff answers only the retained
+/// side of it, and a range entirely below the cutoff answers nothing —
+/// the same shape `get_range` has over the pruned blocks.
+fn slots_by_tag_after_prune_answers_only_retained_slots<B: Backend>() {
+    let (store, _guard) = B::open();
+
+    let slots: Vec<u64> = (0..=1_000).step_by(100).collect();
+    write_indexed_blocks(&store, &slots);
+
+    // Start 0, tip 1000, window 300: prune before slot 700.
+    let done = store.prune_history(300, None).unwrap();
+    assert!(done);
+
+    assert_eq!(tagged_slots(&store, &SHARED_TAG_KEY, 100, 800), [700, 800]);
+    assert!(tagged_slots(&store, &SHARED_TAG_KEY, 0, 699).is_empty());
+    assert_eq!(
+        tagged_slots(&store, &SHARED_TAG_KEY, 0, u64::MAX),
+        [700, 800, 900, 1_000]
+    );
+}
+
+/// The fjall backend sweeps its index keyspaces only when the cutoff has
+/// advanced by a sixteenth of the window since the last sweep, so between
+/// sweeps a pruned block's entries linger; the memory backend has no such
+/// cadence, which is why this is not a conformance case.
+///
+/// Window 1600 makes the threshold 100 slots; each round prunes 40. The
+/// first prune after open always sweeps, the next two fall inside the
+/// threshold and leave the entries of the blocks they pruned in place, and
+/// the fourth crosses it and removes them.
+#[test]
+fn fjall_index_sweep_is_amortized_across_prune_rounds() {
+    let (store, _guard) = Fjall::open();
+
+    let slots: Vec<u64> = (0..=3_000).step_by(10).collect();
+    write_indexed_blocks(&store, &slots);
+
+    let max_slots = 1_600;
+    let max_prune = Some(40);
+
+    // Round 1: cutoff 40, first sweep after open.
+    assert!(!store.prune_history(max_slots, max_prune).unwrap());
+    assert!(!exact_entries_present(&store, 30));
+    assert!(exact_entries_present(&store, 40));
+
+    // Rounds 2 and 3: cutoffs 80 and 120, inside the threshold. The blocks
+    // are gone, their entries are not yet.
+    assert!(!store.prune_history(max_slots, max_prune).unwrap());
+    assert!(!store.prune_history(max_slots, max_prune).unwrap());
+    assert_eq!(store.get_block_by_slot(&40).unwrap(), None);
+    assert_eq!(store.get_block_by_slot(&110).unwrap(), None);
+    assert!(exact_entries_present(&store, 40));
+    assert!(exact_entries_present(&store, 110));
+    assert_eq!(
+        tagged_slots(&store, &SHARED_TAG_KEY, 0, 120),
+        [40, 50, 60, 70, 80, 90, 100, 110, 120]
+    );
+
+    // Round 4: cutoff 160, past the threshold: everything below it goes.
+    assert!(!store.prune_history(max_slots, max_prune).unwrap());
+    assert!(!exact_entries_present(&store, 40));
+    assert!(!exact_entries_present(&store, 110));
+    assert!(!exact_entries_present(&store, 150));
+    assert!(exact_entries_present(&store, 160));
+    assert_eq!(tagged_slots(&store, &SHARED_TAG_KEY, 0, 170), [160, 170]);
+}
+
+// ---------------------------------------------------------------------------
 // Cross-backend agreement: both backends walk identical data identically
 // ---------------------------------------------------------------------------
 
@@ -1278,6 +1465,9 @@ macro_rules! full_suite {
                 apply_index_then_slot_by_tx_hash_resolves,
                 undo_index_removes_exactly_what_apply_index_added,
                 slots_by_tag_bounds_are_inclusive,
+                prune_history_drops_tags_and_exact_below_the_cutoff,
+                prune_keeps_index_entries_at_the_cutoff_slot,
+                slots_by_tag_after_prune_answers_only_retained_slots,
             ]
         );
     };


### PR DESCRIPTION
Piece 5 of the index store dissolution: under `sync.max_history`, the archive's tags and exact lookups for pruned slots are removed by the same housekeeping that prunes the blocks and logs. Before this, nothing pruned them — on mainnet that is 29 GB of `archive-tags` and 6 GB of `index-exact` growing at the full-archive rate under a mode whose point is a bounded footprint.

Plan: `plans/dolos-index-store-dissolution-prune-archive-index.md` in the txpipe domain (awaits #1304, merged).

## What changes

- **fjall archive.** The slot is the *last* key component of an `archive-tags` entry and the *value* of an `index-exact` entry, so neither keyspace can be range-deleted by slot the way the blocks and logs are. `prune_history` now sweeps them under the round's snapshot, after the block and log removals commit: a walk of each keyspace removing every entry below the cutoff, in batches of at most 100,000 removals committed in sequence, so the first sweep after a full-history restore never builds one memory-resident batch. The sweep is amortized: `last_index_sweep: AtomicU64` on the store (zero at open) gates it to run only when the cutoff has advanced by `max(max_slots / 16, 1)` since the last sweep, which is also true on the first prune after open. `done` keeps its meaning; the sweep never changes it. `tags::slot_of_entry` and `exact::slot_of_entry` read the slot from an entry and refuse a malformed one, the same way the record scan does.
- **Memory archive.** `prune_history` retains tags and exact entries at or above the cutoff, every round; no amortization needed for a walk of two ordered maps.
- **Docs.** `operations/performance.mdx` states that `max_history` bounds the two index keyspaces too, with the sweep cadence and the one whole-keyspace scan a node restored from a full-history stele pays on its first sweep; `architecture/data-layer.mdx` names the keyspaces pruning covers; the fjall archive module doc replaces "pruning them is not done yet".

A full-history node never calls `prune_history` and is untouched. Entries of blocks pruned before this lands are not swept retroactively (those nodes are pre-dissolution and re-bootstrap for v1.7). Skipping stale `indexes` layers at restore time is out of scope.

## Verification

- `cargo +nightly-2026-08-27 fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `tests/archive_conformance.rs`: 86 passed, 0 failed (fjall and memory suites plus the fjall-only case). Gains, on fjall and memory, `prune_history_drops_tags_and_exact_below_the_cutoff`, `prune_keeps_index_entries_at_the_cutoff_slot` (the cutoff is exclusive for entries as it is for blocks) and `slots_by_tag_after_prune_answers_only_retained_slots`; plus the fjall-only `fjall_index_sweep_is_amortized_across_prune_rounds` (window 1,600, rounds of 40: the first prune sweeps, the next two leave the pruned blocks' entries in place, the fourth crosses the 100-slot threshold and removes them).
- `cargo test -p dolos-fjall -p dolos-core --all-targets`: 39 + 43 passed, 0 failed.
- `tests/archive_index_roundtrip.rs`, `tests/bootstrap.rs`: 18 passed (3 ignored) and 6 passed, 0 failed.

## Housekeeping on a restored node

A copy of the archive-index acceptance node (preprod, restored from a split-layout stele by #1304's binary: 478 Byron blocks to slot 95020, 981 index records) with `sync.max_history = 21600` (one Byron epoch) added, drained by `dolos data housekeeping` with this PR's debug binary:

- `data check` before: `cursors`, `archive-continuity`, `account-epochs`, `epoch-log` clean; `totals` reports the pre-existing 1,500,000,000-lovelace Byron finding #1304 documented.
- Housekeeping: 7 rounds, cutoffs 10000 → 20802 → 31600 → 42403 → 53201 → 64002 → 73420 (the 10,000-slot cap per round, then the window). With a 21,600-slot window the sweep threshold is 1,350 slots, so every round crossed it and swept: `exact` removed 12, 10, 10, 10, 16, 12, 8 (78 in total, the block-hash and block-number entries of the 39 blocks below slot 73420); `tags` removed 0 (the pruned Byron blocks carry no transactions, so no address tags).
- A second `data housekeeping` converges in one round with nothing to prune and no sweep.
- `data check` after: `cursors`, `archive-continuity`, `account-epochs` clean; `totals` unchanged; **`epoch-log` now reports the `epochs` log empty while the state is in epoch 4**. That is the existing log range-delete in `prune_history` (untouched here, it runs before the sweep) removing the epoch rows below the cutoff — a sliding-history node and the `epoch-log` check disagree independently of this PR. Reported, not fixed here.

`data stats` reports `disk_bytes: 0` for every keyspace on a database this small (everything sits in the journal and memtables), so the footprint comparison the plan asks for needs a node past its first flush; the sweep counts above are the evidence at this scale. Instance left in place for QA under `/Volumes/Santi HDD/dolos-work/prune-archive-index-verify/preprod` (the source node is untouched at `archive-index-verify/preprod`).

Not done here: the plan's live verification — a preprod node with `max_history` of one epoch synced across two epoch boundaries with `data stats` sampled at each — needs a multi-hour sync this session did not run. It is a gate for QA or the founder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLp4a3WMptnuUsDvr3uidi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Archive history pruning now removes outdated archive tags and exact-index entries alongside blocks and logs.
  - Entries at or above the pruning boundary are retained.
  - Index cleanup is performed periodically to reduce unnecessary processing during repeated pruning.
  - Historical lookups now remain consistent with the retained archive after pruning.

- **Documentation**
  - Clarified archive pruning behavior, retained history limits, and index storage impact across data-layer and performance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->