### PR TITLE
fix(storage): close index dissolution follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ projection, and lives in the store that holds what it projects:
 └── scratch  # not a store: stele layers staged in flight by a registry transfer
 ```
 
-Each database is a separate Redb or Fjall store with independent configuration for cache size and durability, depending on the chosen storage backend.
+The persistent WAL uses Redb, while state and archive use separate Fjall databases with independent cache and durability configuration. Builtin memory stores serve ephemeral nodes, tooling, and tests.
 
 ## Crate Architecture
 
@@ -89,15 +89,15 @@ The project follows a modular workspace architecture with clear separation of co
 - **Dependencies**: `dolos-core`, Pallas library for Cardano protocol support
 
 #### `dolos-redb3` (Storage Backend)
-- **Purpose**: Storage backend implementation using the Redb v3 embedded database
+- **Purpose**: Redb v3 implementations retained for the WAL, mempool, and legacy state tests
 - **Components**:
-  - `state`: `StateStore` implementation with UTxO storage and entity tables
-  - `archive`: `ArchiveStore` implementation with block and log storage
   - `wal`: `WalStore` implementation for crash recovery
-- **Role**: Persistence layer implementing the core storage traits
+  - `mempool`: persistent mempool storage
+  - `state`: legacy `StateStore` implementation used by tests, not a supported node configuration backend
+- **Role**: Persistence layer for the WAL and mempool
 
-#### `dolos-fjall` (Alternative Storage Backend)
-- **Purpose**: Alternative storage backend implementation using the Fjall LSM-tree embedded database
+#### `dolos-fjall` (State and Archive Storage)
+- **Purpose**: Persistent state and archive implementation using the Fjall LSM-tree embedded database
 - **Design Philosophy**: Optimized for write-heavy workloads with many keys, ideal for blockchain data
 - **Components**:
   - `state`: `StateStore` implementation with four-keyspace design:
@@ -115,7 +115,7 @@ The project follows a modular workspace architecture with clear separation of co
   - Reduced segment files compared to per-entity keyspaces
   - Chain-agnostic design using dimension hashing
   - LSM-tree optimization for high-write blockchain workloads
-- **Role**: Alternative persistence layer implementing `StateStore` and `ArchiveStore` traits
+- **Role**: Primary persistence layer implementing `StateStore` and `ArchiveStore` traits
 
 ### Service Crates
 
@@ -349,6 +349,6 @@ All agents working on this repository must verify their modifications by running
 - All warnings from `cargo clippy` must be resolved before committing changes
 - Code should follow existing Rust conventions and patterns established in the codebase
 - New implementations should follow the trait-based architecture patterns
-- Storage implementations should maintain consistency between backends (redb3 and fjall)
+- Storage implementations that share a trait should maintain the same observable contract across backends
 
 These verification steps ensure code quality, maintain consistency across storage backends, and prevent introducing technical debt into the codebase.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Dolos connects directly to the Cardano network using Ouroboros Node-to-Node (N2N
 
 ### Operations & Observability
 
-- **Dual storage backends** — Choose between Redb v3 or Fjall LSM-tree based on your workload
+- **Purpose-built storage** — Fjall LSM trees for state and archive data, with a Redb WAL for crash recovery
 - **OpenTelemetry integration** — Distributed tracing with OTLP export
 - **Prometheus metrics** — Health and performance monitoring endpoints
 - **Rust implementation** — Memory safety, high performance, and small binary size
@@ -76,12 +76,12 @@ Dolos connects directly to the Cardano network using Ouroboros Node-to-Node (N2N
 
 Dolos follows a modular, layered architecture:
 
-- **Core abstractions** (`dolos-core`) — Storage traits (State, Archive, WAL, Index), entity-delta system, and batch processing pipeline
+- **Core abstractions** (`dolos-core`) — Storage traits (State, Archive, WAL), entity-delta system, and batch processing pipeline
 - **Cardano logic** (`dolos-cardano`) — Era-specific block processing, validation, reward calculation, and UTxO delta computation
-- **Storage backends** — Pluggable implementations: Redb v3 or Fjall LSM-tree
+- **Storage backends** — Fjall state/archive stores, a Redb WAL, and builtin in-memory stores for ephemeral nodes and tests
 - **Service layer** — gRPC, REST, and Ouroboros protocol servers
 
-Data is organized into four isolated storage layers: State (current ledger), Archive (historical blocks), WAL (crash recovery), and Index (fast lookups). State mutations use an entity-delta pattern enabling efficient rollbacks without full snapshots.
+Data is organized into three storage layers: State (current ledger and live-UTxO tags), Archive (historical blocks and their lookup indexes), and WAL (crash recovery). State mutations use an entity-delta pattern enabling efficient rollbacks without full snapshots.
 
 ## Quick Start
 

--- a/crates/snapshot/src/restore.rs
+++ b/crates/snapshot/src/restore.rs
@@ -93,13 +93,13 @@
 //! index records by their own stored key, entities by namespace and key, UTxOs
 //! by their `TxoRef`.
 //!
-//! One cost is real and worth stating rather than discovering. The redb archive
-//! appends block bodies to flat files and keeps a slot-keyed table of offsets,
-//! so a redone `blocks` layer leaves the superseded bodies in the segment file
-//! with nothing pointing at them. Reads go through the table, so the node is
-//! correct; the dead space is bounded by one layer and is the price of not
-//! starting over. The preflight carries no addend for it; the reason is on
-//! [`Plan::remaining_uncompressed_size`].
+//! One cost is real and worth stating rather than discovering. The fjall
+//! archive appends block bodies to flat files and keeps a slot-keyed table of
+//! offsets, so a redone `blocks` layer leaves the superseded bodies in the
+//! segment file with nothing pointing at them. Reads go through the table, so
+//! the node is correct; the dead space is bounded by one layer and is the price
+//! of not starting over. The preflight carries no addend for it; the reason is
+//! on [`Plan::remaining_uncompressed_size`].
 //!
 //! ## Memory
 //!
@@ -395,7 +395,7 @@ impl Plan {
     /// runs that would finish.
     ///
     /// **No addend.** A redone layer is rewritten and not appended — every
-    /// write path is keyed — with one exception, the redb archive, which
+    /// write path is keyed — with one exception, the fjall archive, which
     /// leaves the superseded block bodies of an interrupted `blocks` layer as
     /// dead space in its segment file. That is past spend, not future spend:
     /// [`preflight::check`] reads free space at check time, so those bytes are
@@ -907,6 +907,9 @@ pub struct Restoring<'a> {
     pub storage_path: &'a Path,
     /// The operator's `--continue`.
     pub resume: bool,
+    /// The operator explicitly accepted the risk of restoring without checking
+    /// the destination and staging volumes against the stele's declared sizes.
+    pub skip_space_check: bool,
 }
 
 /// Restore `plan`'s layers into a store set.
@@ -1086,7 +1089,7 @@ where
         unsized_layers: outlook.remaining.unsized_layers,
     });
 
-    plan.preflight(node.storage_path, checkpoint.resume(), staging)?;
+    check_restore_space(&plan, node, checkpoint.resume(), staging)?;
 
     let summary = restore(
         stele,
@@ -1099,6 +1102,20 @@ where
     )?;
 
     Ok((plan, outlook, summary))
+}
+
+fn check_restore_space(
+    plan: &Plan,
+    node: Restoring<'_>,
+    resume: &Resume,
+    staging: Option<Staging<'_>>,
+) -> Result<(), Error> {
+    if node.skip_space_check {
+        tracing::warn!("skipping restore disk-space preflight by operator request");
+        Ok(())
+    } else {
+        plan.preflight(node.storage_path, resume, staging)
+    }
 }
 
 /// Restore from a stele directory.
@@ -2154,6 +2171,20 @@ mod tests {
             .preflight(temp.path(), &Resume::none(), None)
             .unwrap_err();
         assert!(matches!(err, Error::NotEnoughSpace(_)), "{err:?}");
+
+        check_restore_space(
+            &plan,
+            Restoring {
+                network_magic: 0,
+                max_history: None,
+                storage_path: temp.path(),
+                resume: false,
+                skip_space_check: true,
+            },
+            &Resume::none(),
+            None,
+        )
+        .unwrap();
     }
 
     /// The destination need is the resume's, not the plan's: a resumed

--- a/crates/snapshot/tests/restore_registry.rs
+++ b/crates/snapshot/tests/restore_registry.rs
@@ -198,6 +198,7 @@ fn restoring(storage: &std::path::Path, magic: u64, resume: bool) -> restore::Re
         max_history: None,
         storage_path: storage,
         resume,
+        skip_space_check: false,
     }
 }
 

--- a/src/bin/dolos/bootstrap/stelae.rs
+++ b/src/bin/dolos/bootstrap/stelae.rs
@@ -70,6 +70,11 @@ pub struct Args {
     /// stages nothing
     #[arg(long, value_name = "DIR")]
     pub scratch_dir: Option<PathBuf>,
+
+    /// skip the restore disk-space preflight and continue even when the
+    /// stele's declared sizes exceed the available space
+    #[arg(long, action)]
+    pub skip_space_check: bool,
 }
 
 impl Args {
@@ -88,6 +93,7 @@ impl Args {
             point: Point::default(),
             insecure: false,
             scratch_dir: None,
+            skip_space_check: false,
         })
     }
 }
@@ -98,6 +104,13 @@ struct Node {
     stores: crate::common::Stores,
     magic: u64,
     max_history: Option<u64>,
+}
+
+#[derive(Clone, Copy)]
+struct RestoreOptions<'a> {
+    feedback: &'a Feedback,
+    resume: bool,
+    skip_space_check: bool,
 }
 
 impl Node {
@@ -121,12 +134,17 @@ impl Node {
     }
 
     /// What this node knows about itself, as the restore driver takes it.
-    fn restoring(&self, resume: bool) -> dolos_snapshot::restore::Restoring<'_> {
+    fn restoring(
+        &self,
+        resume: bool,
+        skip_space_check: bool,
+    ) -> dolos_snapshot::restore::Restoring<'_> {
         dolos_snapshot::restore::Restoring {
             network_magic: self.magic,
             max_history: self.max_history,
             storage_path: &self.root,
             resume,
+            skip_space_check,
         }
     }
 
@@ -145,15 +163,14 @@ impl Node {
 fn restore_dir(
     config: &RootConfig,
     dir: &std::path::Path,
-    feedback: &Feedback,
-    resume: bool,
+    options: RestoreOptions<'_>,
 ) -> miette::Result<()> {
     let node = Node::open(config)?;
-    let progress = SteleProgress::restoring(feedback);
+    let progress = SteleProgress::restoring(options.feedback);
 
     let (plan, outlook, summary) = dolos_snapshot::restore::restore_dir(
         dir,
-        node.restoring(resume),
+        node.restoring(options.resume, options.skip_space_check),
         node.target(),
         &progress.observer(),
     )
@@ -173,8 +190,7 @@ fn restore_repo(
     point: Point,
     insecure: bool,
     scratch_dir: Option<&std::path::Path>,
-    feedback: &Feedback,
-    resume: bool,
+    options: RestoreOptions<'_>,
 ) -> miette::Result<()> {
     // First: `Node::open` runs `ensure_storage_path`, so the default of
     // `<storage.path>/scratch` needs no special case on a host where the
@@ -194,12 +210,12 @@ fn restore_repo(
 
     println!("source:   {repo} ({point})");
 
-    let progress = SteleProgress::restoring(feedback);
+    let progress = SteleProgress::restoring(options.feedback);
 
     let (plan, outlook, summary) = registry::restore_registry(
         &registry,
         point,
-        node.restoring(resume),
+        node.restoring(options.resume, options.skip_space_check),
         node.target(),
         &progress.observer(),
     )
@@ -314,16 +330,21 @@ pub fn run(
     feedback: &Feedback,
     resume: bool,
 ) -> miette::Result<()> {
+    let options = RestoreOptions {
+        feedback,
+        resume,
+        skip_space_check: args.skip_space_check,
+    };
+
     match &args.source {
-        Source::Dir(dir) => restore_dir(config, dir, feedback, resume),
+        Source::Dir(dir) => restore_dir(config, dir, options),
         Source::Repo(repo) => restore_repo(
             config,
             repo,
             args.point,
             args.insecure,
             args.scratch_dir.as_deref(),
-            feedback,
-            resume,
+            options,
         ),
     }
 }

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use dolos::storage::ArchiveStoreBackend;
+use dolos::storage::{ArchiveStoreBackend, StateStoreBackend};
 use dolos_core::config::RootConfig;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -126,6 +126,14 @@ fn append_dir_filtered(
     Ok(())
 }
 
+fn ensure_state_exportable(state: &StateStoreBackend, include_state: bool) -> miette::Result<()> {
+    if matches!(state, StateStoreBackend::Memory(_)) && include_state {
+        bail!("the in-memory state keeps nothing on disk to export");
+    }
+
+    Ok(())
+}
+
 pub fn run(
     config: &RootConfig,
     args: &Args,
@@ -139,6 +147,8 @@ pub fn run(
 
     let mut stores = crate::common::open_data_stores(config)?;
     let root = crate::common::ensure_storage_path(config)?;
+
+    ensure_state_exportable(&stores.state, args.include_state)?;
 
     match &mut stores.archive {
         ArchiveStoreBackend::LogsOnly(_) if !args.skip_sanitization => {
@@ -190,4 +200,19 @@ pub fn run(
     archive.finish().into_diagnostic()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn including_an_in_memory_state_is_refused() {
+        let state = StateStoreBackend::in_memory().unwrap();
+
+        ensure_state_exportable(&state, false).unwrap();
+
+        let error = ensure_state_exportable(&state, true).unwrap_err();
+        assert!(error.to_string().contains("nothing on disk to export"));
+    }
 }

--- a/src/bin/dolos/data/export.rs
+++ b/src/bin/dolos/data/export.rs
@@ -134,6 +134,15 @@ fn ensure_state_exportable(state: &StateStoreBackend, include_state: bool) -> mi
     Ok(())
 }
 
+fn create_export_file(
+    output: &Path,
+    state: &StateStoreBackend,
+    include_state: bool,
+) -> miette::Result<File> {
+    ensure_state_exportable(state, include_state)?;
+    File::create(output).into_diagnostic()
+}
+
 pub fn run(
     config: &RootConfig,
     args: &Args,
@@ -141,14 +150,12 @@ pub fn run(
 ) -> miette::Result<()> {
     let pb = feedback.indeterminate_progress_bar();
 
-    let export_file = File::create(&args.output).into_diagnostic()?;
-    let encoder = GzEncoder::new(export_file, Compression::default());
-    let mut archive = Builder::new(encoder);
-
     let mut stores = crate::common::open_data_stores(config)?;
     let root = crate::common::ensure_storage_path(config)?;
 
-    ensure_state_exportable(&stores.state, args.include_state)?;
+    let export_file = create_export_file(&args.output, &stores.state, args.include_state)?;
+    let encoder = GzEncoder::new(export_file, Compression::default());
+    let mut archive = Builder::new(encoder);
 
     match &mut stores.archive {
         ArchiveStoreBackend::LogsOnly(_) if !args.skip_sanitization => {
@@ -208,11 +215,15 @@ mod tests {
 
     #[test]
     fn including_an_in_memory_state_is_refused() {
+        let temp = tempfile::tempdir().unwrap();
+        let output = temp.path().join("existing.tar.gz");
+        std::fs::write(&output, b"keep me").unwrap();
         let state = StateStoreBackend::in_memory().unwrap();
 
         ensure_state_exportable(&state, false).unwrap();
 
-        let error = ensure_state_exportable(&state, true).unwrap_err();
+        let error = create_export_file(&output, &state, true).unwrap_err();
         assert!(error.to_string().contains("nothing on disk to export"));
+        assert_eq!(std::fs::read(output).unwrap(), b"keep me");
     }
 }

--- a/src/bin/dolos/doctor/rebuild_state.rs
+++ b/src/bin/dolos/doctor/rebuild_state.rs
@@ -319,10 +319,10 @@ fn next_chunk(
 
 /// Replay the archive into the rebuild domain in chunks.
 ///
-/// The range iterator is re-opened per chunk: it holds a redb read
-/// transaction, and one held across writes blocks page reclamation for the
-/// whole run. Returns whether the replay stopped at `stop_epoch` rather than
-/// at the archive tip.
+/// The range iterator is re-opened per chunk: it owns a fjall snapshot, and one
+/// held across the whole replay would pin superseded versions while writes
+/// rebuild the state. Returns whether the replay stopped at `stop_epoch`
+/// rather than at the archive tip.
 fn replay(
     domain: &DomainAdapter,
     source: &ArchiveStoreBackend,


### PR DESCRIPTION
## Summary

- add `dolos bootstrap stelae --skip-space-check` to explicitly bypass restore destination and staging disk preflight
- reject `data export --include-state` for the builtin in-memory state backend
- update stale Redb/index-store architecture and rebuild-state documentation

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo clippy -p dolos -p dolos-snapshot --lib --bins -- -D warnings`
- targeted restore-preflight and memory-export regression tests
- `cargo build --release --bin dolos`

The repository-wide all-target clippy command also reaches unrelated pre-existing warnings in Cardano and snapshot test code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to bypass disk-space checks when restoring a stele.
  - State exports now reject unsupported in-memory state exports safely.

- **Bug Fixes**
  - Prevented failed export validation from overwriting existing destination files.

- **Documentation**
  - Clarified storage architecture, including persistent state/archive storage, write-ahead logging, and ephemeral in-memory stores.
  - Updated restore and replay documentation to reflect current storage behavior.

- **Tests**
  - Added coverage for skipped restore disk-space checks and protecting existing files during invalid exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->