### PR TITLE
feat(archive): mixed raw and compressed segments with a recoverable transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ version = "1.7.0-alpha.1"
 dependencies = [
  "dolos-cardano",
  "dolos-core",
+ "dolos-flatfiles",
  "dolos-mithril",
  "dolos-testing",
  "hex",

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -1,7 +1,8 @@
 //! Fjall-based archive store implementation for Dolos.
 //!
 //! The archive keeps block bodies in flat segment files ([`dolos_flatfiles`],
-//! shared byte for byte with the redb backend) and holds the rows that point
+//! raw or compressed per segment, addressed by the same packed locations
+//! either way) and holds the rows that point
 //! into the history — a blocks location table, the derived-log namespaces,
 //! and the two index projections of the blocks — in an LSM tree. Behavior is
 //! pinned by the shared conformance suite (`tests/archive_conformance.rs`),
@@ -68,7 +69,11 @@ use fjall::{
 };
 use pallas::ledger::traverse::MultiEraBlock;
 
-use dolos_flatfiles::{decode_locations, encode_locations, BlockLocation, FlatFileStore};
+use dolos_flatfiles::{
+    compressed::{WriteSummary, WriterOptions},
+    decode_locations, encode_locations, BlockLocation, FlatFileStore, SegmentInfo,
+    SLOTS_PER_SEGMENT,
+};
 
 use crate::keys::{dim_prefix, hash_dimension, DIM_HASH_SIZE};
 use crate::Error;
@@ -179,6 +184,9 @@ impl ArchiveStore {
             .clone()
             .unwrap_or_else(|| path.to_path_buf());
 
+        // Opening recovers any interrupted representation transition and
+        // validates every compressed segment's metadata and dictionary, so a
+        // segment this build cannot read fails the open, naming the segment.
         let flatfiles = FlatFileStore::new(segments_dir).map_err(|e| Error::Io(e.to_string()))?;
 
         Self::from_database(
@@ -264,6 +272,57 @@ impl ArchiveStore {
     /// Get a reference to the underlying database
     pub fn database(&self) -> &Database {
         &self.db
+    }
+
+    /// The block segment files and their representations, ascending.
+    pub fn segments(&self) -> Result<Vec<SegmentInfo>, Error> {
+        self.flatfiles
+            .segments()
+            .map_err(|e| Error::Io(e.to_string()))
+    }
+
+    /// Every location the blocks table holds inside `segment_id`.
+    fn segment_locations(&self, segment_id: u32) -> Result<Vec<BlockLocation>, Error> {
+        let first = segment_id as u64 * SLOTS_PER_SEGMENT;
+        let end = first + SLOTS_PER_SEGMENT;
+        let snapshot = self.db.snapshot();
+        let range = snapshot.range(
+            &self.blocks,
+            first.to_be_bytes().to_vec()..end.to_be_bytes().to_vec(),
+        );
+
+        let mut locations = Vec::new();
+        for guard in range {
+            let (_, value) = guard.into_inner()?;
+            locations.extend(decode_locations(&value).filter(|loc| loc.segment_id == segment_id));
+        }
+
+        Ok(locations)
+    }
+
+    /// Compress the block segment `segment_id` in place, cutting frames at
+    /// the block boundaries the blocks table records for it.
+    ///
+    /// The index is not rewritten: every packed location keeps addressing
+    /// the same logical bytes. A later append to or truncation of the
+    /// segment converts it back to raw on its own. This is the primitive an
+    /// offline sealing tool calls; nothing here schedules it.
+    pub fn seal_segment(
+        &self,
+        segment_id: u32,
+        options: &WriterOptions,
+    ) -> Result<WriteSummary, Error> {
+        let locations = self.segment_locations(segment_id)?;
+        self.flatfiles
+            .seal(segment_id, &locations, options)
+            .map_err(|e| Error::Io(e.to_string()))
+    }
+
+    /// Restore the block segment `segment_id` to its raw representation.
+    pub fn thaw_segment(&self, segment_id: u32) -> Result<(), Error> {
+        self.flatfiles
+            .thaw(segment_id)
+            .map_err(|e| Error::Io(e.to_string()))
     }
 
     /// Per-keyspace disk footprint: `(name, bytes, path)`.

--- a/crates/fjall/src/lib.rs
+++ b/crates/fjall/src/lib.rs
@@ -20,6 +20,10 @@ pub mod archive;
 pub mod keys;
 pub mod state;
 
+/// The segment file crate the archive's public surface speaks in
+/// (`WriterOptions`, `SegmentInfo`, `Representation`).
+pub use dolos_flatfiles as flatfiles;
+
 // Re-export main types for convenience
 pub use state::{StateStore, StateWriter};
 

--- a/crates/flatfiles/COMPRESSED.md
+++ b/crates/flatfiles/COMPRESSED.md
@@ -204,9 +204,10 @@ Dictionary preparation is fallible: a matching content hash establishes
 identity, but malformed trained-dictionary contents still yield an
 `InvalidData` error naming the dictionary instead of panicking.
 
-Producing compressed files from a live store, choosing where dictionaries
-live, and routing `FlatFileStore::read` through this reader are lifecycle
-concerns implemented outside this module.
+Producing compressed files from a live store, where dictionaries live, and
+how `FlatFileStore` routes reads, appends and truncation across raw and
+compressed segments are the store's lifecycle, described in `LIFECYCLE.md`
+beside this file.
 
 The test fixtures under `fixtures/` are the reference bytes for this
 document; `fixtures/README.md` says how they were made.

--- a/crates/flatfiles/LIFECYCLE.md
+++ b/crates/flatfiles/LIFECYCLE.md
@@ -41,9 +41,9 @@ to it, or a truncation inside it, thaws the segment — a complete, verified
 raw file at the same logical offsets, published through the transition below
 — and then proceeds exactly as on a raw segment: the append lands at the
 logical end, the truncation cuts at the requested offset. Truncating a
-compressed segment at or past its logical end changes nothing and converts
-nothing. Truncating any segment **to zero** removes it in whatever
-representation it has, without thawing: there is nothing to carry over.
+segment at or past its end changes nothing and converts nothing. Truncating
+any segment **to zero** removes it in whatever representation it has, without
+thawing: there is nothing to carry over.
 
 Pruning (`delete_segments_before`) removes every file of every segment below
 the threshold — both representations, staged outputs and transition records
@@ -77,7 +77,7 @@ run in opposite directions, under the segment's exclusive lock:
    and content hash against what was written. Anything short of a byte-exact
    match is an error.
 5. **Publish.** Rename the staged file over the destination name and fsync
-   the directory. This is the commit point: the destination is now the
+   the directory. The rename is the commit point: the destination is now the
    segment, in memory and on disk.
 6. **Retire.** Unlink the source representation, fsync, unlink the record,
    fsync. Bump the generation and invalidate the cache.
@@ -85,9 +85,10 @@ run in opposite directions, under the segment's exclusive lock:
 A failure before step 5 removes the staged file and the record and returns
 the error; the source representation was never touched, so a full disk, a
 dictionary that is not installed, or a corrupt frame found during
-verification all leave the last good copy in place. A failure during step 6
-returns the error too, but the destination stays authoritative — the store
-has already switched to it, and the record on disk says so to the next open.
+verification all leave the last good copy in place. A failure after the
+rename — the directory fsync of step 5, or anything in step 6 — returns the
+error too, but the destination stays authoritative — the store has already
+switched to it, and the record on disk says so to the next open.
 
 Sealing needs the dictionary it compresses with to be resolvable by the store
 (installed under `dictionaries/` by default), because the verification is a

--- a/crates/flatfiles/LIFECYCLE.md
+++ b/crates/flatfiles/LIFECYCLE.md
@@ -1,0 +1,161 @@
+# Segment lifecycle
+
+`COMPRESSED.md` describes the bytes of a compressed segment. This document
+describes how `FlatFileStore` lives with both kinds of segment at once: how a
+read finds its bytes, how appends and truncation treat a compressed segment,
+how a segment moves between representations without ever losing its last
+good copy, and what a restart makes of a move that was interrupted.
+
+## One segment, one representation
+
+A segment is stored **raw** (`NNNNNN.segment`, the concatenated block bodies)
+or **compressed** (`NNNNNN.zseg`, the same logical stream in the compressed
+layout). Both are addressed by the same packed `BlockLocation`s: the offset
+and length name bytes of the logical stream, and the store resolves them
+against whichever representation the segment currently has. Nothing in the
+archive index changes when a segment changes representation.
+
+The store learns each segment's representation from the directory when it
+opens and keeps it in memory from then on. Every operation on a segment takes
+that segment's lock: shared for reads and appends, exclusive for anything
+that changes which file is the segment. Segment locks are taken in ascending
+segment order, and the writer table after them, never before, so a
+transition on one segment waits for that segment's in-flight readers and for
+nothing else.
+
+Compressed segments are read through a `ReadCache` keyed by segment number
+*and generation*. The generation is bumped under the exclusive lock whenever
+the file behind a number changes — a transition, a truncation, a removal —
+and the cache is invalidated for that number at the same time, which is why
+a reader can never be handed frames, a parsed seek table or an open handle
+that belong to a file the segment no longer is.
+
+## Appends and truncation
+
+Raw segments append as they always have: the writer handle is opened in
+append mode and each batch is written and fsynced before the index entries
+that point at it are committed.
+
+A **compressed segment that must change** first becomes raw again. An append
+to it, or a truncation inside it, thaws the segment — a complete, verified
+raw file at the same logical offsets, published through the transition below
+— and then proceeds exactly as on a raw segment: the append lands at the
+logical end, the truncation cuts at the requested offset. Truncating a
+compressed segment at or past its logical end changes nothing and converts
+nothing. Truncating any segment **to zero** removes it in whatever
+representation it has, without thawing: there is nothing to carry over.
+
+Pruning (`delete_segments_before`) removes every file of every segment below
+the threshold — both representations, staged outputs and transition records
+alike — after taking each segment's exclusive lock, dropping its writer
+handle and invalidating its cache entries, so the space is reclaimable the
+moment the call returns. Dictionaries are not touched by pruning.
+
+## The transition
+
+`seal` (raw → compressed) and `thaw` (compressed → raw) are one primitive
+run in opposite directions, under the segment's exclusive lock:
+
+1. **Settle.** Re-run the recovery below for this segment, so a transition
+   whose retirement step failed earlier is completed before a new one
+   starts. Refuse if the segment is already in the destination
+   representation.
+2. **Record.** Write `NNNNNN.transition` containing `seal` or `thaw`,
+   through a staged file, an fsync, a rename and a directory fsync. From
+   here the directory says a transition is under way and in which direction.
+3. **Stage.** Write the destination to `NNNNNN.zseg.tmp` or
+   `NNNNNN.segment.tmp` in the segments directory — the same file system as
+   the destination, so the publish is a rename — and fsync it. A seal cuts
+   frames at the block boundaries the caller supplies (the locations the
+   archive index holds for the segment) and keeps any bytes those locations
+   do not cover as frames of their own, so the logical stream is preserved
+   whole. A thaw decodes every frame in order.
+4. **Verify.** Open the staged file the way a restart would. A seal parses
+   the staged segment, resolves its dictionary through the store's own
+   dictionary source, decodes every frame and compares it with the raw bytes
+   it stands for. A thaw reads the staged file back and checks its length
+   and content hash against what was written. Anything short of a byte-exact
+   match is an error.
+5. **Publish.** Rename the staged file over the destination name and fsync
+   the directory. This is the commit point: the destination is now the
+   segment, in memory and on disk.
+6. **Retire.** Unlink the source representation, fsync, unlink the record,
+   fsync. Bump the generation and invalidate the cache.
+
+A failure before step 5 removes the staged file and the record and returns
+the error; the source representation was never touched, so a full disk, a
+dictionary that is not installed, or a corrupt frame found during
+verification all leave the last good copy in place. A failure during step 6
+returns the error too, but the destination stays authoritative — the store
+has already switched to it, and the record on disk says so to the next open.
+
+Sealing needs the dictionary it compresses with to be resolvable by the store
+(installed under `dictionaries/` by default), because the verification is a
+real read. That is deliberate: a segment that can be written but not read
+back on this machine is not published.
+
+## Restart authority
+
+The recovery that runs for every segment at open — and again at the start of
+each transition — decides authority from the record and the representation
+files together, never from file presence alone, and leaves the directory in
+the at-rest shape for the representation it chose.
+
+| record | files present                     | authority  | what recovery does                            |
+|--------|-----------------------------------|------------|-----------------------------------------------|
+| none   | one representation                | that one   | remove any staged file                        |
+| none   | none                              | absent     | remove any staged file                        |
+| none   | raw **and** compressed            | —          | **refuse to open**: nothing says which is right |
+| `seal` | raw only (staged file or not)     | raw        | abort: remove staged file, remove record      |
+| `seal` | compressed (raw present or not)   | compressed | finish: remove raw, remove record             |
+| `seal` | neither representation            | —          | **refuse to open**: the segment is lost       |
+| `thaw` | compressed only (staged or not)   | compressed | abort: remove staged file, remove record      |
+| `thaw` | raw (compressed present or not)   | raw        | finish: remove compressed, remove record      |
+| `thaw` | neither representation            | —          | **refuse to open**: the segment is lost       |
+
+A staged transition record (`NNNNNN.transition.tmp`) is never a record; it is
+removed and the row for "no record" applies.
+
+Read against the six steps above, for a seal (a thaw is the mirror image with
+the roles of the two files exchanged):
+
+| interrupted after | on disk                        | restart authority |
+|-------------------|--------------------------------|-------------------|
+| nothing           | raw                            | raw               |
+| record staged     | raw, `transition.tmp`          | raw               |
+| record written    | raw, record                    | raw               |
+| output staging    | raw, record, partial `.tmp`    | raw               |
+| output fsynced    | raw, record, complete `.tmp`   | raw               |
+| verification      | raw, record, complete `.tmp`   | raw               |
+| **publish**       | raw, record, compressed        | **compressed**    |
+| source unlinked   | record, compressed             | compressed        |
+| record unlinked   | compressed                     | compressed        |
+
+The destination file appears on disk only through the rename in the publish
+step, after verification, which is what makes its presence beside a record
+the commit point. Two consequences matter for correctness:
+
+- A staged output is **never** trusted, however complete it looks; recovery
+  removes it and the transition is simply run again. Transitions are
+  idempotent for that reason.
+- Once a thaw has published, the raw file is the segment, and whatever
+  happens to it before the compressed file is retired — an append, a
+  truncation, a crash in between — stands. A restart that still finds the
+  compressed file finishes retiring it; it does not read it, and it does not
+  resurrect bytes the raw file no longer has.
+
+## Opening a store
+
+Opening performs the recovery above for every segment, then parses each
+compressed segment's metadata frame and seek table and resolves the
+dictionary it names. A segment whose metadata version this build does not
+read, whose dictionary is not installed, or whose installed dictionary does
+not hash to the identity the segment names fails the open with an error that
+names the segment and, where there is one, the dictionary. Frame payloads
+are not decoded at open; a corrupt frame is a read error on the block that
+touches it, as it is for a raw segment whose bytes are damaged.
+
+Dictionaries live in `dictionaries/` under the segments directory, one file
+per identity named by its SHA-256 (`<64 hex digits>.dict`), and are verified
+against that name whenever they are loaded. Installing one is writing that
+file; the store never deletes or rewrites one.

--- a/crates/flatfiles/src/compressed/cache.rs
+++ b/crates/flatfiles/src/compressed/cache.rs
@@ -244,7 +244,9 @@ impl ReadCache {
         Ok(index)
     }
 
-    fn dictionary(
+    /// The prepared dictionary `id` names, resolved through `source` and
+    /// retained under the dictionary budget.
+    pub fn dictionary(
         &self,
         id: DictionaryId,
         source: &dyn DictionarySource,

--- a/crates/flatfiles/src/compressed/dictionary.rs
+++ b/crates/flatfiles/src/compressed/dictionary.rs
@@ -3,7 +3,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::io;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
@@ -223,5 +225,77 @@ impl<T: DictionarySource + ?Sized> DictionarySource for &T {
 impl<T: DictionarySource + ?Sized> DictionarySource for Arc<T> {
     fn dictionary(&self, id: &DictionaryId) -> io::Result<Option<Dictionary>> {
         (**self).dictionary(id)
+    }
+}
+
+/// Dictionaries installed as files in one directory, named by identity:
+/// `<dir>/<64 hex digits>.dict`.
+///
+/// This is where a store keeps the dictionaries its segments name. A file is
+/// read on demand and its content hash checked against the name, so a
+/// renamed or edited file is refused rather than trusted; a missing file is
+/// `Ok(None)`, which a reader reports as a missing dictionary.
+#[derive(Debug, Clone)]
+pub struct DictionaryDir {
+    dir: PathBuf,
+}
+
+impl DictionaryDir {
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Where `id` is expected to live.
+    pub fn file(&self, id: &DictionaryId) -> PathBuf {
+        self.dir.join(format!("{id}.dict"))
+    }
+
+    /// Write `dictionary` under its identity, durably. Installing the same
+    /// dictionary twice is a no-op; a dictionary is never overwritten with
+    /// different bytes because its name is its content hash.
+    pub fn install(&self, dictionary: &Dictionary) -> io::Result<PathBuf> {
+        fs::create_dir_all(&self.dir)?;
+        let target = self.file(&dictionary.id());
+        if let Some(existing) = self.dictionary(&dictionary.id())? {
+            debug_assert_eq!(existing.id(), dictionary.id());
+            return Ok(target);
+        }
+        let staging = self.dir.join(format!("{}.dict.tmp", dictionary.id()));
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&staging)?;
+        file.write_all(dictionary.bytes())?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&staging, &target)?;
+        if cfg!(unix) {
+            fs::File::open(&self.dir)?.sync_all()?;
+        }
+        Ok(target)
+    }
+}
+
+impl DictionarySource for DictionaryDir {
+    fn dictionary(&self, id: &DictionaryId) -> io::Result<Option<Dictionary>> {
+        let path = self.file(id);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!("cannot read dictionary {}: {e}", path.display()),
+                ))
+            }
+        };
+        Dictionary::verified(bytes, *id)
+            .map(Some)
+            .map_err(|e| io::Error::new(e.kind(), format!("{}: {e}", path.display())))
     }
 }

--- a/crates/flatfiles/src/compressed/mod.rs
+++ b/crates/flatfiles/src/compressed/mod.rs
@@ -20,9 +20,9 @@
 //! [`ReadCache`] serves bounded, concurrent point reads across a store's
 //! segments; [`SegmentReader`] is the unbounded single-segment path.
 //!
-//! This module exposes the codec only. Routing a live `FlatFileStore` through
-//! compressed files, and producing them from raw segments, belongs to the
-//! store's lifecycle work.
+//! This module exposes the codec. Routing a live `FlatFileStore` through
+//! compressed files, and producing them from raw segments, is the store's
+//! own lifecycle (`crate::store`, described in `LIFECYCLE.md`).
 
 mod cache;
 mod dictionary;
@@ -32,7 +32,8 @@ mod writer;
 
 pub use cache::{CacheLimits, CacheStats, ReadCache, SegmentRef};
 pub use dictionary::{
-    Dictionary, DictionaryId, DictionarySet, DictionarySource, NoDictionaries, PreparedDictionary,
+    Dictionary, DictionaryDir, DictionaryId, DictionarySet, DictionarySource, NoDictionaries,
+    PreparedDictionary,
 };
 pub use format::{
     FrameMode, Metadata, SeekEntry, METADATA_FRAME_MAGIC, METADATA_FRAME_SIZE, METADATA_MAGIC,

--- a/crates/flatfiles/src/layout.rs
+++ b/crates/flatfiles/src/layout.rs
@@ -293,6 +293,7 @@ pub fn recover(paths: &SegmentPaths, found: Found) -> io::Result<Option<Represen
         },
         Some(transition) if found.has(transition.to()) => {
             remove_if_present(&paths.representation(transition.from()))?;
+            sync_dir(&paths.dir)?;
             Some(transition.to())
         }
         Some(transition) if found.has(transition.from()) => Some(transition.from()),
@@ -377,15 +378,21 @@ impl<'a> TransitionGuard<'a> {
     }
 
     /// Move the verified staged output into place. From here on the
-    /// destination is authoritative.
+    /// destination is authoritative — the rename is the commit point, so a
+    /// failed directory sync after it reports [`published`](Self::published)
+    /// all the same and leaves the record for [`recover`] to finish.
     pub fn publish(&mut self) -> io::Result<()> {
         fs::rename(
             self.staging(),
             self.paths.representation(self.transition.to()),
         )?;
-        sync_dir(&self.paths.dir)?;
         self.published = true;
-        Ok(())
+        sync_dir(&self.paths.dir)
+    }
+
+    /// Whether the destination has been renamed into place.
+    pub fn published(&self) -> bool {
+        self.published
     }
 
     /// Retire the source representation and the record.

--- a/crates/flatfiles/src/layout.rs
+++ b/crates/flatfiles/src/layout.rs
@@ -1,0 +1,478 @@
+//! Segment file names, transition records, and the recovery that resolves a
+//! segment directory to one authoritative representation per segment.
+//!
+//! A segment owns up to six files, all named by its six-digit number:
+//!
+//! ```text
+//! 000012.segment          raw representation
+//! 000012.zseg             compressed representation
+//! 000012.transition       transition record: the word `seal` or `thaw`
+//! 000012.segment.tmp      raw output being staged by a thaw
+//! 000012.zseg.tmp         compressed output being staged by a seal
+//! 000012.transition.tmp   transition record being staged
+//! ```
+//!
+//! At rest a segment has exactly one representation file and nothing else.
+//! A transition publishes the other representation and retires the current
+//! one through the steps in [`recover`]'s table; the transition record is
+//! what tells an interrupted store which of two representation files is the
+//! authoritative one, so authority is never inferred from file presence
+//! alone. `LIFECYCLE.md` beside this crate walks the same table with the
+//! restart authority after every step.
+
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Subdirectory of the segments directory where dictionaries are installed.
+pub const DICTIONARIES_DIR: &str = "dictionaries";
+
+const RAW_EXTENSION: &str = "segment";
+const COMPRESSED_EXTENSION: &str = "zseg";
+const TRANSITION_EXTENSION: &str = "transition";
+const STAGING_SUFFIX: &str = ".tmp";
+
+/// How a segment's bytes are stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Representation {
+    /// The concatenated block bodies, as appended.
+    Raw,
+    /// The same logical stream in the [`compressed`](crate::compressed) layout.
+    Compressed,
+}
+
+impl Representation {
+    fn extension(self) -> &'static str {
+        match self {
+            Representation::Raw => RAW_EXTENSION,
+            Representation::Compressed => COMPRESSED_EXTENSION,
+        }
+    }
+
+    pub fn other(self) -> Self {
+        match self {
+            Representation::Raw => Representation::Compressed,
+            Representation::Compressed => Representation::Raw,
+        }
+    }
+}
+
+impl fmt::Display for Representation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Representation::Raw => "raw",
+            Representation::Compressed => "compressed",
+        })
+    }
+}
+
+/// The direction of a representation change, as the transition record spells
+/// it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transition {
+    /// Raw to compressed.
+    Seal,
+    /// Compressed to raw.
+    Thaw,
+}
+
+impl Transition {
+    pub fn from(self) -> Representation {
+        match self {
+            Transition::Seal => Representation::Raw,
+            Transition::Thaw => Representation::Compressed,
+        }
+    }
+
+    pub fn to(self) -> Representation {
+        self.from().other()
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Transition::Seal => "seal",
+            Transition::Thaw => "thaw",
+        }
+    }
+
+    fn parse(content: &[u8]) -> Option<Self> {
+        match content.strip_suffix(b"\n").unwrap_or(content) {
+            b"seal" => Some(Transition::Seal),
+            b"thaw" => Some(Transition::Thaw),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Transition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// What a file name inside the segments directory denotes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentFile {
+    Representation(Representation),
+    Staging(Representation),
+    Transition,
+    TransitionStaging,
+}
+
+/// Parse a segment file name into the segment it belongs to and its role.
+/// Anything else in the directory is not ours and yields `None`.
+pub fn parse_filename(name: &str) -> Option<(u32, SegmentFile)> {
+    let (id, rest) = name.split_at_checked(6)?;
+    let id = id.parse::<u32>().ok()?;
+    if !id_is_canonical(id, name) {
+        return None;
+    }
+    let rest = rest.strip_prefix('.')?;
+    let (stem, staging) = match rest.strip_suffix(STAGING_SUFFIX) {
+        Some(stem) => (stem, true),
+        None => (rest, false),
+    };
+    let file = match (stem, staging) {
+        (RAW_EXTENSION, false) => SegmentFile::Representation(Representation::Raw),
+        (COMPRESSED_EXTENSION, false) => SegmentFile::Representation(Representation::Compressed),
+        (RAW_EXTENSION, true) => SegmentFile::Staging(Representation::Raw),
+        (COMPRESSED_EXTENSION, true) => SegmentFile::Staging(Representation::Compressed),
+        (TRANSITION_EXTENSION, false) => SegmentFile::Transition,
+        (TRANSITION_EXTENSION, true) => SegmentFile::TransitionStaging,
+        _ => return None,
+    };
+    Some((id, file))
+}
+
+fn id_is_canonical(id: u32, name: &str) -> bool {
+    name.starts_with(&format!("{id:06}"))
+}
+
+/// Every path one segment can own.
+#[derive(Debug, Clone)]
+pub struct SegmentPaths {
+    dir: PathBuf,
+    id: u32,
+}
+
+impl SegmentPaths {
+    pub fn new(dir: &Path, id: u32) -> Self {
+        Self {
+            dir: dir.to_path_buf(),
+            id,
+        }
+    }
+
+    fn named(&self, extension: &str, staging: bool) -> PathBuf {
+        let suffix = if staging { STAGING_SUFFIX } else { "" };
+        self.dir.join(format!("{:06}.{extension}{suffix}", self.id))
+    }
+
+    pub fn representation(&self, representation: Representation) -> PathBuf {
+        self.named(representation.extension(), false)
+    }
+
+    pub fn staging(&self, representation: Representation) -> PathBuf {
+        self.named(representation.extension(), true)
+    }
+
+    pub fn transition(&self) -> PathBuf {
+        self.named(TRANSITION_EXTENSION, false)
+    }
+
+    fn transition_staging(&self) -> PathBuf {
+        self.named(TRANSITION_EXTENSION, true)
+    }
+
+    /// Look at the directory and report which of this segment's files exist.
+    pub fn found(&self) -> io::Result<Found> {
+        let exists = |path: PathBuf| match fs::symlink_metadata(&path) {
+            Ok(_) => Ok(true),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e),
+        };
+        let transition = match fs::read(self.transition()) {
+            Ok(content) => Some(Transition::parse(&content).ok_or_else(|| {
+                invalid(format!(
+                    "segment {:06}: transition record {} is unreadable",
+                    self.id,
+                    self.transition().display()
+                ))
+            })?),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+            Err(e) => return Err(e),
+        };
+        Ok(Found {
+            raw: exists(self.representation(Representation::Raw))?,
+            compressed: exists(self.representation(Representation::Compressed))?,
+            raw_staging: exists(self.staging(Representation::Raw))?,
+            compressed_staging: exists(self.staging(Representation::Compressed))?,
+            transition_staging: exists(self.transition_staging())?,
+            transition,
+        })
+    }
+
+    /// Remove every file of this segment, whatever state it is in.
+    pub fn remove_all(&self) -> io::Result<()> {
+        for path in [
+            self.staging(Representation::Raw),
+            self.staging(Representation::Compressed),
+            self.transition_staging(),
+            self.representation(Representation::Raw),
+            self.representation(Representation::Compressed),
+            self.transition(),
+        ] {
+            remove_if_present(&path)?;
+        }
+        sync_dir(&self.dir)
+    }
+
+    /// Resolve this segment's files to its authoritative representation,
+    /// finishing or abandoning an interrupted transition on the way.
+    pub fn recover(&self) -> io::Result<Option<Representation>> {
+        recover(self, self.found()?)
+    }
+}
+
+/// Which of a segment's files exist.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Found {
+    pub raw: bool,
+    pub compressed: bool,
+    pub raw_staging: bool,
+    pub compressed_staging: bool,
+    pub transition_staging: bool,
+    pub transition: Option<Transition>,
+}
+
+impl Found {
+    fn has(&self, representation: Representation) -> bool {
+        match representation {
+            Representation::Raw => self.raw,
+            Representation::Compressed => self.compressed,
+        }
+    }
+}
+
+/// Decide which representation is authoritative and make the directory say
+/// so, given what is on disk.
+///
+/// | record | files                | authority | action                              |
+/// |--------|----------------------|-----------|-------------------------------------|
+/// | none   | one representation   | that one  | remove staging files                |
+/// | none   | none                 | absent    | remove staging files                |
+/// | none   | both representations | —         | error: no record to decide by       |
+/// | T      | `T.to()` present     | `T.to()`  | finish: unlink `T.from()`, record   |
+/// | T      | only `T.from()`      | `T.from()`| abort: unlink staging, record       |
+/// | T      | neither              | —         | error: the segment is lost          |
+///
+/// The destination file exists only after the transition verified it and
+/// renamed it into place, so its presence beside a record is the commit
+/// point; without the record two representation files mean the directory
+/// was edited by something other than this crate, and the store refuses to
+/// guess which one the index describes.
+pub fn recover(paths: &SegmentPaths, found: Found) -> io::Result<Option<Representation>> {
+    let id = paths.id;
+
+    if found.transition_staging {
+        remove_if_present(&paths.transition_staging())?;
+    }
+
+    let authority = match found.transition {
+        None => match (found.raw, found.compressed) {
+            (true, true) => {
+                return Err(invalid(format!(
+                "segment {id:06} has both a raw and a compressed file and no transition record; \
+                     remove the one the archive index does not describe"
+            )))
+            }
+            (true, false) => Some(Representation::Raw),
+            (false, true) => Some(Representation::Compressed),
+            (false, false) => None,
+        },
+        Some(transition) if found.has(transition.to()) => {
+            remove_if_present(&paths.representation(transition.from()))?;
+            Some(transition.to())
+        }
+        Some(transition) if found.has(transition.from()) => Some(transition.from()),
+        Some(transition) => {
+            return Err(invalid(format!(
+                "segment {id:06} has a {transition} record but neither representation file"
+            )))
+        }
+    };
+
+    if found.raw_staging {
+        remove_if_present(&paths.staging(Representation::Raw))?;
+    }
+    if found.compressed_staging {
+        remove_if_present(&paths.staging(Representation::Compressed))?;
+    }
+    if found.transition.is_some() {
+        remove_if_present(&paths.transition())?;
+    }
+    if found.transition.is_some()
+        || found.raw_staging
+        || found.compressed_staging
+        || found.transition_staging
+    {
+        sync_dir(&paths.dir)?;
+    }
+
+    Ok(authority)
+}
+
+/// A transition in flight: the durable record plus the cleanup its
+/// abandonment requires.
+///
+/// Dropped before [`publish`](Self::publish) it removes the staged output
+/// and the record, leaving the source representation as it was. After the
+/// publish the destination is authoritative and the guard cleans nothing
+/// on drop: what remains is the source and the record, which
+/// [`recover`] finishes on the next open if [`finish`](Self::finish) does
+/// not get to.
+pub struct TransitionGuard<'a> {
+    paths: &'a SegmentPaths,
+    transition: Transition,
+    published: bool,
+}
+
+impl<'a> TransitionGuard<'a> {
+    /// Write the record durably, refusing if one is already present.
+    pub fn begin(paths: &'a SegmentPaths, transition: Transition) -> io::Result<Self> {
+        let record = paths.transition();
+        if fs::symlink_metadata(&record).is_ok() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "segment {:06} already has a transition record at {}",
+                    paths.id,
+                    record.display()
+                ),
+            ));
+        }
+        let staging = paths.transition_staging();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&staging)?;
+        file.write_all(transition.label().as_bytes())?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&staging, &record)?;
+        sync_dir(&paths.dir)?;
+        Ok(Self {
+            paths,
+            transition,
+            published: false,
+        })
+    }
+
+    /// Where the destination is staged.
+    pub fn staging(&self) -> PathBuf {
+        self.paths.staging(self.transition.to())
+    }
+
+    /// Move the verified staged output into place. From here on the
+    /// destination is authoritative.
+    pub fn publish(&mut self) -> io::Result<()> {
+        fs::rename(
+            self.staging(),
+            self.paths.representation(self.transition.to()),
+        )?;
+        sync_dir(&self.paths.dir)?;
+        self.published = true;
+        Ok(())
+    }
+
+    /// Retire the source representation and the record.
+    pub fn finish(self) -> io::Result<()> {
+        debug_assert!(self.published);
+        remove_if_present(&self.paths.representation(self.transition.from()))?;
+        sync_dir(&self.paths.dir)?;
+        remove_if_present(&self.paths.transition())?;
+        sync_dir(&self.paths.dir)
+    }
+}
+
+impl Drop for TransitionGuard<'_> {
+    fn drop(&mut self) {
+        if self.published {
+            return;
+        }
+        let _ = remove_if_present(&self.staging());
+        let _ = remove_if_present(&self.paths.transition());
+        let _ = sync_dir(&self.paths.dir);
+    }
+}
+
+pub fn remove_if_present(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Make directory entry changes durable. Directories cannot be opened for
+/// syncing on Windows, where the rename itself is the durability point.
+pub fn sync_dir(dir: &Path) -> io::Result<()> {
+    if cfg!(unix) {
+        File::open(dir)?.sync_all()
+    } else {
+        Ok(())
+    }
+}
+
+fn invalid(msg: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filenames_parse_to_their_role() {
+        assert_eq!(
+            parse_filename("000012.segment"),
+            Some((12, SegmentFile::Representation(Representation::Raw)))
+        );
+        assert_eq!(
+            parse_filename("000012.zseg"),
+            Some((12, SegmentFile::Representation(Representation::Compressed)))
+        );
+        assert_eq!(
+            parse_filename("000012.segment.tmp"),
+            Some((12, SegmentFile::Staging(Representation::Raw)))
+        );
+        assert_eq!(
+            parse_filename("000012.zseg.tmp"),
+            Some((12, SegmentFile::Staging(Representation::Compressed)))
+        );
+        assert_eq!(
+            parse_filename("000012.transition"),
+            Some((12, SegmentFile::Transition))
+        );
+        assert_eq!(
+            parse_filename("000012.transition.tmp"),
+            Some((12, SegmentFile::TransitionStaging))
+        );
+        assert_eq!(parse_filename("12.segment"), None);
+        assert_eq!(parse_filename("000012.segment.bak"), None);
+        assert_eq!(parse_filename("dictionaries"), None);
+        assert_eq!(parse_filename("+00012.segment"), None);
+    }
+
+    #[test]
+    fn transition_records_round_trip() {
+        for transition in [Transition::Seal, Transition::Thaw] {
+            let text = format!("{transition}\n");
+            assert_eq!(Transition::parse(text.as_bytes()), Some(transition));
+        }
+        assert_eq!(Transition::parse(b"melt"), None);
+    }
+}

--- a/crates/flatfiles/src/lib.rs
+++ b/crates/flatfiles/src/lib.rs
@@ -7,14 +7,17 @@
 //! why this crate knows nothing about Cardano and depends on little beyond
 //! the standard library: `tempfile` for throwaway stores, and `zstd` plus
 //! `sha2` for the [`compressed`] segment codec.
+//!
+//! A segment is stored raw or compressed; the store reads either through the
+//! same [`BlockLocation`]s and moves a segment between the two with a
+//! recoverable transition (`LIFECYCLE.md`).
 
 pub mod compressed;
+mod layout;
+mod store;
 
-use std::collections::{hash_map::Entry, HashMap};
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::PathBuf;
-use std::sync::Mutex;
+pub use layout::{Representation, Transition, DICTIONARIES_DIR};
+pub use store::{FlatFileOptions, FlatFileStore, SegmentInfo};
 
 /// Number of slots per segment file (one Cardano epoch).
 pub const SLOTS_PER_SEGMENT: u64 = 432_000;
@@ -85,162 +88,15 @@ pub fn encode_locations(locations: &[BlockLocation]) -> Vec<u8> {
     buf
 }
 
-/// Segment file name for a given segment ID.
-fn segment_filename(segment_id: u32) -> String {
-    format!("{:06}.segment", segment_id)
-}
-
-/// Manages append-only segment files for block storage.
-pub struct FlatFileStore {
-    segments_dir: PathBuf,
-    writers: Mutex<HashMap<u32, File>>,
-}
-
-impl FlatFileStore {
-    /// Create a new FlatFileStore at the given directory.
-    /// Creates the directory if it does not exist.
-    pub fn new(segments_dir: impl Into<PathBuf>) -> io::Result<Self> {
-        let segments_dir = segments_dir.into();
-        fs::create_dir_all(&segments_dir)?;
-        Ok(Self {
-            segments_dir,
-            writers: Mutex::new(HashMap::new()),
-        })
-    }
-
-    fn segment_path(&self, segment_id: u32) -> PathBuf {
-        self.segments_dir.join(segment_filename(segment_id))
-    }
-
-    /// Get or create an append-mode file handle for a segment.
-    fn get_writer(&self, segment_id: u32) -> io::Result<()> {
-        let mut writers = self.writers.lock().unwrap();
-        if let Entry::Vacant(entry) = writers.entry(segment_id) {
-            let file = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(self.segment_path(segment_id))?;
-            entry.insert(file);
-        }
-        Ok(())
-    }
-
-    /// Append a batch of blocks to their respective segment files.
-    ///
-    /// Each item is `(segment_id, block_data)`. Blocks are appended in order.
-    /// A single fsync is performed per segment file after all blocks for that
-    /// segment have been written.
-    ///
-    /// Returns a `BlockLocation` for each input item, in the same order.
-    pub fn append_batch(&self, items: &[(u32, &[u8])]) -> io::Result<Vec<BlockLocation>> {
-        let mut locations = Vec::with_capacity(items.len());
-        let mut touched_segments: HashMap<u32, ()> = HashMap::new();
-
-        // Ensure all writers exist.
-        for &(segment_id, _) in items {
-            self.get_writer(segment_id)?;
-            touched_segments.insert(segment_id, ());
-        }
-
-        let mut writers = self.writers.lock().unwrap();
-
-        for &(segment_id, data) in items {
-            let file = writers.get_mut(&segment_id).unwrap();
-            // Current position is the offset (file is in append mode).
-            let offset = file.seek(SeekFrom::End(0))?;
-            file.write_all(data)?;
-            locations.push(BlockLocation {
-                segment_id,
-                offset,
-                length: data.len() as u32,
-            });
-        }
-
-        // Fsync all touched segments.
-        for &segment_id in touched_segments.keys() {
-            if let Some(file) = writers.get(&segment_id) {
-                file.sync_data()?;
-            }
-        }
-
-        Ok(locations)
-    }
-
-    /// Read block data at the given location.
-    pub fn read(&self, loc: &BlockLocation) -> io::Result<Vec<u8>> {
-        let mut file = File::open(self.segment_path(loc.segment_id))?;
-        file.seek(SeekFrom::Start(loc.offset))?;
-        let mut buf = vec![0u8; loc.length as usize];
-        file.read_exact(&mut buf)?;
-        Ok(buf)
-    }
-
-    /// Truncate a segment file at the given offset.
-    /// Used for undo: removes everything from `offset` onwards.
-    pub fn truncate(&self, segment_id: u32, offset: u64) -> io::Result<()> {
-        // Drop the cached writer so we reopen fresh next time.
-        {
-            let mut writers = self.writers.lock().unwrap();
-            writers.remove(&segment_id);
-        }
-
-        let path = self.segment_path(segment_id);
-        if !path.exists() {
-            return Ok(());
-        }
-
-        if offset == 0 {
-            // Remove the file entirely if truncating to zero.
-            fs::remove_file(&path)?;
-        } else {
-            let file = OpenOptions::new().write(true).open(&path)?;
-            file.set_len(offset)?;
-            file.sync_data()?;
-        }
-
-        Ok(())
-    }
-
-    /// Delete all segment files with IDs strictly less than `segment_id`.
-    pub fn delete_segments_before(&self, segment_id: u32) -> io::Result<()> {
-        let mut writers = self.writers.lock().unwrap();
-
-        // Remove cached writers for deleted segments.
-        writers.retain(|&id, _| id >= segment_id);
-
-        // Scan directory for segment files to delete.
-        for entry in fs::read_dir(&self.segments_dir)? {
-            let entry = entry?;
-            let name = entry.file_name();
-            let Some(name_str) = name.to_str() else {
-                continue;
-            };
-            if !name_str.ends_with(".segment") {
-                continue;
-            }
-            let prefix = &name_str[..6];
-            if let Ok(id) = prefix.parse::<u32>() {
-                if id < segment_id {
-                    fs::remove_file(entry.path())?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Create a FlatFileStore backed by a temporary directory.
-    /// Returns the TempDir (caller must keep it alive) and the store.
-    pub fn for_tempdir() -> io::Result<(tempfile::TempDir, Self)> {
-        let dir = tempfile::tempdir()?;
-        let store = Self::new(dir.path())?;
-        Ok((dir, store))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn raw_path(store: &FlatFileStore, segment_id: u32) -> std::path::PathBuf {
+        store
+            .segments_dir()
+            .join(format!("{segment_id:06}.segment"))
+    }
 
     #[test]
     fn test_block_location_roundtrip() {
@@ -339,7 +195,7 @@ mod tests {
         store.append_batch(&[(0, b"data".as_slice())]).unwrap();
 
         store.truncate(0, 0).unwrap();
-        assert!(!store.segment_path(0).exists());
+        assert!(!raw_path(&store, 0).exists());
 
         drop(dir);
     }
@@ -357,9 +213,9 @@ mod tests {
 
         store.delete_segments_before(2).unwrap();
 
-        assert!(!store.segment_path(0).exists());
-        assert!(!store.segment_path(1).exists());
-        assert!(store.segment_path(2).exists());
+        assert!(!raw_path(&store, 0).exists());
+        assert!(!raw_path(&store, 1).exists());
+        assert!(raw_path(&store, 2).exists());
 
         drop(dir);
     }

--- a/crates/flatfiles/src/store.rs
+++ b/crates/flatfiles/src/store.rs
@@ -413,7 +413,8 @@ impl FlatFileStore {
     ///
     /// A compressed segment is thawed first and truncated as raw; truncating
     /// to zero removes the segment in whichever representation it has,
-    /// without converting it.
+    /// without converting it. An offset at or past the segment's end changes
+    /// nothing in either representation.
     pub fn truncate(&self, segment_id: u32, offset: u64) -> io::Result<()> {
         let Some(segment) = self.segment(segment_id) else {
             return Ok(());
@@ -454,6 +455,9 @@ impl FlatFileStore {
         let file = OpenOptions::new()
             .write(true)
             .open(self.paths(segment_id).representation(Representation::Raw))?;
+        if offset >= file.metadata()?.len() {
+            return Ok(());
+        }
         file.set_len(offset)?;
         file.sync_data()?;
         self.changed(segment_id, &mut state);
@@ -567,9 +571,12 @@ impl FlatFileStore {
         })?;
         drop(raw);
 
-        guard.publish()?;
-        state.representation = Some(Representation::Compressed);
-        self.changed(segment_id, &mut state);
+        let published = guard.publish();
+        if guard.published() {
+            state.representation = Some(Representation::Compressed);
+            self.changed(segment_id, &mut state);
+        }
+        published?;
         guard.finish()?;
 
         Ok(summary)
@@ -644,9 +651,12 @@ impl FlatFileStore {
             )
         })?;
 
-        guard.publish()?;
-        state.representation = Some(Representation::Raw);
-        self.changed(segment_id, state);
+        let published = guard.publish();
+        if guard.published() {
+            state.representation = Some(Representation::Raw);
+            self.changed(segment_id, state);
+        }
+        published?;
         guard.finish()
     }
 }

--- a/crates/flatfiles/src/store.rs
+++ b/crates/flatfiles/src/store.rs
@@ -1,0 +1,857 @@
+//! The segment store: raw appends, reads dispatched by representation, and
+//! the seal/thaw transition between representations.
+//!
+//! Every segment has one authoritative representation at a time, tracked in
+//! memory from the directory scan at open and changed only under that
+//! segment's exclusive lock. Locks are taken in a fixed order — segment
+//! locks in ascending segment number, then the writer table — so a
+//! transition on one segment waits for that segment's readers and nothing
+//! else, and appends never wait on a segment they do not touch.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+
+use sha2::{Digest, Sha256};
+
+use crate::compressed::{
+    CacheLimits, CacheStats, DictionaryDir, DictionarySource, Metadata, ReadAt, ReadCache,
+    SegmentReader, SegmentRef, SegmentWriter, WriteSummary, WriterOptions,
+};
+use crate::layout::{
+    parse_filename, Representation, SegmentPaths, Transition, TransitionGuard, DICTIONARIES_DIR,
+};
+use crate::BlockLocation;
+
+/// Largest slice of unindexed bytes fed to the compressor as one frame, so
+/// dead space between indexed blocks never needs a buffer its own size.
+const FILLER_FRAME_BYTES: u64 = 4 << 20;
+
+/// How a [`FlatFileStore`] is opened.
+#[derive(Default)]
+pub struct FlatFileOptions {
+    /// Where compressed segments' dictionaries come from. `None` reads them
+    /// from the `dictionaries/` directory beside the segments.
+    pub dictionaries: Option<Arc<dyn DictionarySource>>,
+    /// Bounds on what the compressed-segment reader retains.
+    pub cache: Option<CacheLimits>,
+}
+
+/// One segment as the store sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentInfo {
+    pub segment_id: u32,
+    pub representation: Representation,
+    /// Bytes of block content: the file size of a raw segment, the logical
+    /// length of a compressed one.
+    pub logical_len: u64,
+    /// Bytes on disk.
+    pub physical_len: u64,
+    /// The compressed segment's metadata frame; `None` for a raw segment.
+    pub metadata: Option<Metadata>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SegmentState {
+    representation: Option<Representation>,
+    /// Bumped whenever the file behind the segment changes, so the read
+    /// cache never serves bytes of a previous file under this number.
+    generation: u64,
+}
+
+struct Segment {
+    state: RwLock<SegmentState>,
+}
+
+/// Manages append-only segment files for block storage.
+pub struct FlatFileStore {
+    segments_dir: PathBuf,
+    dictionaries: Arc<dyn DictionarySource>,
+    cache: ReadCache,
+    segments: RwLock<HashMap<u32, Arc<Segment>>>,
+    writers: Mutex<HashMap<u32, File>>,
+}
+
+impl FlatFileStore {
+    /// Open the store at `segments_dir`, creating the directory if needed,
+    /// with dictionaries read from its `dictionaries/` subdirectory.
+    ///
+    /// Opening finishes or abandons any transition that was interrupted,
+    /// then parses every compressed segment's metadata and resolves the
+    /// dictionary it names, so a segment this build cannot read fails here,
+    /// naming the segment, rather than as an empty range later. Frame
+    /// payloads are not touched until they are read.
+    pub fn new(segments_dir: impl Into<PathBuf>) -> io::Result<Self> {
+        Self::with_options(segments_dir, FlatFileOptions::default())
+    }
+
+    /// Open the store with explicit dictionary and cache settings.
+    pub fn with_options(
+        segments_dir: impl Into<PathBuf>,
+        options: FlatFileOptions,
+    ) -> io::Result<Self> {
+        let segments_dir = segments_dir.into();
+        fs::create_dir_all(&segments_dir)?;
+        let dictionaries = options
+            .dictionaries
+            .unwrap_or_else(|| Arc::new(DictionaryDir::new(segments_dir.join(DICTIONARIES_DIR))));
+        let store = Self {
+            segments_dir,
+            dictionaries,
+            cache: ReadCache::new(options.cache.unwrap_or_default()),
+            segments: RwLock::new(HashMap::new()),
+            writers: Mutex::new(HashMap::new()),
+        };
+        store.recover_all()?;
+        Ok(store)
+    }
+
+    /// Create a FlatFileStore backed by a temporary directory.
+    /// Returns the TempDir (caller must keep it alive) and the store.
+    pub fn for_tempdir() -> io::Result<(tempfile::TempDir, Self)> {
+        let dir = tempfile::tempdir()?;
+        let store = Self::new(dir.path())?;
+        Ok((dir, store))
+    }
+
+    pub fn segments_dir(&self) -> &Path {
+        &self.segments_dir
+    }
+
+    /// The dictionaries compressed segments resolve against.
+    pub fn dictionaries(&self) -> &Arc<dyn DictionarySource> {
+        &self.dictionaries
+    }
+
+    pub fn cache_stats(&self) -> CacheStats {
+        self.cache.stats()
+    }
+
+    fn paths(&self, segment_id: u32) -> SegmentPaths {
+        SegmentPaths::new(&self.segments_dir, segment_id)
+    }
+
+    /// Walk the directory once: recover every segment's authority and
+    /// validate the compressed ones.
+    fn recover_all(&self) -> io::Result<()> {
+        let mut ids = BTreeSet::new();
+        for entry in fs::read_dir(&self.segments_dir)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if let Some((id, _)) = parse_filename(name) {
+                ids.insert(id);
+            }
+        }
+
+        let mut segments = HashMap::with_capacity(ids.len());
+        for id in ids {
+            let representation = self.paths(id).recover()?;
+            if representation == Some(Representation::Compressed) {
+                self.validate_compressed(id, 0)?;
+            }
+            segments.insert(
+                id,
+                Arc::new(Segment {
+                    state: RwLock::new(SegmentState {
+                        representation,
+                        generation: 0,
+                    }),
+                }),
+            );
+        }
+        *self.segments.write().unwrap() = segments;
+        Ok(())
+    }
+
+    /// Parse a compressed segment's metadata and seek table and resolve its
+    /// dictionary, warming the cache with both.
+    fn validate_compressed(&self, segment_id: u32, generation: u64) -> io::Result<()> {
+        let path = self
+            .paths(segment_id)
+            .representation(Representation::Compressed);
+        let segment = SegmentRef {
+            segment_id,
+            generation,
+        };
+        let context = |e: io::Error| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "compressed segment {segment_id:06} ({}): {e}",
+                    path.display()
+                ),
+            )
+        };
+        let index = self.cache.index(segment, &path).map_err(context)?;
+        if let Some(id) = index.metadata().dictionary {
+            self.cache
+                .dictionary(id, &*self.dictionaries)
+                .map_err(context)?;
+        }
+        Ok(())
+    }
+
+    fn segment(&self, segment_id: u32) -> Option<Arc<Segment>> {
+        self.segments.read().unwrap().get(&segment_id).cloned()
+    }
+
+    fn segment_or_insert(&self, segment_id: u32) -> Arc<Segment> {
+        if let Some(segment) = self.segment(segment_id) {
+            return segment;
+        }
+        self.segments
+            .write()
+            .unwrap()
+            .entry(segment_id)
+            .or_insert_with(|| {
+                Arc::new(Segment {
+                    state: RwLock::new(SegmentState {
+                        representation: None,
+                        generation: 0,
+                    }),
+                })
+            })
+            .clone()
+    }
+
+    /// Note that the file behind `segment_id` changed.
+    fn changed(&self, segment_id: u32, state: &mut SegmentState) {
+        state.generation += 1;
+        self.cache.invalidate(segment_id);
+    }
+
+    /// Every segment the store holds, ascending.
+    pub fn segments(&self) -> io::Result<Vec<SegmentInfo>> {
+        let ids: BTreeSet<u32> = self.segments.read().unwrap().keys().copied().collect();
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(info) = self.segment_info(id)? {
+                out.push(info);
+            }
+        }
+        Ok(out)
+    }
+
+    /// The representation of `segment_id`, or `None` if the store has no
+    /// such segment.
+    pub fn representation(&self, segment_id: u32) -> Option<Representation> {
+        self.segment(segment_id)?
+            .state
+            .read()
+            .unwrap()
+            .representation
+    }
+
+    fn segment_info(&self, segment_id: u32) -> io::Result<Option<SegmentInfo>> {
+        let Some(segment) = self.segment(segment_id) else {
+            return Ok(None);
+        };
+        let state = segment.state.read().unwrap();
+        let paths = self.paths(segment_id);
+        let info = match state.representation {
+            None => return Ok(None),
+            Some(Representation::Raw) => {
+                let len = fs::metadata(paths.representation(Representation::Raw))?.len();
+                SegmentInfo {
+                    segment_id,
+                    representation: Representation::Raw,
+                    logical_len: len,
+                    physical_len: len,
+                    metadata: None,
+                }
+            }
+            Some(Representation::Compressed) => {
+                let index = self.cache.index(
+                    SegmentRef {
+                        segment_id,
+                        generation: state.generation,
+                    },
+                    &paths.representation(Representation::Compressed),
+                )?;
+                SegmentInfo {
+                    segment_id,
+                    representation: Representation::Compressed,
+                    logical_len: index.logical_len(),
+                    physical_len: index.physical_len(),
+                    metadata: Some(index.metadata().clone()),
+                }
+            }
+        };
+        Ok(Some(info))
+    }
+
+    /// Hold `segment` shared with its representation raw, converting or
+    /// creating it first under the exclusive lock when it is not.
+    fn raw_for_append<'a>(
+        &self,
+        segment_id: u32,
+        segment: &'a Segment,
+    ) -> io::Result<RwLockReadGuard<'a, SegmentState>> {
+        loop {
+            let state = segment.state.read().unwrap();
+            if state.representation == Some(Representation::Raw) {
+                return Ok(state);
+            }
+            drop(state);
+
+            let mut state = segment.state.write().unwrap();
+            match state.representation {
+                Some(Representation::Raw) => {}
+                Some(Representation::Compressed) => {
+                    self.thaw_locked(segment_id, &mut state)?;
+                }
+                None => {
+                    OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(self.paths(segment_id).representation(Representation::Raw))?;
+                    state.representation = Some(Representation::Raw);
+                }
+            }
+        }
+    }
+
+    /// Get or create an append-mode file handle for a raw segment.
+    fn get_writer(&self, segment_id: u32) -> io::Result<()> {
+        let mut writers = self.writers.lock().unwrap();
+        if let std::collections::hash_map::Entry::Vacant(entry) = writers.entry(segment_id) {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(self.paths(segment_id).representation(Representation::Raw))?;
+            entry.insert(file);
+        }
+        Ok(())
+    }
+
+    /// Append a batch of blocks to their respective segment files.
+    ///
+    /// Each item is `(segment_id, block_data)`. Blocks are appended in order.
+    /// A single fsync is performed per segment file after all blocks for that
+    /// segment have been written. A compressed segment is thawed back to raw
+    /// first, so appends always extend a raw file at its logical end.
+    ///
+    /// Returns a `BlockLocation` for each input item, in the same order.
+    pub fn append_batch(&self, items: &[(u32, &[u8])]) -> io::Result<Vec<BlockLocation>> {
+        let touched: BTreeSet<u32> = items.iter().map(|(id, _)| *id).collect();
+        let segments: Vec<(u32, Arc<Segment>)> = touched
+            .iter()
+            .map(|&id| (id, self.segment_or_insert(id)))
+            .collect();
+        let mut guards = Vec::with_capacity(segments.len());
+        for (id, segment) in &segments {
+            guards.push(self.raw_for_append(*id, segment)?);
+        }
+
+        for &(segment_id, _) in items {
+            self.get_writer(segment_id)?;
+        }
+
+        let mut locations = Vec::with_capacity(items.len());
+        let mut writers = self.writers.lock().unwrap();
+
+        for &(segment_id, data) in items {
+            let file = writers.get_mut(&segment_id).unwrap();
+            // Current position is the offset (file is in append mode).
+            let offset = file.seek(SeekFrom::End(0))?;
+            file.write_all(data)?;
+            locations.push(BlockLocation {
+                segment_id,
+                offset,
+                length: data.len() as u32,
+            });
+        }
+
+        for &segment_id in &touched {
+            if let Some(file) = writers.get(&segment_id) {
+                file.sync_data()?;
+            }
+        }
+
+        drop(writers);
+        drop(guards);
+
+        Ok(locations)
+    }
+
+    /// Read block data at the given location.
+    pub fn read(&self, loc: &BlockLocation) -> io::Result<Vec<u8>> {
+        let Some(segment) = self.segment(loc.segment_id) else {
+            return Err(absent(loc.segment_id));
+        };
+        let state = segment.state.read().unwrap();
+        let paths = self.paths(loc.segment_id);
+        match state.representation {
+            None => Err(absent(loc.segment_id)),
+            Some(Representation::Raw) => {
+                let file = File::open(paths.representation(Representation::Raw))?;
+                let mut buf = vec![0u8; loc.length as usize];
+                file.read_exact_at(&mut buf, loc.offset)?;
+                Ok(buf)
+            }
+            Some(Representation::Compressed) => self.cache.read(
+                SegmentRef {
+                    segment_id: loc.segment_id,
+                    generation: state.generation,
+                },
+                &paths.representation(Representation::Compressed),
+                loc.offset,
+                loc.length,
+                &*self.dictionaries,
+            ),
+        }
+    }
+
+    /// Truncate a segment at the given logical offset.
+    /// Used for undo: removes everything from `offset` onwards.
+    ///
+    /// A compressed segment is thawed first and truncated as raw; truncating
+    /// to zero removes the segment in whichever representation it has,
+    /// without converting it.
+    pub fn truncate(&self, segment_id: u32, offset: u64) -> io::Result<()> {
+        let Some(segment) = self.segment(segment_id) else {
+            return Ok(());
+        };
+        let mut state = segment.state.write().unwrap();
+        self.writers.lock().unwrap().remove(&segment_id);
+
+        let Some(representation) = state.representation else {
+            return Ok(());
+        };
+
+        if offset == 0 {
+            self.paths(segment_id).remove_all()?;
+            state.representation = None;
+            self.changed(segment_id, &mut state);
+            return Ok(());
+        }
+
+        if representation == Representation::Compressed {
+            let logical_len = self
+                .cache
+                .index(
+                    SegmentRef {
+                        segment_id,
+                        generation: state.generation,
+                    },
+                    &self
+                        .paths(segment_id)
+                        .representation(Representation::Compressed),
+                )?
+                .logical_len();
+            if offset >= logical_len {
+                return Ok(());
+            }
+            self.thaw_locked(segment_id, &mut state)?;
+        }
+
+        let file = OpenOptions::new()
+            .write(true)
+            .open(self.paths(segment_id).representation(Representation::Raw))?;
+        file.set_len(offset)?;
+        file.sync_data()?;
+        self.changed(segment_id, &mut state);
+
+        Ok(())
+    }
+
+    /// Delete all segments with IDs strictly less than `segment_id`, in
+    /// every representation, along with any transition remnants, releasing
+    /// the handles the store holds on them.
+    pub fn delete_segments_before(&self, segment_id: u32) -> io::Result<()> {
+        let mut doomed: BTreeSet<u32> = self
+            .segments
+            .read()
+            .unwrap()
+            .keys()
+            .copied()
+            .filter(|id| *id < segment_id)
+            .collect();
+        for entry in fs::read_dir(&self.segments_dir)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if let Some((id, _)) = parse_filename(name) {
+                if id < segment_id {
+                    doomed.insert(id);
+                }
+            }
+        }
+
+        for id in doomed {
+            let segment = self.segment_or_insert(id);
+            let mut state = segment.state.write().unwrap();
+            self.writers.lock().unwrap().remove(&id);
+            self.paths(id).remove_all()?;
+            state.representation = None;
+            self.changed(id, &mut state);
+        }
+
+        Ok(())
+    }
+
+    /// Compress a raw segment in place.
+    ///
+    /// `blocks` are the locations the archive index holds inside the
+    /// segment, in any order; they choose the frame boundaries. Bytes no
+    /// location covers are kept as their own frames, so the logical stream
+    /// and every offset into it survive unchanged. The output is staged
+    /// beside the segment, verified frame by frame against the raw bytes,
+    /// and only then published; a failure at any point leaves the raw
+    /// segment as it was. Sealing with a dictionary requires that dictionary
+    /// to be resolvable through the store's dictionary source, since the
+    /// verification reads the staged output the way a restart would.
+    pub fn seal(
+        &self,
+        segment_id: u32,
+        blocks: &[BlockLocation],
+        options: &WriterOptions,
+    ) -> io::Result<WriteSummary> {
+        let segment = self.segment(segment_id).ok_or_else(|| absent(segment_id))?;
+        let mut state = segment.state.write().unwrap();
+        self.writers.lock().unwrap().remove(&segment_id);
+        self.settle(segment_id, &mut state)?;
+
+        match state.representation {
+            Some(Representation::Raw) => {}
+            Some(Representation::Compressed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("segment {segment_id:06} is already compressed"),
+                ))
+            }
+            None => return Err(absent(segment_id)),
+        }
+
+        let paths = self.paths(segment_id);
+        let raw = File::open(paths.representation(Representation::Raw))?;
+        let raw_len = raw.metadata()?.len();
+        let frames = plan_frames(segment_id, blocks, raw_len)?;
+
+        let mut guard = TransitionGuard::begin(&paths, Transition::Seal)?;
+        let staging = guard.staging();
+        let sink = BufWriter::new(
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&staging)?,
+        );
+        let mut writer = SegmentWriter::new(sink, options.clone())?;
+        let mut buf = Vec::new();
+        for range in frames {
+            buf.resize((range.end - range.start) as usize, 0);
+            raw.read_exact_at(&mut buf, range.start)?;
+            writer.push(&buf)?;
+        }
+        let (summary, sink) = writer.finish()?;
+        let file = sink.into_inner().map_err(|e| e.into_error())?;
+        file.sync_all()?;
+        drop(file);
+
+        verify_sealed(&staging, &raw, raw_len, &*self.dictionaries).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "segment {segment_id:06}: staged compressed output failed verification: {e}"
+                ),
+            )
+        })?;
+        drop(raw);
+
+        guard.publish()?;
+        state.representation = Some(Representation::Compressed);
+        self.changed(segment_id, &mut state);
+        guard.finish()?;
+
+        Ok(summary)
+    }
+
+    /// Restore a compressed segment to raw in place, with the same
+    /// guarantees as [`seal`](Self::seal) in the other direction.
+    pub fn thaw(&self, segment_id: u32) -> io::Result<()> {
+        let segment = self.segment(segment_id).ok_or_else(|| absent(segment_id))?;
+        let mut state = segment.state.write().unwrap();
+        self.writers.lock().unwrap().remove(&segment_id);
+        self.settle(segment_id, &mut state)?;
+
+        match state.representation {
+            Some(Representation::Compressed) => self.thaw_locked(segment_id, &mut state),
+            Some(Representation::Raw) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("segment {segment_id:06} is already raw"),
+            )),
+            None => Err(absent(segment_id)),
+        }
+    }
+
+    /// Re-run recovery for one segment whose exclusive lock is held, so a
+    /// transition whose retirement step failed earlier is completed before
+    /// the next one begins.
+    fn settle(&self, segment_id: u32, state: &mut SegmentState) -> io::Result<()> {
+        let representation = self.paths(segment_id).recover()?;
+        if representation != state.representation {
+            state.representation = representation;
+            self.changed(segment_id, state);
+        }
+        Ok(())
+    }
+
+    fn thaw_locked(&self, segment_id: u32, state: &mut SegmentState) -> io::Result<()> {
+        let paths = self.paths(segment_id);
+        let reader = SegmentReader::open(
+            &paths.representation(Representation::Compressed),
+            &*self.dictionaries,
+        )?;
+        let logical_len = reader.index().logical_len();
+
+        let mut guard = TransitionGuard::begin(&paths, Transition::Thaw)?;
+        let staging = guard.staging();
+        let mut sink = BufWriter::new(
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&staging)?,
+        );
+        let mut hasher = Sha256::new();
+        for frame in reader.index().frames() {
+            if frame.decompressed_size == 0 {
+                continue;
+            }
+            let data = reader.read(frame.logical_offset, frame.decompressed_size)?;
+            hasher.update(&data);
+            sink.write_all(&data)?;
+        }
+        sink.flush()?;
+        let file = sink.into_inner().map_err(|e| e.into_error())?;
+        file.sync_all()?;
+        drop(file);
+        drop(reader);
+
+        verify_thawed(&staging, logical_len, hasher.finalize().as_slice()).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("segment {segment_id:06}: staged raw output failed verification: {e}"),
+            )
+        })?;
+
+        guard.publish()?;
+        state.representation = Some(Representation::Raw);
+        self.changed(segment_id, state);
+        guard.finish()
+    }
+}
+
+impl std::fmt::Debug for FlatFileStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlatFileStore")
+            .field("segments_dir", &self.segments_dir)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
+/// Lay out the frames of a seal: the indexed blocks in offset order, with
+/// the bytes between and after them as filler, covering the raw file
+/// exactly.
+fn plan_frames(
+    segment_id: u32,
+    blocks: &[BlockLocation],
+    raw_len: u64,
+) -> io::Result<Vec<Range<u64>>> {
+    let mut ranges: Vec<Range<u64>> = blocks
+        .iter()
+        .filter(|loc| loc.segment_id == segment_id && loc.length > 0)
+        .map(|loc| loc.offset..loc.offset + loc.length as u64)
+        .collect();
+    ranges.sort_by_key(|range| (range.start, range.end));
+    ranges.dedup();
+
+    let mut frames = Vec::with_capacity(ranges.len() + 1);
+    let mut cursor = 0u64;
+    for range in ranges {
+        if range.start < cursor {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "segment {segment_id:06}: block at offset {} overlaps the block ending at {cursor}",
+                    range.start
+                ),
+            ));
+        }
+        if range.end > raw_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "segment {segment_id:06}: block at offset {} with length {} runs past the segment's {raw_len} bytes",
+                    range.start,
+                    range.end - range.start
+                ),
+            ));
+        }
+        push_filler(&mut frames, cursor, range.start);
+        cursor = range.end;
+        frames.push(range);
+    }
+    push_filler(&mut frames, cursor, raw_len);
+    Ok(frames)
+}
+
+fn push_filler(frames: &mut Vec<Range<u64>>, mut from: u64, to: u64) {
+    while from < to {
+        let end = to.min(from + FILLER_FRAME_BYTES);
+        frames.push(from..end);
+        from = end;
+    }
+}
+
+/// Read the staged compressed file the way a restart would and compare every
+/// frame against the raw bytes it stands for.
+fn verify_sealed(
+    staging: &Path,
+    raw: &File,
+    raw_len: u64,
+    dictionaries: &dyn DictionarySource,
+) -> io::Result<()> {
+    let reader = SegmentReader::open(staging, dictionaries)?;
+    let index = reader.index();
+    if index.logical_len() != raw_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "compressed output spans {} logical bytes, raw segment has {raw_len}",
+                index.logical_len()
+            ),
+        ));
+    }
+    let mut expected = Vec::new();
+    for (i, frame) in index.frames().iter().enumerate() {
+        if frame.decompressed_size == 0 {
+            continue;
+        }
+        let decoded = reader.read(frame.logical_offset, frame.decompressed_size)?;
+        expected.resize(frame.decompressed_size as usize, 0);
+        raw.read_exact_at(&mut expected, frame.logical_offset)?;
+        if decoded != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "frame {i} at logical offset {} decodes to different bytes than the raw segment",
+                    frame.logical_offset
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Read the staged raw file back and check it is the stream that was
+/// written to it.
+fn verify_thawed(staging: &Path, logical_len: u64, digest: &[u8]) -> io::Result<()> {
+    let mut file = File::open(staging)?;
+    let len = file.metadata()?.len();
+    if len != logical_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("raw output is {len} bytes, compressed segment spans {logical_len}"),
+        ));
+    }
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 1 << 20];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    if hasher.finalize().as_slice() != digest {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "raw output read back differs from what was written",
+        ));
+    }
+    Ok(())
+}
+
+fn absent(segment_id: u32) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("segment {segment_id:06} is not in the store"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_cover_the_file_with_filler_between_blocks() {
+        let blocks = [
+            BlockLocation {
+                segment_id: 0,
+                offset: 10,
+                length: 5,
+            },
+            BlockLocation {
+                segment_id: 0,
+                offset: 0,
+                length: 4,
+            },
+            BlockLocation {
+                segment_id: 1,
+                offset: 0,
+                length: 100,
+            },
+        ];
+        assert_eq!(
+            plan_frames(0, &blocks, 20).unwrap(),
+            vec![0..4, 4..10, 10..15, 15..20]
+        );
+    }
+
+    #[test]
+    fn frames_refuse_overlaps_and_overruns() {
+        let overlapping = [
+            BlockLocation {
+                segment_id: 0,
+                offset: 0,
+                length: 8,
+            },
+            BlockLocation {
+                segment_id: 0,
+                offset: 4,
+                length: 8,
+            },
+        ];
+        assert_eq!(
+            plan_frames(0, &overlapping, 20).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        let overrun = [BlockLocation {
+            segment_id: 0,
+            offset: 16,
+            length: 8,
+        }];
+        assert_eq!(
+            plan_frames(0, &overrun, 20).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn filler_is_cut_into_bounded_frames() {
+        let frames = plan_frames(0, &[], 3 * FILLER_FRAME_BYTES + 1).unwrap();
+        assert_eq!(frames.len(), 4);
+        assert_eq!(frames.last().unwrap().end, 3 * FILLER_FRAME_BYTES + 1);
+    }
+}

--- a/crates/flatfiles/tests/lifecycle.rs
+++ b/crates/flatfiles/tests/lifecycle.rs
@@ -1,0 +1,780 @@
+//! The store over mixed raw and compressed segments: reads dispatched by
+//! representation, appends and truncation that thaw first, pruning across
+//! representations, the recovery table at every interruption point, and the
+//! validation an open performs.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+
+use dolos_flatfiles::compressed::{
+    CacheLimits, Dictionary, DictionaryDir, WriterOptions, METADATA_FRAME_SIZE,
+};
+use dolos_flatfiles::{
+    BlockLocation, FlatFileOptions, FlatFileStore, Representation, DICTIONARIES_DIR,
+};
+
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+}
+
+fn vocabulary() -> Vec<Vec<u8>> {
+    let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+    (0..48)
+        .map(|_| {
+            let len = 6 + rng.below(30) as usize;
+            (0..len).map(|_| rng.below(256) as u8).collect()
+        })
+        .collect()
+}
+
+/// Compressible pseudo-blocks between `min` and `max` bytes.
+fn blocks(seed: u64, count: usize, min: usize, max: usize) -> Vec<Vec<u8>> {
+    let words = vocabulary();
+    let mut rng = Rng(seed | 1);
+    (0..count)
+        .map(|_| {
+            let target = min + rng.below((max - min + 1) as u64) as usize;
+            let mut block = Vec::with_capacity(target + 40);
+            while block.len() < target {
+                block.extend_from_slice(&words[rng.below(words.len() as u64) as usize]);
+            }
+            block.truncate(target);
+            block
+        })
+        .collect()
+}
+
+fn dictionary() -> Dictionary {
+    Dictionary::new(vocabulary().concat())
+}
+
+type Entry = (Vec<u8>, BlockLocation);
+
+/// Six batches over segments 0, 1 and 2 — two batches per segment, so every
+/// segment has blocks appended in more than one call.
+fn populate(store: &FlatFileStore, seed: u64) -> Vec<Entry> {
+    let bodies = blocks(seed, 90, 200, 3_000);
+    let mut out = Vec::new();
+    for (i, chunk) in bodies.chunks(15).enumerate() {
+        let segment = (i / 2) as u32;
+        let items: Vec<(u32, &[u8])> = chunk.iter().map(|b| (segment, b.as_slice())).collect();
+        let locations = store.append_batch(&items).unwrap();
+        out.extend(chunk.iter().cloned().zip(locations));
+    }
+    out
+}
+
+fn in_segment(entries: &[Entry], segment: u32) -> Vec<BlockLocation> {
+    entries
+        .iter()
+        .filter(|(_, loc)| loc.segment_id == segment)
+        .map(|(_, loc)| *loc)
+        .collect()
+}
+
+fn assert_all_readable(store: &FlatFileStore, entries: &[Entry]) {
+    for (body, loc) in entries {
+        assert_eq!(
+            &store.read(loc).unwrap(),
+            body,
+            "location {loc:?} does not read back"
+        );
+    }
+}
+
+fn files_of(dir: &Path, segment: u32) -> Vec<String> {
+    let prefix = format!("{segment:06}.");
+    let mut names: Vec<String> = fs::read_dir(dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with(&prefix))
+        .collect();
+    names.sort();
+    names
+}
+
+fn raw_path(dir: &Path, segment: u32) -> PathBuf {
+    dir.join(format!("{segment:06}.segment"))
+}
+
+fn zseg_path(dir: &Path, segment: u32) -> PathBuf {
+    dir.join(format!("{segment:06}.zseg"))
+}
+
+fn seal_mixed(dir: &Path, store: &FlatFileStore, entries: &[Entry]) {
+    let dictionary = dictionary();
+    DictionaryDir::new(dir.join(DICTIONARIES_DIR))
+        .install(&dictionary)
+        .unwrap();
+    store
+        .seal(
+            0,
+            &in_segment(entries, 0),
+            &WriterOptions::per_block().with_dictionary(dictionary),
+        )
+        .unwrap();
+    store
+        .seal(1, &in_segment(entries, 1), &WriterOptions::chunked(4096))
+        .unwrap();
+}
+
+#[test]
+fn mixed_segments_read_like_raw() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 1);
+    let raw_lens: Vec<u64> = (0..3)
+        .map(|s| fs::metadata(raw_path(dir.path(), s)).unwrap().len())
+        .collect();
+
+    seal_mixed(dir.path(), &store, &entries);
+
+    assert_eq!(store.representation(0), Some(Representation::Compressed));
+    assert_eq!(store.representation(1), Some(Representation::Compressed));
+    assert_eq!(store.representation(2), Some(Representation::Raw));
+    assert_eq!(store.representation(3), None);
+    assert_all_readable(&store, &entries);
+
+    let infos = store.segments().unwrap();
+    assert_eq!(infos.len(), 3);
+    for (info, raw_len) in infos.iter().zip(&raw_lens) {
+        assert_eq!(info.logical_len, *raw_len, "segment {}", info.segment_id);
+    }
+    assert!(infos[0].metadata.as_ref().unwrap().dictionary.is_some());
+    assert!(infos[1].metadata.as_ref().unwrap().dictionary.is_none());
+    assert!(infos[2].metadata.is_none());
+    assert!(infos[0].physical_len < infos[0].logical_len);
+
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.zseg"]);
+    assert_eq!(files_of(dir.path(), 1), vec!["000001.zseg"]);
+    assert_eq!(files_of(dir.path(), 2), vec!["000002.segment"]);
+
+    drop(store);
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(reopened.representation(0), Some(Representation::Compressed));
+    assert_eq!(reopened.representation(2), Some(Representation::Raw));
+    assert_all_readable(&reopened, &entries);
+}
+
+#[test]
+fn bytes_no_location_covers_survive_sealing() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 2);
+    // A body appended again, the way a resumed import does, that the index
+    // keeps pointing past: nothing describes it, yet it stays in the stream.
+    let dead = blocks(7, 1, 500, 500).remove(0);
+    let dead_loc = store.append_batch(&[(0, dead.as_slice())]).unwrap()[0];
+
+    store
+        .seal(0, &in_segment(&entries, 0), &WriterOptions::per_block())
+        .unwrap();
+
+    assert_all_readable(&store, &entries);
+    assert_eq!(store.read(&dead_loc).unwrap(), dead);
+    assert_eq!(
+        store.segments().unwrap()[0].logical_len,
+        dead_loc.offset + dead.len() as u64
+    );
+
+    drop(store);
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(reopened.read(&dead_loc).unwrap(), dead);
+}
+
+#[test]
+fn appending_to_a_compressed_segment_thaws_it_at_the_same_offsets() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 3);
+    seal_mixed(dir.path(), &store, &entries);
+    let logical_len = store.segments().unwrap()[0].logical_len;
+
+    let more = blocks(11, 3, 300, 900);
+    let items: Vec<(u32, &[u8])> = more.iter().map(|b| (0, b.as_slice())).collect();
+    let locations = store.append_batch(&items).unwrap();
+
+    assert_eq!(locations[0].offset, logical_len);
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+    assert_all_readable(&store, &entries);
+    for (body, loc) in more.iter().zip(&locations) {
+        assert_eq!(&store.read(loc).unwrap(), body);
+    }
+    // The other compressed segment is untouched by the append.
+    assert_eq!(store.representation(1), Some(Representation::Compressed));
+
+    drop(store);
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_all_readable(&reopened, &entries);
+    assert_eq!(reopened.read(&locations[2]).unwrap(), more[2]);
+}
+
+#[test]
+fn truncating_inside_a_compressed_segment_thaws_it_first() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 4);
+    seal_mixed(dir.path(), &store, &entries);
+    let logical_len = store.segments().unwrap()[0].logical_len;
+
+    // At the logical end nothing is cut, so nothing is converted.
+    store.truncate(0, logical_len).unwrap();
+    assert_eq!(store.representation(0), Some(Representation::Compressed));
+
+    let seg0: Vec<&Entry> = entries.iter().filter(|(_, l)| l.segment_id == 0).collect();
+    let cut = seg0[20].1;
+    store.truncate(0, cut.offset).unwrap();
+
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+    for (body, loc) in &seg0[..20] {
+        assert_eq!(&store.read(loc).unwrap(), body);
+    }
+    for (_, loc) in &seg0[20..] {
+        assert!(store.read(loc).is_err(), "{loc:?} survived the cut");
+    }
+
+    let again = blocks(12, 1, 400, 400).remove(0);
+    let loc = store.append_batch(&[(0, again.as_slice())]).unwrap()[0];
+    assert_eq!(loc.offset, cut.offset);
+    assert_eq!(store.read(&loc).unwrap(), again);
+}
+
+#[test]
+fn truncating_to_zero_removes_a_compressed_segment_without_thawing() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 5);
+    seal_mixed(dir.path(), &store, &entries);
+
+    store.truncate(0, 0).unwrap();
+
+    assert!(files_of(dir.path(), 0).is_empty());
+    assert_eq!(store.representation(0), None);
+    let first = &entries[0].1;
+    assert_eq!(
+        store.read(first).unwrap_err().kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let body = blocks(13, 1, 400, 400).remove(0);
+    let loc = store.append_batch(&[(0, body.as_slice())]).unwrap()[0];
+    assert_eq!(loc.offset, 0);
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+
+    drop(store);
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(reopened.read(&loc).unwrap(), body);
+}
+
+#[test]
+fn pruning_removes_every_representation_and_releases_handles() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 6);
+    seal_mixed(dir.path(), &store, &entries);
+    assert_all_readable(&store, &entries);
+    assert!(store.cache_stats().open_handles > 0);
+
+    // Remnants a crash could leave beside an authoritative file.
+    fs::write(dir.path().join("000000.zseg.tmp"), b"half").unwrap();
+    fs::write(dir.path().join("000001.transition.tmp"), b"seal").unwrap();
+
+    store.delete_segments_before(2).unwrap();
+
+    assert!(files_of(dir.path(), 0).is_empty());
+    assert!(files_of(dir.path(), 1).is_empty());
+    assert_eq!(files_of(dir.path(), 2), vec!["000002.segment"]);
+    assert_eq!(store.cache_stats().open_handles, 0);
+    assert_eq!(store.representation(0), None);
+    assert_eq!(store.representation(1), None);
+    for (_, loc) in entries.iter().filter(|(_, l)| l.segment_id < 2) {
+        assert_eq!(store.read(loc).unwrap_err().kind(), io::ErrorKind::NotFound);
+    }
+    for (body, loc) in entries.iter().filter(|(_, l)| l.segment_id == 2) {
+        assert_eq!(&store.read(loc).unwrap(), body);
+    }
+
+    drop(store);
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(reopened.segments().unwrap().len(), 1);
+}
+
+/// One segment's stream in both representations, for composing interrupted
+/// directories by hand.
+struct Pair {
+    entries: Vec<Entry>,
+    raw: Vec<u8>,
+    compressed: Vec<u8>,
+}
+
+fn pair() -> Pair {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let bodies = blocks(21, 30, 200, 2_000);
+    let items: Vec<(u32, &[u8])> = bodies.iter().map(|b| (0, b.as_slice())).collect();
+    let locations = store.append_batch(&items).unwrap();
+    let entries: Vec<Entry> = bodies.into_iter().zip(locations).collect();
+    let raw = fs::read(raw_path(dir.path(), 0)).unwrap();
+    store
+        .seal(0, &in_segment(&entries, 0), &WriterOptions::per_block())
+        .unwrap();
+    let compressed = fs::read(zseg_path(dir.path(), 0)).unwrap();
+    Pair {
+        entries,
+        raw,
+        compressed,
+    }
+}
+
+/// A directory state: file name suffix (after `000000.`) and content.
+type State = Vec<(&'static str, Vec<u8>)>;
+
+fn compose(state: &State) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    for (suffix, content) in state {
+        fs::write(dir.path().join(format!("000000.{suffix}")), content).unwrap();
+    }
+    dir
+}
+
+fn error_of(dir: &Path) -> String {
+    match FlatFileStore::new(dir) {
+        Ok(_) => panic!("{} opened", dir.display()),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Every state a seal or a thaw can be interrupted in, and what a restart
+/// makes of it. `LIFECYCLE.md` is the prose form of this table.
+#[test]
+fn recovery_resolves_every_interruption_point() {
+    let pair = pair();
+    let raw = || pair.raw.clone();
+    let zseg = || pair.compressed.clone();
+    let partial = |bytes: &[u8]| bytes[..bytes.len() / 2].to_vec();
+    let seal = || b"seal\n".to_vec();
+    let thaw = || b"thaw\n".to_vec();
+
+    let cases: Vec<(&str, State, Representation, Vec<&str>)> = vec![
+        // The seal sequence: R → R+I → R+I+T → R+I+Z → I+Z → Z.
+        (
+            "seal: at rest",
+            vec![("segment", raw())],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "seal: record being staged",
+            vec![("segment", raw()), ("transition.tmp", seal())],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "seal: record written",
+            vec![("segment", raw()), ("transition", seal())],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "seal: output partly staged",
+            vec![
+                ("segment", raw()),
+                ("transition", seal()),
+                ("zseg.tmp", partial(&pair.compressed)),
+            ],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "seal: output fully staged, not published",
+            vec![
+                ("segment", raw()),
+                ("transition", seal()),
+                ("zseg.tmp", zseg()),
+            ],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "seal: published, raw not retired",
+            vec![("segment", raw()), ("transition", seal()), ("zseg", zseg())],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        (
+            "seal: raw retired, record not",
+            vec![("transition", seal()), ("zseg", zseg())],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        (
+            "seal: done",
+            vec![("zseg", zseg())],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        // The thaw sequence: Z → Z+I → Z+I+T → Z+I+R → I+R → R.
+        (
+            "thaw: record written",
+            vec![("zseg", zseg()), ("transition", thaw())],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        (
+            "thaw: output partly staged",
+            vec![
+                ("zseg", zseg()),
+                ("transition", thaw()),
+                ("segment.tmp", partial(&pair.raw)),
+            ],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        (
+            "thaw: output fully staged, not published",
+            vec![
+                ("zseg", zseg()),
+                ("transition", thaw()),
+                ("segment.tmp", raw()),
+            ],
+            Representation::Compressed,
+            vec!["000000.zseg"],
+        ),
+        (
+            "thaw: published, compressed not retired",
+            vec![("zseg", zseg()), ("transition", thaw()), ("segment", raw())],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+        (
+            "thaw: compressed retired, record not",
+            vec![("transition", thaw()), ("segment", raw())],
+            Representation::Raw,
+            vec!["000000.segment"],
+        ),
+    ];
+
+    for (name, state, expected, remaining) in cases {
+        let dir = compose(&state);
+        for pass in 0..2 {
+            let store = FlatFileStore::new(dir.path())
+                .unwrap_or_else(|e| panic!("{name}, pass {pass}: {e}"));
+            assert_eq!(
+                store.representation(0),
+                Some(expected),
+                "{name}, pass {pass}"
+            );
+            assert_all_readable(&store, &pair.entries);
+            assert_eq!(files_of(dir.path(), 0), remaining, "{name}, pass {pass}");
+        }
+    }
+}
+
+/// Once a thaw has published its raw file the raw file is the segment, and
+/// what happens to it afterwards — an append, a truncation — is never undone
+/// by a restart that still finds the compressed file waiting to be retired.
+#[test]
+fn recovery_never_revives_compressed_bytes_over_a_mutated_raw_file() {
+    let pair = pair();
+    let extra = blocks(31, 1, 700, 700).remove(0);
+
+    let mut appended = pair.raw.clone();
+    appended.extend_from_slice(&extra);
+    let dir = compose(&vec![
+        ("zseg", pair.compressed.clone()),
+        ("transition", b"thaw\n".to_vec()),
+        ("segment", appended),
+    ]);
+    let store = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    assert_all_readable(&store, &pair.entries);
+    let extra_loc = BlockLocation {
+        segment_id: 0,
+        offset: pair.raw.len() as u64,
+        length: extra.len() as u32,
+    };
+    assert_eq!(store.read(&extra_loc).unwrap(), extra);
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+    drop(store);
+
+    let cut = pair.entries[10].1.offset as usize;
+    let dir = compose(&vec![
+        ("zseg", pair.compressed.clone()),
+        ("transition", b"thaw\n".to_vec()),
+        ("segment", pair.raw[..cut].to_vec()),
+    ]);
+    let store = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    for (body, loc) in &pair.entries[..10] {
+        assert_eq!(&store.read(loc).unwrap(), body);
+    }
+    assert!(store.read(&pair.entries[10].1).is_err());
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+}
+
+#[test]
+fn recovery_refuses_states_no_transition_produces() {
+    let pair = pair();
+
+    let dir = compose(&vec![
+        ("segment", pair.raw.clone()),
+        ("zseg", pair.compressed.clone()),
+    ]);
+    let message = error_of(dir.path());
+    assert!(message.contains("000000"), "{message}");
+    assert!(message.contains("no transition record"), "{message}");
+    // Refusing changed nothing, so the operator can still decide.
+    assert_eq!(
+        files_of(dir.path(), 0),
+        vec!["000000.segment", "000000.zseg"]
+    );
+
+    let dir = compose(&vec![("transition", b"seal\n".to_vec())]);
+    let message = error_of(dir.path());
+    assert!(message.contains("neither representation"), "{message}");
+
+    let dir = compose(&vec![
+        ("segment", pair.raw.clone()),
+        ("transition", b"melt\n".to_vec()),
+    ]);
+    let message = error_of(dir.path());
+    assert!(message.contains("unreadable"), "{message}");
+}
+
+#[test]
+fn open_refuses_a_missing_or_wrong_dictionary() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 8);
+    let dictionary = dictionary();
+    let dictionaries = DictionaryDir::new(dir.path().join(DICTIONARIES_DIR));
+    let installed = dictionaries.install(&dictionary).unwrap();
+    store
+        .seal(
+            1,
+            &in_segment(&entries, 1),
+            &WriterOptions::per_block().with_dictionary(dictionary.clone()),
+        )
+        .unwrap();
+    drop(store);
+
+    fs::remove_file(&installed).unwrap();
+    let message = error_of(dir.path());
+    assert!(message.contains("000001"), "{message}");
+    assert!(message.contains(&dictionary.id().to_string()), "{message}");
+    assert!(message.contains("not available"), "{message}");
+
+    fs::write(&installed, b"not the dictionary the segment names").unwrap();
+    let message = error_of(dir.path());
+    assert!(message.contains("000001"), "{message}");
+    assert!(message.contains("hashes to"), "{message}");
+
+    fs::remove_file(&installed).unwrap();
+    dictionaries.install(&dictionary).unwrap();
+    let store = FlatFileStore::new(dir.path()).unwrap();
+    assert_all_readable(&store, &entries);
+}
+
+#[test]
+fn open_refuses_metadata_this_build_does_not_read() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 9);
+    store
+        .seal(2, &in_segment(&entries, 2), &WriterOptions::per_block())
+        .unwrap();
+    drop(store);
+
+    let path = zseg_path(dir.path(), 2);
+    let mut bytes = fs::read(&path).unwrap();
+    // The payload version sits four bytes into the metadata payload.
+    bytes[8 + 4..8 + 6].copy_from_slice(&7u16.to_le_bytes());
+    fs::write(&path, bytes).unwrap();
+
+    let message = error_of(dir.path());
+    assert!(message.contains("000002"), "{message}");
+    assert!(message.contains("not supported"), "{message}");
+}
+
+#[test]
+fn frame_corruption_is_a_read_error_not_an_open_error() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 10);
+    store
+        .seal(0, &in_segment(&entries, 0), &WriterOptions::per_block())
+        .unwrap();
+    drop(store);
+
+    let path = zseg_path(dir.path(), 0);
+    let mut bytes = fs::read(&path).unwrap();
+    let inside_first_frame = METADATA_FRAME_SIZE + 24;
+    bytes[inside_first_frame] ^= 0xFF;
+    fs::write(&path, bytes).unwrap();
+
+    let store = FlatFileStore::new(dir.path()).unwrap();
+    let first = &entries[0].1;
+    assert_eq!(
+        store.read(first).unwrap_err().kind(),
+        io::ErrorKind::InvalidData
+    );
+    let last_in_segment = in_segment(&entries, 0).last().copied().unwrap();
+    assert!(store.read(&last_in_segment).is_ok());
+}
+
+#[test]
+fn a_failed_seal_leaves_the_raw_segment_and_no_remnants() {
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 14);
+    let seg0 = in_segment(&entries, 0);
+
+    // Overlapping locations are refused before anything is written.
+    let mut overlapping = seg0.clone();
+    overlapping.push(BlockLocation {
+        segment_id: 0,
+        offset: seg0[0].offset + 1,
+        length: 10,
+    });
+    let error = store
+        .seal(0, &overlapping, &WriterOptions::per_block())
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+
+    // A dictionary the store cannot resolve fails the verification of the
+    // staged output, after the record and the staging file exist.
+    let uninstalled = dictionary();
+    let error = store
+        .seal(
+            0,
+            &seg0,
+            &WriterOptions::per_block().with_dictionary(uninstalled.clone()),
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("verification"), "{error}");
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+    assert_all_readable(&store, &entries);
+
+    DictionaryDir::new(dir.path().join(DICTIONARIES_DIR))
+        .install(&uninstalled)
+        .unwrap();
+    store
+        .seal(
+            0,
+            &seg0,
+            &WriterOptions::per_block().with_dictionary(uninstalled),
+        )
+        .unwrap();
+    assert_all_readable(&store, &entries);
+}
+
+#[cfg(unix)]
+#[test]
+fn an_unwritable_directory_fails_the_seal_before_anything_moves() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 15);
+
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+    let result = store.seal(0, &in_segment(&entries, 0), &WriterOptions::per_block());
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+
+    if result.is_ok() {
+        // Running with privileges that ignore directory modes.
+        return;
+    }
+    assert_eq!(store.representation(0), Some(Representation::Raw));
+    assert_eq!(files_of(dir.path(), 0), vec!["000000.segment"]);
+    assert_all_readable(&store, &entries);
+}
+
+#[test]
+fn transitions_refuse_the_wrong_source() {
+    let (_dir, store) = FlatFileStore::for_tempdir().unwrap();
+    let entries = populate(&store, 16);
+    let seg0 = in_segment(&entries, 0);
+
+    assert_eq!(
+        store.thaw(0).unwrap_err().kind(),
+        io::ErrorKind::InvalidInput
+    );
+    store.seal(0, &seg0, &WriterOptions::per_block()).unwrap();
+    assert_eq!(
+        store
+            .seal(0, &seg0, &WriterOptions::per_block())
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::InvalidInput
+    );
+    assert_eq!(
+        store
+            .seal(9, &[], &WriterOptions::per_block())
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    store.thaw(0).unwrap();
+    assert_all_readable(&store, &entries);
+}
+
+#[test]
+fn readers_never_observe_a_transition_in_progress() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FlatFileStore::with_options(
+        dir.path(),
+        FlatFileOptions {
+            dictionaries: None,
+            cache: Some(CacheLimits {
+                handles: 2,
+                inflight_reads: 4,
+                ..CacheLimits::default()
+            }),
+        },
+    )
+    .unwrap();
+    let store = Arc::new(store);
+    let entries = Arc::new(populate(&store, 17));
+    let seg0 = in_segment(&entries, 0);
+    store.seal(0, &seg0, &WriterOptions::per_block()).unwrap();
+
+    let readers: Vec<_> = (0..4)
+        .map(|_| {
+            let store = store.clone();
+            let entries = entries.clone();
+            thread::spawn(move || {
+                for _ in 0..40 {
+                    assert_all_readable(&store, &entries);
+                }
+            })
+        })
+        .collect();
+
+    for round in 0..6 {
+        store.thaw(0).unwrap();
+        let options = if round % 2 == 0 {
+            WriterOptions::chunked(2048)
+        } else {
+            WriterOptions::per_block()
+        };
+        store.seal(0, &seg0, &options).unwrap();
+    }
+
+    for reader in readers {
+        reader
+            .join()
+            .expect("a reader saw a bad read mid-transition");
+    }
+
+    let stats = store.cache_stats();
+    assert!(stats.open_handles <= 2, "{stats:?}");
+    store.delete_segments_before(3).unwrap();
+    assert_eq!(store.cache_stats().open_handles, 0);
+}

