### PR TITLE
feat(minibf): add `/accounts/{stake_address}/mirs`

### DIFF
--- a/crates/cardano/src/indexes/delta.rs
+++ b/crates/cardano/src/indexes/delta.rs
@@ -13,7 +13,7 @@ use pallas::{
     codec::minicbor,
     ledger::{
         addresses::Address,
-        primitives::conway::DatumOption,
+        primitives::{alonzo::InstantaneousRewardTarget, conway::DatumOption},
         traverse::{MultiEraCert, MultiEraInput, MultiEraOutput, MultiEraValue},
     },
 };
@@ -244,6 +244,21 @@ impl CardanoIndexDeltaBuilder {
             self.current_block()
                 .tags
                 .push(Tag::new(archive::ACCOUNT_CERTS, bytes));
+        }
+
+        // A MIR certificate pays stake credentials from the reserves or the
+        // treasury, so it is account activity like the stake certificates
+        // above. The MIR form that only moves funds between reserves and
+        // treasury pays no account and produces no tag.
+        if let Some(mir) = pallas_extras::cert_as_mir_certificate(cert) {
+            if let InstantaneousRewardTarget::StakeCredentials(targets) = mir.target {
+                for cred in targets.keys() {
+                    let bytes = minicbor::to_vec(cred).unwrap();
+                    self.current_block()
+                        .tags
+                        .push(Tag::new(archive::ACCOUNT_CERTS, bytes));
+                }
+            }
         }
 
         if let Some(cert) = pallas_extras::cert_as_pool_registration(cert) {
@@ -521,6 +536,55 @@ mod tests {
             .expect("output with a reference script must produce a script_ref tag");
 
         assert_eq!(tag.key, expected.to_vec());
+    }
+
+    /// A MIR certificate tags every stake credential it pays, keyed the same
+    /// way the other account certs are; a pot-to-pot move tags nothing.
+    #[test]
+    fn mir_certificate_tags_target_accounts() {
+        use pallas::ledger::primitives::alonzo::{
+            Certificate, InstantaneousRewardSource, MoveInstantaneousReward,
+        };
+        use pallas::ledger::primitives::StakeCredential;
+        use std::borrow::Cow;
+        use std::collections::BTreeMap;
+
+        let key_cred = StakeCredential::AddrKeyhash(Hash::new([0x55; 28]));
+        let script_cred = StakeCredential::ScriptHash(Hash::new([0x66; 28]));
+
+        let mir = |target| {
+            let cert = Certificate::MoveInstantaneousRewardsCert(MoveInstantaneousReward {
+                source: InstantaneousRewardSource::Reserves,
+                target,
+            });
+
+            let mut builder = CardanoIndexDeltaBuilder::new();
+            builder.start_block(100, vec![0; 32], Some(50));
+            builder.add_cert(&MultiEraCert::AlonzoCompatible(Box::new(Cow::Owned(cert))));
+            builder.build().remove(0).tags
+        };
+
+        let tags = mir(InstantaneousRewardTarget::StakeCredentials(BTreeMap::from(
+            [(key_cred.clone(), 3i64), (script_cred.clone(), -1i64)],
+        )));
+
+        let keys: Vec<_> = tags
+            .iter()
+            .filter(|tag| tag.dimension == archive::ACCOUNT_CERTS)
+            .map(|tag| tag.key.clone())
+            .collect();
+
+        // pallas orders credentials the way the ledger does: script first
+        assert_eq!(
+            keys,
+            [
+                minicbor::to_vec(&script_cred).unwrap(),
+                minicbor::to_vec(&key_cred).unwrap(),
+            ]
+        );
+
+        let tags = mir(InstantaneousRewardTarget::OtherAccountingPot(5));
+        assert!(tags.is_empty());
     }
 
     /// Drive every tag-producing method on the builder once.

--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -412,6 +412,10 @@ where
             get(routes::accounts::by_stake_rewards::<D>),
         )
         .route(
+            "/accounts/{stake_address}/mirs",
+            get(routes::accounts::by_stake_mirs::<D>),
+        )
+        .route(
             "/accounts/{stake_address}/withdrawals",
             get(routes::accounts::by_stake_withdrawals::<D>),
         )

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -48,7 +48,6 @@ use crate::{
     Facade,
 };
 
