### PR TITLE
feat(minibf): add `/blocks/epoch/{epoch_number}/slot/{slot_number}`

### DIFF
--- a/crates/minibf/src/lib.rs
+++ b/crates/minibf/src/lib.rs
@@ -475,6 +475,10 @@ where
             get(routes::blocks::by_hash_or_number_addresses::<D>),
         )
         .route(
+            "/blocks/epoch/{epoch_number}/slot/{slot_number}",
+            get(routes::blocks::by_epoch_slot::<D>),
+        )
+        .route(
             "/blocks/slot/{slot_number}",
             get(routes::blocks::by_slot::<D>),
         )

--- a/crates/minibf/src/routes/blocks.rs
+++ b/crates/minibf/src/routes/blocks.rs
@@ -379,6 +379,57 @@ where
     Ok(Json(model))
 }
 
+/// `GET /blocks/epoch/{epoch_number}/slot/{slot_number}`: the block at an
+/// epoch-relative slot.
+///
+/// Blockfrost matches the pair against the epoch and epoch-slot columns it
+/// stores per block. Dolos stores blocks by absolute slot, so the handler
+/// turns the pair into an absolute slot with the chain summary and looks
+/// that up.
+pub async fn by_epoch_slot<D>(
+    Path((epoch_number, slot_number)): Path<(String, String)>,
+    State(domain): State<Facade<D>>,
+) -> Result<Json<BlockContent>, StatusCode>
+where
+    D: Domain + Clone + Send + Sync + 'static,
+{
+    // Blockfrost bounds both numbers to a positive signed 32-bit range and
+    // rejects anything else as a bad request.
+    let in_range =
+        |raw: &str| -> Option<u64> { raw.parse::<u64>().ok().filter(|x| *x <= i32::MAX as u64) };
+
+    let epoch = in_range(&epoch_number).ok_or(StatusCode::BAD_REQUEST)?;
+    let slot = in_range(&slot_number).ok_or(StatusCode::BAD_REQUEST)?;
+
+    let chain = domain.get_chain_summary()?;
+
+    // A slot past the end of the epoch names no block; without this guard
+    // the absolute slot would land in a later epoch.
+    let epoch_length = chain.epoch_start(epoch + 1) - chain.epoch_start(epoch);
+    if slot >= epoch_length {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let absolute_slot = chain.epoch_start(epoch) + slot;
+
+    let block = domain
+        .archive()
+        .get_block_by_slot(&absolute_slot)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let (_, tip) = domain
+        .archive()
+        .get_tip()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let mut model = build_block_model(&domain, &block, &tip, &chain).await?;
+    hacks::maybe_set_genesis_previous_block(&domain, &mut model);
+
+    Ok(Json(model))
+}
+
 pub async fn by_hash_or_number_txs<D>(
     Path(hash_or_number): Path<String>,
     Query(params): Query<PaginationParameters>,
@@ -1032,6 +1083,78 @@ mod tests {
         assert_status(
             &app,
             "/blocks/1/addresses",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .await;
+    }
+
+    /// The block behind `/blocks/{hash}`, which carries its own epoch and
+    /// epoch-slot fields — the pair the endpoint under test resolves.
+    async fn block_by_hash(app: &TestApp, hash: &str) -> BlockContent {
+        let (status, bytes) = app.get_bytes(&format!("/blocks/{hash}")).await;
+        assert_eq!(status, StatusCode::OK);
+        serde_json::from_slice(&bytes).expect("failed to parse block")
+    }
+
+    #[tokio::test]
+    async fn blocks_by_epoch_slot_happy_path() {
+        let app = TestApp::new();
+        let expected = block_by_hash(&app, &app.vectors().block_hash).await;
+
+        let epoch = expected.epoch.expect("block has no epoch");
+        let epoch_slot = expected.epoch_slot.expect("block has no epoch slot");
+
+        let path = format!("/blocks/epoch/{epoch}/slot/{epoch_slot}");
+        let (status, bytes) = app.get_bytes(&path).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let model: BlockContent = serde_json::from_slice(&bytes).expect("failed to parse block");
+        assert_eq!(model, expected);
+    }
+
+    #[tokio::test]
+    async fn blocks_by_epoch_slot_not_found() {
+        let app = TestApp::new();
+        let block = block_by_hash(&app, &app.vectors().block_hash).await;
+        let epoch = block.epoch.expect("block has no epoch");
+
+        // an empty slot inside the epoch
+        let path = format!("/blocks/epoch/{epoch}/slot/80000");
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+
+        // a slot past the end of the epoch must not roll into the next one
+        let path = format!("/blocks/epoch/{epoch}/slot/2000000000");
+        assert_status(&app, &path, StatusCode::NOT_FOUND).await;
+
+        // an epoch with no blocks
+        let path = "/blocks/epoch/500/slot/0";
+        assert_status(&app, path, StatusCode::NOT_FOUND).await;
+    }
+
+    #[tokio::test]
+    async fn blocks_by_epoch_slot_bad_request() {
+        let app = TestApp::new();
+
+        for (epoch, slot) in [
+            ("x", "0"),
+            ("2", "x"),
+            ("-1", "0"),
+            ("2", "-5"),
+            // past the positive signed 32-bit range Blockfrost accepts
+            ("2147483648", "0"),
+            ("2", "2147483648"),
+        ] {
+            let path = format!("/blocks/epoch/{epoch}/slot/{slot}");
+            assert_status(&app, &path, StatusCode::BAD_REQUEST).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn blocks_by_epoch_slot_internal_error() {
+        let app = TestApp::new_with_fault(Some(TestFault::ArchiveStoreError));
+        assert_status(
+            &app,
+            "/blocks/epoch/2/slot/0",
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .await;

--- a/docs/content/apis/minibf.mdx
+++ b/docs/content/apis/minibf.mdx
@@ -128,6 +128,7 @@ Dolos provides many, but not all of the Blockfrost endpoints. The following list
 | `/blocks/latest`                                           | Get latest block information                             |
 | `/blocks/latest/txs`                                       | Get transactions for the latest block                    |
 | `/blocks/latest/txs/cbor`                                  | Get transactions with CBOR data for the latest block     |
+| `/blocks/epoch/{epoch_number}/slot/{slot_number}`          | Get block by epoch and epoch-relative slot               |
 | `/blocks/slot/{slot_number}`                               | Get block by slot number                                 |
 | `/blocks/{hash_or_number}`                                 | Get block information                                    |
 | `/blocks/{hash_or_number}/addresses`                       | Get addresses in a specific block                        |


### PR DESCRIPTION
Closes #1115.

## Summary

Adds `/blocks/epoch/{epoch_number}/slot/{slot_number}`. It returns the block at an epoch-relative slot, in the same shape as `/blocks/{hash_or_number}`.

## Semantics (pinned against ryo's `blocks_epoch_number_slot_slot_number.sql`)

The `slot_number` is relative to the epoch, not absolute. Blockfrost matches it against the per-block epoch-slot column; dolos stores blocks by absolute slot, so the handler converts the pair with the chain summary and reuses the `/blocks/slot/{slot}` lookup.

| Input | Response |
| --- | --- |
| A pair naming a block | `200`, the standard block content |
| A slot with no block, an epoch with no blocks | `404` |
| A slot past the end of the epoch | `404` — guarded, so the absolute slot cannot roll into a later epoch |
| A negative, malformed, or past-the-positive-signed-32-bit-range number | `400` (Blockfrost's range rule) |
| A URL with a missing segment (`/blocks/epoch/2/slot`, `/blocks/epoch//slot/0`) | `404` — see note below |

**Note on missing segments:** these URLs never reach the handler. Dolos answers every unmatched path with `404`. Blockfrost's gateway answers every unmatched path — including `/nonexistent` — with a global `400 "Invalid path"`. This divergence predates this PR and applies to every minibf route (`/blocks/slot/` behaves the same way). Matching it would need a router-wide fallback, out of scope here.

## Testing

- 4 inline tests. The happy path reads a block through `/blocks/{hash}`, takes the `epoch`/`epoch_slot` pair from that response, and asserts the new endpoint returns the identical body.
- `cargo test -p dolos-minibf`: 415 passed. Clippy clean, fmt clean (`nightly-2026-08-27`).
- Official preview fixture passes: `blocks/epoch/511/slot/63748` verified against the freshly bootstrapped preview store with this branch's binary.
- Live diff against the Blockfrost preview API: 41/41 match — 32 real (epoch, epoch_slot) pairs spread over epochs 0-1416 return byte-identical bodies (`confirmations` compared with a small tip-drift tolerance), and all 9 negative probes (no-block slot, past-epoch-end slot, empty epoch, malformed and out-of-range numbers) return the same status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve a block using its epoch and slot numbers.
  * Added validation for invalid epoch/slot ranges and missing blocks, with appropriate error responses.

* **Documentation**
  * Documented the new block lookup endpoint in the Mini Blockfrost API coverage list.

* **Tests**
  * Added coverage for successful lookups, missing blocks, invalid ranges, and archive failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->