--- a/crates/flatfiles/tests/lifecycle.rs
+++ b/crates/flatfiles/tests/lifecycle.rs
@@ -228,9 +228,13 @@ fn truncating_inside_a_compressed_segment_thaws_it_first() {
     seal_mixed(dir.path(), &store, &entries);
     let logical_len = store.segments().unwrap()[0].logical_len;
 
-    // At the logical end nothing is cut, so nothing is converted.
+    // At the logical end nothing is cut, so nothing is converted; past the
+    // end of a raw segment nothing is cut and nothing grows either.
     store.truncate(0, logical_len).unwrap();
     assert_eq!(store.representation(0), Some(Representation::Compressed));
+    let raw_len = store.segments().unwrap()[2].logical_len;
+    store.truncate(2, raw_len + 1).unwrap();
+    assert_eq!(store.segments().unwrap()[2].logical_len, raw_len);
 
     let seg0: Vec<&Entry> = entries.iter().filter(|(_, l)| l.segment_id == 0).collect();
     let cut = seg0[20].1;

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -66,5 +66,7 @@ rustls = { version = "0.23", default-features = false, features = [
 ] }
 
 # The export tests drive real store sets through `dolos-testing`'s harness
-# domain and its backend bindings.
+# domain and its backend bindings; the restore suite seals the fjall
+# harness's block segment to export from compressed storage.
 dolos-testing = { path = "../testing" }
+dolos-flatfiles = { path = "../flatfiles" }

--- a/crates/snapshot/tests/restore.rs
+++ b/crates/snapshot/tests/restore.rs
@@ -555,6 +555,49 @@ fn a_restored_node_is_the_node_it_came_from_on_fjall() {
     roundtrip::<FjallStores>();
 }
 
+/// The stele a node publishes does not depend on how its block segments are
+/// stored: sealed per-block or chunked, the export carries the same logical
+/// block records as the raw store, byte for byte, and restores into the same
+/// node.
+#[test]
+fn a_stele_exported_from_compressed_segments_is_the_raw_stele_and_restores() {
+    use dolos_flatfiles::compressed::WriterOptions;
+
+    let domain: ToyDomain<FjallStores> = harness();
+
+    let raw_root = tempfile::tempdir().unwrap();
+    let raw = export_to(raw_root.path(), &domain);
+
+    // The harness ledger sits inside epoch zero, so one segment holds every
+    // block; sealing it turns the whole archive compressed, first per-block
+    // and then chunked.
+    for (name, options) in [
+        ("per-block", WriterOptions::per_block()),
+        ("chunked", WriterOptions::chunked(4096)),
+    ] {
+        if name == "chunked" {
+            domain.archive().thaw_segment(0).unwrap();
+        }
+        domain.archive().seal_segment(0, &options).unwrap();
+
+        let sealed_root = tempfile::tempdir().unwrap();
+        let sealed = export_to(sealed_root.path(), &domain);
+
+        assert_eq!(raw, sealed, "{name}: the inscription moved");
+        assert_eq!(
+            std::fs::read(raw_root.path().join("inscription.json")).unwrap(),
+            std::fs::read(sealed_root.path().join("inscription.json")).unwrap(),
+            "{name}: the document on disk moved"
+        );
+
+        let blank = Blank::<FjallStores>::open();
+        let summary =
+            restore_into(sealed_root.path(), magic_of(&domain), &blank, shredded()).unwrap();
+        assert_eq!(summary.blocks, blocks_of(domain.archive()).len() as u64);
+        assert_stores_match(&blank, &domain);
+    }
+}
+
 // --------------------------------------------------------------------------
 // 3. Cross-check
 // --------------------------------------------------------------------------

--- a/tests/archive_compression.rs
+++ b/tests/archive_compression.rs
@@ -1,0 +1,453 @@
+//! Compressed block segments behave like raw ones through every archive
+//! operation.
+//!
+//! Three stores receive the same history: the builtin memory archive as the
+//! oracle, a fjall archive left raw as the byte-level control, and a fjall
+//! archive whose segments are sealed into a mix of representations —
+//! per-block with a dictionary, chunked, and raw. Every operation the node
+//! performs on an archive — point and range reads from either end, rollback
+//! within and across segment boundaries, a resumed import, a truncation and
+//! a prune — is applied to all three and the results compared, then the
+//! mixed store is reopened to prove what it holds is on disk.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use dolos_core::{
+    builtin::MemoryArchiveStore, ArchiveStore as CoreArchiveStore, ArchiveWriter as _, BlockBody,
+    BlockSlot, ChainPoint, StateSchema,
+};
+use dolos_fjall::archive::ArchiveStore;
+use dolos_fjall::flatfiles::{
+    compressed::{Dictionary, DictionaryDir, WriterOptions},
+    Representation, DICTIONARIES_DIR, SLOTS_PER_SEGMENT,
+};
+
+fn open(dir: &Path) -> ArchiveStore {
+    let config = dolos_core::config::FjallArchiveConfig {
+        cache: Some(16),
+        flush_on_commit: Some(false),
+        worker_threads: Some(1),
+        ..Default::default()
+    };
+    ArchiveStore::open(StateSchema::default(), dir, &config).expect("open the fjall archive")
+}
+
+fn point(slot: u64) -> ChainPoint {
+    ChainPoint::Specific(slot, pallas::crypto::hash::Hash::new([0u8; 32]))
+}
+
+fn slot(segment: u64, k: u64) -> BlockSlot {
+    segment * SLOTS_PER_SEGMENT + k
+}
+
+/// A compressible body of a few hundred bytes, distinct per slot and tag.
+fn body(slot: BlockSlot, tag: u8) -> Vec<u8> {
+    format!("block at slot {slot} tag {tag} ")
+        .repeat(12)
+        .into_bytes()
+}
+
+fn dictionary() -> Dictionary {
+    Dictionary::new(body(0, 0))
+}
+
+fn write<S: CoreArchiveStore>(store: &S, blocks: &[(BlockSlot, Vec<u8>)]) {
+    let writer = store.start_writer().unwrap();
+    for (slot, body) in blocks {
+        writer
+            .apply(&point(*slot), &Arc::new(body.clone()))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+}
+
+fn undo<S: CoreArchiveStore>(store: &S, slots: &[BlockSlot]) {
+    let writer = store.start_writer().unwrap();
+    for slot in slots {
+        writer.undo(&point(*slot)).unwrap();
+    }
+    writer.commit().unwrap();
+}
+
+/// Four segments, with a slot in segments 0 and 1 holding two blocks (the
+/// Byron boundary shape) and every segment written in more than one batch.
+fn write_history<S: CoreArchiveStore>(store: &S) {
+    write(
+        store,
+        &[
+            (slot(0, 1), body(slot(0, 1), 0)),
+            (slot(0, 5), body(slot(0, 5), 0)),
+            (slot(0, 9), body(slot(0, 9), 0)),
+            (slot(1, 0), body(slot(1, 0), 0)),
+            (slot(1, 4), body(slot(1, 4), 0)),
+        ],
+    );
+    write(
+        store,
+        &[
+            (slot(0, 9), body(slot(0, 9), 1)),
+            (slot(0, 13), body(slot(0, 13), 0)),
+            (slot(1, 8), body(slot(1, 8), 0)),
+            (slot(1, 8), body(slot(1, 8), 1)),
+        ],
+    );
+    write(
+        store,
+        &[
+            (slot(2, 2), body(slot(2, 2), 0)),
+            (slot(2, 6), body(slot(2, 6), 0)),
+            (slot(3, 1), body(slot(3, 1), 0)),
+        ],
+    );
+}
+
+fn seal_mixed(dir: &Path, store: &ArchiveStore) {
+    let dictionary = dictionary();
+    DictionaryDir::new(dir.join(DICTIONARIES_DIR))
+        .install(&dictionary)
+        .unwrap();
+    store
+        .seal_segment(0, &WriterOptions::per_block().with_dictionary(dictionary))
+        .unwrap();
+    store
+        .seal_segment(1, &WriterOptions::chunked(1024))
+        .unwrap();
+}
+
+fn representations(store: &ArchiveStore) -> BTreeMap<u32, Representation> {
+    store
+        .segments()
+        .unwrap()
+        .into_iter()
+        .map(|info| (info.segment_id, info.representation))
+        .collect()
+}
+
+/// Everything an archive answers about its blocks.
+#[derive(Debug, PartialEq, Eq)]
+struct View {
+    forward: Vec<(BlockSlot, BlockBody)>,
+    reverse: Vec<(BlockSlot, BlockBody)>,
+    interleaved: Vec<(BlockSlot, BlockBody)>,
+    bounded: Vec<(BlockSlot, BlockBody)>,
+    by_slot: BTreeMap<BlockSlot, Vec<BlockBody>>,
+    first_by_slot: BTreeMap<BlockSlot, Option<BlockBody>>,
+    tip: Option<(BlockSlot, BlockBody)>,
+}
+
+fn view<S: CoreArchiveStore>(store: &S) -> View {
+    let forward: Vec<_> = store.get_range(None, None).unwrap().collect();
+    let reverse: Vec<_> = store.get_range(None, None).unwrap().rev().collect();
+
+    let mut iter = store.get_range(None, None).unwrap();
+    let mut front = Vec::new();
+    let mut back = Vec::new();
+    while let Some(item) = iter.next() {
+        front.push(item);
+        match iter.next_back() {
+            Some(item) => back.push(item),
+            None => break,
+        }
+    }
+    back.reverse();
+    front.extend(back);
+
+    let bounded = store
+        .get_range(Some(slot(0, 5)), Some(slot(2, 6)))
+        .unwrap()
+        .collect();
+
+    let slots: Vec<BlockSlot> = (0..4)
+        .flat_map(|s| (0..16).map(move |k| slot(s, k)))
+        .collect();
+    let by_slot = slots
+        .iter()
+        .map(|s| (*s, store.get_blocks_by_slot(s).unwrap()))
+        .filter(|(_, blocks)| !blocks.is_empty())
+        .collect();
+    let first_by_slot = slots
+        .iter()
+        .map(|s| (*s, store.get_block_by_slot(s).unwrap()))
+        .filter(|(_, block)| block.is_some())
+        .collect();
+
+    View {
+        forward,
+        reverse,
+        interleaved: front,
+        bounded,
+        by_slot,
+        first_by_slot,
+        tip: store.get_tip().unwrap(),
+    }
+}
+
+/// The oracle, the raw control and the mixed store, over the same history.
+struct Trio {
+    memory: MemoryArchiveStore,
+    raw: ArchiveStore,
+    /// Taken out only while the store is closed for a reopen: fjall locks
+    /// its directory, so the drop has to finish before the open starts.
+    mixed: Option<ArchiveStore>,
+    _raw_dir: tempfile::TempDir,
+    mixed_dir: tempfile::TempDir,
+}
+
+impl Trio {
+    fn new() -> Self {
+        let memory = MemoryArchiveStore::new(StateSchema::default());
+        let raw_dir = tempfile::tempdir().unwrap();
+        let mixed_dir = tempfile::tempdir().unwrap();
+        let raw = open(raw_dir.path());
+        let mixed = open(mixed_dir.path());
+        for store in [&raw, &mixed] {
+            write_history(store);
+        }
+        write_history(&memory);
+        seal_mixed(mixed_dir.path(), &mixed);
+        Self {
+            memory,
+            raw,
+            mixed: Some(mixed),
+            _raw_dir: raw_dir,
+            mixed_dir,
+        }
+    }
+
+    fn mixed(&self) -> &ArchiveStore {
+        self.mixed.as_ref().expect("the mixed store is open")
+    }
+
+    /// The two on-disk stores, for applying one mutation to both.
+    fn fjall(&self) -> [&ArchiveStore; 2] {
+        [&self.raw, self.mixed()]
+    }
+
+    fn assert_agree(&self, what: &str) {
+        let expected = view(&self.memory);
+        assert_eq!(view(&self.raw), expected, "raw fjall diverged: {what}");
+        assert_eq!(view(self.mixed()), expected, "mixed fjall diverged: {what}");
+        assert!(!expected.forward.is_empty(), "{what}: the fixture is empty");
+    }
+
+    /// Close the mixed store and open it again from disk.
+    fn reopen_mixed(&mut self) {
+        drop(self.mixed.take());
+        self.mixed = Some(open(self.mixed_dir.path()));
+    }
+
+    fn segment_files(&self, segment: u32) -> Vec<String> {
+        let prefix = format!("{segment:06}.");
+        let mut names: Vec<String> = fs::read_dir(self.mixed_dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with(&prefix))
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+#[test]
+fn a_mixed_store_reads_like_a_raw_one() {
+    let mut trio = Trio::new();
+
+    assert_eq!(
+        representations(trio.mixed()),
+        BTreeMap::from([
+            (0, Representation::Compressed),
+            (1, Representation::Compressed),
+            (2, Representation::Raw),
+            (3, Representation::Raw),
+        ])
+    );
+    let sealed = trio.mixed().segments().unwrap();
+    assert!(sealed[0].metadata.as_ref().unwrap().dictionary.is_some());
+    assert!(sealed[1].metadata.as_ref().unwrap().dictionary.is_none());
+
+    trio.assert_agree("after sealing");
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+    assert_eq!(trio.segment_files(0), vec!["000000.zseg"]);
+    assert_eq!(trio.segment_files(1), vec!["000001.zseg"]);
+}
+
+#[test]
+fn rollback_within_and_across_compressed_segments_preserves_the_rest() {
+    let mut trio = Trio::new();
+
+    // Within segment 1: the shared slot unwinds newest first, then the
+    // older block, then a block earlier in the same compressed segment.
+    let within = [slot(1, 8), slot(1, 8), slot(1, 4)];
+    for store in trio.fjall() {
+        undo(store, &within);
+    }
+    undo(&trio.memory, &within);
+    trio.assert_agree("after undoing inside a compressed segment");
+    assert_eq!(
+        trio.mixed().segments().unwrap()[1].representation,
+        Representation::Raw
+    );
+    assert_eq!(
+        trio.mixed().segments().unwrap()[0].representation,
+        Representation::Compressed,
+        "a rollback in one segment must not convert another"
+    );
+
+    // Across: from the raw tip back through the compressed segment 0.
+    let across = [slot(3, 1), slot(2, 6), slot(2, 2), slot(1, 0), slot(0, 13)];
+    for store in trio.fjall() {
+        undo(store, &across);
+    }
+    undo(&trio.memory, &across);
+    trio.assert_agree("after undoing across segments");
+
+    // Appending after the rollback continues where the cut left off.
+    let more = [
+        (slot(0, 13), body(slot(0, 13), 7)),
+        (slot(1, 2), body(slot(1, 2), 7)),
+        (slot(2, 3), body(slot(2, 3), 7)),
+    ];
+    for store in trio.fjall() {
+        write(store, &more);
+    }
+    write(&trio.memory, &more);
+    trio.assert_agree("after appending past the rollback");
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+    for segment in 0..3 {
+        assert_eq!(
+            trio.segment_files(segment),
+            vec![format!("{segment:06}.segment")],
+            "segment {segment} keeps only its raw file"
+        );
+    }
+}
+
+#[test]
+fn truncate_front_at_a_segment_boundary_removes_the_compressed_segment_whole() {
+    let mut trio = Trio::new();
+
+    // The cut lands before segment 1's first byte: the segment goes as a
+    // file, in its compressed form, and segment 0 is not touched.
+    let after = point(slot(0, 13));
+    for store in trio.fjall() {
+        store.truncate_front(&after).unwrap();
+    }
+    trio.memory.truncate_front(&after).unwrap();
+    trio.assert_agree("after truncate_front at the boundary");
+    assert!(trio.segment_files(1).is_empty());
+    assert_eq!(trio.segment_files(0), vec!["000000.zseg"]);
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+}
+
+#[test]
+fn truncate_front_inside_a_compressed_segment_thaws_it() {
+    let mut trio = Trio::new();
+
+    let after = point(slot(0, 5));
+    for store in trio.fjall() {
+        store.truncate_front(&after).unwrap();
+    }
+    trio.memory.truncate_front(&after).unwrap();
+    trio.assert_agree("after truncate_front inside segment 0");
+    assert_eq!(trio.segment_files(0), vec!["000000.segment"]);
+
+    // Appending after the cut lands at the cut.
+    let more = [(slot(0, 6), body(slot(0, 6), 9))];
+    for store in trio.fjall() {
+        write(store, &more);
+    }
+    write(&trio.memory, &more);
+    trio.assert_agree("after appending past the cut");
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+}
+
+#[test]
+fn a_repeated_import_keeps_the_original_location() {
+    let mut trio = Trio::new();
+    let before: BTreeMap<u32, u64> = trio
+        .mixed()
+        .segments()
+        .unwrap()
+        .into_iter()
+        .map(|info| (info.segment_id, info.logical_len))
+        .collect();
+
+    // The same block again, the way a resumed restore rewrites a layer.
+    let again = [(slot(0, 5), body(slot(0, 5), 0))];
+    for store in trio.fjall() {
+        write(store, &again);
+    }
+    write(&trio.memory, &again);
+    trio.assert_agree("after importing a block again");
+
+    // The copy went to the end of the segment and nothing points at it; the
+    // index still describes the original bytes, which the seal preserved.
+    let after = trio.mixed().segments().unwrap();
+    assert_eq!(after[0].representation, Representation::Raw);
+    assert_eq!(
+        after[0].logical_len,
+        before[&0] + body(slot(0, 5), 0).len() as u64
+    );
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+}
+
+#[test]
+fn pruning_drops_compressed_segments_and_survives_a_reopen() {
+    let mut trio = Trio::new();
+
+    // The history spans slots 1 .. 3·SEGMENT+1; keeping two segments' worth
+    // moves the cutoff into segment 1, which prunes segment 0 whole.
+    let max_slots = 2 * SLOTS_PER_SEGMENT;
+    for store in trio.fjall() {
+        assert!(store.prune_history(max_slots, None).unwrap());
+    }
+    assert!(trio.memory.prune_history(max_slots, None).unwrap());
+    trio.assert_agree("after pruning");
+
+    assert!(trio.segment_files(0).is_empty());
+    assert_eq!(trio.segment_files(1), vec!["000001.zseg"]);
+    assert!(!representations(trio.mixed()).contains_key(&0));
+
+    trio.reopen_mixed();
+    trio.assert_agree("after reopening");
+}
+
+#[test]
+fn opening_refuses_a_sealed_segment_whose_dictionary_is_gone() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = open(dir.path());
+    write_history(&store);
+    let dictionary = dictionary();
+    let installed = DictionaryDir::new(dir.path().join(DICTIONARIES_DIR))
+        .install(&dictionary)
+        .unwrap();
+    store
+        .seal_segment(
+            0,
+            &WriterOptions::per_block().with_dictionary(dictionary.clone()),
+        )
+        .unwrap();
+    drop(store);
+
+    fs::remove_file(&installed).unwrap();
+    let config = dolos_core::config::FjallArchiveConfig::default();
+    let error = match ArchiveStore::open(StateSchema::default(), dir.path(), &config) {
+        Ok(_) => panic!("the archive opened without the dictionary its segment names"),
+        Err(e) => e.to_string(),
+    };
+    assert!(error.contains("000000"), "{error}");
+    assert!(error.contains(&dictionary.id().to_string()), "{error}");
+}


### PR DESCRIPTION
Batch 2 of balanced archive compression: `plans/dolos-archive-compression-lifecycle.md` in the txpipe Brain. Builds on #1308 (the codec). Compressed history now behaves like raw history through archive reads, rollback, re-appends and pruning, and a segment moves between the two representations through a transition that survives interruption.

## What changes

**`dolos-flatfiles`**
- `FlatFileStore` tracks one authoritative representation per segment (`NNNNNN.segment` raw, `NNNNNN.zseg` compressed) and dispatches every read by it, through the format batch's `ReadCache` keyed by segment *and generation*. Locks: per-segment `RwLock` (shared for reads/appends, exclusive for anything that changes which file is the segment), taken in ascending segment order, then the writer table.
- `seal(segment, indexed_locations, options)` / `thaw(segment)`: one transition primitive run in either direction — durable transition record → staged output on the same filesystem → fsync → verify (a seal decodes every frame back against the raw bytes through the store's own dictionary source; a thaw hashes the staged file back) → rename → retire source → remove record. Nothing before the rename touches the source; a failure after it leaves the destination authoritative in memory and on disk. Bytes no location covers (dead space from resumed imports) are kept as their own frames, so the logical stream and every packed offset survive unchanged.
- Appends and truncation of a compressed segment thaw it first at the same logical offsets; truncate-to-zero removes the segment in whatever form without thawing; `delete_segments_before` removes both representations and any remnants, drops writers and invalidates the cache so the space is reclaimable at once.
- Opening runs recovery for every segment and validates each compressed segment's metadata and dictionary; failures name the segment (and dictionary). Frame payloads stay lazy.
- `DictionaryDir`: dictionaries installed as `dictionaries/<sha256>.dict` beside the segments, hash-verified on load. This is the store's default `DictionarySource`; `FlatFileOptions` overrides it and the cache limits.
- `LIFECYCLE.md`: the protocol and the **restart authority table** for every state before/after each publish, rename and unlink.

**`dolos-fjall`**
- `ArchiveStore::seal_segment`, `thaw_segment`, `segments()`: the offline-tool entry points. `seal_segment` collects the blocks table's locations for the segment and hands them to the store. No scheduler, no config surface, no trait change; the index is never rewritten. `pub use dolos_flatfiles as flatfiles`.

## Restart authority (summary; full table in `crates/flatfiles/LIFECYCLE.md`)

| record | files | authority |
|---|---|---|
| none | one representation | that one |
| none | both | refuse to open |
| `seal`/`thaw` | destination present (source or not) | destination — finish retiring the source |
| `seal`/`thaw` | source only (staged file or not) | source — abort, drop staging |
| `seal`/`thaw` | neither | refuse to open |

A staged output is never trusted however complete; transitions are idempotent. Once a thaw has published, a raw append or truncate stands and a restart never revives the compressed bytes.

## Verification

- `crates/flatfiles/tests/lifecycle.rs` (16 tests): mixed per-block+dictionary / chunked / raw reads incl. reopen; dead-space preservation; append-after-seal offsets; truncate inside (thaws) / at end (no-op) / to zero (no thaw); prune releases handles; **every interruption point of seal and thaw composed on disk and reopened twice** (13 states) plus the two post-publish mutation states; the three refused states; missing/wrong dictionary and unsupported metadata fail open naming the segment; frame corruption is a read error not an open error; failed seals (overlap, unresolvable dictionary, unwritable directory) leave the raw file and no remnants; 4 reader threads hammering during 6 thaw/seal rounds see no bad read, handles bounded and released.
- `tests/archive_compression.rs` (7 tests): memory oracle vs raw fjall vs mixed fjall over four segments with two-block slots: forward/reverse/interleaved/bounded ranges, per-slot reads, tip; rollback within and across compressed segments then re-append; truncate_front at a boundary (removes the compressed segment whole) and inside one (thaws); repeated import keeps the original location; prune drops the compressed segment; every scenario reopened from disk; open refused when a sealed segment's dictionary is gone.
- `crates/snapshot/tests/restore.rs`: a stele exported from the fjall harness with its segment sealed per-block and then chunked is byte-identical to the raw export and restores into the same node.
- `cargo +nightly fmt`, `cargo clippy --workspace --all-targets --all-features` (only pre-existing warnings in `dolos-cardano` tests and `crates/snapshot/tests/publish.rs` remain, untouched), `cargo build --workspace --all-targets --all-features`, and both `cargo test` commands from `AGENTS.md`: 90 test binaries, all green.

## Boundaries

- No config surface, no CLI, no scheduler and no dictionary training: those are the sealing batch. `DictionaryDir::install` exists so the tests (and later the tool) place a dictionary the store's convention finds.
- Writer-FD eviction and fsync policy stay with `plans/dolos-flatfile-append-cost.md`; this PR only drops the writer of a segment whose file changes.
- The rollback/index ordering finding and the iterator's inability to propagate mid-stream errors are unchanged and out of scope; `BlockIter` still skips unreadable blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQJTbpF1gZfmKfX5sDFR9P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing archive segments in raw or compressed formats.
  - Added APIs to inspect segments and seal or thaw them between formats.
  - Added filesystem-backed dictionary storage with validation and caching.
  - Added automatic recovery and validation when reopening interrupted or compressed segment transitions.
- **Bug Fixes**
  - Ensured archive operations, exports, and restores remain consistent across raw and compressed segments.
- **Documentation**
  - Added documentation covering segment lifecycle, transitions, recovery, and dictionary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->