### PR TITLE
fix(ci): respect unavailable Windows CPU counters

### DIFF
--- a/xtask/src/perf/storage/node.rs
+++ b/xtask/src/perf/storage/node.rs
@@ -1453,7 +1453,8 @@ mod tests {
             "127.0.0.1:3900".parse().unwrap(),
         );
         assert!(toml.contains("version = \"v3\""));
-        assert!(toml.contains("byron_path = \"/g/byron.json\""));
+        let byron = Path::new("/g").join("byron.json");
+        assert!(toml.contains(&format!("byron_path = {:?}", byron.display().to_string())));
         assert!(toml.contains("[serve.grpc]\nlisten_address = \"127.0.0.1:3900\""));
         assert!(toml.contains("magic = 42\nis_testnet = true"));
         assert!(!toml.contains("minibf"));

--- a/xtask/tests/storage_perf_smoke.rs
+++ b/xtask/tests/storage_perf_smoke.rs
@@ -106,7 +106,10 @@ fn smoke_preset_runs_every_workload_and_verifies_bodies() {
         .find(|w| w["codec"]["codec"] == "zstd3-dict" && w["metrics"]["batch"] == 7)
         .unwrap();
     assert!(dict["metrics"]["ratio"].as_f64().unwrap() < 0.8);
-    assert!(dict["metrics"]["encode_cpu_ms"].as_f64().unwrap() > 0.0);
+    assert_eq!(
+        dict["metrics"]["encode_cpu_ms"].as_f64().unwrap() > 0.0,
+        xtask::perf::measure::thread_cpu_available()
+    );
     assert_eq!(dict["metrics"]["batch_latency"]["count"], 58);
     let store = writes
         .iter()


### PR DESCRIPTION
## Summary

- make the storage performance smoke assertion follow the harness counter capability
- preserve the positive CPU-time assertion on Unix
- accept the documented zero-value fallback when Windows has no thread CPU clock

## Tests

- `cargo test -p xtask --test storage_perf_smoke`
- `cargo +nightly-2026-08-27 fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated performance smoke-test validation to accommodate environments where thread CPU timing is unavailable.
  - Continued verifying CPU encoding metrics when timing data is supported.
  - Improved configuration checks to work consistently across operating systems by using platform-aware path formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->