### PR TITLE
feat(archive): offline sealing, dictionary training and restore commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "dolos-testing",
  "dolos-trp",
  "flate2",
+ "fs4",
  "futures-core",
  "futures-util",
  "gasket",
@@ -1467,6 +1468,7 @@ dependencies = [
  "trait-variant",
  "vergen-gitcl",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ inquire = { version = "0.9.4", optional = true }
 toml = { version = "0.8.13", optional = true }
 console-subscriber = { version = "0.4.1", optional = true }
 flate2 = "1.0.34"
+fs4 = "1.1"
+zstd = "0.13"
 tar = "0.4.41"
 paste = "1.0.15"
 redb-extras = "0.6.1"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -354,6 +354,13 @@ pub struct FjallArchiveConfig {
     /// Memtable size in MB before flush (default: 64).
     #[serde(default)]
     pub memtable_size_mb: Option<usize>,
+    /// Compressed block segments: the sealing profile the maintenance
+    /// commands apply and the bounds of the reader that serves compressed
+    /// segments. Omitted, the archive appends raw segments, reads whatever
+    /// representation each segment has under the default bounds, and starts
+    /// no background work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compression: Option<Box<ArchiveCompressionConfig>>,
 }
 
 impl FjallArchiveConfig {
@@ -366,7 +373,135 @@ impl FjallArchiveConfig {
             && self.l0_threshold.is_none()
             && self.worker_threads.is_none()
             && self.memtable_size_mb.is_none()
+            && self.compression.is_none()
     }
+}
+
+/// Default frame target of the chunked profile: 256 KiB.
+pub const DEFAULT_CHUNK_TARGET: u32 = 256 * 1024;
+
+/// How a sealed segment cuts its zstd frames.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CompressionProfile {
+    /// One frame per block, compressed with a trained dictionary. Point
+    /// reads touch one block's bytes.
+    #[default]
+    PerBlock,
+    /// Adjacent blocks share a frame of about `chunk_target` bytes, without
+    /// a dictionary. Scans read fewer bytes; a point read decodes its whole
+    /// frame.
+    Chunked,
+}
+
+impl CompressionProfile {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PerBlock => "per-block",
+            Self::Chunked => "chunked",
+        }
+    }
+}
+
+impl std::fmt::Display for CompressionProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The `storage.archive.compression` table.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ArchiveCompressionConfig {
+    /// The profile `dolos data archive-compression seal` applies:
+    /// `per-block` (the default, which needs `dictionary`) or `chunked`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<CompressionProfile>,
+    /// Identity — 64 hex digits, the SHA-256 of its bytes — of the installed
+    /// dictionary per-block sealing compresses with. Naming one selects
+    /// the per-block profile when `profile` is omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dictionary: Option<String>,
+    /// Frame target in bytes for the chunked profile (default 262144).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunk_target: Option<u32>,
+    /// Bounds of the compressed-segment reader, separate from the archive
+    /// index cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<CompressionCacheConfig>,
+}
+
+impl ArchiveCompressionConfig {
+    /// The selected profile: explicit, else per-block when a dictionary is
+    /// named, else `None` — no profile means the seal command needs one on
+    /// its command line.
+    pub fn profile(&self) -> Option<CompressionProfile> {
+        self.profile.or(if self.dictionary.is_some() {
+            Some(CompressionProfile::PerBlock)
+        } else {
+            None
+        })
+    }
+
+    pub fn chunk_target(&self) -> u32 {
+        self.chunk_target.unwrap_or(DEFAULT_CHUNK_TARGET)
+    }
+
+    /// Reject values no command could act on, at load rather than when a
+    /// segment is about to be rewritten.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.chunk_target == Some(0) {
+            return Err(
+                "storage.archive.compression.chunk_target must be greater than zero".to_string(),
+            );
+        }
+        if let Some(dictionary) = &self.dictionary {
+            let is_hex =
+                dictionary.len() == 64 && dictionary.bytes().all(|b| b.is_ascii_hexdigit());
+            if !is_hex {
+                return Err(format!(
+                    "storage.archive.compression.dictionary must be the 64 hex digits of an \
+                     installed dictionary's identity, not {dictionary:?}"
+                ));
+            }
+        }
+        if self.profile == Some(CompressionProfile::PerBlock) && self.dictionary.is_none() {
+            return Err("storage.archive.compression.profile = \"per-block\" needs \
+                 storage.archive.compression.dictionary: train one with \
+                 `dolos data archive-compression train-dictionary`"
+                .to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Bounds of the reader that serves compressed segments. Every field falls
+/// back to the reader's own default when omitted.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CompressionCacheConfig {
+    /// Decoded frame bytes retained across all segments, in MB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frame_mb: Option<usize>,
+    /// Decoded frames retained across all segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frame_entries: Option<usize>,
+    /// Parsed seek-table bytes retained, in MB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_mb: Option<usize>,
+    /// Parsed seek tables retained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_entries: Option<usize>,
+    /// Dictionary bytes and prepared decoders retained, in MB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dictionary_mb: Option<usize>,
+    /// Prepared dictionaries retained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dictionary_entries: Option<usize>,
+    /// Open segment files, active reads included.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handles: Option<usize>,
+    /// Reads in flight across all compressed segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inflight_reads: Option<usize>,
 }
 
 /// Archive store configuration.
@@ -1211,5 +1346,91 @@ mod tests {
 
         let json = serde_json::to_value(ArchiveStoreConfig::NoOp).unwrap();
         assert_eq!(json["backend"], "no_op");
+    }
+
+    const DICTIONARY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn compression_config_round_trips_profiles_dictionary_and_cache_limits() {
+        use serde_json::json;
+
+        let source = json!({
+            "backend": "fjall",
+            "compression": {
+                "profile": "chunked",
+                "dictionary": DICTIONARY,
+                "chunk_target": 65536,
+                "cache": { "frame_mb": 128, "handles": 8, "inflight_reads": 4 }
+            }
+        });
+        let archive: ArchiveStoreConfig = serde_json::from_value(source.clone()).unwrap();
+        let ArchiveStoreConfig::Fjall(cfg) = &archive else {
+            panic!("expected the fjall backend");
+        };
+        let compression = cfg.compression.as_ref().unwrap();
+        assert_eq!(compression.profile(), Some(CompressionProfile::Chunked));
+        assert_eq!(compression.dictionary.as_deref(), Some(DICTIONARY));
+        assert_eq!(compression.chunk_target(), 65536);
+        let cache = compression.cache.as_ref().unwrap();
+        assert_eq!(cache.frame_mb, Some(128));
+        assert_eq!(cache.handles, Some(8));
+        assert_eq!(cache.inflight_reads, Some(4));
+        assert_eq!(cache.index_mb, None);
+        assert!(!cfg.is_default());
+
+        assert_eq!(
+            serde_json::to_value(&archive).unwrap()["compression"],
+            source["compression"]
+        );
+    }
+
+    #[test]
+    fn a_dictionary_alone_selects_per_block_and_nothing_selects_no_profile() {
+        let cfg = ArchiveCompressionConfig {
+            dictionary: Some(DICTIONARY.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(cfg.profile(), Some(CompressionProfile::PerBlock));
+        assert_eq!(cfg.chunk_target(), DEFAULT_CHUNK_TARGET);
+        cfg.validate().unwrap();
+
+        let cfg = ArchiveCompressionConfig::default();
+        assert_eq!(cfg.profile(), None);
+        cfg.validate().unwrap();
+        assert_eq!(
+            serde_json::to_value(&cfg).unwrap(),
+            serde_json::json!({}),
+            "omitted fields are not serialized"
+        );
+    }
+
+    #[test]
+    fn compression_config_rejects_what_no_command_could_act_on() {
+        let per_block_without_dictionary = ArchiveCompressionConfig {
+            profile: Some(CompressionProfile::PerBlock),
+            ..Default::default()
+        };
+        let err = per_block_without_dictionary.validate().unwrap_err();
+        assert!(
+            err.contains("needs storage.archive.compression.dictionary"),
+            "{err}"
+        );
+
+        let zero_target = ArchiveCompressionConfig {
+            profile: Some(CompressionProfile::Chunked),
+            chunk_target: Some(0),
+            ..Default::default()
+        };
+        let err = zero_target.validate().unwrap_err();
+        assert!(err.contains("chunk_target"), "{err}");
+
+        for bad in ["abc", &DICTIONARY[..63], &format!("{}g", &DICTIONARY[..63])] {
+            let cfg = ArchiveCompressionConfig {
+                dictionary: Some(bad.to_string()),
+                ..Default::default()
+            };
+            let err = cfg.validate().unwrap_err();
+            assert!(err.contains("64 hex digits"), "{bad}: {err}");
+        }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -413,7 +413,8 @@ impl std::fmt::Display for CompressionProfile {
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ArchiveCompressionConfig {
     /// The profile `dolos data archive-compression seal` applies:
-    /// `per-block` (the default, which needs `dictionary`) or `chunked`.
+    /// `per-block` (which needs `dictionary`) or `chunked`. Omitted, a named
+    /// `dictionary` selects `per-block`; otherwise `seal` needs `--profile`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile: Option<CompressionProfile>,
     /// Identity — 64 hex digits, the SHA-256 of its bytes — of the installed

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -360,7 +360,7 @@ pub struct FjallArchiveConfig {
     /// representation each segment has under the default bounds, and starts
     /// no background work.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub compression: Option<Box<ArchiveCompressionConfig>>,
+    pub block_compression: Option<Box<ArchiveCompressionConfig>>,
 }
 
 impl FjallArchiveConfig {
@@ -373,7 +373,7 @@ impl FjallArchiveConfig {
             && self.l0_threshold.is_none()
             && self.worker_threads.is_none()
             && self.memtable_size_mb.is_none()
-            && self.compression.is_none()
+            && self.block_compression.is_none()
     }
 }
 
@@ -409,7 +409,7 @@ impl std::fmt::Display for CompressionProfile {
     }
 }
 
-/// The `storage.archive.compression` table.
+/// The `storage.archive.block_compression` table.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ArchiveCompressionConfig {
     /// The profile `dolos data archive-compression seal` applies:
@@ -452,7 +452,8 @@ impl ArchiveCompressionConfig {
     pub fn validate(&self) -> Result<(), String> {
         if self.chunk_target == Some(0) {
             return Err(
-                "storage.archive.compression.chunk_target must be greater than zero".to_string(),
+                "storage.archive.block_compression.chunk_target must be greater than zero"
+                    .to_string(),
             );
         }
         if let Some(dictionary) = &self.dictionary {
@@ -460,16 +461,31 @@ impl ArchiveCompressionConfig {
                 dictionary.len() == 64 && dictionary.bytes().all(|b| b.is_ascii_hexdigit());
             if !is_hex {
                 return Err(format!(
-                    "storage.archive.compression.dictionary must be the 64 hex digits of an \
+                    "storage.archive.block_compression.dictionary must be the 64 hex digits of an \
                      installed dictionary's identity, not {dictionary:?}"
                 ));
             }
         }
         if self.profile == Some(CompressionProfile::PerBlock) && self.dictionary.is_none() {
-            return Err("storage.archive.compression.profile = \"per-block\" needs \
-                 storage.archive.compression.dictionary: train one with \
+            return Err(
+                "storage.archive.block_compression.profile = \"per-block\" needs \
+                 storage.archive.block_compression.dictionary: train one with \
                  `dolos data archive-compression train-dictionary`"
-                .to_string());
+                    .to_string(),
+            );
+        }
+        if let Some(cache) = &self.cache {
+            for (field, value) in [
+                ("frame_mb", cache.frame_mb),
+                ("index_mb", cache.index_mb),
+                ("dictionary_mb", cache.dictionary_mb),
+            ] {
+                if value.is_some_and(|mb| mb.checked_mul(1 << 20).is_none()) {
+                    return Err(format!(
+                        "storage.archive.block_compression.cache.{field} is too large"
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -1357,7 +1373,7 @@ mod tests {
 
         let source = json!({
             "backend": "fjall",
-            "compression": {
+            "block_compression": {
                 "profile": "chunked",
                 "dictionary": DICTIONARY,
                 "chunk_target": 65536,
@@ -1368,7 +1384,7 @@ mod tests {
         let ArchiveStoreConfig::Fjall(cfg) = &archive else {
             panic!("expected the fjall backend");
         };
-        let compression = cfg.compression.as_ref().unwrap();
+        let compression = cfg.block_compression.as_ref().unwrap();
         assert_eq!(compression.profile(), Some(CompressionProfile::Chunked));
         assert_eq!(compression.dictionary.as_deref(), Some(DICTIONARY));
         assert_eq!(compression.chunk_target(), 65536);
@@ -1380,8 +1396,8 @@ mod tests {
         assert!(!cfg.is_default());
 
         assert_eq!(
-            serde_json::to_value(&archive).unwrap()["compression"],
-            source["compression"]
+            serde_json::to_value(&archive).unwrap()["block_compression"],
+            source["block_compression"]
         );
     }
 
@@ -1413,7 +1429,7 @@ mod tests {
         };
         let err = per_block_without_dictionary.validate().unwrap_err();
         assert!(
-            err.contains("needs storage.archive.compression.dictionary"),
+            err.contains("needs storage.archive.block_compression.dictionary"),
             "{err}"
         );
 
@@ -1433,5 +1449,15 @@ mod tests {
             let err = cfg.validate().unwrap_err();
             assert!(err.contains("64 hex digits"), "{bad}: {err}");
         }
+
+        let overflowing_cache = ArchiveCompressionConfig {
+            cache: Some(CompressionCacheConfig {
+                frame_mb: Some(usize::MAX),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = overflowing_cache.validate().unwrap_err();
+        assert!(err.contains("cache.frame_mb is too large"), "{err}");
     }
 }

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -70,9 +70,9 @@ use fjall::{
 use pallas::ledger::traverse::MultiEraBlock;
 
 use dolos_flatfiles::{
-    compressed::{WriteSummary, WriterOptions},
-    decode_locations, encode_locations, BlockLocation, FlatFileStore, SegmentInfo,
-    SLOTS_PER_SEGMENT,
+    compressed::{CacheLimits, WriteSummary, WriterOptions},
+    decode_locations, encode_locations, Access, BlockLocation, FlatFileOptions, FlatFileStore,
+    SegmentInfo, SLOTS_PER_SEGMENT,
 };
 
 use crate::keys::{dim_prefix, hash_dimension, DIM_HASH_SIZE};
@@ -121,6 +121,28 @@ mod keyspace_names {
     pub const EXACT: &str = "index-exact";
 }
 
+/// The compressed-segment reader's bounds from the archive configuration:
+/// each field the operator set, the reader's own default for the rest.
+fn compressed_cache_limits(config: &FjallArchiveConfig) -> CacheLimits {
+    let defaults = CacheLimits::default();
+    let Some(cache) = config.compression.as_ref().and_then(|c| c.cache.as_ref()) else {
+        return defaults;
+    };
+    let mb = |value: Option<usize>, default: usize| value.map_or(default, |mb| mb << 20);
+    CacheLimits {
+        frame_bytes: mb(cache.frame_mb, defaults.frame_bytes),
+        frame_entries: cache.frame_entries.unwrap_or(defaults.frame_entries),
+        index_bytes: mb(cache.index_mb, defaults.index_bytes),
+        index_entries: cache.index_entries.unwrap_or(defaults.index_entries),
+        dictionary_bytes: mb(cache.dictionary_mb, defaults.dictionary_bytes),
+        dictionary_entries: cache
+            .dictionary_entries
+            .unwrap_or(defaults.dictionary_entries),
+        handles: cache.handles.unwrap_or(defaults.handles),
+        inflight_reads: cache.inflight_reads.unwrap_or(defaults.inflight_reads),
+    }
+}
+
 fn io_err(e: std::io::Error) -> ArchiveError {
     ArchiveError::InternalError(e.to_string())
 }
@@ -161,8 +183,36 @@ impl ArchiveStore {
         path: impl AsRef<Path>,
         config: &FjallArchiveConfig,
     ) -> Result<Self, Error> {
+        Self::open_with_access(schema, path, config, Access::Shared)
+    }
+
+    /// Open the store holding its segments directory exclusively, for
+    /// offline maintenance that rewrites segment files. Refuses, without
+    /// waiting, while any other store — a running node, another maintenance
+    /// command — holds the directory, and keeps every later shared open out
+    /// until this store is dropped.
+    pub fn open_exclusive(
+        schema: StateSchema,
+        path: impl AsRef<Path>,
+        config: &FjallArchiveConfig,
+    ) -> Result<Self, Error> {
+        Self::open_with_access(schema, path, config, Access::Exclusive)
+    }
+
+    fn open_with_access(
+        schema: StateSchema,
+        path: impl AsRef<Path>,
+        config: &FjallArchiveConfig,
+        access: Access,
+    ) -> Result<Self, Error> {
         let path = path.as_ref();
         std::fs::create_dir_all(path).map_err(|e| Error::Io(e.to_string()))?;
+
+        // A compression table no command could act on fails here, before
+        // anything is opened, rather than when a segment is about to move.
+        if let Some(compression) = &config.compression {
+            compression.validate().map_err(Error::Config)?;
+        }
 
         let cache_size = config.cache.unwrap_or(DEFAULT_CACHE_SIZE_MB);
         let cache_bytes = (cache_size * 1024 * 1024) as u64;
@@ -187,7 +237,13 @@ impl ArchiveStore {
         // Opening recovers any interrupted representation transition and
         // validates every compressed segment's metadata and dictionary, so a
         // segment this build cannot read fails the open, naming the segment.
-        let flatfiles = FlatFileStore::new(segments_dir).map_err(|e| Error::Io(e.to_string()))?;
+        let options = FlatFileOptions {
+            dictionaries: None,
+            cache: Some(compressed_cache_limits(config)),
+            access,
+        };
+        let flatfiles = FlatFileStore::with_options(segments_dir, options)
+            .map_err(|e| Error::Io(e.to_string()))?;
 
         Self::from_database(
             db,
@@ -281,8 +337,27 @@ impl ArchiveStore {
             .map_err(|e| Error::Io(e.to_string()))
     }
 
-    /// Every location the blocks table holds inside `segment_id`.
-    fn segment_locations(&self, segment_id: u32) -> Result<Vec<BlockLocation>, Error> {
+    /// The directory the block segment files live in.
+    pub fn segments_dir(&self) -> &Path {
+        self.flatfiles.segments_dir()
+    }
+
+    /// The bounds the compressed-segment reader was opened with.
+    pub fn compressed_cache_limits(&self) -> CacheLimits {
+        self.flatfiles.cache_limits()
+    }
+
+    /// Read the bytes one packed location addresses, from whichever
+    /// representation its segment has.
+    pub fn read_location(&self, location: &BlockLocation) -> Result<Vec<u8>, Error> {
+        self.flatfiles
+            .read(location)
+            .map_err(|e| Error::Io(e.to_string()))
+    }
+
+    /// Every location the blocks table holds inside `segment_id`, in slot
+    /// order, newest first within a slot.
+    pub fn segment_locations(&self, segment_id: u32) -> Result<Vec<BlockLocation>, Error> {
         let first = segment_id as u64 * SLOTS_PER_SEGMENT;
         let end = first + SLOTS_PER_SEGMENT;
         let snapshot = self.db.snapshot();
@@ -313,8 +388,22 @@ impl ArchiveStore {
         options: &WriterOptions,
     ) -> Result<WriteSummary, Error> {
         let locations = self.segment_locations(segment_id)?;
+        self.seal_segment_at(segment_id, &locations, options)
+    }
+
+    /// Compress the block segment `segment_id` in place, cutting frames at
+    /// the boundaries the caller supplies — every body in the segment's
+    /// stream, including the ones the blocks table no longer points at, when
+    /// the caller has walked the stream itself. The boundaries must cover
+    /// the file without overlap; bytes they leave out become filler frames.
+    pub fn seal_segment_at(
+        &self,
+        segment_id: u32,
+        boundaries: &[BlockLocation],
+        options: &WriterOptions,
+    ) -> Result<WriteSummary, Error> {
         self.flatfiles
-            .seal(segment_id, &locations, options)
+            .seal(segment_id, boundaries, options)
             .map_err(|e| Error::Io(e.to_string()))
     }
 

--- a/crates/fjall/src/archive/mod.rs
+++ b/crates/fjall/src/archive/mod.rs
@@ -125,7 +125,11 @@ mod keyspace_names {
 /// each field the operator set, the reader's own default for the rest.
 fn compressed_cache_limits(config: &FjallArchiveConfig) -> CacheLimits {
     let defaults = CacheLimits::default();
-    let Some(cache) = config.compression.as_ref().and_then(|c| c.cache.as_ref()) else {
+    let Some(cache) = config
+        .block_compression
+        .as_ref()
+        .and_then(|c| c.cache.as_ref())
+    else {
         return defaults;
     };
     let mb = |value: Option<usize>, default: usize| value.map_or(default, |mb| mb << 20);
@@ -210,7 +214,7 @@ impl ArchiveStore {
 
         // A compression table no command could act on fails here, before
         // anything is opened, rather than when a segment is about to move.
-        if let Some(compression) = &config.compression {
+        if let Some(compression) = &config.block_compression {
             compression.validate().map_err(Error::Config)?;
         }
 

--- a/crates/fjall/src/lib.rs
+++ b/crates/fjall/src/lib.rs
@@ -47,6 +47,9 @@ pub enum Error {
 
     #[error("io error: {0}")]
     Io(String),
+
+    #[error("configuration error: {0}")]
+    Config(String),
 }
 
 impl From<Error> for StateError {

--- a/crates/flatfiles/LIFECYCLE.md
+++ b/crates/flatfiles/LIFECYCLE.md
@@ -145,6 +145,20 @@ the commit point. Two consequences matter for correctness:
   compressed file finishes retiring it; it does not read it, and it does not
   resurrect bytes the raw file no longer has.
 
+## The directory lease
+
+Every open takes an advisory lock on `.lease` in the segments directory —
+shared by default, exclusive when the caller says it will rewrite segments —
+and holds it until the store is dropped, after every other handle. A shared
+open fails while an exclusive holder exists and an exclusive open fails while
+any holder exists, in either case without waiting and with an error naming
+the directory. The lease lives with the files rather than with the archive
+index, so two configurations that point `blocks_path` at one directory
+contend on the same lease whatever index each opens, and offline maintenance
+can never rewrite a segment a running node is reading. The lease is per open
+handle, not per process: a second store on the same directory inside one
+process contends the same way.
+
 ## Opening a store
 
 Opening performs the recovery above for every segment, then parses each

--- a/crates/flatfiles/src/lease.rs
+++ b/crates/flatfiles/src/lease.rs
@@ -1,0 +1,136 @@
+//! The segments-directory lease: one advisory lock that every store open
+//! holds shared and offline maintenance holds exclusive.
+//!
+//! The lock lives in the segments directory itself, so it follows the files
+//! whichever configuration names them: two configs pointing `blocks_path` at
+//! the same directory contend on the same lease, and fjall's own lock on the
+//! index directory — which they need not share — is not what keeps a
+//! maintenance run from rewriting segments under a running node.
+
+use std::fmt;
+use std::fs::{self, File, OpenOptions, TryLockError};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The lease file's name inside the segments directory. It never parses as
+/// a segment file, and it carries no content: the lock is the file.
+pub const LEASE_FILE: &str = ".lease";
+
+/// How a store holds the segments directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Access {
+    /// Read and append; any number of holders, as a running node does.
+    #[default]
+    Shared,
+    /// Rewrite segment files; one holder and no shared ones, as offline
+    /// maintenance does.
+    Exclusive,
+}
+
+impl fmt::Display for Access {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Access::Shared => "shared",
+            Access::Exclusive => "exclusive",
+        })
+    }
+}
+
+/// A held lease. Dropping it releases the lock.
+#[derive(Debug)]
+pub struct Lease {
+    _file: File,
+    path: PathBuf,
+    access: Access,
+}
+
+impl Lease {
+    /// Take the lease on `dir` without waiting. A conflicting holder yields
+    /// a `WouldBlock` error naming the directory and what holds it.
+    pub fn acquire(dir: &Path, access: Access) -> io::Result<Self> {
+        fs::create_dir_all(dir)?;
+        let path = dir.join(LEASE_FILE);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+        let taken = match access {
+            Access::Shared => file.try_lock_shared(),
+            Access::Exclusive => file.try_lock(),
+        };
+        match taken {
+            Ok(()) => Ok(Self {
+                _file: file,
+                path,
+                access,
+            }),
+            Err(TryLockError::WouldBlock) => Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                match access {
+                    Access::Shared => format!(
+                        "segments directory {} is under exclusive maintenance by another process",
+                        dir.display()
+                    ),
+                    Access::Exclusive => format!(
+                        "segments directory {} is open in another process (a running node or \
+                         another maintenance command); stop it before rewriting segments",
+                        dir.display()
+                    ),
+                },
+            )),
+            Err(TryLockError::Error(e)) => Err(e),
+        }
+    }
+
+    pub fn access(&self) -> Access {
+        self.access
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_holders_coexist() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = Lease::acquire(dir.path(), Access::Shared).unwrap();
+        let second = Lease::acquire(dir.path(), Access::Shared).unwrap();
+        assert_eq!(first.access(), Access::Shared);
+        assert_eq!(second.path(), dir.path().join(LEASE_FILE));
+    }
+
+    #[test]
+    fn exclusive_refuses_and_is_refused_by_shared() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let shared = Lease::acquire(dir.path(), Access::Shared).unwrap();
+        let refused = Lease::acquire(dir.path(), Access::Exclusive).unwrap_err();
+        assert_eq!(refused.kind(), io::ErrorKind::WouldBlock);
+        assert!(refused.to_string().contains("open in another process"));
+        drop(shared);
+
+        let exclusive = Lease::acquire(dir.path(), Access::Exclusive).unwrap();
+        let refused = Lease::acquire(dir.path(), Access::Shared).unwrap_err();
+        assert_eq!(refused.kind(), io::ErrorKind::WouldBlock);
+        assert!(refused.to_string().contains("exclusive maintenance"));
+        let refused = Lease::acquire(dir.path(), Access::Exclusive).unwrap_err();
+        assert_eq!(refused.kind(), io::ErrorKind::WouldBlock);
+        drop(exclusive);
+
+        Lease::acquire(dir.path(), Access::Exclusive).unwrap();
+    }
+
+    #[test]
+    fn dropping_the_lease_releases_it() {
+        let dir = tempfile::tempdir().unwrap();
+        drop(Lease::acquire(dir.path(), Access::Exclusive).unwrap());
+        Lease::acquire(dir.path(), Access::Shared).unwrap();
+    }
+}

--- a/crates/flatfiles/src/lib.rs
+++ b/crates/flatfiles/src/lib.rs
@@ -14,9 +14,11 @@
 
 pub mod compressed;
 mod layout;
+mod lease;
 mod store;
 
-pub use layout::{Representation, Transition, DICTIONARIES_DIR};
+pub use layout::{Found, Representation, SegmentPaths, Transition, DICTIONARIES_DIR};
+pub use lease::{Access, Lease, LEASE_FILE};
 pub use store::{FlatFileOptions, FlatFileStore, SegmentInfo};
 
 /// Number of slots per segment file (one Cardano epoch).

--- a/crates/flatfiles/src/store.rs
+++ b/crates/flatfiles/src/store.rs
@@ -22,8 +22,10 @@ use crate::compressed::{
     SegmentReader, SegmentRef, SegmentWriter, WriteSummary, WriterOptions,
 };
 use crate::layout::{
-    parse_filename, Representation, SegmentPaths, Transition, TransitionGuard, DICTIONARIES_DIR,
+    parse_filename, Found, Representation, SegmentPaths, Transition, TransitionGuard,
+    DICTIONARIES_DIR,
 };
+use crate::lease::{Access, Lease};
 use crate::BlockLocation;
 
 /// Largest slice of unindexed bytes fed to the compressor as one frame, so
@@ -38,6 +40,9 @@ pub struct FlatFileOptions {
     pub dictionaries: Option<Arc<dyn DictionarySource>>,
     /// Bounds on what the compressed-segment reader retains.
     pub cache: Option<CacheLimits>,
+    /// How the segments directory is held: shared, as a node does, or
+    /// exclusive, as offline maintenance that rewrites segments must.
+    pub access: Access,
 }
 
 /// One segment as the store sees it.
@@ -73,6 +78,9 @@ pub struct FlatFileStore {
     cache: ReadCache,
     segments: RwLock<HashMap<u32, Arc<Segment>>>,
     writers: Mutex<HashMap<u32, File>>,
+    /// Held for the store's lifetime; declared last so it is released after
+    /// every handle above it is closed.
+    lease: Lease,
 }
 
 impl FlatFileStore {
@@ -88,13 +96,18 @@ impl FlatFileStore {
         Self::with_options(segments_dir, FlatFileOptions::default())
     }
 
-    /// Open the store with explicit dictionary and cache settings.
+    /// Open the store with explicit dictionary, cache and access settings.
+    ///
+    /// The segments directory's [`Lease`] is taken first, so a directory
+    /// under exclusive maintenance refuses a shared open and an open store
+    /// refuses an exclusive one, whichever configuration named the directory.
     pub fn with_options(
         segments_dir: impl Into<PathBuf>,
         options: FlatFileOptions,
     ) -> io::Result<Self> {
         let segments_dir = segments_dir.into();
         fs::create_dir_all(&segments_dir)?;
+        let lease = Lease::acquire(&segments_dir, options.access)?;
         let dictionaries = options
             .dictionaries
             .unwrap_or_else(|| Arc::new(DictionaryDir::new(segments_dir.join(DICTIONARIES_DIR))));
@@ -104,9 +117,40 @@ impl FlatFileStore {
             cache: ReadCache::new(options.cache.unwrap_or_default()),
             segments: RwLock::new(HashMap::new()),
             writers: Mutex::new(HashMap::new()),
+            lease,
         };
         store.recover_all()?;
         Ok(store)
+    }
+
+    /// Report every segment's files as they are on disk, without taking the
+    /// lease, recovering anything, or opening a store — what a tool that
+    /// describes a directory needs when a node may hold it. Ascending by
+    /// segment number.
+    pub fn scan(segments_dir: &Path) -> io::Result<Vec<(u32, Found)>> {
+        let mut ids = BTreeSet::new();
+        for entry in fs::read_dir(segments_dir)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if let Some((id, _)) = parse_filename(name) {
+                ids.insert(id);
+            }
+        }
+        ids.into_iter()
+            .map(|id| {
+                SegmentPaths::new(segments_dir, id)
+                    .found()
+                    .map(|found| (id, found))
+            })
+            .collect()
+    }
+
+    /// How this store holds its segments directory.
+    pub fn access(&self) -> Access {
+        self.lease.access()
     }
 
     /// Create a FlatFileStore backed by a temporary directory.
@@ -128,6 +172,11 @@ impl FlatFileStore {
 
     pub fn cache_stats(&self) -> CacheStats {
         self.cache.stats()
+    }
+
+    /// The bounds the compressed-segment reader was opened with.
+    pub fn cache_limits(&self) -> CacheLimits {
+        self.cache.limits()
     }
 
     fn paths(&self, segment_id: u32) -> SegmentPaths {

--- a/crates/flatfiles/tests/lifecycle.rs
+++ b/crates/flatfiles/tests/lifecycle.rs
@@ -741,6 +741,7 @@ fn readers_never_observe_a_transition_in_progress() {
                 inflight_reads: 4,
                 ..CacheLimits::default()
             }),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -781,4 +782,68 @@ fn readers_never_observe_a_transition_in_progress() {
     assert!(stats.open_handles <= 2, "{stats:?}");
     store.delete_segments_before(3).unwrap();
     assert_eq!(store.cache_stats().open_handles, 0);
+}
+
+#[test]
+fn the_lease_keeps_maintenance_and_nodes_apart() {
+    use dolos_flatfiles::Access;
+
+    let dir = tempfile::tempdir().unwrap();
+    let node = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(node.access(), Access::Shared);
+
+    let exclusive = FlatFileOptions {
+        access: Access::Exclusive,
+        ..Default::default()
+    };
+    let refused = FlatFileStore::with_options(dir.path(), exclusive).unwrap_err();
+    assert_eq!(refused.kind(), io::ErrorKind::WouldBlock);
+    assert!(refused
+        .to_string()
+        .contains(&dir.path().display().to_string()));
+
+    drop(node);
+    let maintenance = FlatFileStore::with_options(
+        dir.path(),
+        FlatFileOptions {
+            access: Access::Exclusive,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(maintenance.access(), Access::Exclusive);
+    let refused = FlatFileStore::new(dir.path()).unwrap_err();
+    assert_eq!(refused.kind(), io::ErrorKind::WouldBlock);
+
+    drop(maintenance);
+    FlatFileStore::new(dir.path()).unwrap();
+}
+
+#[test]
+fn a_scan_describes_the_directory_without_recovering_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FlatFileStore::new(dir.path()).unwrap();
+    let entries = populate(&store, 5);
+    let seg1 = in_segment(&entries, 1);
+    store.seal(1, &seg1, &WriterOptions::per_block()).unwrap();
+    drop(store);
+
+    fs::write(dir.path().join("000000.transition"), "seal\n").unwrap();
+    fs::write(dir.path().join("000000.zseg.tmp"), b"partial").unwrap();
+
+    let scanned = FlatFileStore::scan(dir.path()).unwrap();
+    let ids: Vec<u32> = scanned.iter().map(|(id, _)| *id).collect();
+    assert_eq!(ids, (0..3).collect::<Vec<_>>());
+    let (_, seg0) = &scanned[0];
+    assert!(seg0.raw && seg0.compressed_staging && !seg0.compressed);
+    assert_eq!(seg0.transition, Some(dolos_flatfiles::Transition::Seal));
+    let (_, seg1) = &scanned[1];
+    assert!(seg1.compressed && !seg1.raw && seg1.transition.is_none());
+
+    assert!(dir.path().join("000000.transition").exists());
+    assert!(dir.path().join("000000.zseg.tmp").exists());
+
+    let reopened = FlatFileStore::new(dir.path()).unwrap();
+    assert_eq!(reopened.representation(0), Some(Representation::Raw));
+    assert!(!dir.path().join("000000.transition").exists());
 }

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -173,9 +173,9 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 - `blocks_path`: optional override for block segment files.
 - `cache`: size (MB) of the archive index cache.
 - `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.
-- `compression`: the table below. Omit it to keep raw segments and default read bounds.
+- `block_compression`: the table below. Omit it to keep raw block segments and default read bounds.
 
-### `storage.archive.compression` section
+### `storage.archive.block_compression` section
 
 | property     | type    | example       |
 | ------------ | ------- | ------------- |

--- a/docs/content/configuration/schema.mdx
+++ b/docs/content/configuration/schema.mdx
@@ -173,6 +173,23 @@ deletes the files it has consumed as it goes. `--download-dir` moves it.
 - `blocks_path`: optional override for block segment files.
 - `cache`: size (MB) of the archive index cache.
 - `max_journal_size`, `flush_on_commit`, `l0_threshold`, `worker_threads`, `memtable_size_mb`: Fjall tuning options.
+- `compression`: the table below. Omit it to keep raw segments and default read bounds.
+
+### `storage.archive.compression` section
+
+| property     | type    | example       |
+| ------------ | ------- | ------------- |
+| profile      | string  | "per-block"   |
+| dictionary   | string  | "3f9a…c2e1"   |
+| chunk_target | integer | 262144        |
+| cache        | table   | see below     |
+
+- `profile`: the profile `dolos data archive-compression seal` applies: `per-block` (one zstd frame per block, needs `dictionary`) or `chunked` (adjacent blocks share a frame of about `chunk_target` bytes, no dictionary). Naming a `dictionary` without a `profile` selects `per-block`; naming neither selects no profile and the command needs `--profile`.
+- `dictionary`: identity of the installed dictionary per-block sealing compresses with — the 64 hex digits `train-dictionary` reports.
+- `chunk_target`: frame target in bytes for the chunked profile (defaults to 262144, must be greater than zero).
+- `cache`: bounds of the reader that serves compressed segments, separate from the archive index cache: `frame_mb` / `frame_entries` (decoded frames retained), `index_mb` / `index_entries` (parsed seek tables), `dictionary_mb` / `dictionary_entries` (dictionaries and their prepared decoders), `handles` (open segment files), `inflight_reads` (concurrent reads). Each falls back to the reader's default when omitted.
+
+The node never seals on its own in this release; the table is read by the maintenance commands and by the reader. Values no command could act on fail when the archive is opened. See [Archive Compression](../operations/archive-compression) for the profiles' tradeoffs and the runbook.
 
 ### `storage.index` section — removed in v1.7
 

--- a/docs/content/operations/archive-compression.mdx
+++ b/docs/content/operations/archive-compression.mdx
@@ -17,12 +17,12 @@ still appends raw segments and never compresses on its own.
 Both profiles use zstd level 3 and the same on-disk container; they differ
 in where frame boundaries fall.
 
-- **`per-block`** (the default) compresses every block as a frame of its
-  own, using a **dictionary** trained on blocks of the same network. A
-  point read decodes exactly one block's bytes, so single-block lookups —
-  transactions, blocks by hash — cost what they cost raw, while the segment
-  shrinks by roughly a third to a half. A dictionary is required: small
-  blocks compress poorly without one.
+- **`per-block`** compresses every block as a frame of its own, using a
+  **dictionary** trained on blocks of the same network. A point read decodes
+  exactly one block's bytes, so single-block lookups — transactions, blocks
+  by hash — cost what they cost raw, while the segment shrinks by roughly a
+  third to a half. A dictionary is required: small blocks compress poorly
+  without one.
 - **`chunked`** groups adjacent blocks into frames of about `chunk_target`
   bytes (256 KiB unless configured) and needs no dictionary. Scans over
   consecutive blocks — epoch listings, chain walks — read far fewer bytes
@@ -31,7 +31,7 @@ in where frame boundaries fall.
 
 The tradeoff was measured on mainnet and preprod archives during the
 research that led to this feature: per-block with a dictionary is close to
-free on the read path and is the safe default for a node serving point
+free on the read path and is the safe choice for a node serving point
 lookups; chunked is the profile for scan-heavy workloads. How much any
 storage layer gains in bandwidth or IOPS depends on the workload and the
 device, so measure your own before counting on a number.

--- a/docs/content/operations/archive-compression.mdx
+++ b/docs/content/operations/archive-compression.mdx
@@ -39,12 +39,12 @@ device, so measure your own before counting on a number.
 ## Configuration
 
 ```toml
-[storage.archive.compression]
+[storage.archive.block_compression]
 profile = "per-block"          # or "chunked"
 dictionary = "<64 hex digits>" # required by per-block; naming one selects per-block
 chunk_target = 262144          # chunked only, bytes
 
-[storage.archive.compression.cache]
+[storage.archive.block_compression.cache]
 frame_mb = 64                  # decoded frames retained across all segments
 index_mb = 32                  # parsed seek tables retained
 dictionary_mb = 8              # dictionaries and their prepared decoders

--- a/docs/content/operations/archive-compression.mdx
+++ b/docs/content/operations/archive-compression.mdx
@@ -1,0 +1,152 @@
+---
+title: Archive Compression
+sidebar:
+  order: 6
+---
+
+Dolos keeps archived block bodies in flat segment files, one per epoch, and
+the archive index addresses a block by its byte offset inside its segment.
+A completed segment can be **sealed**: rewritten as independently
+compressed zstd frames that keep every offset meaningful, so the index is
+never rewritten and reads keep working through the same locations. Sealing
+is an explicit, offline maintenance step in this release; the node itself
+still appends raw segments and never compresses on its own.
+
+## Profiles
+
+Both profiles use zstd level 3 and the same on-disk container; they differ
+in where frame boundaries fall.
+
+- **`per-block`** (the default) compresses every block as a frame of its
+  own, using a **dictionary** trained on blocks of the same network. A
+  point read decodes exactly one block's bytes, so single-block lookups —
+  transactions, blocks by hash — cost what they cost raw, while the segment
+  shrinks by roughly a third to a half. A dictionary is required: small
+  blocks compress poorly without one.
+- **`chunked`** groups adjacent blocks into frames of about `chunk_target`
+  bytes (256 KiB unless configured) and needs no dictionary. Scans over
+  consecutive blocks — epoch listings, chain walks — read far fewer bytes
+  and decompress once per group, but a single-block read decodes its whole
+  frame first, which costs more CPU per lookup.
+
+The tradeoff was measured on mainnet and preprod archives during the
+research that led to this feature: per-block with a dictionary is close to
+free on the read path and is the safe default for a node serving point
+lookups; chunked is the profile for scan-heavy workloads. How much any
+storage layer gains in bandwidth or IOPS depends on the workload and the
+device, so measure your own before counting on a number.
+
+## Configuration
+
+```toml
+[storage.archive.compression]
+profile = "per-block"          # or "chunked"
+dictionary = "<64 hex digits>" # required by per-block; naming one selects per-block
+chunk_target = 262144          # chunked only, bytes
+
+[storage.archive.compression.cache]
+frame_mb = 64                  # decoded frames retained across all segments
+index_mb = 32                  # parsed seek tables retained
+dictionary_mb = 8              # dictionaries and their prepared decoders
+handles = 64                   # open segment files
+inflight_reads = 16            # concurrent reads across compressed segments
+```
+
+The table selects what `seal` applies and bounds the reader that serves
+compressed segments; the reader's cache is separate from the archive index
+cache (`storage.archive.cache`). Omitting the table changes nothing about
+how the node runs: segments stay raw, any already-sealed segment is still
+read under the default bounds, and no background work starts. Values no
+command could act on — a per-block profile without a dictionary, a zero
+chunk target, a dictionary that is not 64 hex digits — fail when the
+archive is opened rather than when a segment is about to be rewritten.
+See the [configuration schema](../configuration/schema#storagearchive-section)
+for the full reference.
+
+## Runbook
+
+Every command below resolves the segment directory through the archive
+configuration and must run with the node **stopped**: `seal` and
+`restore-raw` take the segment directory exclusively and are refused, without
+waiting, while a node or another maintenance command holds it — whichever
+configuration file names the directory. `inspect` only reads the directory
+and can run at any time.
+
+1. **Train a dictionary** (per-block only). Pick a range of completed
+   segments representative of what you will seal — a few recent epochs —
+   and record the seed; the same seed over the same range trains the same
+   dictionary.
+
+   ```sh
+   dolos data archive-compression train-dictionary --from 500 --to 502 --seed 1
+   ```
+
+   The command reports the dictionary's identity, its path under
+   `dictionaries/` in the segment directory, and the sample it was trained
+   on; a `.json` manifest beside the `.dict` file records the same, network
+   magic included. Several dictionaries can stay installed side by side.
+
+2. **Check what a run would do**, then seal. Segment numbers are epoch
+   numbers; the segment holding the archive tip and anything past it are
+   refused, so stop the range one short of the current epoch.
+
+   ```sh
+   dolos data archive-compression seal --from 0 --to 499 --dry-run
+   dolos data archive-compression seal --from 0 --to 499
+   ```
+
+   Pass `--profile`, `--dictionary` and `--chunk-target` to override the
+   configuration for one run. Segments are converted one at a time: each is
+   walked block by block, staged as a complete compressed file beside the
+   original, decoded and compared against the raw bytes, and only then
+   published. A segment that is already compressed is skipped and reported
+   with the profile it actually has; a new profile does not recompress it.
+
+3. **Inspect** the directory at any time — with the node running too:
+
+   ```sh
+   dolos data archive-compression inspect
+   ```
+
+   It lists every segment with its representation, profile, dictionary and
+   logical versus on-disk size, the installed dictionaries and their
+   manifests, and any transition an interruption left pending.
+
+4. **Restore to raw** before running an older binary, or to undo a profile
+   choice:
+
+   ```sh
+   dolos data archive-compression restore-raw --from 0 --to 499
+   ```
+
+`--json` on any command prints the same report as JSON.
+
+## Space, interruption and recovery
+
+- **Headroom.** A conversion stages one whole segment at a time next to the
+  original, so the segment directory needs free space for the largest
+  segment in the range plus a small margin. The command checks before each
+  segment and refuses when it does not fit; nothing is touched.
+- **Interruption.** Killing a run at any point loses nothing: the original
+  representation stays authoritative until the staged file has been
+  verified and renamed into place, and a durable transition record says
+  which file is the segment from then on. The next open of the archive —
+  by the node or by the next maintenance command — finishes or discards the
+  interrupted step. Rerunning the same command resumes where it stopped.
+- **Failures** before publication — no space, a missing dictionary, a
+  corrupt frame found by verification, a stream that does not end on a
+  whole block — return an error naming the segment and leave the raw file
+  as it was.
+
+## Backups and downgrades
+
+Dictionaries are part of durable storage. A segment sealed with one cannot
+be read without it, so a file-level backup of the archive must include the
+`dictionaries/` directory under the segment directory, and a dictionary is
+never modified or deleted by Dolos; retraining installs a new one under a
+new identity. A restored backup opens as it was, dictionaries included.
+
+Older binaries know neither the compressed segment layout nor the directory
+lease. Run `restore-raw` over every compressed segment before starting an
+older binary on the same data, and do not run an older and a newer binary
+against the same segment directory at the same time.

--- a/docs/content/operations/index.mdx
+++ b/docs/content/operations/index.mdx
@@ -14,4 +14,5 @@ Guidance for running and operating a Dolos instance: how it runs, how to read it
   <LinkCard title="Tracing" href="./operations/tracing" />
   <LinkCard title="Performance" href="./operations/performance" />
   <LinkCard title="Troubleshooting" href="./operations/troubleshooting" />
+  <LinkCard title="Archive Compression" href="./operations/archive-compression" />
 </CardGrid>

--- a/src/bin/dolos/data/archive_compression/dictionary.rs
+++ b/src/bin/dolos/data/archive_compression/dictionary.rs
@@ -3,9 +3,10 @@
 //! the sample the dictionary was trained on, so a later seal can refuse a
 //! dictionary trained for another network and an operator can reproduce it.
 
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dolos_fjall::flatfiles::compressed::{
     Dictionary, DictionaryDir, DictionaryId, DictionarySource as _,
@@ -13,6 +14,8 @@ use dolos_fjall::flatfiles::compressed::{
 use dolos_fjall::flatfiles::DICTIONARIES_DIR;
 use miette::{bail, IntoDiagnostic, WrapErr};
 use serde::{Deserialize, Serialize};
+
+static NEXT_STAGING_ID: AtomicU64 = AtomicU64::new(0);
 
 /// What a dictionary was trained on. Written once, beside the dictionary,
 /// under its identity.
@@ -81,27 +84,43 @@ pub fn write_manifest(
     if target.exists() {
         return Ok(target);
     }
-    // Staged under this process's id, so two trainers publishing the same
-    // dictionary never share a staging file; the rename is atomic, so a
-    // reader sees a complete manifest or none.
-    let staging = dictionaries
-        .path()
-        .join(format!("{id}.json.{}.tmp", std::process::id()));
     let text = serde_json::to_string_pretty(manifest).into_diagnostic()?;
     let write = || -> std::io::Result<()> {
-        let mut file = fs::File::create(&staging)?;
-        file.write_all(text.as_bytes())?;
-        file.write_all(b"\n")?;
-        file.sync_all()?;
-        drop(file);
-        fs::rename(&staging, &target)?;
+        let (staging, mut file) = loop {
+            let staging_id = NEXT_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+            let staging = dictionaries
+                .path()
+                .join(format!("{id}.json.{}.{staging_id}.tmp", std::process::id()));
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&staging)
+            {
+                Ok(file) => break (staging, file),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        };
+        let publish = (|| {
+            file.write_all(text.as_bytes())?;
+            file.write_all(b"\n")?;
+            file.sync_all()?;
+            drop(file);
+            match fs::hard_link(&staging, &target) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                Err(e) => Err(e),
+            }
+        })();
+        let cleanup = fs::remove_file(&staging);
+        publish?;
+        cleanup?;
         if cfg!(unix) {
-            fs::File::open(dictionaries.path())?.sync_all()?;
+            File::open(dictionaries.path())?.sync_all()?;
         }
         Ok(())
     };
     if let Err(e) = write() {
-        let _ = fs::remove_file(&staging);
         return Err(e)
             .into_diagnostic()
             .wrap_err_with(|| format!("writing {}", target.display()));
@@ -196,4 +215,58 @@ pub fn installed(dictionaries: &DictionaryDir) -> miette::Result<Vec<Installed>>
         });
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    const ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn manifest(seed: u64) -> Manifest {
+        Manifest {
+            network_magic: 42,
+            from_segment: 1,
+            to_segment: 2,
+            population: 3,
+            samples: 3,
+            sample_bytes: 4,
+            sample_budget_bytes: 5,
+            seed,
+            max_size: 6,
+            zstd_version: 7,
+        }
+    }
+
+    #[test]
+    fn concurrent_writers_publish_one_complete_manifest_without_staging_residue() {
+        let temp = tempfile::tempdir().unwrap();
+        let dictionaries = Arc::new(DictionaryDir::new(temp.path().to_path_buf()));
+        let id = DictionaryId::from_hex(ID).unwrap();
+        let writers = 16;
+        let barrier = Arc::new(Barrier::new(writers));
+        let mut threads = Vec::new();
+
+        for seed in 0..writers as u64 {
+            let dictionaries = dictionaries.clone();
+            let barrier = barrier.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                write_manifest(&dictionaries, &id, &manifest(seed)).unwrap();
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let published = read_manifest(&dictionaries, &id).unwrap().unwrap();
+        assert!(published.seed < writers as u64);
+        assert!(fs::read_dir(temp.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".tmp")));
+    }
 }

--- a/src/bin/dolos/data/archive_compression/dictionary.rs
+++ b/src/bin/dolos/data/archive_compression/dictionary.rs
@@ -1,0 +1,191 @@
+//! Dictionaries as the maintenance commands see them: the `.dict` file the
+//! store reads, plus a `.json` manifest beside it recording the network and
+//! the sample the dictionary was trained on, so a later seal can refuse a
+//! dictionary trained for another network and an operator can reproduce it.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use dolos_fjall::flatfiles::compressed::{
+    Dictionary, DictionaryDir, DictionaryId, DictionarySource as _,
+};
+use dolos_fjall::flatfiles::DICTIONARIES_DIR;
+use miette::{bail, IntoDiagnostic, WrapErr};
+use serde::{Deserialize, Serialize};
+
+/// What a dictionary was trained on. Written once, beside the dictionary,
+/// under its identity.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Manifest {
+    pub network_magic: u64,
+    pub from_segment: u32,
+    pub to_segment: u32,
+    /// Blocks the range held when the sample was drawn.
+    pub population: usize,
+    /// Blocks the trainer saw.
+    pub samples: usize,
+    pub sample_bytes: u64,
+    pub sample_budget_bytes: u64,
+    pub seed: u64,
+    pub max_size: usize,
+    pub zstd_version: u32,
+}
+
+pub fn dir(segments_dir: &Path) -> DictionaryDir {
+    DictionaryDir::new(segments_dir.join(DICTIONARIES_DIR))
+}
+
+pub fn manifest_path(dictionaries: &DictionaryDir, id: &DictionaryId) -> PathBuf {
+    dictionaries.path().join(format!("{id}.json"))
+}
+
+pub fn parse_id(text: &str) -> miette::Result<DictionaryId> {
+    match DictionaryId::from_hex(text.trim()) {
+        Some(id) => Ok(id),
+        None => bail!(
+            "{text:?} is not a dictionary identity: expected the 64 hex digits of the \
+             dictionary's SHA-256"
+        ),
+    }
+}
+
+pub fn read_manifest(
+    dictionaries: &DictionaryDir,
+    id: &DictionaryId,
+) -> miette::Result<Option<Manifest>> {
+    let path = manifest_path(dictionaries, id);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(e)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("reading {}", path.display()))
+        }
+    };
+    serde_json::from_str(&text)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parsing {}", path.display()))
+        .map(Some)
+}
+
+/// Write the manifest beside its dictionary, durably; an existing manifest
+/// is kept, since the dictionary it describes cannot have changed.
+pub fn write_manifest(
+    dictionaries: &DictionaryDir,
+    id: &DictionaryId,
+    manifest: &Manifest,
+) -> miette::Result<PathBuf> {
+    let target = manifest_path(dictionaries, id);
+    if target.exists() {
+        return Ok(target);
+    }
+    let staging = dictionaries.path().join(format!("{id}.json.tmp"));
+    let text = serde_json::to_string_pretty(manifest).into_diagnostic()?;
+    let write = || -> std::io::Result<()> {
+        let mut file = fs::File::create(&staging)?;
+        file.write_all(text.as_bytes())?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&staging, &target)?;
+        if cfg!(unix) {
+            fs::File::open(dictionaries.path())?.sync_all()?;
+        }
+        Ok(())
+    };
+    write()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("writing {}", target.display()))?;
+    Ok(target)
+}
+
+/// Load the dictionary a seal compresses with, refusing one that is not
+/// installed, does not hash to its name, or was trained for another network.
+pub fn resolve(
+    dictionaries: &DictionaryDir,
+    id: &DictionaryId,
+    network_magic: u64,
+) -> miette::Result<Dictionary> {
+    let dictionary = match dictionaries.dictionary(id) {
+        Ok(Some(dictionary)) => dictionary,
+        Ok(None) => bail!(
+            "dictionary {id} is not installed at {}: train one with `dolos data \
+             archive-compression train-dictionary`, or restore its .dict file from a backup",
+            dictionaries.file(id).display()
+        ),
+        Err(e) => bail!("dictionary {id} cannot be used: {e}"),
+    };
+    match read_manifest(dictionaries, id)? {
+        Some(manifest) if manifest.network_magic != network_magic => bail!(
+            "dictionary {id} was trained on network magic {} and this archive is network \
+             magic {network_magic}; refusing to seal with it",
+            manifest.network_magic
+        ),
+        Some(_) => {}
+        None => eprintln!(
+            "warning: dictionary {id} has no manifest at {}; its network cannot be checked",
+            manifest_path(dictionaries, id).display()
+        ),
+    }
+    Ok(dictionary)
+}
+
+/// One installed dictionary, as `inspect` reports it.
+#[derive(Debug, Serialize)]
+pub struct Installed {
+    pub id: String,
+    pub bytes: u64,
+    pub path: PathBuf,
+    /// `None` when the file hashes to its name; the error otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub problem: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Manifest>,
+}
+
+/// Every `.dict` file under the dictionaries directory, ascending by
+/// identity.
+pub fn installed(dictionaries: &DictionaryDir) -> miette::Result<Vec<Installed>> {
+    let entries = match fs::read_dir(dictionaries.path()) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("listing {}", dictionaries.path().display()))
+        }
+    };
+    let mut ids = Vec::new();
+    for entry in entries {
+        let entry = entry.into_diagnostic()?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if let Some(id) = name.strip_suffix(".dict").and_then(DictionaryId::from_hex) {
+            ids.push(id);
+        }
+    }
+    ids.sort();
+
+    let mut out = Vec::with_capacity(ids.len());
+    for id in ids {
+        let path = dictionaries.file(&id);
+        let bytes = fs::metadata(&path).into_diagnostic()?.len();
+        let problem = match dictionaries.dictionary(&id) {
+            Ok(Some(_)) => None,
+            Ok(None) => Some("file disappeared while listing".to_string()),
+            Err(e) => Some(e.to_string()),
+        };
+        out.push(Installed {
+            id: id.to_string(),
+            bytes,
+            path,
+            problem,
+            manifest: read_manifest(dictionaries, &id)?,
+        });
+    }
+    Ok(out)
+}

--- a/src/bin/dolos/data/archive_compression/dictionary.rs
+++ b/src/bin/dolos/data/archive_compression/dictionary.rs
@@ -81,7 +81,12 @@ pub fn write_manifest(
     if target.exists() {
         return Ok(target);
     }
-    let staging = dictionaries.path().join(format!("{id}.json.tmp"));
+    // Staged under this process's id, so two trainers publishing the same
+    // dictionary never share a staging file; the rename is atomic, so a
+    // reader sees a complete manifest or none.
+    let staging = dictionaries
+        .path()
+        .join(format!("{id}.json.{}.tmp", std::process::id()));
     let text = serde_json::to_string_pretty(manifest).into_diagnostic()?;
     let write = || -> std::io::Result<()> {
         let mut file = fs::File::create(&staging)?;
@@ -95,9 +100,12 @@ pub fn write_manifest(
         }
         Ok(())
     };
-    write()
-        .into_diagnostic()
-        .wrap_err_with(|| format!("writing {}", target.display()))?;
+    if let Err(e) = write() {
+        let _ = fs::remove_file(&staging);
+        return Err(e)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("writing {}", target.display()));
+    }
     Ok(target)
 }
 

--- a/src/bin/dolos/data/archive_compression/inspect.rs
+++ b/src/bin/dolos/data/archive_compression/inspect.rs
@@ -230,7 +230,7 @@ fn describe(
 pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
     let dir = segments_dir(config)?;
     let compression = match &config.storage.archive {
-        ArchiveStoreConfig::Fjall(cfg) => cfg.compression.clone().map(|c| *c),
+        ArchiveStoreConfig::Fjall(cfg) => cfg.block_compression.clone().map(|c| *c),
         _ => None,
     }
     .unwrap_or_default();

--- a/src/bin/dolos/data/archive_compression/inspect.rs
+++ b/src/bin/dolos/data/archive_compression/inspect.rs
@@ -1,0 +1,370 @@
+//! Describe a segments directory from its files alone: which representation
+//! each segment has, what a compressed one was sealed with and whether its
+//! dictionary is installed, and what an interrupted transition left behind
+//! — without opening a store, so nothing is recovered or rewritten and a
+//! running node is not disturbed.
+
+use std::fs::File;
+use std::io;
+
+use dolos_core::config::{ArchiveCompressionConfig, ArchiveStoreConfig, RootConfig};
+use dolos_fjall::flatfiles::compressed::{
+    DictionaryDir, DictionarySource as _, FrameMode, SegmentIndex,
+};
+use dolos_fjall::flatfiles::{
+    Access, FlatFileStore, Found, Lease, Representation, SegmentPaths, Transition,
+};
+use miette::{IntoDiagnostic, WrapErr};
+use serde::Serialize;
+
+use super::dictionary::{self, Installed};
+use super::{bytes, segments_dir};
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    /// first segment number to describe (inclusive)
+    #[arg(long)]
+    from: Option<u32>,
+
+    /// last segment number to describe (inclusive)
+    #[arg(long)]
+    to: Option<u32>,
+
+    /// print the report as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    segments_dir: String,
+    /// Whether another process holds the directory exclusively right now.
+    maintenance_in_progress: bool,
+    config: ArchiveCompressionConfig,
+    dictionaries: Vec<Installed>,
+    segments: Vec<Segment>,
+    pending: Vec<Pending>,
+    totals: Totals,
+}
+
+#[derive(Debug, Serialize)]
+struct Segment {
+    segment: u32,
+    representation: String,
+    logical_len: u64,
+    physical_len: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frames: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dictionary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dictionary_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    problem: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Pending {
+    segment: u32,
+    description: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Totals {
+    segments: usize,
+    raw: usize,
+    compressed: usize,
+    logical_len: u64,
+    physical_len: u64,
+}
+
+/// The recovery table, read without acting on it.
+fn authority(found: &Found) -> Result<Option<Representation>, String> {
+    match found.transition {
+        None => match (found.raw, found.compressed) {
+            (true, true) => Err(
+                "both a raw and a compressed file and no transition record; the store refuses \
+                 to open until one is removed"
+                    .to_string(),
+            ),
+            (true, false) => Ok(Some(Representation::Raw)),
+            (false, true) => Ok(Some(Representation::Compressed)),
+            (false, false) => Ok(None),
+        },
+        Some(transition) => {
+            let has = |r: Representation| match r {
+                Representation::Raw => found.raw,
+                Representation::Compressed => found.compressed,
+            };
+            if has(transition.to()) {
+                Ok(Some(transition.to()))
+            } else if has(transition.from()) {
+                Ok(Some(transition.from()))
+            } else {
+                Err(format!(
+                    "a {transition} record and neither representation file; the segment is lost"
+                ))
+            }
+        }
+    }
+}
+
+fn pending(segment: u32, found: &Found) -> Option<Pending> {
+    let staged = match (found.raw_staging, found.compressed_staging) {
+        (true, true) => Some("staged raw and compressed outputs"),
+        (true, false) => Some("a staged raw output"),
+        (false, true) => Some("a staged compressed output"),
+        (false, false) => None,
+    };
+    let description = match (found.transition, staged) {
+        (Some(transition), staged) => {
+            let published = match transition {
+                Transition::Seal => found.compressed,
+                Transition::Thaw => found.raw,
+            };
+            let outcome = if published {
+                format!(
+                    "the {} file is published and authoritative; the next open retires the {} \
+                     file and the record",
+                    transition.to(),
+                    transition.from()
+                )
+            } else {
+                format!(
+                    "the {} file stays authoritative; the next open discards {} and the record",
+                    transition.from(),
+                    staged.unwrap_or("nothing")
+                )
+            };
+            format!("interrupted {transition}: {outcome}")
+        }
+        (None, Some(staged)) => {
+            format!("{staged} without a transition record; the next open discards it")
+        }
+        (None, None) if found.transition_staging => {
+            "a staged transition record; the next open discards it".to_string()
+        }
+        (None, None) => return None,
+    };
+    Some(Pending {
+        segment,
+        description,
+    })
+}
+
+fn describe(
+    id: u32,
+    found: &Found,
+    paths: &SegmentPaths,
+    dictionaries: &DictionaryDir,
+) -> Option<Segment> {
+    let representation = match authority(found) {
+        Ok(Some(representation)) => representation,
+        Ok(None) => return None,
+        Err(problem) => {
+            return Some(Segment {
+                segment: id,
+                representation: "unresolved".to_string(),
+                logical_len: 0,
+                physical_len: 0,
+                profile: None,
+                level: None,
+                frames: None,
+                dictionary: None,
+                dictionary_status: None,
+                problem: Some(problem),
+            })
+        }
+    };
+    let path = paths.representation(representation);
+    let mut segment = Segment {
+        segment: id,
+        representation: representation.to_string(),
+        logical_len: 0,
+        physical_len: 0,
+        profile: None,
+        level: None,
+        frames: None,
+        dictionary: None,
+        dictionary_status: None,
+        problem: None,
+    };
+    let parsed: io::Result<()> = (|| {
+        let file = File::open(&path)?;
+        let physical_len = file.metadata()?.len();
+        segment.physical_len = physical_len;
+        match representation {
+            Representation::Raw => segment.logical_len = physical_len,
+            Representation::Compressed => {
+                let index = SegmentIndex::parse(&file)?;
+                let metadata = index.metadata();
+                segment.logical_len = index.logical_len();
+                segment.profile = Some(match metadata.mode {
+                    FrameMode::PerBlock => "per-block".to_string(),
+                    FrameMode::Chunked { target } => format!("chunked ({})", bytes(target as u64)),
+                });
+                segment.level = Some(metadata.level);
+                segment.frames = Some(index.frames().len().saturating_sub(1));
+                if let Some(dictionary) = metadata.dictionary {
+                    segment.dictionary = Some(dictionary.to_string());
+                    segment.dictionary_status = Some(match dictionaries.dictionary(&dictionary) {
+                        Ok(Some(_)) => "installed".to_string(),
+                        Ok(None) => "missing: the store refuses to open".to_string(),
+                        Err(e) => format!("unusable: {e}"),
+                    });
+                }
+            }
+        }
+        Ok(())
+    })();
+    if let Err(e) = parsed {
+        segment.problem = Some(format!("{}: {e}", path.display()));
+    }
+    Some(segment)
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    let dir = segments_dir(config)?;
+    let compression = match &config.storage.archive {
+        ArchiveStoreConfig::Fjall(cfg) => cfg.compression.clone().map(|c| *c),
+        _ => None,
+    }
+    .unwrap_or_default();
+
+    let lease = match Lease::acquire(&dir, Access::Shared) {
+        Ok(lease) => Some(lease),
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => None,
+        Err(e) => {
+            return Err(e)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("taking the lease on {}", dir.display()))
+        }
+    };
+
+    let dictionaries = dictionary::dir(&dir);
+    let scanned = FlatFileStore::scan(&dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("scanning {}", dir.display()))?;
+
+    let mut segments = Vec::new();
+    let mut pending_work = Vec::new();
+    let mut totals = Totals::default();
+    for (id, found) in &scanned {
+        if args.from.is_some_and(|from| *id < from) || args.to.is_some_and(|to| *id > to) {
+            continue;
+        }
+        if let Some(pending) = pending(*id, found) {
+            pending_work.push(pending);
+        }
+        let paths = SegmentPaths::new(&dir, *id);
+        if let Some(segment) = describe(*id, found, &paths, &dictionaries) {
+            totals.segments += 1;
+            match segment.representation.as_str() {
+                "raw" => totals.raw += 1,
+                "compressed" => totals.compressed += 1,
+                _ => {}
+            }
+            totals.logical_len += segment.logical_len;
+            totals.physical_len += segment.physical_len;
+            segments.push(segment);
+        }
+    }
+
+    let report = Report {
+        segments_dir: dir.display().to_string(),
+        maintenance_in_progress: lease.is_none(),
+        config: compression,
+        dictionaries: dictionary::installed(&dictionaries)?,
+        segments,
+        pending: pending_work,
+        totals,
+    };
+    drop(lease);
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).into_diagnostic()?
+        );
+        return Ok(());
+    }
+
+    println!("segments directory: {}", report.segments_dir);
+    if report.maintenance_in_progress {
+        println!("  held exclusively by another process: files may be in motion");
+    }
+    println!(
+        "config: profile {}, dictionary {}, chunk target {}",
+        report
+            .config
+            .profile()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        report.config.dictionary.as_deref().unwrap_or("none"),
+        bytes(report.config.chunk_target() as u64)
+    );
+
+    println!("dictionaries ({}):", report.dictionaries.len());
+    for d in &report.dictionaries {
+        let mut line = format!("  {}  {}", d.id, bytes(d.bytes));
+        match &d.manifest {
+            Some(m) => line.push_str(&format!(
+                "  network {}  segments {:06}-{:06}, {} samples, seed {}",
+                m.network_magic, m.from_segment, m.to_segment, m.samples, m.seed
+            )),
+            None => line.push_str("  no manifest"),
+        }
+        if let Some(problem) = &d.problem {
+            line.push_str(&format!("  PROBLEM: {problem}"));
+        }
+        println!("{line}");
+    }
+
+    println!("segments ({}):", report.segments.len());
+    for s in &report.segments {
+        let mut line = format!("  {:06}  {:<10}", s.segment, s.representation);
+        match s.representation.as_str() {
+            "raw" => line.push_str(&format!("  {}", bytes(s.logical_len))),
+            "compressed" => line.push_str(&format!(
+                "  {}  {} -> {} ({:.1}%)  {} frames",
+                s.profile.as_deref().unwrap_or("?"),
+                bytes(s.logical_len),
+                bytes(s.physical_len),
+                100.0 * s.physical_len as f64 / s.logical_len.max(1) as f64,
+                s.frames.unwrap_or(0)
+            )),
+            _ => {}
+        }
+        if let Some(d) = &s.dictionary {
+            line.push_str(&format!(
+                "  dictionary {d} ({})",
+                s.dictionary_status.as_deref().unwrap_or("?")
+            ));
+        }
+        if let Some(problem) = &s.problem {
+            line.push_str(&format!("  PROBLEM: {problem}"));
+        }
+        println!("{line}");
+    }
+
+    if !report.pending.is_empty() {
+        println!("pending ({}):", report.pending.len());
+        for p in &report.pending {
+            println!("  {:06}  {}", p.segment, p.description);
+        }
+    }
+
+    println!(
+        "totals: {} segments ({} raw, {} compressed), {} of blocks on {} of disk",
+        report.totals.segments,
+        report.totals.raw,
+        report.totals.compressed,
+        bytes(report.totals.logical_len),
+        bytes(report.totals.physical_len)
+    );
+    Ok(())
+}

--- a/src/bin/dolos/data/archive_compression/mod.rs
+++ b/src/bin/dolos/data/archive_compression/mod.rs
@@ -1,0 +1,176 @@
+//! Offline maintenance of compressed block segments: training dictionaries,
+//! sealing completed segments, describing a segments directory, and
+//! restoring segments to raw before a downgrade.
+//!
+//! Every command resolves the segments directory through the archive
+//! configuration, the way the store does. The two that rewrite segments —
+//! `seal` and `restore-raw` — open the archive holding that directory
+//! exclusively, so a running node or a second maintenance command is refused
+//! rather than raced; `train-dictionary` only reads blocks, and `inspect`
+//! only reads the directory.
+
+use std::ops::RangeInclusive;
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+use dolos_core::config::{ArchiveStoreConfig, FjallArchiveConfig, RootConfig};
+use dolos_core::ArchiveStore as _;
+use dolos_fjall::archive::ArchiveStore;
+use dolos_fjall::flatfiles::BlockLocation;
+use miette::{bail, Context, IntoDiagnostic};
+
+mod dictionary;
+mod inspect;
+mod restore_raw;
+mod seal;
+mod train;
+mod walk;
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// trains a zstd dictionary on a sample of archived blocks and installs it
+    TrainDictionary(train::Args),
+    /// compresses completed block segments in place
+    Seal(seal::Args),
+    /// describes the block segments, their representations and dictionaries
+    Inspect(inspect::Args),
+    /// restores compressed block segments to raw in place
+    RestoreRaw(restore_raw::Args),
+}
+
+pub fn run(config: &RootConfig, command: &Command) -> miette::Result<()> {
+    match command {
+        Command::TrainDictionary(x) => train::run(config, x),
+        Command::Seal(x) => seal::run(config, x),
+        Command::Inspect(x) => inspect::run(config, x),
+        Command::RestoreRaw(x) => restore_raw::run(config, x),
+    }
+}
+
+/// A closed range of segment numbers, as every command takes it.
+#[derive(Debug, Clone, Copy, clap::Args)]
+pub struct SegmentRange {
+    /// first segment number of the range (inclusive)
+    #[arg(long)]
+    from: u32,
+
+    /// last segment number of the range (inclusive)
+    #[arg(long)]
+    to: u32,
+}
+
+impl SegmentRange {
+    fn segments(&self) -> miette::Result<RangeInclusive<u32>> {
+        if self.to < self.from {
+            bail!(
+                "--to {} is below --from {}; the range is inclusive on both ends",
+                self.to,
+                self.from
+            );
+        }
+        Ok(self.from..=self.to)
+    }
+}
+
+/// The fjall archive this configuration names: its directory and options.
+fn fjall_archive(config: &RootConfig) -> miette::Result<(PathBuf, &FjallArchiveConfig)> {
+    match &config.storage.archive {
+        ArchiveStoreConfig::Fjall(cfg) => {
+            let path = config
+                .storage
+                .archive_path()
+                .expect("a fjall archive resolves to a path");
+            Ok((path, cfg))
+        }
+        ArchiveStoreConfig::InMemory => {
+            bail!("archive compression needs the fjall archive backend, not in_memory")
+        }
+        ArchiveStoreConfig::NoOp => {
+            bail!("archive compression needs the fjall archive backend, not no_op")
+        }
+    }
+}
+
+/// Where the block segment files live: `blocks_path` as configured, else
+/// the archive directory — the resolution the store itself applies.
+fn segments_dir(config: &RootConfig) -> miette::Result<PathBuf> {
+    let (path, cfg) = fjall_archive(config)?;
+    Ok(cfg.blocks_path.clone().unwrap_or(path))
+}
+
+/// Open the archive, exclusively when the command will rewrite segments.
+fn open_archive(config: &RootConfig, exclusive: bool) -> miette::Result<ArchiveStore> {
+    let (path, cfg) = fjall_archive(config)?;
+    let schema = dolos_cardano::model::build_schema();
+    let opened = if exclusive {
+        ArchiveStore::open_exclusive(schema, &path, cfg)
+    } else {
+        ArchiveStore::open(schema, &path, cfg)
+    };
+    opened.into_diagnostic().wrap_err_with(|| {
+        format!(
+            "opening the archive at {}{}",
+            path.display(),
+            if exclusive {
+                " for exclusive maintenance"
+            } else {
+                ""
+            }
+        )
+    })
+}
+
+/// The segment holding the archive tip, which sealing never touches.
+fn tip_segment(archive: &ArchiveStore) -> miette::Result<Option<(u32, u64)>> {
+    let tip = archive
+        .get_tip()
+        .into_diagnostic()
+        .wrap_err("reading the archive tip")?;
+    Ok(tip.map(|(slot, _)| (BlockLocation::segment_for_slot(slot), slot)))
+}
+
+/// Refuse to start work whose scratch output could not fit beside its
+/// source: the transition stages a complete file before it publishes.
+fn ensure_headroom(dir: &Path, needed: u64, what: &str) -> miette::Result<()> {
+    let available = fs4::available_space(dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("checking the free space at {}", dir.display()))?;
+    if available < needed {
+        bail!(
+            "{what} needs {} of scratch space at {} and only {} is available; \
+             nothing was changed",
+            bytes(needed),
+            dir.display(),
+            bytes(available)
+        );
+    }
+    Ok(())
+}
+
+/// Scratch space a seal or thaw of a segment with `logical_len` bytes may
+/// need: the whole stream again, plus framing overhead in the worst case.
+fn scratch_for(logical_len: u64) -> u64 {
+    logical_len + logical_len / 64 + (1 << 20)
+}
+
+fn bytes(n: u64) -> String {
+    const KB: f64 = 1000.0;
+    let n = n as f64;
+    if n >= KB * KB * KB {
+        format!("{:.1} GB", n / (KB * KB * KB))
+    } else if n >= KB * KB {
+        format!("{:.1} MB", n / (KB * KB))
+    } else if n >= KB {
+        format!("{:.1} KB", n / KB)
+    } else {
+        format!("{n} B")
+    }
+}
+
+fn setup_tracing(config: &RootConfig, verbose: bool) -> miette::Result<()> {
+    if verbose {
+        crate::common::setup_tracing(&config.logging, &config.telemetry)
+    } else {
+        crate::common::setup_tracing_error_only()
+    }
+}

--- a/src/bin/dolos/data/archive_compression/restore_raw.rs
+++ b/src/bin/dolos/data/archive_compression/restore_raw.rs
@@ -1,0 +1,122 @@
+//! Restore compressed segments to raw in place, through the same verified
+//! transition sealing uses, in the other direction.
+
+use dolos_core::config::RootConfig;
+use dolos_fjall::flatfiles::{Representation, SegmentInfo};
+use miette::{IntoDiagnostic, WrapErr};
+use serde::Serialize;
+
+use super::{bytes, ensure_headroom, open_archive, scratch_for, setup_tracing, SegmentRange};
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[command(flatten)]
+    range: SegmentRange,
+
+    /// report what would be restored without changing anything
+    #[arg(long)]
+    dry_run: bool,
+
+    /// print the report as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// enable verbose logging
+    #[arg(long)]
+    verbose: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Outcome {
+    segment: u32,
+    action: &'static str,
+    logical_len: u64,
+    physical_len_before: u64,
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    setup_tracing(config, args.verbose)?;
+    let segments = args.range.segments()?;
+
+    let archive = open_archive(config, true)?;
+    let infos: std::collections::BTreeMap<u32, SegmentInfo> = archive
+        .segments()
+        .into_diagnostic()
+        .wrap_err("listing the segments")?
+        .into_iter()
+        .map(|info| (info.segment_id, info))
+        .collect();
+    let dir = archive.segments_dir().to_path_buf();
+
+    let mut outcomes = Vec::new();
+    for segment in segments {
+        let outcome = match infos.get(&segment) {
+            None => Outcome {
+                segment,
+                action: "absent",
+                logical_len: 0,
+                physical_len_before: 0,
+            },
+            Some(info) if info.representation == Representation::Raw => Outcome {
+                segment,
+                action: "already-raw",
+                logical_len: info.logical_len,
+                physical_len_before: info.physical_len,
+            },
+            Some(info) => {
+                ensure_headroom(
+                    &dir,
+                    scratch_for(info.logical_len),
+                    &format!("restoring segment {segment:06}"),
+                )?;
+                if args.dry_run {
+                    Outcome {
+                        segment,
+                        action: "would-restore",
+                        logical_len: info.logical_len,
+                        physical_len_before: info.physical_len,
+                    }
+                } else {
+                    archive
+                        .thaw_segment(segment)
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("restoring segment {segment:06} to raw"))?;
+                    Outcome {
+                        segment,
+                        action: "restored",
+                        logical_len: info.logical_len,
+                        physical_len_before: info.physical_len,
+                    }
+                }
+            }
+        };
+        if !args.json {
+            let line = match outcome.action {
+                "absent" => "no such segment in the archive".to_string(),
+                "already-raw" => {
+                    format!("already raw ({}), left as is", bytes(outcome.logical_len))
+                }
+                "would-restore" => format!(
+                    "dry run: would restore {} on disk to {} raw",
+                    bytes(outcome.physical_len_before),
+                    bytes(outcome.logical_len)
+                ),
+                _ => format!(
+                    "restored to raw: {} on disk -> {}",
+                    bytes(outcome.physical_len_before),
+                    bytes(outcome.logical_len)
+                ),
+            };
+            println!("segment {segment:06}: {line}");
+        }
+        outcomes.push(outcome);
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&outcomes).into_diagnostic()?
+        );
+    }
+    Ok(())
+}

--- a/src/bin/dolos/data/archive_compression/seal.rs
+++ b/src/bin/dolos/data/archive_compression/seal.rs
@@ -1,0 +1,368 @@
+//! Compress completed raw segments in place, one at a time, through the
+//! store's verified transition.
+
+use std::collections::HashSet;
+
+use clap::ValueEnum;
+use dolos_core::config::{CompressionProfile, RootConfig};
+use dolos_fjall::archive::ArchiveStore;
+use dolos_fjall::flatfiles::compressed::{FrameMode, Metadata, WriterOptions};
+use dolos_fjall::flatfiles::{Representation, SegmentInfo};
+use miette::{bail, IntoDiagnostic, WrapErr};
+use serde::Serialize;
+
+use super::dictionary;
+use super::walk;
+use super::{
+    bytes, ensure_headroom, open_archive, scratch_for, segments_dir, setup_tracing, tip_segment,
+    SegmentRange,
+};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Profile {
+    PerBlock,
+    Chunked,
+}
+
+impl From<Profile> for CompressionProfile {
+    fn from(profile: Profile) -> Self {
+        match profile {
+            Profile::PerBlock => CompressionProfile::PerBlock,
+            Profile::Chunked => CompressionProfile::Chunked,
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[command(flatten)]
+    range: SegmentRange,
+
+    /// profile to seal with; defaults to storage.archive.compression.profile
+    #[arg(long, value_enum)]
+    profile: Option<Profile>,
+
+    /// identity of the installed dictionary the per-block profile compresses
+    /// with; defaults to storage.archive.compression.dictionary
+    #[arg(long)]
+    dictionary: Option<String>,
+
+    /// frame target of the chunked profile, in bytes; defaults to
+    /// storage.archive.compression.chunk_target
+    #[arg(long)]
+    chunk_target: Option<u32>,
+
+    /// report what would be sealed without changing anything
+    #[arg(long)]
+    dry_run: bool,
+
+    /// print the report as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// enable verbose logging
+    #[arg(long)]
+    verbose: bool,
+}
+
+/// What the run decided for one segment.
+#[derive(Debug, Serialize)]
+struct Outcome {
+    segment: u32,
+    action: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dictionary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bodies: Option<usize>,
+    logical_len: u64,
+    physical_len: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frames: Option<u32>,
+}
+
+/// The profile a run seals with, resolved from the command line over the
+/// configuration and loaded before any segment is touched.
+struct Selection {
+    profile: CompressionProfile,
+    options: WriterOptions,
+    dictionary: Option<String>,
+}
+
+fn describe(metadata: &Metadata) -> (String, Option<String>) {
+    let profile = match metadata.mode {
+        FrameMode::PerBlock => "per-block".to_string(),
+        FrameMode::Chunked { target } => format!("chunked ({} frames)", bytes(target as u64)),
+    };
+    (profile, metadata.dictionary.map(|id| id.to_string()))
+}
+
+fn select(config: &RootConfig, args: &Args) -> miette::Result<Selection> {
+    let compression = match &config.storage.archive {
+        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => cfg.compression.clone().map(|c| *c),
+        _ => None,
+    }
+    .unwrap_or_default();
+
+    let profile = match args.profile {
+        Some(profile) => profile.into(),
+        None => match compression.profile() {
+            Some(profile) => profile,
+            None => bail!(
+                "no sealing profile selected: pass --profile per-block|chunked or set \
+                 storage.archive.compression.profile"
+            ),
+        },
+    };
+
+    match profile {
+        CompressionProfile::PerBlock => {
+            if args.chunk_target.is_some() {
+                bail!("--chunk-target applies to the chunked profile only");
+            }
+            let id = match args
+                .dictionary
+                .as_deref()
+                .or(compression.dictionary.as_deref())
+            {
+                Some(id) => dictionary::parse_id(id)?,
+                None => bail!(
+                    "the per-block profile needs a dictionary: pass --dictionary <identity> or \
+                     set storage.archive.compression.dictionary (train one with `dolos data \
+                     archive-compression train-dictionary`)"
+                ),
+            };
+            let dictionaries = dictionary::dir(&segments_dir(config)?);
+            let dictionary = dictionary::resolve(&dictionaries, &id, config.chain.magic())?;
+            Ok(Selection {
+                profile,
+                options: WriterOptions::per_block().with_dictionary(dictionary),
+                dictionary: Some(id.to_string()),
+            })
+        }
+        CompressionProfile::Chunked => {
+            if args.dictionary.is_some() {
+                bail!("--dictionary applies to the per-block profile only");
+            }
+            let target = args
+                .chunk_target
+                .unwrap_or_else(|| compression.chunk_target());
+            if target == 0 {
+                bail!("--chunk-target must be greater than zero");
+            }
+            Ok(Selection {
+                profile,
+                options: WriterOptions::chunked(target),
+                dictionary: None,
+            })
+        }
+    }
+}
+
+/// The boundaries a seal cuts at: every body of the stream, checked against
+/// the index so a location the index holds is always a whole body.
+fn boundaries(archive: &ArchiveStore, info: &SegmentInfo) -> miette::Result<Vec<walk::Body>> {
+    let segment = info.segment_id;
+    let bodies = walk::walk(archive, segment, info.logical_len)?;
+    let covered: HashSet<(u64, u32)> = bodies
+        .iter()
+        .map(|b| (b.location.offset, b.location.length))
+        .collect();
+    let indexed = archive
+        .segment_locations(segment)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("listing the indexed blocks of segment {segment:06}"))?;
+    if let Some(stray) = indexed
+        .iter()
+        .find(|loc| !covered.contains(&(loc.offset, loc.length)))
+    {
+        bail!(
+            "segment {segment:06}: the archive index points at offset {} length {}, which is \
+             not a body of the segment stream; the index and the segment disagree, refusing \
+             to seal",
+            stray.offset,
+            stray.length
+        );
+    }
+    Ok(bodies)
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    setup_tracing(config, args.verbose)?;
+    let segments = args.range.segments()?;
+
+    let archive = open_archive(config, true)?;
+    let selection = select(config, args)?;
+
+    if let Some((tip_segment, tip_slot)) = tip_segment(&archive)? {
+        if *segments.end() >= tip_segment {
+            bail!(
+                "segment {tip_segment:06} holds the archive tip (slot {tip_slot}) and is still \
+                 being appended to; sealing stops at segment {:06}",
+                tip_segment.saturating_sub(1)
+            );
+        }
+    } else {
+        bail!("the archive is empty; there is nothing to seal");
+    }
+
+    let infos: std::collections::BTreeMap<u32, SegmentInfo> = archive
+        .segments()
+        .into_diagnostic()
+        .wrap_err("listing the segments")?
+        .into_iter()
+        .map(|info| (info.segment_id, info))
+        .collect();
+    let dir = archive.segments_dir().to_path_buf();
+
+    let mut outcomes = Vec::new();
+    for segment in segments {
+        let Some(info) = infos.get(&segment) else {
+            outcomes.push(report(
+                args.json,
+                Outcome {
+                    segment,
+                    action: "absent",
+                    profile: None,
+                    dictionary: None,
+                    bodies: None,
+                    logical_len: 0,
+                    physical_len: 0,
+                    frames: None,
+                },
+            ));
+            continue;
+        };
+
+        if info.representation == Representation::Compressed {
+            let (profile, dictionary) = info.metadata.as_ref().map(describe).unwrap_or_default();
+            outcomes.push(report(
+                args.json,
+                Outcome {
+                    segment,
+                    action: "already-compressed",
+                    profile: Some(profile),
+                    dictionary,
+                    bodies: None,
+                    logical_len: info.logical_len,
+                    physical_len: info.physical_len,
+                    frames: None,
+                },
+            ));
+            continue;
+        }
+
+        if info.logical_len == 0 {
+            outcomes.push(report(
+                args.json,
+                Outcome {
+                    segment,
+                    action: "empty",
+                    profile: None,
+                    dictionary: None,
+                    bodies: Some(0),
+                    logical_len: 0,
+                    physical_len: 0,
+                    frames: None,
+                },
+            ));
+            continue;
+        }
+
+        let bodies = boundaries(&archive, info)?;
+        ensure_headroom(
+            &dir,
+            scratch_for(info.logical_len),
+            &format!("sealing segment {segment:06}"),
+        )?;
+
+        if args.dry_run {
+            outcomes.push(report(
+                args.json,
+                Outcome {
+                    segment,
+                    action: "would-seal",
+                    profile: Some(selection.profile.to_string()),
+                    dictionary: selection.dictionary.clone(),
+                    bodies: Some(bodies.len()),
+                    logical_len: info.logical_len,
+                    physical_len: info.physical_len,
+                    frames: None,
+                },
+            ));
+            continue;
+        }
+
+        let locations: Vec<_> = bodies.iter().map(|b| b.location).collect();
+        let summary = archive
+            .seal_segment_at(segment, &locations, &selection.options)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("sealing segment {segment:06}"))?;
+        outcomes.push(report(
+            args.json,
+            Outcome {
+                segment,
+                action: "sealed",
+                profile: Some(selection.profile.to_string()),
+                dictionary: selection.dictionary.clone(),
+                bodies: Some(bodies.len()),
+                logical_len: summary.logical_len,
+                physical_len: summary.physical_len,
+                frames: Some(summary.frames),
+            },
+        ));
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&outcomes).into_diagnostic()?
+        );
+    }
+    Ok(())
+}
+
+/// Print the outcome as a line unless the run reports JSON at the end.
+fn report(json: bool, outcome: Outcome) -> Outcome {
+    if !json {
+        let segment = outcome.segment;
+        let line = match outcome.action {
+            "absent" => "no such segment in the archive".to_string(),
+            "empty" => "empty, nothing to seal".to_string(),
+            "already-compressed" => format!(
+                "already compressed as {}{}: {} on disk for {}, left as is",
+                outcome.profile.as_deref().unwrap_or("?"),
+                with_dictionary(&outcome),
+                bytes(outcome.physical_len),
+                bytes(outcome.logical_len),
+            ),
+            "would-seal" => format!(
+                "dry run: would seal {} bodies ({}) as {}{}",
+                outcome.bodies.unwrap_or(0),
+                bytes(outcome.logical_len),
+                outcome.profile.as_deref().unwrap_or("?"),
+                with_dictionary(&outcome),
+            ),
+            _ => format!(
+                "sealed {} bodies as {}{}: {} -> {} ({:.1}%), {} frames",
+                outcome.bodies.unwrap_or(0),
+                outcome.profile.as_deref().unwrap_or("?"),
+                with_dictionary(&outcome),
+                bytes(outcome.logical_len),
+                bytes(outcome.physical_len),
+                100.0 * outcome.physical_len as f64 / outcome.logical_len.max(1) as f64,
+                outcome.frames.unwrap_or(0),
+            ),
+        };
+        println!("segment {segment:06}: {line}");
+    }
+    outcome
+}
+
+fn with_dictionary(outcome: &Outcome) -> String {
+    match &outcome.dictionary {
+        Some(id) => format!(" with dictionary {id}"),
+        None => String::new(),
+    }
+}

--- a/src/bin/dolos/data/archive_compression/seal.rs
+++ b/src/bin/dolos/data/archive_compression/seal.rs
@@ -38,17 +38,18 @@ pub struct Args {
     #[command(flatten)]
     range: SegmentRange,
 
-    /// profile to seal with; defaults to storage.archive.compression.profile
+    /// profile to seal with; defaults to
+    /// storage.archive.block_compression.profile
     #[arg(long, value_enum)]
     profile: Option<Profile>,
 
     /// identity of the installed dictionary the per-block profile compresses
-    /// with; defaults to storage.archive.compression.dictionary
+    /// with; defaults to storage.archive.block_compression.dictionary
     #[arg(long)]
     dictionary: Option<String>,
 
     /// frame target of the chunked profile, in bytes; defaults to
-    /// storage.archive.compression.chunk_target
+    /// storage.archive.block_compression.chunk_target
     #[arg(long)]
     chunk_target: Option<u32>,
 
@@ -100,7 +101,9 @@ fn describe(metadata: &Metadata) -> (String, Option<String>) {
 
 fn select(config: &RootConfig, args: &Args) -> miette::Result<Selection> {
     let compression = match &config.storage.archive {
-        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => cfg.compression.clone().map(|c| *c),
+        dolos_core::config::ArchiveStoreConfig::Fjall(cfg) => {
+            cfg.block_compression.clone().map(|c| *c)
+        }
         _ => None,
     }
     .unwrap_or_default();
@@ -111,7 +114,7 @@ fn select(config: &RootConfig, args: &Args) -> miette::Result<Selection> {
             Some(profile) => profile,
             None => bail!(
                 "no sealing profile selected: pass --profile per-block|chunked or set \
-                 storage.archive.compression.profile"
+                 storage.archive.block_compression.profile"
             ),
         },
     };
@@ -129,7 +132,7 @@ fn select(config: &RootConfig, args: &Args) -> miette::Result<Selection> {
                 Some(id) => dictionary::parse_id(id)?,
                 None => bail!(
                     "the per-block profile needs a dictionary: pass --dictionary <identity> or \
-                     set storage.archive.compression.dictionary (train one with `dolos data \
+                     set storage.archive.block_compression.dictionary (train one with `dolos data \
                      archive-compression train-dictionary`)"
                 ),
             };

--- a/src/bin/dolos/data/archive_compression/train.rs
+++ b/src/bin/dolos/data/archive_compression/train.rs
@@ -199,7 +199,7 @@ pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
             report.manifest.network_magic
         );
         println!(
-            "  select it with storage.archive.compression.dictionary = \"{}\"",
+            "  select it with storage.archive.block_compression.dictionary = \"{}\"",
             report.dictionary
         );
     }

--- a/src/bin/dolos/data/archive_compression/train.rs
+++ b/src/bin/dolos/data/archive_compression/train.rs
@@ -1,0 +1,207 @@
+//! Train a dictionary on a reproducible sample of archived blocks and
+//! install it under its identity.
+
+use std::collections::HashSet;
+
+use dolos_core::config::RootConfig;
+use dolos_fjall::flatfiles::compressed::Dictionary;
+use dolos_fjall::flatfiles::BlockLocation;
+use miette::{bail, IntoDiagnostic, WrapErr};
+use serde::Serialize;
+
+use super::dictionary::{self, Manifest};
+use super::{bytes, open_archive, segments_dir, setup_tracing, SegmentRange};
+
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    #[command(flatten)]
+    range: SegmentRange,
+
+    /// blocks to sample from the range
+    #[arg(long, default_value_t = 20_000)]
+    samples: usize,
+
+    /// most sample bytes to feed the trainer, in MB
+    #[arg(long, default_value_t = 256)]
+    sample_budget_mb: u64,
+
+    /// seed of the sample selection; the same seed over the same archive
+    /// range trains the same dictionary
+    #[arg(long, default_value_t = 0)]
+    seed: u64,
+
+    /// largest dictionary to produce, in bytes
+    #[arg(long, default_value_t = 112_640)]
+    max_size: usize,
+
+    /// print the report as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// enable verbose logging
+    #[arg(long)]
+    verbose: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    dictionary: String,
+    bytes: u64,
+    path: String,
+    #[serde(flatten)]
+    manifest: Manifest,
+}
+
+/// splitmix64: a tiny deterministic generator, so a seed names a sample.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// `count` distinct positions out of `population`, by a partial shuffle.
+fn select(population: usize, count: usize, seed: u64) -> Vec<usize> {
+    let mut rng = Rng(seed);
+    let mut positions: Vec<usize> = (0..population).collect();
+    let count = count.min(population);
+    for i in 0..count {
+        let j = i + rng.below(population - i);
+        positions.swap(i, j);
+    }
+    positions.truncate(count);
+    positions
+}
+
+pub fn run(config: &RootConfig, args: &Args) -> miette::Result<()> {
+    setup_tracing(config, args.verbose)?;
+    let segments = args.range.segments()?;
+    if args.samples == 0 {
+        bail!("--samples must be at least one");
+    }
+    let budget = args.sample_budget_mb.saturating_mul(1 << 20);
+
+    let archive = open_archive(config, false)?;
+
+    let mut population: Vec<BlockLocation> = Vec::new();
+    for segment in segments.clone() {
+        population.extend(
+            archive
+                .segment_locations(segment)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("listing the blocks of segment {segment:06}"))?,
+        );
+    }
+    if population.is_empty() {
+        bail!(
+            "segments {:06} to {:06} hold no indexed blocks to sample",
+            segments.start(),
+            segments.end()
+        );
+    }
+
+    let chosen: HashSet<usize> = select(population.len(), args.samples, args.seed)
+        .into_iter()
+        .collect();
+    let mut selected: Vec<BlockLocation> = population
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| chosen.contains(i))
+        .map(|(_, loc)| *loc)
+        .collect();
+    selected.sort_by_key(|loc| (loc.segment_id, loc.offset));
+
+    let mut samples: Vec<Vec<u8>> = Vec::with_capacity(selected.len());
+    let mut sample_bytes = 0u64;
+    for loc in &selected {
+        if sample_bytes + loc.length as u64 > budget {
+            break;
+        }
+        let body = archive
+            .read_location(loc)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("reading the block at {loc:?}"))?;
+        sample_bytes += body.len() as u64;
+        samples.push(body);
+    }
+    if samples.is_empty() {
+        bail!(
+            "the sample budget of {} does not fit a single block; raise --sample-budget-mb",
+            bytes(budget)
+        );
+    }
+
+    let trained = zstd::dict::from_samples(&samples, args.max_size)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "training a {}-byte dictionary on {} blocks ({}); zstd needs more or larger \
+                 samples than that",
+                args.max_size,
+                samples.len(),
+                bytes(sample_bytes)
+            )
+        })?;
+    let dictionary = Dictionary::new(trained);
+
+    let dictionaries = dictionary::dir(&segments_dir(config)?);
+    let path = dictionaries
+        .install(&dictionary)
+        .into_diagnostic()
+        .wrap_err("installing the dictionary")?;
+    let manifest = Manifest {
+        network_magic: config.chain.magic(),
+        from_segment: *segments.start(),
+        to_segment: *segments.end(),
+        population: population.len(),
+        samples: samples.len(),
+        sample_bytes,
+        sample_budget_bytes: budget,
+        seed: args.seed,
+        max_size: args.max_size,
+        zstd_version: zstd::zstd_safe::version_number(),
+    };
+    dictionary::write_manifest(&dictionaries, &dictionary.id(), &manifest)?;
+
+    let report = Report {
+        dictionary: dictionary.id().to_string(),
+        bytes: dictionary.bytes().len() as u64,
+        path: path.display().to_string(),
+        manifest,
+    };
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).into_diagnostic()?
+        );
+    } else {
+        println!("dictionary {}", report.dictionary);
+        println!("  installed at {} ({})", report.path, bytes(report.bytes));
+        println!(
+            "  trained on {} of {} blocks in segments {:06} to {:06} ({} of a {} budget), \
+             seed {}, network magic {}",
+            report.manifest.samples,
+            report.manifest.population,
+            report.manifest.from_segment,
+            report.manifest.to_segment,
+            bytes(report.manifest.sample_bytes),
+            bytes(report.manifest.sample_budget_bytes),
+            report.manifest.seed,
+            report.manifest.network_magic
+        );
+        println!(
+            "  select it with storage.archive.compression.dictionary = \"{}\"",
+            report.dictionary
+        );
+    }
+    Ok(())
+}

