### PR TITLE
fix(data-check): explain mid-epoch supply gaps instead of reporting value creation

### DIFF
--- a/src/bin/dolos/data/check/mod.rs
+++ b/src/bin/dolos/data/check/mod.rs
@@ -90,6 +90,47 @@ impl std::fmt::Display for Issue {
     }
 }
 
+/// One invariant that cannot be asserted at this particular store position.
+///
+/// This is deliberately not an [`Issue`]: a known structural limit must stay
+/// visible to the operator without making a consistent store fail the check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotAssertable {
+    pub check: CheckKind,
+    pub detail: String,
+}
+
+impl NotAssertable {
+    pub fn new(check: CheckKind, detail: impl Into<String>) -> Self {
+        Self {
+            check,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for NotAssertable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.check, self.detail)
+    }
+}
+
+/// Findings from one check, separating inconsistencies from structural skips.
+#[derive(Debug, Default)]
+pub struct CheckResult {
+    pub issues: Vec<Issue>,
+    pub not_assertable: Vec<NotAssertable>,
+}
+
+impl From<Vec<Issue>> for CheckResult {
+    fn from(issues: Vec<Issue>) -> Self {
+        Self {
+            issues,
+            not_assertable: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, clap::Args)]
 pub struct Args {
     /// check to run; repeatable, runs all of them when omitted
@@ -121,6 +162,7 @@ struct Timing {
     check: CheckKind,
     elapsed: Duration,
     issues: usize,
+    not_assertable: usize,
 }
 
 pub fn run(
@@ -141,10 +183,10 @@ pub fn run(
         let started = Instant::now();
 
         let found = match check {
-            CheckKind::Cursors => cursors::run(&stores),
-            CheckKind::ArchiveContinuity => archive::run(&stores, &progress),
-            CheckKind::AccountEpochs => accounts::run(&stores, &progress),
-            CheckKind::EpochLog => epoch_log::run(&stores),
+            CheckKind::Cursors => cursors::run(&stores).map(CheckResult::from),
+            CheckKind::ArchiveContinuity => archive::run(&stores, &progress).map(CheckResult::from),
+            CheckKind::AccountEpochs => accounts::run(&stores, &progress).map(CheckResult::from),
+            CheckKind::EpochLog => epoch_log::run(&stores).map(CheckResult::from),
             CheckKind::Totals => totals::run(&stores, &genesis, &progress),
         };
 
@@ -156,27 +198,38 @@ pub fn run(
 
         let found = found?;
 
-        for issue in &found {
+        for issue in &found.issues {
             eprintln!("{issue}");
+        }
+
+        for skipped in &found.not_assertable {
+            println!("{skipped}");
         }
 
         timings.push(Timing {
             check,
             elapsed,
-            issues: found.len(),
+            issues: found.issues.len(),
+            not_assertable: found.not_assertable.len(),
         });
 
-        issues.extend(found);
+        issues.extend(found.issues);
     }
 
     println!();
 
     for timing in &timings {
+        let skipped = match timing.not_assertable {
+            0 => String::new(),
+            count => format!(", {count} not assertable at this tip"),
+        };
+
         println!(
-            "{:<20} {:>10.2?}  {} issue(s)",
+            "{:<20} {:>10.2?}  {} issue(s){}",
             timing.check.name(),
             timing.elapsed,
-            timing.issues
+            timing.issues,
+            skipped,
         );
     }
 
@@ -278,11 +331,20 @@ mod tests {
         let (found, referent_issues) =
             totals::recompute(domain.state(), anchors, |_, _| {}).unwrap();
         issues.extend(referent_issues);
-        issues.extend(totals::check_pots(
-            &totals::live_pots(&epoch).expect("harness epoch can be placed at the tip"),
-            &found,
-            domain.genesis().shelley.max_lovelace_supply,
-        ));
+        issues.extend(
+            totals::check_pots(
+                &totals::live_pots(&epoch).expect("harness epoch can be placed at the tip"),
+                &found,
+                totals::SupplyCheck::Exact {
+                    max_supply: domain
+                        .genesis()
+                        .shelley
+                        .max_lovelace_supply
+                        .expect("the test genesis fixes a maximum supply"),
+                },
+            )
+            .issues,
+        );
 
         issues
     }

--- a/src/bin/dolos/data/check/totals.rs
+++ b/src/bin/dolos/data/check/totals.rs
@@ -22,8 +22,12 @@
 //!
 //! Rolling forward is only exact for the pots whose within-epoch movement
 //! `RollingStats` records in full, so the tip comparison stays narrow: the
-//! UTxO pot, the account count, the DRep deposits, and total supply
-//! conservation. Three pots have no honest figure at the tip at all:
+//! UTxO pot, the account count, and the DRep deposits. Total supply is exact
+//! only at an epoch boundary; mid-epoch, a newly registered pool's deposit has
+//! left the UTxO set while `pool_count` deliberately remains at its boundary
+//! value. At such a tip the check reports the exact in-flight pool deposits as
+//! not assertable, then still asserts that they account for the whole supply
+//! gap. Three pots have no honest figure at the tip at all:
 //!
 //! - **rewards, reserves, treasury.** Their within-epoch movement includes MIR
 //!   certificates, and `RollingStats` records the amounts the certificates *ask
@@ -124,7 +128,7 @@ use pallas::ledger::primitives::conway::DRep;
 use pallas::ledger::primitives::Epoch;
 use pallas::ledger::traverse::MultiEraOutput;
 
-use super::{CheckKind, Issue};
+use super::{CheckKind, CheckResult, Issue, NotAssertable};
 
 const CHECK: CheckKind = CheckKind::Totals;
 
@@ -480,12 +484,28 @@ fn note_pv10(snapshot: &EpochState, seen_pre_pv10: &mut bool, pv10_epoch: &mut O
 pub struct Recomputed {
     pub utxo_lovelace: u64,
     pub registered_accounts: u64,
+    pub registered_pools: u64,
     pub drep_deposits: u64,
 }
 
+/// How strongly total supply can be asserted at the current tip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupplyCheck {
+    /// The network genesis does not define a fixed maximum supply.
+    Unavailable,
+    /// Every pot has its boundary value, so the genesis total must match exactly.
+    Exact { max_supply: u64 },
+    /// `pool_count` is stale by design; account for the live pool-count delta.
+    MidEpoch {
+        max_supply: u64,
+        live_pool_count: u64,
+    },
+}
+
 /// Compare the recomputed figures against the pots the node claims.
-pub fn check_pots(claimed: &Pots, found: &Recomputed, max_supply: Option<u64>) -> Vec<Issue> {
+pub fn check_pots(claimed: &Pots, found: &Recomputed, supply: SupplyCheck) -> CheckResult {
     let mut issues = Vec::new();
+    let mut not_assertable = Vec::new();
 
     let mut compare = |what: &str, claimed: u64, found: u64, hint: &str| {
         if claimed != found {
@@ -521,22 +541,86 @@ pub fn check_pots(claimed: &Pots, found: &Recomputed, max_supply: Option<u64>) -
         "every registered DRep's deposit is held in the pot until it unregisters",
     );
 
-    // Total supply is fixed by genesis and only ever moves between pots.
-    if let Some(max_supply) = max_supply {
-        if !claimed.is_consistent(max_supply) {
-            issues.push(Issue::new(
-                CHECK,
-                format!(
-                    "the pots add up to {} lovelace but genesis fixes the supply at {max_supply} \
-                     (off by {}); value was created or destroyed",
-                    claimed.max_supply(),
-                    claimed.max_supply().abs_diff(max_supply),
-                ),
-            ));
+    match supply {
+        SupplyCheck::Unavailable => {}
+        // Total supply is fixed by genesis and only ever moves between pots.
+        SupplyCheck::Exact { max_supply } => {
+            if !claimed.is_consistent(max_supply) {
+                issues.push(Issue::new(
+                    CHECK,
+                    format!(
+                        "the pots add up to {} lovelace but genesis fixes the supply at \
+                         {max_supply} (off by {}); value was created or destroyed",
+                        claimed.max_supply(),
+                        claimed.max_supply().abs_diff(max_supply),
+                    ),
+                ));
+            }
+        }
+        SupplyCheck::MidEpoch {
+            max_supply,
+            live_pool_count,
+        } => {
+            let Some(in_flight_pool_count) = live_pool_count.checked_sub(claimed.pool_count) else {
+                issues.push(Issue::new(
+                    CHECK,
+                    format!(
+                        "the live state holds {live_pool_count} pools but the boundary pot claims \
+                         {}; the mid-epoch pool-deposit gap cannot be accounted for",
+                        claimed.pool_count,
+                    ),
+                ));
+                return CheckResult {
+                    issues,
+                    not_assertable,
+                };
+            };
+
+            let Some(in_flight_lovelace) =
+                in_flight_pool_count.checked_mul(claimed.deposit_per_pool)
+            else {
+                issues.push(Issue::new(
+                    CHECK,
+                    "the in-flight pool deposits overflow the lovelace total",
+                ));
+                return CheckResult {
+                    issues,
+                    not_assertable,
+                };
+            };
+
+            let accounted_supply = claimed.max_supply().checked_add(in_flight_lovelace);
+
+            if accounted_supply != Some(max_supply) {
+                let accounted_supply = accounted_supply.unwrap_or(u64::MAX);
+                issues.push(Issue::new(
+                    CHECK,
+                    format!(
+                        "the mid-epoch pots plus {in_flight_pool_count} in-flight pool deposit(s) \
+                         ({in_flight_lovelace} lovelace) account for {accounted_supply} lovelace, \
+                         but genesis fixes the supply at {max_supply} (off by {}); the pool \
+                         deposits do not explain the discrepancy",
+                        accounted_supply.abs_diff(max_supply),
+                    ),
+                ));
+            } else {
+                not_assertable.push(NotAssertable::new(
+                    CHECK,
+                    format!(
+                        "exact supply is not assertable at a mid-epoch tip: \
+                         {in_flight_pool_count} pool deposit(s), totaling {in_flight_lovelace} \
+                         lovelace, are absent from the boundary-valued pool pot; after accounting \
+                         for them the genesis supply matches",
+                    ),
+                ));
+            }
         }
     }
 
-    issues
+    CheckResult {
+        issues,
+        not_assertable,
+    }
 }
 
 /// What one DRep row says, reduced to what the referent rules ask of it.
@@ -954,6 +1038,7 @@ pub fn recompute<S: StateStore>(
     let found = Recomputed {
         utxo_lovelace: sum_utxo_lovelace(state, |seen| on_progress("utxos", seen))?,
         registered_accounts,
+        registered_pools: referents.pools.len() as u64,
         drep_deposits: sum_drep_deposits(state)?,
     };
 
@@ -964,7 +1049,7 @@ pub fn run(
     stores: &crate::common::Stores,
     genesis: &Genesis,
     progress: &ProgressBar,
-) -> miette::Result<Vec<Issue>> {
+) -> miette::Result<CheckResult> {
     let epoch = stores
         .state
         .read_entity_typed::<EpochState>(EpochState::NS, &EpochState::singleton_key())
@@ -974,7 +1059,7 @@ pub fn run(
     let Some(epoch) = epoch else {
         // Nothing to compare against; `cursors` reports a state store that
         // was never bootstrapped.
-        return Ok(Vec::new());
+        return Ok(CheckResult::default());
     };
 
     let snapshots = stores
@@ -1002,13 +1087,44 @@ pub fn run(
 
     issues.extend(referent_issues);
 
-    match live_pots(&epoch) {
-        Some(claimed) => issues.extend(check_pots(
-            &claimed,
-            &found,
-            genesis.shelley.max_lovelace_supply,
-        )),
-        None => issues.push(Issue::new(
+    let max_supply = genesis.shelley.max_lovelace_supply;
+    let supply = match (
+        stores
+            .state
+            .read_cursor()
+            .into_diagnostic()
+            .context("reading the state cursor for the supply check")?,
+        chain_summary(&stores.state)?,
+        max_supply,
+    ) {
+        (_, _, None) => Some(SupplyCheck::Unavailable),
+        (
+            Some(dolos_core::ChainPoint::Slot(slot) | dolos_core::ChainPoint::Specific(slot, _)),
+            Some(summary),
+            Some(max_supply),
+        ) => {
+            let (_, epoch_slot) = summary.slot_epoch(slot);
+            if epoch_slot == 0 {
+                Some(SupplyCheck::Exact { max_supply })
+            } else {
+                Some(SupplyCheck::MidEpoch {
+                    max_supply,
+                    live_pool_count: found.registered_pools,
+                })
+            }
+        }
+        _ => None,
+    };
+
+    let mut not_assertable = Vec::new();
+
+    match (live_pots(&epoch), supply) {
+        (Some(claimed), Some(supply)) => {
+            let checked = check_pots(&claimed, &found, supply);
+            issues.extend(checked.issues);
+            not_assertable.extend(checked.not_assertable);
+        }
+        (None, _) => issues.push(Issue::new(
             CHECK,
             format!(
                 "epoch {} has accumulated this epoch's deltas but carries no live protocol \
@@ -1017,9 +1133,17 @@ pub fn run(
                 epoch.number,
             ),
         )),
+        (Some(_), None) => issues.push(Issue::new(
+            CHECK,
+            "the state cursor or chain summary is missing, so the supply assertion cannot \
+             determine whether the tip is an epoch boundary",
+        )),
     }
 
-    Ok(issues)
+    Ok(CheckResult {
+        issues,
+        not_assertable,
+    })
 }
 
 #[cfg(test)]
@@ -1071,12 +1195,20 @@ mod tests {
         let found = Recomputed {
             utxo_lovelace: 500,
             registered_accounts: 3,
+            registered_pools: 0,
             drep_deposits: 0,
         };
 
-        let issues = check_pots(&pots(500, 3), &found, Some(MAX_SUPPLY));
+        let result = check_pots(
+            &pots(500, 3),
+            &found,
+            SupplyCheck::Exact {
+                max_supply: MAX_SUPPLY,
+            },
+        );
 
-        assert!(issues.is_empty(), "{issues:?}");
+        assert!(result.issues.is_empty(), "{:?}", result.issues);
+        assert!(result.not_assertable.is_empty());
     }
 
     /// The corruption fixture: a doctored pot figure. The UTxO set is intact,
@@ -1086,13 +1218,22 @@ mod tests {
         let found = Recomputed {
             utxo_lovelace: 500,
             registered_accounts: 3,
+            registered_pools: 0,
             drep_deposits: 0,
         };
 
         let mut claimed = pots(500, 3);
         claimed.utxos += 42;
 
-        let issues = check_pots(&claimed, &found, None);
+        let expected = claimed.max_supply();
+        let issues = check_pots(
+            &claimed,
+            &found,
+            SupplyCheck::Exact {
+                max_supply: expected,
+            },
+        )
+        .issues;
 
         assert_eq!(issues.len(), 1, "{issues:?}");
         assert_eq!(issues[0].check, CheckKind::Totals);
@@ -1107,16 +1248,83 @@ mod tests {
         let found = Recomputed {
             utxo_lovelace: 542,
             registered_accounts: 3,
+            registered_pools: 0,
             drep_deposits: 0,
         };
 
         let mut claimed = pots(500, 3);
         claimed.utxos += 42;
 
-        let issues = check_pots(&claimed, &found, Some(MAX_SUPPLY));
+        let issues = check_pots(
+            &claimed,
+            &found,
+            SupplyCheck::Exact {
+                max_supply: MAX_SUPPLY,
+            },
+        )
+        .issues;
 
         assert_eq!(issues.len(), 1, "{issues:?}");
         assert!(issues[0].detail.contains("genesis fixes the supply"));
+    }
+
+    fn mid_epoch_pots(extra_gap: u64) -> (Pots, Recomputed) {
+        let mut claimed = pots(2_000_000_000, 3);
+        claimed.deposit_per_pool = 500_000_000;
+        claimed.pool_count = 2;
+        claimed.reserves -= 1_000_000_000;
+
+        // A third pool registered after the boundary. Its 500 ADA deposit has
+        // left the live UTxO set, while the boundary-valued count remains two.
+        claimed.utxos -= 500_000_000 + extra_gap;
+
+        let found = Recomputed {
+            utxo_lovelace: claimed.utxos,
+            registered_accounts: 3,
+            registered_pools: 3,
+            drep_deposits: 0,
+        };
+
+        (claimed, found)
+    }
+
+    #[test]
+    fn mid_epoch_pool_deposit_is_explained_without_an_issue() {
+        let (claimed, found) = mid_epoch_pots(0);
+
+        let result = check_pots(
+            &claimed,
+            &found,
+            SupplyCheck::MidEpoch {
+                max_supply: MAX_SUPPLY,
+                live_pool_count: found.registered_pools,
+            },
+        );
+
+        assert!(result.issues.is_empty(), "{:?}", result.issues);
+        assert_eq!(result.not_assertable.len(), 1);
+        assert!(result.not_assertable[0].detail.contains("1 pool deposit"));
+        assert!(result.not_assertable[0]
+            .detail
+            .contains("500000000 lovelace"));
+    }
+
+    #[test]
+    fn mid_epoch_pool_deposit_does_not_hide_a_residual_discrepancy() {
+        let (claimed, found) = mid_epoch_pots(1);
+
+        let result = check_pots(
+            &claimed,
+            &found,
+            SupplyCheck::MidEpoch {
+                max_supply: MAX_SUPPLY,
+                live_pool_count: found.registered_pools,
+            },
+        );
+
+        assert_eq!(result.issues.len(), 1, "{:?}", result.issues);
+        assert!(result.issues[0].detail.contains("off by 1"));
+        assert!(result.not_assertable.is_empty());
     }
 
     #[test]

--- a/src/bin/dolos/data/check/totals.rs
+++ b/src/bin/dolos/data/check/totals.rs
@@ -493,7 +493,8 @@ pub struct Recomputed {
 pub enum SupplyCheck {
     /// The network genesis does not define a fixed maximum supply.
     Unavailable,
-    /// Every pot has its boundary value, so the genesis total must match exactly.
+    /// Every pot has its boundary value, so the genesis total must match
+    /// exactly.
     Exact { max_supply: u64 },
     /// `pool_count` is stale by design; account for the live pool-count delta.
     MidEpoch {


### PR DESCRIPTION
When a pool pays its registration deposit during an epoch, the live UTxO pot changes before the boundary-valued pool count does. `dolos data check` now accounts for that gap instead of reporting valid state as created or destroyed supply. Any unexplained residual still fails.

The checker excludes retired pools from live deposit accounting, recognizes rolling activity even in a slot-zero block, and reports a skipped assertion only when nonzero lovelace is in flight. Untouched boundaries and zero-value gaps remain exact checks. The CLI summary and module documentation explain the distinction.

Validation on PR head `9259a8df`:

- Formatter and full workspace build pass.
- Default workspace suite: 1,511 passed, 48 ignored.
- All-features workspace suite with the repository's three service exclusions: 1,026 passed, 53 ignored.
- Regressions cover retired pools, boundary corruption, first-block registration, explained deposits, zero-count/zero-value deposits, and an extra one-lovelace discrepancy.
- Replacement mainnet store `mainnet-v17-stelae-20260910`, tip `197512829`: all five consistency checks passed on `306e7439`. After the final zero-value-only adjustment, totals passed again on the final source in 9.79 seconds; the other four checks are unchanged. This store has no deposit gap, so no skip is expected. Positive-gap reporting is covered synthetically.

Remaining QA gate: full-workspace Clippy completes with seven pre-existing warnings in unchanged Cardano and snapshot test files. `-D warnings` fails on those warnings; the warning-free requirement has not been waived. The plan records the required scope decision for their mechanical cleanup.

Plan: `plans/dolos-data-check-mid-epoch-supply.md`. Merge remains with the founder after QA completion.