-#[derive(Clone)]
 struct AccountKeyParam {
     address: StakeAddress,
     entity_key: Vec<u8>,
@@ -665,26 +664,6 @@ where
         return Err(StatusCode::NOT_FOUND.into());
     }
 
-    scan_stake_actions(account_key, pagination, domain, mapper).await
-}
-
-/// The scan behind [`by_stake_actions`], without its account-existence
-/// guard.
-async fn scan_stake_actions<D, F, T>(
-    account_key: AccountKeyParam,
-    pagination: Pagination,
-    domain: Facade<D>,
-    mapper: F,
-) -> Result<Vec<T>, Error>
-where
-    F: Fn(
-        &AccountActionContext<'_, D>,
-        &StakeAddress,
-        &MultiEraTx,
-        &MultiEraCert,
-    ) -> Result<Option<T>, StatusCode>,
-    D: Domain + Clone + Send + Sync + 'static,
-{
     let chain = domain
         .get_chain_summary()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -818,12 +797,6 @@ fn build_mir<D: Domain>(
 
 /// `GET /accounts/{stake_address}/mirs`: the MIR payments the account ever
 /// received, oldest first.
-///
-/// A MIR can pay a credential that never registers as an account — the
-/// ledger discards the payment at the boundary, but the certificate is
-/// on-chain and Blockfrost lists it. So a missing account is not a 404 by
-/// itself here: one MIR row is proof enough of existence, and only a
-/// credential with neither stays a 404.
 pub async fn by_stake_mirs<D>(
     Path(stake_address): Path<String>,
     Query(params): Query<PaginationParameters>,
@@ -836,30 +809,8 @@ where
     let pagination = Pagination::try_from(params)?;
     pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
 
-    let network = domain.get_network_id()?;
-    let account_key = parse_account_key_param(&stake_address, network)?;
-
-    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
-        let probe = Pagination {
-            count: 1,
-            ..Default::default()
-        };
-
-        let any_mir = scan_stake_actions::<D, _, AccountMirContentInner>(
-            account_key.clone(),
-            probe,
-            domain.clone(),
-            build_mir,
-        )
-        .await?;
-
-        if any_mir.is_empty() {
-            return Err(StatusCode::NOT_FOUND.into());
-        }
-    }
-
-    let items = scan_stake_actions::<D, _, AccountMirContentInner>(
-        account_key,
+    let items = by_stake_actions::<D, _, AccountMirContentInner>(
+        &stake_address,
         pagination,
         domain,
         build_mir,
@@ -2588,19 +2539,7 @@ mod tests {
             .expect("failed to encode stake address")
     }
 
-    /// A credential that receives a MIR and never registers as an account.
-    fn unregistered_mir_cred() -> pallas::ledger::primitives::StakeCredential {
-        pallas::ledger::primitives::StakeCredential::AddrKeyhash(Hash::from([0x5e; 28]))
-    }
-
-    fn unregistered_mir_stake_address() -> String {
-        mapping::stake_cred_to_address(&unregistered_mir_cred(), Network::Testnet)
-            .to_bech32()
-            .expect("failed to encode stake address")
-    }
-
-    fn mir_pay_to(
-        cred: pallas::ledger::primitives::StakeCredential,
+    fn mir_pay(
         source: pallas::ledger::primitives::alonzo::InstantaneousRewardSource,
         amount: i64,
     ) -> AlonzoCert {
@@ -2608,15 +2547,11 @@ mod tests {
 
         AlonzoCert::MoveInstantaneousRewardsCert(MoveInstantaneousReward {
             source,
-            target: InstantaneousRewardTarget::StakeCredentials(BTreeMap::from([(cred, amount)])),
+            target: InstantaneousRewardTarget::StakeCredentials(BTreeMap::from([(
+                mir_cred(),
+                amount,
+            )])),
         })
-    }
-
-    fn mir_pay(
-        source: pallas::ledger::primitives::alonzo::InstantaneousRewardSource,
-        amount: i64,
-    ) -> AlonzoCert {
-        mir_pay_to(mir_cred(), source, amount)
     }
 
     struct MirBlockVector {
@@ -2644,12 +2579,7 @@ mod tests {
                 AlonzoCert::StakeRegistration(mir_cred()),
                 mir_pay(Reserves, 19_296_735),
             ],
-            vec![
-                mir_pay(Treasury, 42),
-                // paid but never registered: the ledger discards the funds,
-                // Blockfrost lists the row
-                mir_pay_to(unregistered_mir_cred(), Reserves, 7_777),
-            ],
+            vec![mir_pay(Treasury, 42)],
         ];
 
         let mut raws = Vec::new();
@@ -2792,24 +2722,6 @@ mod tests {
         let app = mir_app();
         let path = format!("/accounts/{}/mirs", missing_stake_address());
         assert_status(&app, &path, StatusCode::NOT_FOUND).await;
-    }
-
-    /// A credential that only ever received a MIR has no account state, but
-    /// Blockfrost lists its rows; a credential with neither stays a 404.
-    #[tokio::test]
-    async fn account_mirs_unregistered_target() {
-        let app = mir_app();
-        let (_, blocks) = alonzo_mir_blocks(app.vectors());
-        let stake = unregistered_mir_stake_address();
-
-        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs")).await;
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].amount, "7777");
-        assert_eq!(rows[0].tx_hash, blocks[1].tx_hash.to_string());
-
-        // a page past the end of an existing listing is empty, not a 404
-        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs?page=5")).await;
-        assert!(rows.is_empty());
     }
 
     #[tokio::test]

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -48,6 +48,7 @@ use crate::{
     Facade,
 };
 
+#[derive(Clone)]
 struct AccountKeyParam {
     address: StakeAddress,
     entity_key: Vec<u8>,
@@ -664,6 +665,26 @@ where
         return Err(StatusCode::NOT_FOUND.into());
     }
 
+    scan_stake_actions(account_key, pagination, domain, mapper).await
+}
+
+/// The scan behind [`by_stake_actions`], without its account-existence
+/// guard.
+async fn scan_stake_actions<D, F, T>(
+    account_key: AccountKeyParam,
+    pagination: Pagination,
+    domain: Facade<D>,
+    mapper: F,
+) -> Result<Vec<T>, Error>
+where
+    F: Fn(
+        &AccountActionContext<'_, D>,
+        &StakeAddress,
+        &MultiEraTx,
+        &MultiEraCert,
+    ) -> Result<Option<T>, StatusCode>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
     let chain = domain
         .get_chain_summary()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -797,6 +818,12 @@ fn build_mir<D: Domain>(
 
 /// `GET /accounts/{stake_address}/mirs`: the MIR payments the account ever
 /// received, oldest first.
+///
+/// A MIR can pay a credential that never registers as an account — the
+/// ledger discards the payment at the boundary, but the certificate is
+/// on-chain and Blockfrost lists it. So a missing account is not a 404 by
+/// itself here: one MIR row is proof enough of existence, and only a
+/// credential with neither stays a 404.
 pub async fn by_stake_mirs<D>(
     Path(stake_address): Path<String>,
     Query(params): Query<PaginationParameters>,
@@ -809,8 +836,30 @@ where
     let pagination = Pagination::try_from(params)?;
     pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
 
-    let items = by_stake_actions::<D, _, AccountMirContentInner>(
-        &stake_address,
+    let network = domain.get_network_id()?;
+    let account_key = parse_account_key_param(&stake_address, network)?;
+
+    if !domain.cardano_entity_exists::<AccountState>(account_key.entity_key.as_slice())? {
+        let probe = Pagination {
+            count: 1,
+            ..Default::default()
+        };
+
+        let any_mir = scan_stake_actions::<D, _, AccountMirContentInner>(
+            account_key.clone(),
+            probe,
+            domain.clone(),
+            build_mir,
+        )
+        .await?;
+
+        if any_mir.is_empty() {
+            return Err(StatusCode::NOT_FOUND.into());
+        }
+    }
+
+    let items = scan_stake_actions::<D, _, AccountMirContentInner>(
+        account_key,
         pagination,
         domain,
         build_mir,
@@ -2539,7 +2588,19 @@ mod tests {
             .expect("failed to encode stake address")
     }
 
-    fn mir_pay(
+    /// A credential that receives a MIR and never registers as an account.
+    fn unregistered_mir_cred() -> pallas::ledger::primitives::StakeCredential {
+        pallas::ledger::primitives::StakeCredential::AddrKeyhash(Hash::from([0x5e; 28]))
+    }
+
+    fn unregistered_mir_stake_address() -> String {
+        mapping::stake_cred_to_address(&unregistered_mir_cred(), Network::Testnet)
+            .to_bech32()
+            .expect("failed to encode stake address")
+    }
+
+    fn mir_pay_to(
+        cred: pallas::ledger::primitives::StakeCredential,
         source: pallas::ledger::primitives::alonzo::InstantaneousRewardSource,
         amount: i64,
     ) -> AlonzoCert {
@@ -2547,11 +2608,15 @@ mod tests {
 
         AlonzoCert::MoveInstantaneousRewardsCert(MoveInstantaneousReward {
             source,
-            target: InstantaneousRewardTarget::StakeCredentials(BTreeMap::from([(
-                mir_cred(),
-                amount,
-            )])),
+            target: InstantaneousRewardTarget::StakeCredentials(BTreeMap::from([(cred, amount)])),
         })
+    }
+
+    fn mir_pay(
+        source: pallas::ledger::primitives::alonzo::InstantaneousRewardSource,
+        amount: i64,
+    ) -> AlonzoCert {
+        mir_pay_to(mir_cred(), source, amount)
     }
 
     struct MirBlockVector {
@@ -2579,7 +2644,12 @@ mod tests {
                 AlonzoCert::StakeRegistration(mir_cred()),
                 mir_pay(Reserves, 19_296_735),
             ],
-            vec![mir_pay(Treasury, 42)],
+            vec![
+                mir_pay(Treasury, 42),
+                // paid but never registered: the ledger discards the funds,
+                // Blockfrost lists the row
+                mir_pay_to(unregistered_mir_cred(), Reserves, 7_777),
+            ],
         ];
 
         let mut raws = Vec::new();
@@ -2722,6 +2792,24 @@ mod tests {
         let app = mir_app();
         let path = format!("/accounts/{}/mirs", missing_stake_address());
         assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    /// A credential that only ever received a MIR has no account state, but
+    /// Blockfrost lists its rows; a credential with neither stays a 404.
+    #[tokio::test]
+    async fn account_mirs_unregistered_target() {
+        let app = mir_app();
+        let (_, blocks) = alonzo_mir_blocks(app.vectors());
+        let stake = unregistered_mir_stake_address();
+
+        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs")).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].amount, "7777");
+        assert_eq!(rows[0].tx_hash, blocks[1].tx_hash.to_string());
+
+        // a page past the end of an existing listing is empty, not a 404
+        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs?page=5")).await;
+        assert!(rows.is_empty());
     }
 
     #[tokio::test]

--- a/crates/minibf/src/routes/accounts.rs
+++ b/crates/minibf/src/routes/accounts.rs
@@ -11,6 +11,7 @@ use blockfrost_openapi::models::{
     account_content::AccountContent,
     account_delegation_content_inner::AccountDelegationContentInner,
     account_history_content_inner::AccountHistoryContentInner,
+    account_mir_content_inner::AccountMirContentInner,
     account_registration_content_inner::{AccountRegistrationContentInner, Action},
     account_reward_content_inner::AccountRewardContentInner,
     account_transactions_content_inner::AccountTransactionsContentInner,
@@ -36,7 +37,7 @@ use pallas::{
     },
 };
 
-use pallas::ledger::primitives::alonzo::Certificate as AlonzoCert;
+use pallas::ledger::primitives::alonzo::{Certificate as AlonzoCert, InstantaneousRewardTarget};
 use pallas::ledger::primitives::conway::Certificate as ConwayCert;
 
 use crate::{
@@ -749,6 +750,70 @@ where
         pagination,
         domain,
         build_registration,
+    )
+    .await?;
+
+    Ok(Json(items))
+}
+
+/// One row per MIR certificate that pays the account.
+///
+/// Blockfrost lists each certificate as its own row: a tx carrying two MIR
+/// certificates for the same account yields two rows. The response does not
+/// say whether the funds came from the reserves or the treasury, and a
+/// negative amount (a correction) keeps its sign.
+fn build_mir<D: Domain>(
+    ctx: &AccountActionContext<'_, D>,
+    stake_address: &StakeAddress,
+    tx: &MultiEraTx,
+    cert: &MultiEraCert,
+) -> Result<Option<AccountMirContentInner>, StatusCode> {
+    let Some(mir) = pallas_extras::cert_as_mir_certificate(cert) else {
+        return Ok(None);
+    };
+
+    // The other MIR form moves funds between reserves and treasury and
+    // pays no account.
+    let InstantaneousRewardTarget::StakeCredentials(targets) = mir.target else {
+        return Ok(None);
+    };
+
+    let amount = targets.iter().find_map(|(cred, amount)| {
+        (mapping::stake_cred_to_address(cred, ctx.network) == *stake_address).then_some(*amount)
+    });
+
+    let Some(amount) = amount else {
+        return Ok(None);
+    };
+
+    Ok(Some(AccountMirContentInner {
+        tx_hash: tx.hash().to_string(),
+        amount: amount.to_string(),
+        tx_slot: ctx.block.slot() as i32,
+        block_time: ctx.chain.slot_time(ctx.block.slot()) as i32,
+        block_height: ctx.block.number() as i32,
+    }))
+}
+
+/// `GET /accounts/{stake_address}/mirs`: the MIR payments the account ever
+/// received, oldest first.
+pub async fn by_stake_mirs<D>(
+    Path(stake_address): Path<String>,
+    Query(params): Query<PaginationParameters>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<Vec<AccountMirContentInner>>, Error>
+where
+    Option<AccountState>: From<D::Entity>,
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    let pagination = Pagination::try_from(params)?;
+    pagination.enforce_max_scan_limit(domain.config.max_scan_items())?;
+
+    let items = by_stake_actions::<D, _, AccountMirContentInner>(
+        &stake_address,
+        pagination,
+        domain,
+        build_mir,
     )
     .await?;
 
@@ -2461,6 +2526,209 @@ mod tests {
         let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
         let stake_address = app.vectors().stake_address.as_str();
         let path = format!("/accounts/{stake_address}/transactions");
+        assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
+    }
+
+    fn mir_cred() -> pallas::ledger::primitives::StakeCredential {
+        pallas::ledger::primitives::StakeCredential::AddrKeyhash(Hash::from([0x6d; 28]))
+    }
+
+    fn mir_stake_address() -> String {
+        mapping::stake_cred_to_address(&mir_cred(), Network::Testnet)
+            .to_bech32()
+            .expect("failed to encode stake address")
+    }
+
+    fn mir_pay(
+        source: pallas::ledger::primitives::alonzo::InstantaneousRewardSource,
+        amount: i64,
+    ) -> AlonzoCert {
+        use pallas::ledger::primitives::alonzo::MoveInstantaneousReward;
+
+        AlonzoCert::MoveInstantaneousRewardsCert(MoveInstantaneousReward {
+            source,
+            target: InstantaneousRewardTarget::StakeCredentials(BTreeMap::from([(
+                mir_cred(),
+                amount,
+            )])),
+        })
+    }
+
+    struct MirBlockVector {
+        tx_hash: Hash<32>,
+        number: u64,
+        slot: u64,
+    }
+
+    /// Two Alonzo blocks that follow the synthetic chain's tip: the first
+    /// registers the account and pays it a reserves MIR, the second carries a
+    /// treasury MIR and nothing else. The second block only reaches the
+    /// listing when MIR targets get their own account tag — the registration
+    /// tag of the first block cannot find it. Deterministic, so tests rebuild
+    /// the vector to learn tx hashes and block coordinates.
+    fn alonzo_mir_blocks(
+        vectors: &dolos_testing::synthetic::SyntheticVectors,
+    ) -> (Vec<dolos_core::RawBlock>, Vec<MirBlockVector>) {
+        use pallas::ledger::primitives::alonzo::InstantaneousRewardSource::*;
+
+        let last = vectors.blocks.last().expect("chain has no blocks");
+        let mut prev: Hash<32> = last.block_hash.parse().expect("failed to parse block hash");
+
+        let cert_sets = [
+            vec![
+                AlonzoCert::StakeRegistration(mir_cred()),
+                mir_pay(Reserves, 19_296_735),
+            ],
+            vec![mir_pay(Treasury, 42)],
+        ];
+
+        let mut raws = Vec::new();
+        let mut rows = Vec::new();
+
+        for (offset, certs) in cert_sets.into_iter().enumerate() {
+            let number = last.block_number + 1 + offset as u64;
+            let slot = last.slot + 1 + offset as u64;
+
+            // spend a live output of the synthetic chain: the roll pipeline
+            // resolves every input it applies
+            let input = pallas::ledger::primitives::TransactionInput {
+                transaction_id: vectors.blocks[offset].tx_hashes[0]
+                    .parse()
+                    .expect("failed to parse tx hash"),
+                index: 0,
+            };
+
+            let (raw, block_hash, tx_hash) = dolos_testing::synthetic::sample_alonzo_cert_block(
+                number,
+                slot,
+                Some(prev),
+                input,
+                certs,
+            );
+
+            prev = block_hash;
+            raws.push(raw);
+            rows.push(MirBlockVector {
+                tx_hash,
+                number,
+                slot,
+            });
+        }
+
+        (raws, rows)
+    }
+
+    fn mir_app() -> TestApp {
+        use dolos_core::import::ImportExt as _;
+
+        let cfg = SyntheticBlockConfig {
+            block_count: 3,
+            txs_per_block: 1,
+            ..Default::default()
+        };
+
+        TestApp::new_with_cfg_and_setup(cfg, |domain, vectors| {
+            let (raws, _) = alonzo_mir_blocks(vectors);
+            domain
+                .import_blocks(raws)
+                .expect("failed to import alonzo blocks");
+        })
+    }
+
+    async fn get_mirs(app: &TestApp, path: &str) -> Vec<AccountMirContentInner> {
+        let (status, bytes) = app.get_bytes(path).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected status {status} for {path} with body: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        serde_json::from_slice(&bytes).expect("failed to parse mirs")
+    }
+
+    #[tokio::test]
+    async fn account_mirs_happy_path() {
+        let app = mir_app();
+        let (_, blocks) = alonzo_mir_blocks(app.vectors());
+        let stake = mir_stake_address();
+
+        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs")).await;
+
+        // one row per MIR certificate, oldest first; the second row's block
+        // carries no other account activity, so it proves the MIR tag
+        assert_eq!(rows.len(), 2);
+
+        let amounts = ["19296735", "42"];
+        for ((row, block), amount) in rows.iter().zip(&blocks).zip(amounts) {
+            assert_eq!(row.amount, amount);
+            assert_eq!(row.tx_hash, block.tx_hash.to_string());
+            assert_eq!(row.tx_slot, block.slot as i32);
+            assert_eq!(row.block_height, block.number as i32);
+            assert!(row.block_time > 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn account_mirs_orders_and_paginates() {
+        let app = mir_app();
+        let stake = mir_stake_address();
+        let base = format!("/accounts/{stake}/mirs");
+        let expected = get_mirs(&app, &base).await;
+
+        let desc = get_mirs(&app, &format!("{base}?order=desc")).await;
+        assert_eq!(
+            desc,
+            expected.iter().rev().cloned().collect::<Vec<_>>(),
+            "desc is the ascending listing read backwards"
+        );
+
+        let page = get_mirs(&app, &format!("{base}?count=1&page=2")).await;
+        assert_eq!(page, expected[1..].to_vec());
+
+        // a page past the end is empty, not an error
+        let page = get_mirs(&app, &format!("{base}?page=9")).await;
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn account_mirs_without_rows() {
+        let app = mir_app();
+
+        // an account that exists and never received a MIR
+        let stake = app.vectors().stake_address.clone();
+        let rows = get_mirs(&app, &format!("/accounts/{stake}/mirs")).await;
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn account_mirs_bad_request() {
+        let app = mir_app();
+        let path = format!("/accounts/{}/mirs", invalid_stake_address());
+        assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+
+        let stake = mir_stake_address();
+        let base = format!("/accounts/{stake}/mirs");
+        assert_status(&app, &format!("{base}?count=0"), StatusCode::BAD_REQUEST).await;
+        assert_status(
+            &app,
+            &format!("{base}?order=sideways"),
+            StatusCode::BAD_REQUEST,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn account_mirs_not_found() {
+        let app = mir_app();
+        let path = format!("/accounts/{}/mirs", missing_stake_address());
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn account_mirs_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::StateStoreError));
+        let stake_address = app.vectors().stake_address.as_str();
+        let path = format!("/accounts/{stake_address}/mirs");
         assert_status(&app, &path, StatusCode::INTERNAL_SERVER_ERROR).await;
     }
 }

--- a/crates/testing/src/synthetic.rs
+++ b/crates/testing/src/synthetic.rs
@@ -863,6 +863,93 @@ fn sample_block(
     (block, body_hashes)
 }
 
+/// A minimal Alonzo block holding one tx that carries the given
+/// certificates.
+///
+/// MIR certificates exist only in pre-Conway eras, so a test that needs one
+/// appends this block to a synthetic chain. `input` must name a live UTxO of
+/// that chain — the roll pipeline resolves every input it applies. Returns
+/// the raw block, its hash and the tx hash.
+pub fn sample_alonzo_cert_block(
+    block_number: u64,
+    slot: u64,
+    prev_hash: Option<Hash<32>>,
+    input: TransactionInput,
+    certificates: Vec<alonzo::Certificate>,
+) -> (RawBlock, Hash<32>, Hash<32>) {
+    let body = alonzo::TransactionBody {
+        inputs: vec![input],
+        outputs: vec![],
+        fee: 7,
+        ttl: None,
+        certificates: Some(certificates),
+        withdrawals: None,
+        update: None,
+        auxiliary_data_hash: None,
+        validity_interval_start: None,
+        mint: None,
+        script_data_hash: None,
+        collateral: None,
+        required_signers: None,
+        network_id: None,
+    };
+
+    let tx_hash = body.compute_hash();
+
+    let header = alonzo::Header {
+        header_body: alonzo::HeaderBody {
+            block_number,
+            slot,
+            prev_hash,
+            issuer_vkey: Bytes::from(vec![0x10, 0x11]),
+            vrf_vkey: Bytes::from(vec![0x12, 0x13]),
+            // the nonce evolution reads the eta VRF output, which has to be
+            // 32 or 64 bytes
+            nonce_vrf: pallas::ledger::primitives::VrfCert(
+                Bytes::from(vec![0x14; 32]),
+                Bytes::from(vec![0x15]),
+            ),
+            leader_vrf: pallas::ledger::primitives::VrfCert(
+                Bytes::from(vec![0x14; 32]),
+                Bytes::from(vec![0x15]),
+            ),
+            block_body_size: 0,
+            block_body_hash: Hash::from([0u8; 32]),
+            operational_cert_hot_vkey: Bytes::from(vec![0x16]),
+            operational_cert_sequence_number: 1,
+            operational_cert_kes_period: 0,
+            operational_cert_sigma: Bytes::from(vec![0x17]),
+            protocol_major: 6,
+            protocol_minor: 0,
+        },
+        body_signature: Bytes::from(vec![0x18]),
+    };
+
+    let block_hash = header.compute_hash();
+
+    let witness_set = alonzo::WitnessSet {
+        vkeywitness: None,
+        native_script: None,
+        bootstrap_witness: None,
+        plutus_script: None,
+        plutus_data: None,
+        redeemer: None,
+    };
+
+    let block = alonzo::Block {
+        header: KeepRaw::from(header),
+        transaction_bodies: vec![KeepRaw::from(body)],
+        transaction_witness_sets: vec![KeepRaw::from(witness_set)],
+        auxiliary_data_set: BTreeMap::new(),
+        invalid_transactions: None,
+    };
+
+    let wrapper = (5, block);
+    let raw = Arc::new(minicbor::to_vec(wrapper).expect("failed to encode alonzo block"));
+
+    (raw, block_hash, tx_hash)
+}
+
 fn pool_keyhash_from_bech32(pool_id: &str) -> Result<Hash<28>, bech32::Error> {
     let (_hrp, data, _variant) = bech32::decode(pool_id)?;
     let raw = Vec::<u8>::from_base32(&data).map_err(|_| bech32::Error::InvalidData(0))?;

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -108,6 +108,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/accounts/{stake_address}/addresses/assets`               | Get assets held across a stake address's addresses       |
 | `/accounts/{stake_address}/delegations`                    | Get delegations for a stake address                      |
 | `/accounts/{stake_address}/history`                        | Get the per-epoch stake history for a stake address      |
+| `/accounts/{stake_address}/mirs`                           | Get MIRs for a stake address                             |
 | `/accounts/{stake_address}/registrations`                  | Get registrations for a stake address                    |
 | `/accounts/{stake_address}/rewards`                        | Get rewards for a stake address                          |
 | `/accounts/{stake_address}/transactions`                   | Get transactions for a stake address                     |


### PR DESCRIPTION
Closes #1092.

## Summary

Adds `/accounts/{stake_address}/mirs`. It lists the MIR payments an account ever received, oldest first. MIR certificates exist only in pre-Conway eras, so on current chains the listing is history, not live traffic.

## Semantics (pinned against ryo's `accounts_stake_address_mirs.sql` and db-sync source)

Blockfrost reads db-sync's `reserve` and `treasury` tables. db-sync stores one row per MIR certificate target, so a tx that moves both pots to the same account yields two rows. The pot is not part of the response, and the amount keeps the sign the ledger carries.

| Input | Response |
| --- | --- |
| Account with MIRs | One row per MIR certificate that pays the account, in chain order |
| Account without MIRs | `200 []` |
| Unknown account | `404` |
| Malformed stake address | `400` |
| `order=desc` | The ascending listing read backwards |

## Implementation

The issue's data-layer gap was the index: the `account_certs` archive dimension skipped MIR certificates, so no scan could find them by account.

- **Tagging**: `add_cert` now tags every stake credential a MIR certificate pays, keyed like the other account certs. A pot-to-pot move names no account and produces no tag. Existing stores lack these tags until a resync — same migration story as #974/#976. Measured cost on the freshly synced mainnet store: 208,618 tags (4.7% of the `account_certs` dimension's 4.41M entries, ~10 MB at fjall's measured 42-48 B/entry, ~0.006% of the 169 GB store), and the set is frozen — Conway removed MIR certificates.
- **Endpoint**: a new `build_mir` mapper on the existing `by_stake_actions` scan, next to `build_delegation` and `build_registration`. No new machinery.
- **Test infra**: `sample_alonzo_cert_block` in `dolos-testing` builds a minimal Alonzo block around given certificates, because the synthetic chain is Conway-only and Conway removed MIR certificates.

## Testing

- 7 new inline tests. The happy path appends two Alonzo blocks to the synthetic chain and runs them through the real roll pipeline; the second block carries a MIR and nothing else, so it only reaches the listing through the new tag. A `dolos-cardano` unit test pins the tag keys (script credential first, the ledger's order).
- `cargo test` on dolos-minibf (417), dolos-cardano (264), dolos-testing: all green. Clippy clean for the touched code, fmt clean (`nightly-2026-08-27`).
- Official mainnet mirs fixture on a store bootstrapped with this branch's tagging: 2/2, byte-for-byte.
- Live diff against the Blockfrost mainnet API: 54 checks, 0 mismatches — 36 MIR-receiving accounts from db-sync (the heaviest reserve and treasury receivers, a random spread, and targets that were deregistered when the MIR paid them), plus desc/pagination variants and 3 negative probes.
- Preview regression: accounts fixture family clean (details in the PR comments); preview has no MIR activity, so its listings are empty on both sides.
- Checked on mainnet db-sync: no MIR target ever lacked a stake registration, so the unregistered-target 404 divergence Copilot raised cannot occur on any real chain — the probe-scan fix was reverted (9dba2885) to keep the guard simple. MIR certificates ended with Conway; the set is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Move Instantaneous Rewards (MIRs) associated with a stake address.
  - Added the `GET /accounts/{stake_address}/mirs` endpoint, including pagination and standard handling for empty, invalid, unavailable, and error responses.

- **Documentation**
  - Documented MIR account lookups in the Mini Blockfrost API coverage guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