--- a/src/bin/dolos/data/archive_compression/walk.rs
+++ b/src/bin/dolos/data/archive_compression/walk.rs
@@ -1,0 +1,106 @@
+//! Walks a raw segment as the stream of CBOR items it is. Every stored body
+//! is one item, so the boundaries come from the bytes themselves and cover
+//! the bodies the archive index no longer points at — a duplicate from a
+//! resumed import, a block a rollback displaced — as well as the ones it
+//! does. A stream that does not end on an item boundary is refused.
+
+use dolos_fjall::archive::ArchiveStore;
+use dolos_fjall::flatfiles::BlockLocation;
+use miette::{bail, IntoDiagnostic, WrapErr};
+use pallas::codec::minicbor::Decoder;
+use pallas::ledger::traverse::MultiEraBlock;
+
+/// How much of the stream is read at a time. An item longer than this is
+/// handled by reading on until it is complete.
+const WINDOW: u64 = 8 << 20;
+
+/// One body of the stream.
+#[derive(Debug, Clone, Copy)]
+pub struct Body {
+    pub location: BlockLocation,
+}
+
+/// Every body of segment `segment_id`, in physical order, covering exactly
+/// `logical_len` bytes.
+pub fn walk(
+    archive: &ArchiveStore,
+    segment_id: u32,
+    logical_len: u64,
+) -> miette::Result<Vec<Body>> {
+    let mut bodies = Vec::new();
+    let mut buf: Vec<u8> = Vec::new();
+    // `buf[0]` sits at logical offset `base`; `end` is the offset after its
+    // last byte; `pos` is where the next item starts.
+    let mut base = 0u64;
+    let mut end = 0u64;
+    let mut pos = 0u64;
+
+    while pos < logical_len {
+        let start = (pos - base) as usize;
+        let mut decoder = Decoder::new(&buf[start..]);
+        match decoder.skip() {
+            Ok(()) => {
+                let length = decoder.position();
+                let item = &buf[start..start + length];
+                let slot = MultiEraBlock::decode(item)
+                    .map(|block| block.slot())
+                    .map_err(|e| {
+                        miette::miette!(
+                            "segment {segment_id:06}: the CBOR item at offset {pos} is not a \
+                             block: {e}"
+                        )
+                    })?;
+                let length = u32::try_from(length).into_diagnostic().wrap_err_with(|| {
+                    format!("segment {segment_id:06}: the body at offset {pos} is too long")
+                })?;
+                let home = BlockLocation::segment_for_slot(slot);
+                if home != segment_id {
+                    bail!(
+                        "segment {segment_id:06}: the block at offset {pos} carries slot {slot}, \
+                         which belongs to segment {home:06}; refusing to seal a stream that is \
+                         not this segment's"
+                    );
+                }
+                bodies.push(Body {
+                    location: BlockLocation {
+                        segment_id,
+                        offset: pos,
+                        length,
+                    },
+                });
+                pos += length as u64;
+            }
+            Err(e) if e.is_end_of_input() => {
+                if end >= logical_len {
+                    bail!(
+                        "segment {segment_id:06}: the {} trailing bytes at offset {pos} are not a \
+                         whole CBOR item; the stream is incomplete and cannot be sealed as it is",
+                        logical_len - pos
+                    );
+                }
+                let take = WINDOW.min(logical_len - end);
+                let chunk = archive
+                    .read_location(&BlockLocation {
+                        segment_id,
+                        offset: end,
+                        length: take as u32,
+                    })
+                    .into_diagnostic()
+                    .wrap_err_with(|| {
+                        format!("segment {segment_id:06}: reading {take} bytes at offset {end}")
+                    })?;
+                if start > 0 {
+                    buf.drain(..start);
+                    base = pos;
+                }
+                buf.extend_from_slice(&chunk);
+                end += take;
+            }
+            Err(e) => {
+                bail!("segment {segment_id:06}: the bytes at offset {pos} are not a CBOR item: {e}")
+            }
+        }
+    }
+
+    Ok(bodies)
+}

