### PR TITLE
feat(minibf): add `/addresses/{address}/extended` endpoint

### DIFF
--- a/crates/cardano/src/cip68.rs
+++ b/crates/cardano/src/cip68.rs
@@ -429,7 +429,8 @@ mod tests {
 
     #[test]
     fn rejects_metadata_missing_a_required_property() {
-        // fungible properties and no image: this datum does not meet a non-fungible standard
+        // fungible properties and no image: this datum does not meet a non-fungible
+        // standard
         let value = metadata(&[
             ("name", JsonValue::String("token".into())),
             ("description", JsonValue::String("a token".into())),

--- a/crates/cardano/src/cip68.rs
+++ b/crates/cardano/src/cip68.rs
@@ -316,11 +316,25 @@ fn map_schema_lookup(schema: &'static [ItemProperty], key: &str) -> Option<Prope
         .map(|property| property.scheme)
 }
 
+/// Converts a single bounded-bytes value to a string. CIP-68 defines a
+/// bytestring property, such as `mediaType`, as a single value. This
+/// converter does not accept an array.
 fn convert_bytestring_value(value: &PlutusData) -> Option<JsonValue> {
     match value {
         PlutusData::BoundedBytes(bytes) => {
             Some(JsonValue::String(to_utf8_or_hex(bytes.as_slice())))
         }
+        _ => None,
+    }
+}
+
+/// Converts a bounded-bytes value, or an array of bounded-bytes parts, to a
+/// single string. CIP-68 defines the `src` property as a uri. Version 3
+/// splits a uri of more than 64 bytes into an array of parts. This converter
+/// joins the parts into one string.
+fn convert_split_bytestring_value(value: &PlutusData) -> Option<JsonValue> {
+    match value {
+        PlutusData::BoundedBytes(_) => convert_bytestring_value(value),
         PlutusData::Array(items) => {
             let mut buffer = Vec::new();
             for item in items.iter() {
@@ -371,10 +385,11 @@ fn convert_map_value(value: &PlutusData, schema: &'static [ItemProperty]) -> Opt
 
 fn convert_datum_value(value: &PlutusData, schema: PropertyScheme) -> Option<JsonValue> {
     match schema.kind {
-        // the bytestring converter joins an array of byte parts into one
-        // string. a version 3 `src` uses this form for a payload of more than
-        // 64 bytes, so this converter gives a single string for it.
-        PropertyKind::Bytestring | PropertyKind::StringOrArray => convert_bytestring_value(value),
+        PropertyKind::Bytestring => convert_bytestring_value(value),
+        // a bytestring, or a split bytestring. a version 3 `src` uses the
+        // split form for a payload of more than 64 bytes. the converter joins
+        // the parts into one string.
+        PropertyKind::StringOrArray => convert_split_bytestring_value(value),
         PropertyKind::Number => convert_number_value(value),
         PropertyKind::Array => {
             let PlutusData::Array(items) = value else {
@@ -470,6 +485,18 @@ mod tests {
             .iter()
             .map(|(key, value)| (key.to_string(), value.clone()))
             .collect()
+    }
+
+    fn bytes(value: &str) -> PlutusData {
+        PlutusData::BoundedBytes(value.as_bytes().to_vec().into())
+    }
+
+    fn array(items: Vec<PlutusData>) -> PlutusData {
+        PlutusData::Array(pallas::ledger::primitives::MaybeIndefArray::Def(items))
+    }
+
+    fn plutus_map(pairs: Vec<(PlutusData, PlutusData)>) -> PlutusData {
+        PlutusData::Map(pairs.into())
     }
 
     #[test]
@@ -597,6 +624,54 @@ mod tests {
         let not_object = nft_with_files(json!(["not-an-object"]));
         assert!(!cip68_metadata_is_valid(
             &not_object,
+            Cip68TokenStandard::Nft
+        ));
+    }
+
+    /// Builds a files item as a Plutus map, and returns the parsed metadata of
+    /// an NFT datum that holds it. The datum also has `name` and `image`, so
+    /// only the files item decides the result.
+    fn parse_nft_with_files_item(
+        item: Vec<(PlutusData, PlutusData)>,
+    ) -> HashMap<String, JsonValue> {
+        let map = vec![
+            (bytes("name"), bytes("token")),
+            (bytes("image"), bytes("ipfs://x")),
+            (bytes("files"), array(vec![plutus_map(item)])),
+        ];
+        parse_cip68_metadata_map(&map, Cip68TokenStandard::Nft).expect("parses")
+    }
+
+    #[test]
+    fn parses_a_split_src_but_not_a_split_media_type() {
+        // `src` is a uri. a version 3 datum splits a long uri into parts. the
+        // parser joins the parts, and the datum meets the scheme.
+        let split_src = parse_nft_with_files_item(vec![
+            (bytes("mediaType"), bytes("image/png")),
+            (
+                bytes("src"),
+                array(vec![bytes("ipfs://part-one"), bytes("-two")]),
+            ),
+        ]);
+        assert_eq!(
+            split_src.get("files"),
+            Some(&json!([{ "mediaType": "image/png", "src": "ipfs://part-one-two" }]))
+        );
+        assert!(cip68_metadata_is_valid(&split_src, Cip68TokenStandard::Nft));
+
+        // `mediaType` is a bounded-bytes value, not a uri. the parser does
+        // not accept an array for it, so it keeps the whole files value in its
+        // hex form. the hex string is not an array, so the datum does not meet
+        // the scheme, and the caller uses the CIP-25 metadata instead.
+        let split_media_type = parse_nft_with_files_item(vec![
+            (
+                bytes("mediaType"),
+                array(vec![bytes("image/"), bytes("png")]),
+            ),
+            (bytes("src"), bytes("ipfs://y")),
+        ]);
+        assert!(!cip68_metadata_is_valid(
+            &split_media_type,
             Cip68TokenStandard::Nft
         ));
     }

--- a/crates/cardano/src/cip68.rs
+++ b/crates/cardano/src/cip68.rs
@@ -79,12 +79,24 @@ pub enum PropertyKind {
     Bytestring,
     Number,
     Array,
+    /// A string, or an array of strings. The `src` property of a files item
+    /// uses this kind. The parser gives a single string for both forms. The
+    /// validator accepts both forms.
+    StringOrArray,
+}
+
+/// One key in a files item, its scheme, and whether the item must have it.
+#[derive(Debug, Clone, Copy)]
+pub struct ItemProperty {
+    pub key: &'static str,
+    pub scheme: PropertyScheme,
+    pub required: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct PropertyScheme {
     pub kind: PropertyKind,
-    pub items: Option<&'static [(&'static str, PropertyScheme)]>,
+    pub items: Option<&'static [ItemProperty]>,
 }
 
 const fn bytestring_scheme() -> PropertyScheme {
@@ -101,17 +113,35 @@ const fn number_scheme() -> PropertyScheme {
     }
 }
 
-const fn array_scheme(items: &'static [(&'static str, PropertyScheme)]) -> PropertyScheme {
+const fn string_or_array_scheme() -> PropertyScheme {
+    PropertyScheme {
+        kind: PropertyKind::StringOrArray,
+        items: None,
+    }
+}
+
+const fn array_scheme(items: &'static [ItemProperty]) -> PropertyScheme {
     PropertyScheme {
         kind: PropertyKind::Array,
         items: Some(items),
     }
 }
 
-const FILES_ITEM_SCHEMA: &[(&str, PropertyScheme)] = &[
-    ("name", bytestring_scheme()),
-    ("mediaType", bytestring_scheme()),
-    ("src", bytestring_scheme()),
+const fn item(key: &'static str, scheme: PropertyScheme, required: bool) -> ItemProperty {
+    ItemProperty {
+        key,
+        scheme,
+        required,
+    }
+}
+
+// A files item must have `mediaType` and `src`. The `name` property is
+// optional. The `src` property is a string, or an array of strings. Other
+// properties are permitted.
+const FILES_ITEM_SCHEMA: &[ItemProperty] = &[
+    item("name", bytestring_scheme(), false),
+    item("mediaType", bytestring_scheme(), true),
+    item("src", string_or_array_scheme(), true),
 ];
 
 pub fn property_scheme_for_key(standard: Cip68TokenStandard, key: &str) -> Option<PropertyScheme> {
@@ -155,12 +185,41 @@ fn required_properties(standard: Cip68TokenStandard) -> &'static [&'static str] 
     }
 }
 
-fn value_matches_kind(value: &JsonValue, kind: PropertyKind) -> bool {
-    match kind {
+fn value_matches_kind(value: &JsonValue, scheme: PropertyScheme) -> bool {
+    match scheme.kind {
         PropertyKind::Bytestring => value.is_string(),
         PropertyKind::Number => value.is_number(),
-        PropertyKind::Array => value.is_array(),
+        PropertyKind::StringOrArray => {
+            value.is_string()
+                || value
+                    .as_array()
+                    .is_some_and(|items| items.iter().all(JsonValue::is_string))
+        }
+        PropertyKind::Array => match (value.as_array(), scheme.items) {
+            (Some(items), Some(item_schema)) => items
+                .iter()
+                .all(|item| item_matches_schema(item, item_schema)),
+            (Some(_), None) => true,
+            (None, _) => false,
+        },
     }
+}
+
+/// Whether one item of an array property meets its scheme. The item must be an
+/// object. It must have every required key with a value of the correct kind.
+/// A key that the scheme declares as optional must also have the correct kind
+/// when it is present. Other keys are permitted.
+fn item_matches_schema(item: &JsonValue, schema: &'static [ItemProperty]) -> bool {
+    let Some(object) = item.as_object() else {
+        return false;
+    };
+
+    schema
+        .iter()
+        .all(|property| match object.get(property.key) {
+            Some(value) => value_matches_kind(value, property.scheme),
+            None => !property.required,
+        })
 }
 
 /// Whether a parsed datum meets the scheme of its standard. The datum must
@@ -180,7 +239,7 @@ pub fn cip68_metadata_is_valid(
 
     metadata.iter().all(
         |(key, value)| match property_scheme_for_key(standard, key) {
-            Some(scheme) => value_matches_kind(value, scheme.kind),
+            Some(scheme) => value_matches_kind(value, scheme),
             None => true,
         },
     )
@@ -250,14 +309,11 @@ fn to_utf8_or_hex(bytes: &[u8]) -> String {
     }
 }
 
-fn map_schema_lookup(
-    schema: &'static [(&'static str, PropertyScheme)],
-    key: &str,
-) -> Option<PropertyScheme> {
+fn map_schema_lookup(schema: &'static [ItemProperty], key: &str) -> Option<PropertyScheme> {
     schema
         .iter()
-        .find(|(name, _)| *name == key)
-        .map(|(_, scheme)| *scheme)
+        .find(|property| property.key == key)
+        .map(|property| property.scheme)
 }
 
 fn convert_bytestring_value(value: &PlutusData) -> Option<JsonValue> {
@@ -289,10 +345,7 @@ fn convert_number_value(value: &PlutusData) -> Option<JsonValue> {
     }
 }
 
-fn convert_map_value(
-    value: &PlutusData,
-    schema: &'static [(&'static str, PropertyScheme)],
-) -> Option<JsonValue> {
+fn convert_map_value(value: &PlutusData, schema: &'static [ItemProperty]) -> Option<JsonValue> {
     let PlutusData::Map(map) = value else {
         return None;
     };
@@ -304,8 +357,12 @@ fn convert_map_value(
             PlutusData::BigInt(BigInt::Int(int)) => int.deref().to_string(),
             _ => return None,
         };
-        let value_schema = map_schema_lookup(schema, &key_str)?;
-        let converted = convert_datum_value(value, value_schema)?;
+        // the scheme permits other properties. a key that the scheme does not
+        // declare keeps its hex form.
+        let converted = match map_schema_lookup(schema, &key_str) {
+            Some(value_schema) => convert_datum_value(value, value_schema)?,
+            None => JsonValue::String(encode_to_hex(value).ok()?),
+        };
         object.insert(key_str, converted);
     }
 
@@ -314,7 +371,10 @@ fn convert_map_value(
 
 fn convert_datum_value(value: &PlutusData, schema: PropertyScheme) -> Option<JsonValue> {
     match schema.kind {
-        PropertyKind::Bytestring => convert_bytestring_value(value),
+        // the bytestring converter joins an array of byte parts into one
+        // string. a version 3 `src` uses this form for a payload of more than
+        // 64 bytes, so this converter gives a single string for it.
+        PropertyKind::Bytestring | PropertyKind::StringOrArray => convert_bytestring_value(value),
         PropertyKind::Number => convert_number_value(value),
         PropertyKind::Array => {
             let PlutusData::Array(items) = value else {
@@ -369,6 +429,7 @@ pub fn parse_cip67_label_from_asset_name(asset_name: &[u8]) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn label_hex(number: u32) -> String {
         let number_hex = format!("{:04x}", number);
@@ -461,6 +522,83 @@ mod tests {
         ]);
 
         assert!(cip68_metadata_is_valid(&value, Cip68TokenStandard::Nft));
+    }
+
+    fn nft_with_files(files: JsonValue) -> HashMap<String, JsonValue> {
+        metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("image", JsonValue::String("ipfs://x".into())),
+            ("files", files),
+        ])
+    }
+
+    #[test]
+    fn rejects_files_item_without_the_required_keys() {
+        // an empty files item has no `mediaType` and no `src`. the scheme
+        // requires both, so this datum does not meet the scheme.
+        let empty = nft_with_files(json!([{}]));
+        assert!(!cip68_metadata_is_valid(&empty, Cip68TokenStandard::Nft));
+
+        // a files item that has no `src`.
+        let no_src = nft_with_files(json!([{ "mediaType": "image/png" }]));
+        assert!(!cip68_metadata_is_valid(&no_src, Cip68TokenStandard::Nft));
+
+        // a files item that has no `mediaType`.
+        let no_media_type = nft_with_files(json!([{ "src": "ipfs://y" }]));
+        assert!(!cip68_metadata_is_valid(
+            &no_media_type,
+            Cip68TokenStandard::Nft
+        ));
+    }
+
+    #[test]
+    fn accepts_a_files_item_that_meets_the_scheme() {
+        // `name` is optional. `src` is a string.
+        let string_src = nft_with_files(json!([{
+            "mediaType": "image/png",
+            "src": "ipfs://y",
+        }]));
+        assert!(cip68_metadata_is_valid(
+            &string_src,
+            Cip68TokenStandard::Nft
+        ));
+
+        // `src` is an array of strings. a version 3 payload uses this form.
+        let array_src = nft_with_files(json!([{
+            "mediaType": "image/png",
+            "src": ["ipfs://part-one", "part-two"],
+        }]));
+        assert!(cip68_metadata_is_valid(&array_src, Cip68TokenStandard::Nft));
+
+        // the scheme permits other keys in a files item.
+        let extra_key = nft_with_files(json!([{
+            "mediaType": "image/png",
+            "src": "ipfs://y",
+            "name": "picture",
+            "note": "extra",
+        }]));
+        assert!(cip68_metadata_is_valid(&extra_key, Cip68TokenStandard::Nft));
+    }
+
+    #[test]
+    fn rejects_files_item_of_the_wrong_kind() {
+        // `src` must be a string, or an array of strings. a number does not
+        // meet the scheme.
+        let number_src = nft_with_files(json!([{
+            "mediaType": "image/png",
+            "src": 7,
+        }]));
+        assert!(!cip68_metadata_is_valid(
+            &number_src,
+            Cip68TokenStandard::Nft
+        ));
+
+        // a files item that is not an object.
+        let not_object = nft_with_files(json!(["not-an-object"]));
+        assert!(!cip68_metadata_is_valid(
+            &not_object,
+            Cip68TokenStandard::Nft
+        ));
     }
 
     #[test]

--- a/crates/cardano/src/cip68.rs
+++ b/crates/cardano/src/cip68.rs
@@ -145,6 +145,47 @@ pub fn property_scheme_for_key(standard: Cip68TokenStandard, key: &str) -> Optio
     }
 }
 
+/// These are the properties that a standard requires. A datum that does not
+/// have all of them describes no asset. As a result, it has no metadata.
+fn required_properties(standard: Cip68TokenStandard) -> &'static [&'static str] {
+    match standard {
+        // the 222 standard and the 444 standard both show the asset
+        Cip68TokenStandard::Nft | Cip68TokenStandard::Rft => &["name", "image"],
+        Cip68TokenStandard::Ft => &["name", "description"],
+    }
+}
+
+fn value_matches_kind(value: &JsonValue, kind: PropertyKind) -> bool {
+    match kind {
+        PropertyKind::Bytestring => value.is_string(),
+        PropertyKind::Number => value.is_number(),
+        PropertyKind::Array => value.is_array(),
+    }
+}
+
+/// Whether a parsed datum meets the scheme of its standard. The datum must
+/// have every required property. Each property that the scheme declares must
+/// have the kind of value that the scheme gives it. A property that the
+/// scheme does not declare can have any value.
+pub fn cip68_metadata_is_valid(
+    metadata: &HashMap<String, JsonValue>,
+    standard: Cip68TokenStandard,
+) -> bool {
+    if !required_properties(standard)
+        .iter()
+        .all(|key| metadata.contains_key(*key))
+    {
+        return false;
+    }
+
+    metadata.iter().all(
+        |(key, value)| match property_scheme_for_key(standard, key) {
+            Some(scheme) => value_matches_kind(value, scheme.kind),
+            None => true,
+        },
+    )
+}
+
 pub fn cip_68_reference_asset(
     policy_id: &str,
     asset_name: &str,
@@ -361,6 +402,64 @@ mod tests {
         let hex = label_hex(222);
         let bytes = hex::decode(hex).expect("valid hex");
         assert_eq!(parse_cip67_label_from_asset_name(&bytes), Some(222));
+    }
+
+    fn metadata(pairs: &[(&str, JsonValue)]) -> HashMap<String, JsonValue> {
+        pairs
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn accepts_metadata_that_meets_the_scheme() {
+        let nft = metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("image", JsonValue::String("ipfs://x".into())),
+        ]);
+        assert!(cip68_metadata_is_valid(&nft, Cip68TokenStandard::Nft));
+
+        let ft = metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("description", JsonValue::String("a token".into())),
+            ("decimals", JsonValue::Number(6.into())),
+        ]);
+        assert!(cip68_metadata_is_valid(&ft, Cip68TokenStandard::Ft));
+    }
+
+    #[test]
+    fn rejects_metadata_missing_a_required_property() {
+        // fungible properties and no image: this datum does not meet a non-fungible standard
+        let value = metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("description", JsonValue::String("a token".into())),
+        ]);
+
+        assert!(!cip68_metadata_is_valid(&value, Cip68TokenStandard::Nft));
+        assert!(!cip68_metadata_is_valid(&value, Cip68TokenStandard::Rft));
+        assert!(cip68_metadata_is_valid(&value, Cip68TokenStandard::Ft));
+    }
+
+    #[test]
+    fn rejects_declared_property_of_the_wrong_kind() {
+        let value = metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("description", JsonValue::String("a token".into())),
+            ("decimals", JsonValue::String("02".into())),
+        ]);
+
+        assert!(!cip68_metadata_is_valid(&value, Cip68TokenStandard::Ft));
+    }
+
+    #[test]
+    fn ignores_properties_the_scheme_does_not_declare() {
+        let value = metadata(&[
+            ("name", JsonValue::String("token".into())),
+            ("image", JsonValue::String("ipfs://x".into())),
+            ("decimals", JsonValue::String("02".into())),
+        ]);
+
+        assert!(cip68_metadata_is_valid(&value, Cip68TokenStandard::Nft));
     }
 
     #[test]

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -424,6 +424,10 @@ where
             get(routes::addresses::by_address::<D>),
         )
         .route(
+            "/addresses/{address}/extended",
+            get(routes::addresses::extended::<D>),
+        )
+        .route(
             "/addresses/{address}/utxos",
             get(routes::addresses::utxos::<D>),
         )

--- a/crates/minibf/src/mapping.rs
+++ b/crates/minibf/src/mapping.rs
@@ -30,6 +30,8 @@ use std::{
 
 use blockfrost_openapi::models::{
     address_content::{AddressContent, Type as AddressType},
+    address_content_extended::{AddressContentExtended, Type as AddressExtendedType},
+    address_content_extended_amount_inner::AddressContentExtendedAmountInner,
     address_utxo_content_inner::AddressUtxoContentInner,
     block_content::BlockContent,
     block_content_addresses_inner::BlockContentAddressesInner,
@@ -412,6 +414,26 @@ pub enum AddressKind {
     Byron,
 }
 
+impl AddressKind {
+    /// Every address model shares these three response fields:
+    /// - the stake address that controls the key
+    /// - whether the address is from the Byron era
+    /// - whether the payment part is a script
+    ///
+    /// A bare payment credential has no stake part. As a result, it reports no
+    /// stake address.
+    fn parts(self) -> (Option<String>, bool, bool) {
+        match self {
+            AddressKind::Payment { script } => (None, false, script),
+            AddressKind::Shelley {
+                stake_address,
+                script,
+            } => (stake_address, false, script),
+            AddressKind::Byron => (None, true, false),
+        }
+    }
+}
+
 pub struct AddressModelBuilder {
     pub address: String,
     pub amount: Vec<TxContentOutputAmountInner>,
@@ -422,20 +444,43 @@ impl IntoModel<AddressContent> for AddressModelBuilder {
     type SortKey = ();
 
     fn into_model(self) -> Result<AddressContent, StatusCode> {
-        let (stake_address, r#type, script) = match self.kind {
-            AddressKind::Payment { script } => (None, AddressType::Shelley, script),
-            AddressKind::Shelley {
-                stake_address,
-                script,
-            } => (stake_address, AddressType::Shelley, script),
-            AddressKind::Byron => (None, AddressType::Byron, false),
-        };
+        let (stake_address, byron, script) = self.kind.parts();
 
         Ok(AddressContent {
             address: self.address,
             amount: self.amount,
             stake_address,
-            r#type,
+            r#type: if byron {
+                AddressType::Byron
+            } else {
+                AddressType::Shelley
+            },
+            script,
+        })
+    }
+}
+
+pub struct AddressExtendedModelBuilder {
+    pub address: String,
+    pub amount: Vec<AddressContentExtendedAmountInner>,
+    pub kind: AddressKind,
+}
+
+impl IntoModel<AddressContentExtended> for AddressExtendedModelBuilder {
+    type SortKey = ();
+
+    fn into_model(self) -> Result<AddressContentExtended, StatusCode> {
+        let (stake_address, byron, script) = self.kind.parts();
+
+        Ok(AddressContentExtended {
+            address: self.address,
+            amount: self.amount,
+            stake_address,
+            r#type: if byron {
+                AddressExtendedType::Byron
+            } else {
+                AddressExtendedType::Shelley
+            },
             script,
         })
     }

--- a/crates/minibf/src/routes/addresses.rs
+++ b/crates/minibf/src/routes/addresses.rs
@@ -6,12 +6,14 @@ use axum::{
     Json,
 };
 use blockfrost_openapi::models::{
-    address_content::AddressContent, address_content_total::AddressContentTotal,
+    address_content::AddressContent, address_content_extended::AddressContentExtended,
+    address_content_extended_amount_inner::AddressContentExtendedAmountInner,
+    address_content_total::AddressContentTotal,
     address_transactions_content_inner::AddressTransactionsContentInner,
     address_utxo_content_inner::AddressUtxoContentInner,
     tx_content_output_amount_inner::TxContentOutputAmountInner,
 };
-use futures_util::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt, TryStreamExt};
 use itertools::Either;
 use pallas::ledger::{
     addresses::{Address, ShelleyPaymentPart, StakePayload},
@@ -20,6 +22,7 @@ use pallas::ledger::{
 
 use dolos_cardano::{
     indexes::{AsyncCardanoQueryExt, CardanoStateIndexExt, SlotOrder},
+    model::AssetState,
     pallas_extras, ChainSummary,
 };
 use dolos_core::{BlockBody, BlockSlot, Domain, StateStore as _, TxoRef};
@@ -27,10 +30,15 @@ use dolos_core::{BlockBody, BlockSlot, Domain, StateStore as _, TxoRef};
 use crate::{
     error::Error,
     inputs::{tx_touches_output, InputDeps, InputResolver},
-    mapping::{aggregate_assets, AddressKind, AddressModelBuilder, AssetTotals, IntoModel},
+    mapping::{
+        aggregate_assets, AddressExtendedModelBuilder, AddressKind, AddressModelBuilder,
+        AssetTotals, IntoModel,
+    },
     pagination::{Order, Pagination, PaginationParameters},
     Facade,
 };
+
+use super::assets::AssetAmountExtras;
 
 impl From<Order> for SlotOrder {
     fn from(order: Order) -> Self {
@@ -239,6 +247,60 @@ where
     let amount = amount_for_refs(&domain, refs)?;
 
     let model = AddressModelBuilder {
+        address,
+        amount,
+        kind: parsed.into_model_kind(),
+    }
+    .into_model()
+    .map_err(Error::Code)?;
+
+    Ok(Json(model))
+}
+
+/// This constant sets how many units of an address resolve their metadata at
+/// the same time. Each unit needs one request to the off-chain registry. One
+/// request at a time is slow for an address that holds many tokens.
+const EXTENDED_ASSET_CONCURRENCY: usize = 16;
+
+pub async fn extended<D>(
+    Path(address): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<AddressContentExtended>, Error>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+    Option<AssetState>: From<D::Entity>,
+{
+    let parsed = parse_address(&address)?;
+    let refs = refs_for_parsed_address(&domain, &parsed)?;
+
+    if refs.is_empty() && !is_address_in_chain(&domain, &address).await? {
+        return Err(StatusCode::NOT_FOUND.into());
+    }
+
+    let amount = futures_util::stream::iter(amount_for_refs(&domain, refs)?)
+        .map(|entry| {
+            let domain = &domain;
+
+            async move {
+                let extras = if entry.unit == "lovelace" {
+                    AssetAmountExtras::lovelace()
+                } else {
+                    AssetAmountExtras::resolve(domain, &entry.unit).await?
+                };
+
+                Ok::<_, Error>(AddressContentExtendedAmountInner {
+                    unit: entry.unit,
+                    quantity: entry.quantity,
+                    decimals: extras.decimals,
+                    has_nft_onchain_metadata: extras.has_nft_onchain_metadata,
+                })
+            }
+        })
+        .buffered(EXTENDED_ASSET_CONCURRENCY)
+        .try_collect()
+        .await?;
+
+    let model = AddressExtendedModelBuilder {
         address,
         amount,
         kind: parsed.into_model_kind(),
@@ -677,6 +739,7 @@ mod tests {
     use crate::test_support::{TestApp, TestFault};
     use blockfrost_openapi::models::{
         address_content::{AddressContent, Type as AddressType},
+        address_content_extended::Type as AddressExtendedType,
         address_transactions_content_inner::AddressTransactionsContentInner,
         address_utxo_content_inner::AddressUtxoContentInner,
     };
@@ -779,6 +842,130 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
         let address = app.vectors().address.as_str();
         let path = format!("/addresses/{address}");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_happy_path() {
+        let app = TestApp::new();
+        let address = app.vectors().address.as_str();
+        let path = format!("/addresses/{address}/extended");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AddressContentExtended =
+            serde_json::from_slice(&bytes).expect("failed to parse extended address content");
+
+        assert_eq!(item.address, address);
+        assert_eq!(item.r#type, AddressExtendedType::Shelley);
+        assert!(item.stake_address.is_some());
+        assert!(!item.script);
+
+        let lovelace = item.amount.first().expect("expected a lovelace entry");
+        assert_eq!(lovelace.unit, "lovelace");
+        assert_eq!(lovelace.decimals, Some(6));
+        assert!(!lovelace.has_nft_onchain_metadata);
+
+        // the test mints the synthetic asset with no metadata of any standard
+        let asset = item
+            .amount
+            .iter()
+            .find(|x| x.unit == app.vectors().asset_unit)
+            .expect("expected the synthetic asset");
+        assert_eq!(asset.decimals, None);
+        assert!(!asset.has_nft_onchain_metadata);
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_matches_plain_amounts() {
+        let app = TestApp::new();
+        let address = app.vectors().address.as_str();
+
+        let (_, plain) = app.get_bytes(&format!("/addresses/{address}")).await;
+        let (_, extended) = app
+            .get_bytes(&format!("/addresses/{address}/extended"))
+            .await;
+
+        let plain: AddressContent =
+            serde_json::from_slice(&plain).expect("failed to parse address");
+        let extended: AddressContentExtended =
+            serde_json::from_slice(&extended).expect("failed to parse extended address");
+
+        let plain: Vec<_> = plain
+            .amount
+            .iter()
+            .map(|x| (&x.unit, &x.quantity))
+            .collect();
+        let extended: Vec<_> = extended
+            .amount
+            .iter()
+            .map(|x| (&x.unit, &x.quantity))
+            .collect();
+
+        assert_eq!(plain, extended);
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_payment_credential_happy_path() {
+        let app = TestApp::new();
+        let address = Address::from_bech32(app.vectors().address.as_str())
+            .expect("invalid synthetic test address");
+
+        let Address::Shelley(shelley) = address else {
+            panic!("expected shelley test address")
+        };
+
+        let payment_cred = bech32::encode::<bech32::Bech32>(
+            bech32::Hrp::parse("addr_vkh").expect("invalid hrp"),
+            &shelley.payment().to_vec(),
+        )
+        .expect("failed to encode payment credential");
+
+        let path = format!("/addresses/{payment_cred}/extended");
+        let (status, bytes) = app.get_bytes(&path).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let item: AddressContentExtended =
+            serde_json::from_slice(&bytes).expect("failed to parse extended address content");
+
+        assert_eq!(item.address, payment_cred);
+        assert_eq!(item.r#type, AddressExtendedType::Shelley);
+        assert_eq!(item.stake_address, None);
+        assert!(!item.script);
+        assert!(!item.amount.is_empty());
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_bad_request() {
+        let app = TestApp::new();
+        let path = format!("/addresses/{}/extended", invalid_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_not_found() {
+        let app = TestApp::new();
+        let path = format!("/addresses/{}/extended", missing_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn addresses_extended_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let address = app.vectors().address.as_str();
+        let path = format!("/addresses/{address}/extended");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -621,13 +621,19 @@ impl AssetAmountExtras {
         };
 
         let onchain = builder.onchain_metadata(domain).await?;
-        let registry = builder.offchain_metadata(unit).await?;
+
+        // the registry request reaches an external service. the on-chain datum
+        // already declares the decimal places of every CIP-68 fungible asset,
+        // so a known value makes the request unnecessary
+        let onchain_decimals = onchain.as_ref().and_then(OnchainMetadata::decimals);
+        let registry = if onchain_decimals.is_some() {
+            None
+        } else {
+            builder.offchain_metadata(unit).await?
+        };
 
         Ok(Self {
-            decimals: onchain
-                .as_ref()
-                .and_then(OnchainMetadata::decimals)
-                .or_else(|| registry.and_then(|metadata| metadata.decimals)),
+            decimals: onchain_decimals.or_else(|| registry.and_then(|metadata| metadata.decimals)),
             has_nft_onchain_metadata: onchain.is_some_and(|x| x.is_present()),
         })
     }

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -355,20 +355,21 @@ where
 /// The HTTP client that every token-registry request shares. `reqwest::Client`
 /// holds an internal connection pool, so one instance reuses DNS and TLS across
 /// the many concurrent lookups that `/addresses/{address}/extended` starts.
-fn token_registry_client() -> Result<&'static reqwest::Client, StatusCode> {
+///
+/// `get_or_init` builds the client one time. Two concurrent calls do not
+/// build two clients. The builder fails only when the TLS backend does not
+/// start. In that case, this function uses the default client. As a result,
+/// the caller gets a client and does not handle a `Result`.
+fn token_registry_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
-    if let Some(client) = CLIENT.get() {
-        return Ok(client);
-    }
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .user_agent("Dolos MiniBF")
-        .build()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    Ok(CLIENT.get_or_init(|| client))
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("Dolos MiniBF")
+            .build()
+            .unwrap_or_default()
+    })
 }
 
 struct AssetModelBuilder {
@@ -457,20 +458,20 @@ impl AssetModelBuilder {
 
         let url = format!("{url}/metadata/{asset}");
 
-        let res = token_registry_client()?
-            .get(&url)
-            .send()
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        // The off-chain metadata adds to the response. It is not necessary.
+        // If the token registry does not answer, or sends data that does not
+        // parse, the code reports no metadata. The request does not fail.
+        let Ok(res) = token_registry_client().get(&url).send().await else {
+            return Ok(None);
+        };
 
         if res.status() != StatusCode::OK {
             return Ok(None);
         }
 
-        let metadata: TokenRegistryMetadata = res
-            .json()
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let Ok(metadata) = res.json::<TokenRegistryMetadata>().await else {
+            return Ok(None);
+        };
 
         if metadata.name.is_none() || metadata.description.is_none() {
             return Ok(None);

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -352,6 +352,11 @@ where
     Ok(last_metadata)
 }
 
+/// The time limit for one token-registry request. The client applies this
+/// limit. Each request also applies it, so the limit holds even if the client
+/// falls back to the default and loses its own limit.
+const TOKEN_REGISTRY_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// The HTTP client that every token-registry request shares. `reqwest::Client`
 /// holds an internal connection pool, so one instance reuses DNS and TLS across
 /// the many concurrent lookups that `/addresses/{address}/extended` starts.
@@ -359,13 +364,15 @@ where
 /// `get_or_init` builds the client one time. Two concurrent calls do not
 /// build two clients. The builder fails only when the TLS backend does not
 /// start. In that case, this function uses the default client. As a result,
-/// the caller gets a client and does not handle a `Result`.
+/// the caller gets a client and does not handle a `Result`. The default
+/// client has no time limit, so each request applies `TOKEN_REGISTRY_TIMEOUT`
+/// on its own.
 fn token_registry_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
+            .timeout(TOKEN_REGISTRY_TIMEOUT)
             .user_agent("Dolos MiniBF")
             .build()
             .unwrap_or_default()
@@ -461,7 +468,12 @@ impl AssetModelBuilder {
         // The off-chain metadata adds to the response. It is not necessary.
         // If the token registry does not answer, or sends data that does not
         // parse, the code reports no metadata. The request does not fail.
-        let Ok(res) = token_registry_client().get(&url).send().await else {
+        let Ok(res) = token_registry_client()
+            .get(&url)
+            .timeout(TOKEN_REGISTRY_TIMEOUT)
+            .send()
+            .await
+        else {
             return Ok(None);
         };
 

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -342,10 +342,18 @@ where
             continue;
         }
 
+        // the last matching output that has a datum wins. one transaction can
+        // hold the reference token in more than one output. only the output
+        // that locks the token has a datum. an output that has no datum makes
+        // no claim about the metadata. as a result, it does not replace an
+        // earlier datum.
+        //
+        // a datum has an unknown version, or it does not meet the scheme of its
+        // label. in these cases the datum describes nothing, this code returns
+        // `None`, and it replaces any earlier CIP-68 metadata. the caller then
+        // uses the CIP-25 metadata of the minting transaction.
         if let Some(datum_option) = output.datum() {
-            if let Some(out) = metadata_from_datum_option(domain, &datum_option, standard).await? {
-                last_metadata = Some(out);
-            }
+            last_metadata = metadata_from_datum_option(domain, &datum_option, standard).await?;
         }
     }
 

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -16,7 +16,10 @@ use blockfrost_openapi::models::{
 };
 use dolos_cardano::{
     cip25::{cip25_metadata_is_valid, Cip25MetadataVersion},
-    cip68::{cip_68_reference_asset, encode_to_hex, parse_cip68_metadata_map, Cip68TokenStandard},
+    cip68::{
+        cip68_metadata_is_valid, cip_68_reference_asset, encode_to_hex, parse_cip68_metadata_map,
+        Cip68TokenStandard,
+    },
     indexes::{AsyncCardanoQueryExt, CardanoStateIndexExt, SlotOrder},
     model::AssetState,
     ChainSummary,
@@ -50,6 +53,9 @@ struct OnchainMetadata {
     version: Option<OnchainMetadataStandard>,
     metadata: HashMap<String, serde_json::Value>,
     extra: Option<String>,
+    /// This field is set when the metadata comes from a CIP-68 reference
+    /// datum. Only this datum can declare decimal places.
+    cip68: Option<Cip68TokenStandard>,
 }
 impl OnchainMetadata {
     fn from_plutus_data(
@@ -77,15 +83,24 @@ impl OnchainMetadata {
             return Ok(None);
         };
 
+        // a datum whose version the standard does not define describes nothing.
+        // a datum that does not meet the scheme of its label describes nothing too.
+        // then the asset uses the CIP-25 metadata from its minting transaction
+        let version = match version {
+            1 => OnchainMetadataStandard::Cip68v1,
+            2 => OnchainMetadataStandard::Cip68v2,
+            3 => OnchainMetadataStandard::Cip68v3,
+            _ => return Ok(None),
+        };
+
         let metadata = parse_cip68_metadata_map(map.as_slice(), standard)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-        let version = match version {
-            1 => Some(OnchainMetadataStandard::Cip68v1),
-            2 => Some(OnchainMetadataStandard::Cip68v2),
-            3 => Some(OnchainMetadataStandard::Cip68v3),
-            _ => None,
-        };
+        if !cip68_metadata_is_valid(&metadata, standard) {
+            return Ok(None);
+        }
+
+        let version = Some(version);
 
         let extra = constr
             .fields
@@ -98,6 +113,7 @@ impl OnchainMetadata {
             metadata,
             version,
             extra,
+            cip68: Some(standard),
         }))
     }
 
@@ -152,7 +168,29 @@ impl OnchainMetadata {
             metadata,
             version,
             extra,
+            cip68: None,
         }))
+    }
+
+    /// The decimal places that the asset declares on chain. Only the CIP-68
+    /// fungible standard and rich fungible standard define this property.
+    /// CIP-25 has no equivalent.
+    fn decimals(&self) -> Option<i32> {
+        match self.cip68 {
+            Some(Cip68TokenStandard::Ft) | Some(Cip68TokenStandard::Rft) => self
+                .metadata
+                .get("decimals")
+                .and_then(serde_json::Value::as_i64)
+                .and_then(|value| i32::try_from(value).ok()),
+            _ => None,
+        }
+    }
+
+    /// Whether the asset has usable on-chain metadata. A CIP-25 label that has
+    /// no entry for this asset parses into an empty map. An empty map is the
+    /// same as no metadata.
+    fn is_present(&self) -> bool {
+        !self.metadata.is_empty()
     }
 }
 
@@ -292,10 +330,11 @@ async fn last_cip68_metadata_from_tx<D>(
     tx: &MultiEraTx<'_>,
     ref_asset_bytes: &[u8],
     standard: Cip68TokenStandard,
-) -> Result<Option<OnchainMetadata>, StatusCode>
+) -> Result<(bool, Option<OnchainMetadata>), StatusCode>
 where
     D: Domain + Clone + Send + Sync + 'static,
 {
+    let mut found_datum = false;
     let mut last_metadata = None;
 
     for output in tx.outputs().iter() {
@@ -304,13 +343,14 @@ where
         }
 
         if let Some(datum_option) = output.datum() {
+            found_datum = true;
             if let Some(out) = metadata_from_datum_option(domain, &datum_option, standard).await? {
                 last_metadata = Some(out);
             }
         }
     }
 
-    Ok(last_metadata)
+    Ok((found_datum, last_metadata))
 }
 
 struct AssetModelBuilder {
@@ -339,6 +379,8 @@ impl AssetModelBuilder {
             None => None,
         };
 
+        let mut latest_cip68_datum_found = false;
+
         if let Some((_, standard, ref_asset_bytes)) = &cip68_reference {
             let entity_key = pallas::crypto::hash::Hasher::<256>::hash(ref_asset_bytes.as_slice());
             let ref_state = domain.read_cardano_entity::<AssetState>(entity_key.as_slice())?;
@@ -351,9 +393,12 @@ impl AssetModelBuilder {
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
                 {
                     let tx = decode_era_tx(era, &cbor)?;
-                    if let Some(metadata) =
-                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard).await?
-                    {
+                    let (found_datum, metadata) =
+                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard)
+                            .await?;
+                    latest_cip68_datum_found = found_datum;
+
+                    if let Some(metadata) = metadata {
                         return Ok(Some(metadata));
                     }
                 }
@@ -377,11 +422,15 @@ impl AssetModelBuilder {
         if let Some(EraCbor(era, cbor)) = &cip25_tx {
             let tx = decode_era_tx(*era, cbor)?;
 
-            if let Some((_, standard, ref_asset_bytes)) = &cip68_reference {
-                if let Some(metadata) =
-                    last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard).await?
-                {
-                    return Ok(Some(metadata));
+            if !latest_cip68_datum_found {
+                if let Some((_, standard, ref_asset_bytes)) = &cip68_reference {
+                    let (_, metadata) =
+                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard)
+                            .await?;
+
+                    if let Some(metadata) = metadata {
+                        return Ok(Some(metadata));
+                    }
                 }
             }
 
@@ -503,17 +552,14 @@ where
     Ok((subject, state))
 }
 
-pub async fn by_subject<D>(
-    Path(unit): Path<String>,
-    State(domain): State<Facade<D>>,
-) -> Result<Json<Asset>, Error>
+/// Loads the minting state and the minting transaction that holds the
+/// metadata of an asset.
+async fn load_asset_builder<D>(domain: &Facade<D>, unit: String) -> Result<AssetModelBuilder, Error>
 where
-    Option<AssetState>: From<D::Entity>,
     D: Domain + Clone + Send + Sync + 'static,
+    Option<AssetState>: From<D::Entity>,
 {
-    let (subject, asset_state) = resolve_asset_state(&domain, &unit)?;
-
-    let registry_url = domain.config.token_registry_url.clone();
+    let (subject, asset_state) = resolve_asset_state(domain, &unit)?;
 
     let initial_tx = if let Some(initial_tx) = asset_state.initial_tx {
         domain
@@ -525,13 +571,81 @@ where
         None
     };
 
-    let model = AssetModelBuilder {
+    Ok(AssetModelBuilder {
         subject,
         unit,
         asset_state,
         initial_tx,
-        registry_url,
-    };
+        registry_url: domain.config.token_registry_url.clone(),
+    })
+}
+
+/// The facts that an amount entry reports about its unit, in addition to the
+/// quantity.
+pub(crate) struct AssetAmountExtras {
+    pub decimals: Option<i32>,
+    pub has_nft_onchain_metadata: bool,
+}
+
+impl AssetAmountExtras {
+    /// Lovelace is not a minted asset. It holds no metadata. Its six decimal
+    /// places are a property of the currency itself.
+    pub fn lovelace() -> Self {
+        Self {
+            decimals: Some(6),
+            has_nft_onchain_metadata: false,
+        }
+    }
+
+    /// The values that an asset reports when the code can derive nothing for
+    /// it.
+    fn bare() -> Self {
+        Self {
+            decimals: None,
+            has_nft_onchain_metadata: false,
+        }
+    }
+
+    /// Derives the metadata facts of a single unit. If the standard declares
+    /// decimal places, they come from the CIP-68 reference datum. If it does
+    /// not, they come from the off-chain token registry.
+    pub async fn resolve<D>(domain: &Facade<D>, unit: &str) -> Result<Self, Error>
+    where
+        D: Domain + Clone + Send + Sync + 'static,
+        Option<AssetState>: From<D::Entity>,
+    {
+        let builder = match load_asset_builder(domain, unit.to_string()).await {
+            Ok(builder) => builder,
+            // an asset that a live utxo holds always has minting state. a
+            // missing state must not make the whole address request fail
+            Err(Error::InvalidAsset) | Err(Error::Code(StatusCode::NOT_FOUND)) => {
+                return Ok(Self::bare())
+            }
+            Err(err) => return Err(err),
+        };
+
+        let onchain = builder.onchain_metadata(domain).await?;
+        let registry = builder.offchain_metadata(unit).await?;
+
+        Ok(Self {
+            decimals: onchain
+                .as_ref()
+                .and_then(OnchainMetadata::decimals)
+                .or_else(|| registry.and_then(|metadata| metadata.decimals)),
+            has_nft_onchain_metadata: onchain.is_some_and(|x| x.is_present()),
+        })
+    }
+}
+
+pub async fn by_subject<D>(
+    Path(unit): Path<String>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Asset>, Error>
+where
+    Option<AssetState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let model = load_asset_builder(&domain, unit).await?;
 
     Ok(Json(model.into_model(&domain).await?))
 }

--- a/crates/minibf/src/routes/assets.rs
+++ b/crates/minibf/src/routes/assets.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Deref, time::Duration};
+use std::{collections::HashMap, ops::Deref, sync::OnceLock, time::Duration};
 
 use indexmap::IndexSet;
 
@@ -53,8 +53,8 @@ struct OnchainMetadata {
     version: Option<OnchainMetadataStandard>,
     metadata: HashMap<String, serde_json::Value>,
     extra: Option<String>,
-    /// This field is set when the metadata comes from a CIP-68 reference
-    /// datum. Only this datum can declare decimal places.
+    /// This field holds the standard when the metadata comes from a CIP-68
+    /// reference datum. Only this datum can declare decimal places.
     cip68: Option<Cip68TokenStandard>,
 }
 impl OnchainMetadata {
@@ -83,9 +83,10 @@ impl OnchainMetadata {
             return Ok(None);
         };
 
-        // a datum whose version the standard does not define describes nothing.
-        // a datum that does not meet the scheme of its label describes nothing too.
-        // then the asset uses the CIP-25 metadata from its minting transaction
+        // a datum with a version that the standard does not define describes
+        // nothing. a datum that does not meet the scheme of its label also
+        // describes nothing. in both cases the asset uses the CIP-25 metadata
+        // from its minting transaction
         let version = match version {
             1 => OnchainMetadataStandard::Cip68v1,
             2 => OnchainMetadataStandard::Cip68v2,
@@ -330,11 +331,10 @@ async fn last_cip68_metadata_from_tx<D>(
     tx: &MultiEraTx<'_>,
     ref_asset_bytes: &[u8],
     standard: Cip68TokenStandard,
-) -> Result<(bool, Option<OnchainMetadata>), StatusCode>
+) -> Result<Option<OnchainMetadata>, StatusCode>
 where
     D: Domain + Clone + Send + Sync + 'static,
 {
-    let mut found_datum = false;
     let mut last_metadata = None;
 
     for output in tx.outputs().iter() {
@@ -343,14 +343,32 @@ where
         }
 
         if let Some(datum_option) = output.datum() {
-            found_datum = true;
             if let Some(out) = metadata_from_datum_option(domain, &datum_option, standard).await? {
                 last_metadata = Some(out);
             }
         }
     }
 
-    Ok((found_datum, last_metadata))
+    Ok(last_metadata)
+}
+
+/// The HTTP client that every token-registry request shares. `reqwest::Client`
+/// holds an internal connection pool, so one instance reuses DNS and TLS across
+/// the many concurrent lookups that `/addresses/{address}/extended` starts.
+fn token_registry_client() -> Result<&'static reqwest::Client, StatusCode> {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+    if let Some(client) = CLIENT.get() {
+        return Ok(client);
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .user_agent("Dolos MiniBF")
+        .build()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(CLIENT.get_or_init(|| client))
 }
 
 struct AssetModelBuilder {
@@ -379,8 +397,6 @@ impl AssetModelBuilder {
             None => None,
         };
 
-        let mut latest_cip68_datum_found = false;
-
         if let Some((_, standard, ref_asset_bytes)) = &cip68_reference {
             let entity_key = pallas::crypto::hash::Hasher::<256>::hash(ref_asset_bytes.as_slice());
             let ref_state = domain.read_cardano_entity::<AssetState>(entity_key.as_slice())?;
@@ -393,12 +409,10 @@ impl AssetModelBuilder {
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
                 {
                     let tx = decode_era_tx(era, &cbor)?;
-                    let (found_datum, metadata) =
-                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard)
-                            .await?;
-                    latest_cip68_datum_found = found_datum;
 
-                    if let Some(metadata) = metadata {
+                    if let Some(metadata) =
+                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard).await?
+                    {
                         return Ok(Some(metadata));
                     }
                 }
@@ -422,18 +436,6 @@ impl AssetModelBuilder {
         if let Some(EraCbor(era, cbor)) = &cip25_tx {
             let tx = decode_era_tx(*era, cbor)?;
 
-            if !latest_cip68_datum_found {
-                if let Some((_, standard, ref_asset_bytes)) = &cip68_reference {
-                    let (_, metadata) =
-                        last_cip68_metadata_from_tx(domain, &tx, ref_asset_bytes, *standard)
-                            .await?;
-
-                    if let Some(metadata) = metadata {
-                        return Ok(Some(metadata));
-                    }
-                }
-            }
-
             let out = tx
                 .metadata()
                 .find(721)
@@ -455,13 +457,7 @@ impl AssetModelBuilder {
 
         let url = format!("{url}/metadata/{asset}");
 
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .user_agent("Dolos MiniBF")
-            .build()
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-        let res = client
+        let res = token_registry_client()?
             .get(&url)
             .send()
             .await

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -114,6 +114,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}/utxos`                          | Get UTXOs for a stake address                            |
 | `/accounts/{stake_address}/withdrawals`                    | Get withdrawals for a stake address                      |
 | `/addresses/{address}`                                     | Get general information for a specific address           |
+| `/addresses/{address}/extended`                            | Get address information with per-asset decimals          |
 | `/addresses/{address}/total`                               | Get lifetime received/sent totals for a specific address |
 | `/addresses/{address}/transactions`                        | Get transactions for a specific address                  |
 | `/addresses/{address}/txs`                                 | Alias of `/addresses/{address}/transactions`             |

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -114,7 +114,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}/utxos`                          | Get UTXOs for a stake address                            |
 | `/accounts/{stake_address}/withdrawals`                    | Get withdrawals for a stake address                      |
 | `/addresses/{address}`                                     | Get general information for a specific address           |
-| `/addresses/{address}/extended`                            | Get address information with per-asset decimals          |
+| `/addresses/{address}/extended`                            | Get address information with extended asset data         |
 | `/addresses/{address}/total`                               | Get lifetime received/sent totals for a specific address |
 | `/addresses/{address}/transactions`                        | Get transactions for a specific address                  |
 | `/addresses/{address}/txs`                                 | Alias of `/addresses/{address}/transactions`             |


### PR DESCRIPTION
Resolves #1079.

## Implementation

Add the extended address endpoint. The endpoint returns the address amounts. For each unit, it adds the decimal places and the `has_nft_onchain_metadata` flag. Lovelace reports 6 decimal places and no metadata.

If the CIP-68 standard declares decimal places, derive them from the reference datum. If the datum does not declare them, use the off-chain token registry.

Validate the CIP-68 datum against the scheme of its label. A datum that has an unknown version describes nothing. A datum that does not meet the scheme also describes nothing. In these cases, the asset uses the CIP-25 metadata of the minting transaction. The asset does not use an older CIP-68 datum.

## Testing

The upstream Blockfrost suite covers the endpoint in these fixtures:
- https://github.com/blockfrost/blockfrost-tests/blob/0f3f3ea268983a6cf2e6f7fd24c5082fc3a91e0e/src/fixtures/preprod/addresses/address-extended.ts
- https://github.com/blockfrost/blockfrost-tests/blob/0f3f3ea268983a6cf2e6f7fd24c5082fc3a91e0e/src/fixtures/preview/addresses/address-extended.ts
- https://github.com/blockfrost/blockfrost-tests/blob/0f3f3ea268983a6cf2e6f7fd24c5082fc3a91e0e/src/fixtures/mainnet/addresses/address-extended.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `/addresses/{address}/extended` endpoint, providing address details with enriched asset information.
  - Extended asset responses with decimal precision and NFT metadata availability.
  - Added support for validating CIP-68 file metadata, including string or multi-part source values.

- **Bug Fixes**
  - Invalid or unsupported CIP-68 metadata now safely falls back to alternative metadata.
  - Improved handling of unknown metadata fields and invalid addresses.
  - Token registry request failures no longer produce internal server errors.

- **Documentation**
  - Documented the extended address endpoint in the API reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->