--- a/src/bin/dolos/data/mod.rs
+++ b/src/bin/dolos/data/mod.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use clap::{Parser, Subcommand};
 use dolos_core::config::RootConfig;
 
+mod archive_compression;
 mod check;
 mod clear_state;
 mod compute_nonce;
@@ -65,6 +66,9 @@ pub enum Command {
     Housekeeping(housekeeping::Args),
     /// imports blocks from immutable DB into archive store only
     ImportArchive(import_archive::Args),
+    /// offline maintenance of compressed block segments
+    #[command(subcommand)]
+    ArchiveCompression(archive_compression::Command),
 }
 
 #[derive(Debug, Parser)]
@@ -97,6 +101,7 @@ pub fn run(
         Command::Stats(x) => stats::run(config, x)?,
         Command::Housekeeping(x) => housekeeping::run(config, x)?,
         Command::ImportArchive(x) => import_archive::run(config, x, feedback)?,
+        Command::ArchiveCompression(x) => archive_compression::run(config, x)?,
     }
 
     Ok(())

--- a/tests/archive_compression_cli.rs
+++ b/tests/archive_compression_cli.rs
@@ -1,0 +1,762 @@
+//! The offline maintenance commands, driven through the built binary the
+//! way an operator runs them: train a dictionary, seal completed segments,
+//! inspect the directory, restore to raw — and every refusal the plan asks
+//! for: the tip segment, a running node or a second maintenance process, a
+//! missing or foreign dictionary, a stream that does not end on a block, and
+//! an interrupted transition that has to be settled first.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use dolos_core::{ArchiveStore as _, ArchiveWriter as _, BlockSlot, ChainPoint, StateSchema};
+use dolos_fjall::archive::ArchiveStore;
+use dolos_fjall::flatfiles::{
+    Access, BlockLocation, FlatFileOptions, FlatFileStore, Representation, DICTIONARIES_DIR,
+    SLOTS_PER_SEGMENT,
+};
+use dolos_testing::blocks::make_conway_block_with_prev;
+
+struct Workspace {
+    dir: tempfile::TempDir,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = Self { dir };
+        ws.configure("");
+        ws
+    }
+
+    fn path(&self) -> &Path {
+        self.dir.path()
+    }
+
+    fn archive_dir(&self) -> PathBuf {
+        self.path().join("data").join("archive")
+    }
+
+    /// Write `dolos.toml`, with `archive_extra` appended to the
+    /// `storage.archive` table.
+    fn configure(&self, archive_extra: &str) {
+        let config = format!(
+            r#"[upstream]
+peer_address = "127.0.0.1:1"
+
+[storage]
+version = "v3"
+path = "data"
+
+[storage.archive]
+backend = "fjall"
+cache = 16
+worker_threads = 1
+{archive_extra}
+
+[genesis]
+byron_path = "byron.json"
+shelley_path = "shelley.json"
+alonzo_path = "alonzo.json"
+conway_path = "conway.json"
+
+[chain]
+type = "cardano"
+magic = 2
+is_testnet = true
+"#
+        );
+        fs::write(self.path().join("dolos.toml"), config).unwrap();
+    }
+
+    fn open(&self) -> ArchiveStore {
+        let config = dolos_core::config::FjallArchiveConfig {
+            cache: Some(16),
+            worker_threads: Some(1),
+            ..Default::default()
+        };
+        ArchiveStore::open(StateSchema::default(), self.archive_dir(), &config).unwrap()
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_dolos"))
+            .current_dir(self.path())
+            .args(["data", "archive-compression"])
+            .args(args)
+            .output()
+            .unwrap()
+    }
+
+    fn ok(&self, args: &[&str]) -> String {
+        let out = self.run(args);
+        assert!(
+            out.status.success(),
+            "`{}` failed:\n{}{}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    fn fails(&self, args: &[&str]) -> String {
+        let out = self.run(args);
+        assert!(
+            !out.status.success(),
+            "`{}` should have failed:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stdout)
+        );
+        // miette wraps and decorates the diagnostic; assertions want the words.
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        text.split_whitespace()
+            .filter(|word| !matches!(*word, "×" | "│" | "╰─▶" | "├─▶"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn files(&self, segment: u32) -> Vec<String> {
+        let prefix = format!("{segment:06}.");
+        let mut names: Vec<String> = fs::read_dir(self.archive_dir())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with(&prefix))
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn raw_file(&self, segment: u32) -> PathBuf {
+        self.archive_dir().join(format!("{segment:06}.segment"))
+    }
+}
+
+/// An exclusive in-process open, retried for a moment: a sibling test's
+/// child process duplicates every descriptor of this process between fork
+/// and exec, and holds the advisory lock for that instant.
+fn open_exclusive(ws: &Workspace) -> FlatFileStore {
+    let mut attempts = 0;
+    loop {
+        let opened = FlatFileStore::with_options(
+            ws.archive_dir(),
+            FlatFileOptions {
+                access: Access::Exclusive,
+                ..Default::default()
+            },
+        );
+        match opened {
+            Ok(store) => return store,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock && attempts < 100 => {
+                attempts += 1;
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(e) => panic!("exclusive open: {e}"),
+        }
+    }
+}
+
+fn slot(segment: u64, k: u64) -> BlockSlot {
+    segment * SLOTS_PER_SEGMENT + k
+}
+
+fn block(slot: BlockSlot, number: u64) -> (ChainPoint, Vec<u8>) {
+    let (point, body) = make_conway_block_with_prev(slot, None, number);
+    (point, body.as_ref().clone())
+}
+
+/// Segments 0 to 3 with the tip in segment 3, forty blocks each, and a slot
+/// in segment 1 holding two blocks (the Byron boundary shape).
+fn write_history(store: &ArchiveStore) -> Vec<(BlockSlot, Vec<u8>)> {
+    let mut written = Vec::new();
+    for segment in 0..4u64 {
+        let writer = store.start_writer().unwrap();
+        for k in 0..40u64 {
+            let (point, body) = block(slot(segment, k * 7), segment * 100 + k);
+            writer.apply(&point, &body.clone().into()).unwrap();
+            written.push((point.slot(), body));
+            if segment == 1 && k == 3 {
+                let (point, body) = block(slot(segment, k * 7), 9_999);
+                writer.apply(&point, &body.clone().into()).unwrap();
+                written.push((point.slot(), body));
+            }
+        }
+        writer.commit().unwrap();
+    }
+    written
+}
+
+/// A valid block body appended to segment 1 that the index never learns of:
+/// what a duplicate restore write leaves behind.
+fn plant_unreferenced_body(ws: &Workspace) -> (BlockLocation, Vec<u8>) {
+    let flatfiles = FlatFileStore::new(ws.archive_dir()).unwrap();
+    let (_, body) = block(slot(1, 5), 4_242);
+    let location = flatfiles.append_batch(&[(1, body.as_slice())]).unwrap()[0];
+    (location, body)
+}
+
+fn view(store: &ArchiveStore) -> Vec<(BlockSlot, Vec<u8>)> {
+    store.get_range(None, None).unwrap().collect()
+}
+
+fn by_slot(store: &ArchiveStore, slots: &[BlockSlot]) -> BTreeMap<BlockSlot, Vec<Vec<u8>>> {
+    slots
+        .iter()
+        .map(|s| (*s, store.get_blocks_by_slot(s).unwrap()))
+        .collect()
+}
+
+fn representations(store: &ArchiveStore) -> BTreeMap<u32, Representation> {
+    store
+        .segments()
+        .unwrap()
+        .into_iter()
+        .map(|info| (info.segment_id, info.representation))
+        .collect()
+}
+
+fn train(ws: &Workspace, from: &str, to: &str, seed: &str) -> String {
+    let report = ws.ok(&[
+        "train-dictionary",
+        "--from",
+        from,
+        "--to",
+        to,
+        "--samples",
+        "200",
+        "--max-size",
+        "4096",
+        "--seed",
+        seed,
+        "--json",
+    ]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(report["network_magic"], 2);
+    assert_eq!(report["seed"].as_str().map(str::to_string), None);
+    report["dictionary"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn seal_inspect_and_restore_round_trip() {
+    let ws = Workspace::new();
+    let written = write_history(&ws.open());
+    let (dead_loc, dead_body) = plant_unreferenced_body(&ws);
+    let slots: Vec<BlockSlot> = written.iter().map(|(s, _)| *s).collect();
+
+    let (expected_view, expected_by_slot) = {
+        let store = ws.open();
+        (view(&store), by_slot(&store, &slots))
+    };
+    let raw_bytes: Vec<Vec<u8>> = (0..3).map(|s| fs::read(ws.raw_file(s)).unwrap()).collect();
+
+    // A dry run plans and changes nothing.
+    let out = ws.ok(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "1",
+        "--profile",
+        "chunked",
+        "--chunk-target",
+        "4096",
+        "--dry-run",
+    ]);
+    assert!(
+        out.contains("segment 000000: dry run: would seal 40 bodies"),
+        "{out}"
+    );
+    assert!(
+        out.contains("segment 000001: dry run: would seal 42 bodies"),
+        "{out}"
+    );
+    assert_eq!(ws.files(0), vec!["000000.segment"]);
+    assert_eq!(ws.files(1), vec!["000001.segment"]);
+
+    // The tip segment and anything past it are refused before any work.
+    let err = ws.fails(&["seal", "--from", "2", "--to", "3", "--profile", "chunked"]);
+    assert!(
+        err.contains("segment 000003 holds the archive tip"),
+        "{err}"
+    );
+    assert_eq!(ws.files(2), vec!["000002.segment"]);
+
+    let dictionary = train(&ws, "0", "1", "7");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(
+            ws.archive_dir()
+                .join(DICTIONARIES_DIR)
+                .join(format!("{dictionary}.json")),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(manifest["network_magic"], 2);
+    assert_eq!(manifest["seed"], 7);
+    assert_eq!(manifest["from_segment"], 0);
+    assert_eq!(manifest["to_segment"], 1);
+    assert!(manifest["samples"].as_u64().unwrap() > 0);
+
+    // The same seed over the same range trains the same dictionary.
+    assert_eq!(train(&ws, "0", "1", "7"), dictionary);
+
+    let out = ws.ok(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "1",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        &dictionary,
+    ]);
+    assert!(
+        out.contains("segment 000000: sealed 40 bodies as per-block with dictionary"),
+        "{out}"
+    );
+    assert!(
+        out.contains("segment 000001: sealed 42 bodies as per-block with dictionary"),
+        "{out}"
+    );
+    let out = ws.ok(&[
+        "seal",
+        "--from",
+        "2",
+        "--to",
+        "2",
+        "--profile",
+        "chunked",
+        "--chunk-target",
+        "4096",
+    ]);
+    assert!(
+        out.contains("segment 000002: sealed 40 bodies as chunked"),
+        "{out}"
+    );
+    assert_eq!(ws.files(0), vec!["000000.zseg"]);
+    assert_eq!(ws.files(1), vec!["000001.zseg"]);
+    assert_eq!(ws.files(2), vec!["000002.zseg"]);
+    assert_eq!(ws.files(3), vec!["000003.segment"]);
+
+    // Served without touching the index, the unreferenced body included.
+    {
+        let store = ws.open();
+        assert_eq!(
+            representations(&store),
+            BTreeMap::from([
+                (0, Representation::Compressed),
+                (1, Representation::Compressed),
+                (2, Representation::Compressed),
+                (3, Representation::Raw),
+            ])
+        );
+        assert_eq!(view(&store), expected_view);
+        assert_eq!(by_slot(&store, &slots), expected_by_slot);
+        assert_eq!(store.read_location(&dead_loc).unwrap(), dead_body);
+    }
+
+    // A second run is idempotent and reports what each segment actually is.
+    let sizes_before: Vec<u64> = (0..3)
+        .map(|s| {
+            fs::metadata(ws.archive_dir().join(format!("{s:06}.zseg")))
+                .unwrap()
+                .len()
+        })
+        .collect();
+    let out = ws.ok(&["seal", "--from", "0", "--to", "2", "--profile", "chunked"]);
+    assert!(
+        out.contains("segment 000000: already compressed as per-block with dictionary"),
+        "{out}"
+    );
+    assert!(
+        out.contains("segment 000002: already compressed as chunked (4.1 KB frames)"),
+        "{out}"
+    );
+    let sizes_after: Vec<u64> = (0..3)
+        .map(|s| {
+            fs::metadata(ws.archive_dir().join(format!("{s:06}.zseg")))
+                .unwrap()
+                .len()
+        })
+        .collect();
+    assert_eq!(sizes_before, sizes_after);
+
+    // Inspect reports representation, profile, dictionary and sizes.
+    let report = ws.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(report["maintenance_in_progress"], false);
+    assert_eq!(report["totals"]["segments"], 4);
+    assert_eq!(report["totals"]["compressed"], 3);
+    assert_eq!(report["pending"].as_array().unwrap().len(), 0);
+    let segments = report["segments"].as_array().unwrap();
+    assert_eq!(segments[0]["representation"], "compressed");
+    assert_eq!(segments[0]["profile"], "per-block");
+    assert_eq!(segments[0]["dictionary"], dictionary);
+    assert_eq!(segments[0]["dictionary_status"], "installed");
+    assert_eq!(
+        segments[0]["logical_len"].as_u64().unwrap(),
+        raw_bytes[0].len() as u64
+    );
+    assert_eq!(
+        segments[0]["physical_len"].as_u64().unwrap(),
+        sizes_after[0]
+    );
+    assert_eq!(segments[2]["profile"], "chunked (4.1 KB)");
+    assert_eq!(segments[3]["representation"], "raw");
+    assert_eq!(report["dictionaries"][0]["id"], dictionary);
+    assert_eq!(report["dictionaries"][0]["manifest"]["seed"], 7);
+    let text = ws.ok(&["inspect"]);
+    assert!(text.contains("000000  compressed  per-block"), "{text}");
+    assert!(text.contains("000003  raw"), "{text}");
+
+    // Restore to raw gives back the original streams, byte for byte.
+    let out = ws.ok(&["restore-raw", "--from", "0", "--to", "3"]);
+    assert!(out.contains("segment 000000: restored to raw"), "{out}");
+    assert!(out.contains("segment 000003: already raw"), "{out}");
+    for s in 0..3 {
+        assert_eq!(ws.files(s), vec![format!("{s:06}.segment")]);
+        assert_eq!(fs::read(ws.raw_file(s)).unwrap(), raw_bytes[s as usize]);
+    }
+    let out = ws.ok(&["restore-raw", "--from", "0", "--to", "0", "--dry-run"]);
+    assert!(out.contains("segment 000000: already raw"), "{out}");
+    let store = ws.open();
+    assert_eq!(view(&store), expected_view);
+    assert_eq!(store.read_location(&dead_loc).unwrap(), dead_body);
+}
+
+#[test]
+fn contention_on_the_segments_directory_is_refused() {
+    let ws = Workspace::new();
+    write_history(&ws.open());
+
+    // A store that holds the directory shared — a node — keeps maintenance out.
+    let node = FlatFileStore::new(ws.archive_dir()).unwrap();
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0", "--profile", "chunked"]);
+    assert!(err.contains("open in another process"), "{err}");
+    let err = ws.fails(&["restore-raw", "--from", "0", "--to", "0"]);
+    assert!(err.contains("open in another process"), "{err}");
+    assert_eq!(ws.files(0), vec!["000000.segment"]);
+    drop(node);
+
+    // A second maintenance holder does too, and inspect says so.
+    let maintenance = open_exclusive(&ws);
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0", "--profile", "chunked"]);
+    assert!(err.contains("open in another process"), "{err}");
+    let report = ws.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(report["maintenance_in_progress"], true);
+    drop(maintenance);
+
+    // A second configuration naming the same segment directory through
+    // `blocks_path`, with an index of its own, contends on the same lease.
+    let other = Workspace::new();
+    other.configure(&format!(
+        "blocks_path = {:?}",
+        ws.archive_dir().display().to_string()
+    ));
+    let node = FlatFileStore::new(ws.archive_dir()).unwrap();
+    let err = other.fails(&["seal", "--from", "0", "--to", "0", "--profile", "chunked"]);
+    assert!(err.contains("open in another process"), "{err}");
+    drop(node);
+
+    // With nobody holding it, maintenance proceeds and a node is kept out
+    // only while it runs.
+    let out = ws.ok(&["seal", "--from", "0", "--to", "0", "--profile", "chunked"]);
+    assert!(out.contains("segment 000000: sealed"), "{out}");
+    FlatFileStore::new(ws.archive_dir()).unwrap();
+}
+
+#[test]
+fn failures_before_publication_leave_the_raw_segment_as_it_was() {
+    let ws = Workspace::new();
+    write_history(&ws.open());
+    let original = fs::read(ws.raw_file(0)).unwrap();
+    let untouched = |ws: &Workspace| {
+        assert_eq!(ws.files(0), vec!["000000.segment"]);
+        assert_eq!(fs::read(ws.raw_file(0)).unwrap(), original);
+    };
+
+    // No profile at all.
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0"]);
+    assert!(err.contains("no sealing profile selected"), "{err}");
+
+    // Per-block without a dictionary, and with one that is not installed.
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0", "--profile", "per-block"]);
+    assert!(err.contains("needs a dictionary"), "{err}");
+    let absent = "ab".repeat(32);
+    let err = ws.fails(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "0",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        &absent,
+    ]);
+    assert!(err.contains("is not installed"), "{err}");
+    let err = ws.fails(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "0",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        "nope",
+    ]);
+    assert!(err.contains("not a dictionary identity"), "{err}");
+    untouched(&ws);
+
+    // A dictionary trained for another network.
+    let dictionary = train(&ws, "1", "2", "1");
+    let manifest_path = ws
+        .archive_dir()
+        .join(DICTIONARIES_DIR)
+        .join(format!("{dictionary}.json"));
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["network_magic"] = serde_json::json!(764_824_073);
+    fs::write(&manifest_path, manifest.to_string()).unwrap();
+    let err = ws.fails(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "0",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        &dictionary,
+    ]);
+    assert!(err.contains("trained on network magic 764824073"), "{err}");
+    untouched(&ws);
+
+    // A configuration no command could act on fails at open.
+    ws.configure("[storage.archive.compression]\nprofile = \"per-block\"");
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0"]);
+    assert!(
+        err.contains("needs storage.archive.compression.dictionary"),
+        "{err}"
+    );
+    ws.configure("");
+    untouched(&ws);
+
+    // A stream that does not end on a whole CBOR item.
+    let flatfiles = FlatFileStore::new(ws.archive_dir()).unwrap();
+    flatfiles.append_batch(&[(0, &[0x9f, 0x82][..])]).unwrap();
+    drop(flatfiles);
+    let err = ws.fails(&["seal", "--from", "0", "--to", "0", "--profile", "chunked"]);
+    assert!(err.contains("trailing bytes at offset"), "{err}");
+    assert_eq!(ws.files(0), vec!["000000.segment"]);
+    let bytes = fs::read(ws.raw_file(0)).unwrap();
+    assert_eq!(&bytes[..original.len()], &original[..]);
+    assert_eq!(&bytes[original.len()..], &[0x9f, 0x82]);
+}
+
+#[test]
+fn interrupted_transitions_are_settled_before_new_work() {
+    let ws = Workspace::new();
+    write_history(&ws.open());
+    let raw2 = fs::read(ws.raw_file(2)).unwrap();
+
+    // Interrupted before publication: raw stays authoritative and the
+    // staged output is discarded, then the seal proceeds.
+    fs::write(ws.archive_dir().join("000002.transition"), "seal\n").unwrap();
+    fs::write(ws.archive_dir().join("000002.zseg.tmp"), b"half a file").unwrap();
+    let report = ws.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(report["pending"][0]["segment"], 2);
+    let description = report["pending"][0]["description"].as_str().unwrap();
+    assert!(
+        description.contains("interrupted seal: the raw file stays authoritative"),
+        "{description}"
+    );
+    assert!(
+        ws.archive_dir().join("000002.zseg.tmp").exists(),
+        "inspect does not recover"
+    );
+
+    let out = ws.ok(&[
+        "seal",
+        "--from",
+        "2",
+        "--to",
+        "2",
+        "--profile",
+        "chunked",
+        "--chunk-target",
+        "4096",
+    ]);
+    assert!(out.contains("segment 000002: sealed"), "{out}");
+    assert_eq!(ws.files(2), vec!["000002.zseg"]);
+
+    // Interrupted after publication: the compressed file is the segment and
+    // the raw leftover is retired, never read.
+    fs::write(ws.archive_dir().join("000002.transition"), "seal\n").unwrap();
+    fs::write(ws.raw_file(2), b"stale raw bytes").unwrap();
+    let report = ws.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    let description = report["pending"][0]["description"].as_str().unwrap();
+    assert!(
+        description.contains("the compressed file is published and authoritative"),
+        "{description}"
+    );
+    let out = ws.ok(&["seal", "--from", "2", "--to", "2", "--profile", "chunked"]);
+    assert!(out.contains("segment 000002: already compressed"), "{out}");
+    assert_eq!(ws.files(2), vec!["000002.zseg"]);
+
+    ws.ok(&["restore-raw", "--from", "2", "--to", "2"]);
+    assert_eq!(fs::read(ws.raw_file(2)).unwrap(), raw2);
+}
+
+#[test]
+fn dictionaries_survive_restart_and_a_file_level_backup() {
+    let ws = Workspace::new();
+    write_history(&ws.open());
+    let expected = view(&ws.open());
+
+    let first = train(&ws, "0", "0", "1");
+    let second = train(&ws, "1", "2", "2");
+    assert_ne!(first, second);
+    ws.ok(&[
+        "seal",
+        "--from",
+        "0",
+        "--to",
+        "0",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        &first,
+    ]);
+    ws.ok(&[
+        "seal",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--profile",
+        "per-block",
+        "--dictionary",
+        &second,
+    ]);
+
+    // The configuration can name the dictionary instead of the command line.
+    ws.configure(&format!(
+        "[storage.archive.compression]\nprofile = \"per-block\"\ndictionary = \"{first}\""
+    ));
+    let out = ws.ok(&["seal", "--from", "2", "--to", "2"]);
+    assert!(
+        out.contains(&format!("as per-block with dictionary {first}")),
+        "{out}"
+    );
+    ws.configure("");
+
+    // Restart: both dictionaries resolve and every segment is served.
+    assert_eq!(view(&ws.open()), expected);
+
+    // A file-level copy of the whole storage directory is a complete backup.
+    let backup = Workspace::new();
+    copy_dir(&ws.path().join("data"), &backup.path().join("data"));
+    assert_eq!(view(&backup.open()), expected);
+    let report = backup.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    let ids: Vec<&str> = report["dictionaries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["id"].as_str().unwrap())
+        .collect();
+    let mut expected_ids = vec![first.as_str(), second.as_str()];
+    expected_ids.sort();
+    assert_eq!(ids, expected_ids);
+    assert!(report["dictionaries"][0]["manifest"].is_object());
+
+    // Without its dictionary a segment cannot be opened, and inspect says which.
+    fs::remove_file(
+        ws.archive_dir()
+            .join(DICTIONARIES_DIR)
+            .join(format!("{second}.dict")),
+    )
+    .unwrap();
+    let config = dolos_core::config::FjallArchiveConfig::default();
+    let err = ArchiveStore::open(StateSchema::default(), ws.archive_dir(), &config)
+        .err()
+        .expect("a segment without its dictionary refuses to open")
+        .to_string();
+    assert!(err.contains(&second), "{err}");
+    let report = ws.ok(&["inspect", "--json"]);
+    let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(report["segments"][1]["dictionary"], second);
+    assert!(report["segments"][1]["dictionary_status"]
+        .as_str()
+        .unwrap()
+        .starts_with("missing"));
+}
+
+fn copy_dir(from: &Path, to: &Path) {
+    fs::create_dir_all(to).unwrap();
+    for entry in fs::read_dir(from).unwrap() {
+        let entry = entry.unwrap();
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+#[test]
+fn the_reader_bounds_come_from_the_configuration() {
+    use dolos_core::config::{
+        ArchiveCompressionConfig, CompressionCacheConfig, FjallArchiveConfig,
+    };
+    use dolos_fjall::flatfiles::compressed::CacheLimits;
+
+    let ws = Workspace::new();
+    let config = FjallArchiveConfig {
+        cache: Some(16),
+        worker_threads: Some(1),
+        compression: Some(Box::new(ArchiveCompressionConfig {
+            cache: Some(CompressionCacheConfig {
+                frame_mb: Some(3),
+                handles: Some(2),
+                inflight_reads: Some(1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let store = ArchiveStore::open(StateSchema::default(), ws.archive_dir(), &config).unwrap();
+    let limits = store.compressed_cache_limits();
+    let defaults = CacheLimits::default();
+    assert_eq!(limits.frame_bytes, 3 << 20);
+    assert_eq!(limits.handles, 2);
+    assert_eq!(limits.inflight_reads, 1);
+    assert_eq!(limits.index_bytes, defaults.index_bytes);
+    assert_eq!(limits.dictionary_entries, defaults.dictionary_entries);
+    drop(store);
+
+    let invalid = FjallArchiveConfig {
+        compression: Some(Box::new(ArchiveCompressionConfig {
+            chunk_target: Some(0),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let err = ArchiveStore::open(StateSchema::default(), ws.archive_dir(), &invalid)
+        .err()
+        .expect("a zero chunk target fails the open")
+        .to_string();
+    assert!(err.contains("chunk_target"), "{err}");
+}

--- a/tests/archive_compression_cli.rs
+++ b/tests/archive_compression_cli.rs
@@ -540,10 +540,10 @@ fn failures_before_publication_leave_the_raw_segment_as_it_was() {
     untouched(&ws);
 
     // A configuration no command could act on fails at open.
-    ws.configure("[storage.archive.compression]\nprofile = \"per-block\"");
+    ws.configure("[storage.archive.block_compression]\nprofile = \"per-block\"");
     let err = ws.fails(&["seal", "--from", "0", "--to", "0"]);
     assert!(
-        err.contains("needs storage.archive.compression.dictionary"),
+        err.contains("needs storage.archive.block_compression.dictionary"),
         "{err}"
     );
     ws.configure("");
@@ -651,7 +651,7 @@ fn dictionaries_survive_restart_and_a_file_level_backup() {
 
     // The configuration can name the dictionary instead of the command line.
     ws.configure(&format!(
-        "[storage.archive.compression]\nprofile = \"per-block\"\ndictionary = \"{first}\""
+        "[storage.archive.block_compression]\nprofile = \"per-block\"\ndictionary = \"{first}\""
     ));
     let out = ws.ok(&["seal", "--from", "2", "--to", "2"]);
     assert!(
@@ -726,7 +726,7 @@ fn the_reader_bounds_come_from_the_configuration() {
     let config = FjallArchiveConfig {
         cache: Some(16),
         worker_threads: Some(1),
-        compression: Some(Box::new(ArchiveCompressionConfig {
+        block_compression: Some(Box::new(ArchiveCompressionConfig {
             cache: Some(CompressionCacheConfig {
                 frame_mb: Some(3),
                 handles: Some(2),
@@ -748,7 +748,7 @@ fn the_reader_bounds_come_from_the_configuration() {
     drop(store);
 
     let invalid = FjallArchiveConfig {
-        compression: Some(Box::new(ArchiveCompressionConfig {
+        block_compression: Some(Box::new(ArchiveCompressionConfig {
             chunk_target: Some(0),
             ..Default::default()
         })),


### PR DESCRIPTION
Batch 3 of balanced archive compression: `plans/dolos-archive-compression-sealing.md` in the txpipe Brain. Builds on #1308 (the codec) and #1309 (the mixed-store lifecycle). An operator can now train a dictionary, seal completed segments, inspect the segment directory and restore segments to raw through `dolos data archive-compression`, offline, with explicit profiles and dictionaries that are part of durable storage.

## What changes

**`dolos-flatfiles`**
- `lease.rs`: every store open takes an advisory lock on `.lease` in the segments directory — shared by default, exclusive when `FlatFileOptions::access` says the caller will rewrite segments — and holds it until the store is dropped, after every other handle. A shared open fails while an exclusive holder exists and an exclusive open fails while any holder exists, without waiting and naming the directory. The lease lives with the files, so two configurations pointing `blocks_path` at one directory contend on the same lease whatever index each opens; it is per open handle, so a second store in one process contends the same way. Documented in `LIFECYCLE.md`.
- `FlatFileStore::scan(dir)`: the files of every segment as they are on disk, without taking the lease, recovering, or opening a store — what `inspect` needs while a node may hold the directory. `cache_limits()` and `access()` report what the store was opened with. `Found` and `SegmentPaths` are exported for the same purpose.

**`dolos-core`**
- `storage.archive.compression`: `profile` (`per-block` | `chunked`), `dictionary` (64 hex digits of an installed dictionary's identity; naming one selects per-block), `chunk_target` (default 256 KiB) and a `cache` table bounding the compressed-segment reader (`frame_mb`/`frame_entries`, `index_mb`/`index_entries`, `dictionary_mb`/`dictionary_entries`, `handles`, `inflight_reads`) separately from the archive index cache. `ArchiveCompressionConfig::validate` rejects what no command could act on — per-block without a dictionary, a zero chunk target, a malformed identity. Omitted, the archive appends raw, reads whatever each segment is under the default bounds, and starts no background work. `is_default` accounts for it.

**`dolos-fjall`**
- `ArchiveStore::open` validates the compression table before anything is opened and passes the reader bounds through; `open_exclusive` opens the segments directory under the exclusive lease. `seal_segment_at(segment, boundaries, options)` seals at boundaries the caller walked; `segment_locations`, `read_location`, `segments_dir`, `compressed_cache_limits` are the tool entry points. `Error::Config` names a configuration failure.

**`dolos` — `dolos data archive-compression`**
- `train-dictionary --from --to [--samples --sample-budget-mb --seed --max-size]`: a reproducible sample (splitmix64 over the range's indexed blocks, bounded by the byte budget) trains a zstd dictionary, installed atomically under its SHA-256 identity by `DictionaryDir::install`, with a `<id>.json` manifest beside it recording network magic, range, population, sample count and bytes, budget, seed, max size and zstd version. Several generations stay installed side by side; nothing is ever replaced.
- `seal --from --to [--profile --dictionary --chunk-target --dry-run]`: opens the archive exclusively, resolves the profile from the command line over the configuration, loads the selected dictionary before any segment is touched — refusing one that is not installed, does not hash to its name, or whose manifest names another network — and refuses the tip segment and anything past it before work. Each raw segment is walked as the CBOR stream it is (`walk.rs`: every item is a body, including bodies the index no longer points at; a stream not ending on a whole item is refused; the index's locations are checked to be bodies of the stream), headroom for one staged segment is checked, and the batch 2 transition seals it at those boundaries — one segment at a time, verified before publication. Already compressed segments are skipped and reported with the profile they actually have; a new profile never recompresses them. `--dry-run` plans and mutates nothing.
- `inspect [--from --to] [--json]`: representation, profile, level, frames, dictionary and whether it is installed, logical and physical sizes per segment, totals, installed dictionaries with manifests, pending work an interruption left (what the next open will do with it), and whether another process holds the directory exclusively. It never opens a store, so nothing is recovered.
- `restore-raw --from --to [--dry-run]`: the same transition in the other direction, under the exclusive lease, headroom checked.
- `--json` on every command prints the same report as JSON.

**Docs**
- `docs/content/operations/archive-compression.mdx`: profiles and their tradeoffs (by reference to the research, without its tables or an EBS promise), configuration, a copy-pastable train / dry-run / seal / inspect / restore-raw runbook, headroom, interruption and recovery, dictionaries in file-level backups, and restoring to raw before an older binary — which knows neither the layout nor the lease.
- `docs/content/configuration/schema.mdx`: the `storage.archive.compression` table.

## Verification

- `tests/archive_compression_cli.rs` (6 tests, through the built binary the way an operator runs it): dry run then seal per-block with a trained dictionary and chunked with a 4 KiB target, served through the untouched index with an unreferenced body and a two-block slot included, a second run idempotent with sizes unchanged and actual profiles reported, `inspect` text and JSON, restore-raw byte-identical to the original streams; the tip segment refused; contention refused for a node holding the directory, a second maintenance holder (`inspect` says so), and a second configuration reaching the directory through `blocks_path`; no profile, per-block without a dictionary, a dictionary not installed or not an identity, one trained for another network, an unusable configuration and a partial CBOR tail all fail leaving the raw file as it was; interrupted seals before and after publication are settled before new work; two dictionaries survive a restart and a file-level copy of the storage directory, a missing one refuses the open and `inspect` names it; reader bounds come from the configuration and a zero chunk target fails the open.
- `crates/flatfiles/tests/lifecycle.rs`: the lease keeps maintenance and nodes apart, a scan describes the directory without recovering it; `crates/flatfiles/src/lease.rs` unit tests.
- `crates/core/src/config.rs`: compression config round trip (profiles, dictionary identity, cache limits), the dictionary-alone-selects-per-block rule, `is_default`, and every rejected value.
- `cargo +nightly-2026-08-27 fmt --check`, `cargo clippy --workspace --all-targets --all-features` (only the pre-existing `crates/snapshot/tests/publish.rs` doc warnings remain, untouched), `cargo build --workspace --all-targets --all-features`, and both `cargo test` commands from `AGENTS.md`: every test binary green, no failures (the CLI suite runs in about 14 s).

## Boundaries

- Offline only: no daemon task, periodic trainer or hot dictionary replacement — those are the automatic-sealing batch, which reuses these services inside the node.
- No storage-version bump: an older binary ignores `.lease` (it never parses as a segment file) and the docs say to restore every compressed segment to raw before running one; mixed-version concurrent access is not claimed.
- Scan batching, workload benchmarks and the supported-profile verdict stay with the scans batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV4fVUmNsGRcoUFgsAsTEu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archive compression with per-block and chunked profiles, configurable dictionaries, chunk sizes, and reader caches.
  * Added commands to train dictionaries, compress segments, inspect archive status, and restore raw segments.
  * Added dry-run and JSON output options.
  * Added shared and exclusive directory leases for node access and offline maintenance.
  * Added archive scanning and detailed compressed-segment inspection.
* **Documentation**
  * Added configuration guidance and an archive-compression operations runbook.
* **Bug Fixes**
  * Added validation and clear errors for invalid compression, dictionary, and storage configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->