### PR TITLE
feat: expose headless bulk replay engine

### DIFF
--- a/crates/core/src/import.rs
+++ b/crates/core/src/import.rs
@@ -106,6 +106,118 @@ pub enum WalSeed {
     Seeded(ChainPoint),
 }
 
+/// The durable relationship between state and WAL after recovering a bulk
+/// replay checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BulkRecovery {
+    /// Neither store has a cursor yet.
+    Empty,
+    /// Both stores already name the same committed point.
+    Aligned { position: ChainPoint },
+    /// Bulk import committed state past the WAL, so the WAL was reseeded to
+    /// the state cursor.
+    WalSeeded {
+        previous: Option<ChainPoint>,
+        position: ChainPoint,
+    },
+    /// WAL is ahead of state. Normal domain bootstrap owns replaying it
+    /// forward; bulk recovery deliberately leaves both stores unchanged.
+    WalAhead {
+        wal: ChainPoint,
+        state: Option<ChainPoint>,
+    },
+}
+
+/// Why a bulk checkpoint cannot be recovered automatically.
+#[derive(Debug, thiserror::Error)]
+pub enum BulkRecoveryError {
+    #[error("reading state cursor during bulk checkpoint recovery")]
+    ReadState(#[source] StateError),
+
+    #[error("reading WAL tip during bulk checkpoint recovery")]
+    ReadWal(#[source] WalError),
+
+    #[error("state cursor at slot {slot} has no block hash; refusing to reseed the WAL")]
+    UnanchoredState { slot: BlockSlot },
+
+    #[error("WAL point {wal} and state point {state} disagree at slot {slot}")]
+    DivergedAtSlot {
+        slot: BlockSlot,
+        wal: ChainPoint,
+        state: ChainPoint,
+    },
+
+    #[error("WAL point {wal} exists but state has no cursor")]
+    MissingState { wal: ChainPoint },
+
+    #[error("seeding WAL from the bulk-import state cursor")]
+    ResetWal(#[source] WalError),
+}
+
+/// Reconcile the one expected bulk-import crash shape: state ahead of WAL.
+///
+/// [`ImportExt`] intentionally skips WAL writes, so every successfully
+/// committed import batch can leave state ahead until the replay session
+/// checkpoints. Reseeding the WAL to a fully-defined state cursor is safe in
+/// that one direction. Other shapes are either left to normal bootstrap (WAL
+/// ahead) or refused (an unanchored/divergent cursor), so corrupt state is not
+/// mistaken for ordinary replay recovery.
+///
+/// This function only reads state and writes WAL. It never drains chain work,
+/// advances state, touches the archive, or performs housekeeping. Callers may
+/// therefore run it before publishing a pending boundary and before building
+/// the next replay domain.
+pub fn recover_bulk_checkpoint<S, W>(state: &S, wal: &W) -> Result<BulkRecovery, BulkRecoveryError>
+where
+    S: StateStore,
+    W: WalStore,
+{
+    let state = state.read_cursor().map_err(BulkRecoveryError::ReadState)?;
+    let wal_tip = wal
+        .find_tip()
+        .map_err(BulkRecoveryError::ReadWal)?
+        .map(|(point, _)| point);
+
+    if let Some(state) = state.as_ref() {
+        if !state.is_fully_defined() {
+            return Err(BulkRecoveryError::UnanchoredState { slot: state.slot() });
+        }
+    }
+
+    match (wal_tip, state) {
+        (None, None) => Ok(BulkRecovery::Empty),
+        (None, Some(position)) => {
+            wal.reset_to(&position)
+                .map_err(BulkRecoveryError::ResetWal)?;
+            Ok(BulkRecovery::WalSeeded {
+                previous: None,
+                position,
+            })
+        }
+        (Some(wal), None) if wal == ChainPoint::Origin => {
+            Ok(BulkRecovery::WalAhead { wal, state: None })
+        }
+        (Some(wal), None) => Err(BulkRecoveryError::MissingState { wal }),
+        (Some(wal), Some(state)) if wal == state => Ok(BulkRecovery::Aligned { position: state }),
+        (Some(wal), Some(state)) if wal.slot() == state.slot() => {
+            Err(BulkRecoveryError::DivergedAtSlot {
+                slot: state.slot(),
+                wal,
+                state,
+            })
+        }
+        (Some(wal), Some(state)) if wal.slot() > state.slot() => Ok(BulkRecovery::WalAhead {
+            wal,
+            state: Some(state),
+        }),
+        (previous, Some(position)) => {
+            wal.reset_to(&position)
+                .map_err(BulkRecoveryError::ResetWal)?;
+            Ok(BulkRecovery::WalSeeded { previous, position })
+        }
+    }
+}
+
 /// Why the WAL could not be seeded from the state cursor.
 ///
 /// One variant per step, each carrying the message the bootstrap command has

--- a/crates/core/src/import.rs
+++ b/crates/core/src/import.rs
@@ -106,118 +106,6 @@ pub enum WalSeed {
     Seeded(ChainPoint),
 }
 
-/// The durable relationship between state and WAL after recovering a bulk
-/// replay checkpoint.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BulkRecovery {
-    /// Neither store has a cursor yet.
-    Empty,
-    /// Both stores already name the same committed point.
-    Aligned { position: ChainPoint },
-    /// Bulk import committed state past the WAL, so the WAL was reseeded to
-    /// the state cursor.
-    WalSeeded {
-        previous: Option<ChainPoint>,
-        position: ChainPoint,
-    },
-    /// WAL is ahead of state. Normal domain bootstrap owns replaying it
-    /// forward; bulk recovery deliberately leaves both stores unchanged.
-    WalAhead {
-        wal: ChainPoint,
-        state: Option<ChainPoint>,
-    },
-}
-
-/// Why a bulk checkpoint cannot be recovered automatically.
-#[derive(Debug, thiserror::Error)]
-pub enum BulkRecoveryError {
-    #[error("reading state cursor during bulk checkpoint recovery")]
-    ReadState(#[source] StateError),
-
-    #[error("reading WAL tip during bulk checkpoint recovery")]
-    ReadWal(#[source] WalError),
-
-    #[error("state cursor at slot {slot} has no block hash; refusing to reseed the WAL")]
-    UnanchoredState { slot: BlockSlot },
-
-    #[error("WAL point {wal} and state point {state} disagree at slot {slot}")]
-    DivergedAtSlot {
-        slot: BlockSlot,
-        wal: ChainPoint,
-        state: ChainPoint,
-    },
-
-    #[error("WAL point {wal} exists but state has no cursor")]
-    MissingState { wal: ChainPoint },
-
-    #[error("seeding WAL from the bulk-import state cursor")]
-    ResetWal(#[source] WalError),
-}
-
-/// Reconcile the one expected bulk-import crash shape: state ahead of WAL.
-///
-/// [`ImportExt`] intentionally skips WAL writes, so every successfully
-/// committed import batch can leave state ahead until the replay session
-/// checkpoints. Reseeding the WAL to a fully-defined state cursor is safe in
-/// that one direction. Other shapes are either left to normal bootstrap (WAL
-/// ahead) or refused (an unanchored/divergent cursor), so corrupt state is not
-/// mistaken for ordinary replay recovery.
-///
-/// This function only reads state and writes WAL. It never drains chain work,
-/// advances state, touches the archive, or performs housekeeping. Callers may
-/// therefore run it before publishing a pending boundary and before building
-/// the next replay domain.
-pub fn recover_bulk_checkpoint<S, W>(state: &S, wal: &W) -> Result<BulkRecovery, BulkRecoveryError>
-where
-    S: StateStore,
-    W: WalStore,
-{
-    let state = state.read_cursor().map_err(BulkRecoveryError::ReadState)?;
-    let wal_tip = wal
-        .find_tip()
-        .map_err(BulkRecoveryError::ReadWal)?
-        .map(|(point, _)| point);
-
-    if let Some(state) = state.as_ref() {
-        if !state.is_fully_defined() {
-            return Err(BulkRecoveryError::UnanchoredState { slot: state.slot() });
-        }
-    }
-
-    match (wal_tip, state) {
-        (None, None) => Ok(BulkRecovery::Empty),
-        (None, Some(position)) => {
-            wal.reset_to(&position)
-                .map_err(BulkRecoveryError::ResetWal)?;
-            Ok(BulkRecovery::WalSeeded {
-                previous: None,
-                position,
-            })
-        }
-        (Some(wal), None) if wal == ChainPoint::Origin => {
-            Ok(BulkRecovery::WalAhead { wal, state: None })
-        }
-        (Some(wal), None) => Err(BulkRecoveryError::MissingState { wal }),
-        (Some(wal), Some(state)) if wal == state => Ok(BulkRecovery::Aligned { position: state }),
-        (Some(wal), Some(state)) if wal.slot() == state.slot() => {
-            Err(BulkRecoveryError::DivergedAtSlot {
-                slot: state.slot(),
-                wal,
-                state,
-            })
-        }
-        (Some(wal), Some(state)) if wal.slot() > state.slot() => Ok(BulkRecovery::WalAhead {
-            wal,
-            state: Some(state),
-        }),
-        (previous, Some(position)) => {
-            wal.reset_to(&position)
-                .map_err(BulkRecoveryError::ResetWal)?;
-            Ok(BulkRecovery::WalSeeded { previous, position })
-        }
-    }
-}
-
 /// Why the WAL could not be seeded from the state cursor.
 ///
 /// One variant per step, each carrying the message the bootstrap command has
@@ -266,4 +154,27 @@ where
     wal.reset_to(&cursor).map_err(WalSeedError::Reset)?;
 
     Ok(WalSeed::Seeded(cursor))
+}
+
+/// The durable result of importing one batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayProgress {
+    /// The batch committed normally at this state-store position.
+    Committed { position: ChainPoint },
+    /// The configured stopping epoch fired after its anchoring block committed.
+    Boundary { position: ChainPoint },
+}
+
+impl ReplayProgress {
+    /// The committed state cursor reported by this import.
+    pub fn position(&self) -> &ChainPoint {
+        match self {
+            Self::Committed { position } | Self::Boundary { position } => position,
+        }
+    }
+
+    /// Whether the configured stopping boundary was reached.
+    pub fn is_boundary(&self) -> bool {
+        matches!(self, Self::Boundary { .. })
+    }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,10 +45,7 @@ pub mod wal;
 pub mod work_unit;
 
 pub use bootstrap::BootstrapExt;
-pub use import::{
-    recover_bulk_checkpoint, seed_wal_from_state, BulkRecovery, BulkRecoveryError, ImportExt,
-    WalSeed, WalSeedError,
-};
+pub use import::{seed_wal_from_state, ImportExt, ReplayProgress, WalSeed, WalSeedError};
 pub use submit::SubmitExt;
 pub use sync::SyncExt;
 pub use work_unit::{MempoolUpdate, WorkUnit};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,7 +45,10 @@ pub mod wal;
 pub mod work_unit;
 
 pub use bootstrap::BootstrapExt;
-pub use import::{seed_wal_from_state, ImportExt, WalSeed, WalSeedError};
+pub use import::{
+    recover_bulk_checkpoint, seed_wal_from_state, BulkRecovery, BulkRecoveryError, ImportExt,
+    WalSeed, WalSeedError,
+};
 pub use submit::SubmitExt;
 pub use sync::SyncExt;
 pub use work_unit::{MempoolUpdate, WorkUnit};

--- a/crates/snapshot/src/backfill.rs
+++ b/crates/snapshot/src/backfill.rs
@@ -69,8 +69,8 @@ use std::sync::Arc;
 
 use dolos_core::config::{MithrilConfig, RootConfig};
 use dolos_core::{
-    seed_wal_from_state, BlockSlot, Domain, DomainError, Genesis, ImportExt as _, StateStore as _,
-    WalSeedError,
+    recover_bulk_checkpoint, BlockSlot, BulkRecoveryError, Domain, DomainError, Genesis,
+    ImportExt as _, StateStore as _,
 };
 use dolos_mithril as mithril;
 use dolos_mithril::mithril_client::feedback::FeedbackReceiver;
@@ -125,8 +125,8 @@ pub enum Error {
     #[error("planning the publish")]
     Planning(#[source] crate::Error),
 
-    #[error("seeding the WAL from the state cursor")]
-    WalSeed(#[source] WalSeedError),
+    #[error("recovering the bulk-replay checkpoint: {0}")]
+    Recovery(#[source] BulkRecoveryError),
 
     #[error("pruning excess history")]
     Housekeeping(#[source] DomainError),
@@ -601,7 +601,7 @@ impl<D: Domain> Driver<'_, D> {
         // refuses the same state as an unanchored point, with the sentence
         // that names the command's own subject.
         if cursor.is_fully_defined() {
-            seed_wal_from_state(&stores.state, &stores.wal).map_err(Error::WalSeed)?;
+            recover_bulk_checkpoint(&stores.state, &stores.wal).map_err(Error::Recovery)?;
         }
 
         let summary = dolos_cardano::eras::load_chain_summary_from_state(&stores.state)
@@ -832,7 +832,7 @@ impl<D: Domain> Driver<'_, D> {
 
         // Whatever ended the replay, the chunks it committed are in the state
         // and the WAL must agree before the next domain open.
-        seed_wal_from_state(domain.state(), domain.wal()).map_err(Error::WalSeed)?;
+        recover_bulk_checkpoint(domain.state(), domain.wal()).map_err(Error::Recovery)?;
 
         self.replay.round_finished();
 

--- a/crates/snapshot/src/backfill.rs
+++ b/crates/snapshot/src/backfill.rs
@@ -134,6 +134,12 @@ pub enum Error {
     #[error("importing an immutable block chunk")]
     Import(#[source] DomainError),
 
+    #[error("replay failed ({replay}) and shutting down also failed ({shutdown})")]
+    ReplayAndShutdown {
+        replay: Box<Error>,
+        shutdown: Box<Error>,
+    },
+
     #[error("iterating the local immutable db: {0}")]
     ImmutableDb(String),
 
@@ -507,10 +513,25 @@ pub struct Driver<'a, D: Domain> {
     /// Beside [`Driver::build_domain`] and for the same reason: a domain's
     /// teardown is not on the [`Domain`] trait either, so the half of its
     /// lifecycle that flushes is the caller's too.
-    pub shutdown_domain: &'a dyn Fn(&D) -> Result<(), Error>,
+    pub shutdown_domain: &'a dyn Fn(D) -> Result<(), Error>,
 
     /// Where the planned sequence goes.
     pub publish: &'a dyn Publish<D>,
+}
+
+fn finish_extend(
+    replay: Result<Advance, Error>,
+    shutdown: Result<(), Error>,
+) -> Result<Advance, Error> {
+    match (replay, shutdown) {
+        (Ok(advance), Ok(())) => Ok(advance),
+        (Err(replay), Ok(())) => Err(replay),
+        (Ok(_), Err(shutdown)) => Err(shutdown),
+        (Err(replay), Err(shutdown)) => Err(Error::ReplayAndShutdown {
+            replay: Box::new(replay),
+            shutdown: Box::new(shutdown),
+        }),
+    }
 }
 
 impl<D: Domain> Driver<'_, D> {
@@ -673,12 +694,9 @@ impl<D: Domain> Driver<'_, D> {
 
         // Shut down even when the replay failed: fjall in particular has
         // background work to flush before the handle drops.
-        let shutdown = (self.shutdown_domain)(&domain);
+        let shutdown = (self.shutdown_domain)(domain);
 
-        let advance = result?;
-        shutdown?;
-
-        Ok(advance)
+        finish_extend(result, shutdown)
     }
 
     /// Import what is on disk, fetching windows from mithril whenever the
@@ -1053,6 +1071,20 @@ mod tests {
         assert!(!fetch_advanced(Some(5), Some(5)));
         assert!(!fetch_advanced(Some(5), None));
         assert!(!fetch_advanced(None, None));
+    }
+
+    #[test]
+    fn replay_and_shutdown_failures_are_both_preserved() {
+        let Err(error) = finish_extend(Err(Error::Interrupted), Err(Error::EmptyWindow)) else {
+            panic!("simultaneous failures unexpectedly succeeded");
+        };
+
+        let Error::ReplayAndShutdown { replay, shutdown } = error else {
+            panic!("simultaneous failures lost their combined error");
+        };
+
+        assert!(matches!(*replay, Error::Interrupted));
+        assert!(matches!(*shutdown, Error::EmptyWindow));
     }
 
     #[test]

--- a/crates/snapshot/src/backfill.rs
+++ b/crates/snapshot/src/backfill.rs
@@ -56,29 +56,23 @@
 //!
 //! This module is orchestration only: it composes the mithril fetch, the
 //! import lifecycle, and the publish path `snapshot publish --repo` uses, and
-//! changes none of them. Everything a *process* owns stays outside it, on
-//! [`Driver`]'s seams — the tokio runtime the mithril calls are driven on, the
-//! shutdown token the signal handler cancels, the renderers, and the steps a
-//! [`Domain`] does not expose: opening the stores without a domain, building
-//! and tearing down one that stops at a chosen epoch, and publishing a plan.
-//! That split is what keeps the shutdown semantics the binary's, where the
-//! signals arrive.
+//! changes none of them. Process setup and signal handling stay in the host.
+//! The driver owns source acquisition, publication order and cancellation.
+//! A workspace supplies non-advancing profile inspection and an exclusive
+//! replay session. Engine initialization and persistence are not host policy.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use dolos_core::config::{MithrilConfig, RootConfig};
-use dolos_core::{
-    recover_bulk_checkpoint, BlockSlot, BulkRecoveryError, Domain, DomainError, Genesis,
-    ImportExt as _, StateStore as _,
-};
+use dolos_core::{BlockSlot, ChainPoint, Genesis, RawBlock, ReplayProgress};
 use dolos_mithril as mithril;
 use dolos_mithril::mithril_client::feedback::FeedbackReceiver;
 use itertools::Itertools as _;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::{export::Plan, planning, retry};
+use crate::{export::Plan, planning, retry, source::SnapshotSource};
 
 /// Blocks handed to `import_blocks` per batch.
 const IMPORT_CHUNK: usize = 100;
@@ -107,32 +101,17 @@ const INTERRUPTED: &str =
 /// What the daemon refused, or what refused it.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// A seam the caller supplied failed: opening the stores, building a
-    /// domain, or publishing. Its rendering is the caller's — the daemon only
+    /// A seam the caller supplied failed: opening a workspace, replaying,
+    /// or publishing. Its rendering is the caller's — the daemon only
     /// says which step it was in.
     #[error("{0}")]
     Caller(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[error("reading the state cursor")]
-    Cursor(#[source] dolos_core::StateError),
-
-    #[error("loading the chain summary")]
-    ChainSummary(#[source] dolos_core::ChainError),
 
     #[error("reading snapshot.state_epochs")]
     RetainedEpochs(#[source] crate::Error),
 
     #[error("planning the publish")]
     Planning(#[source] crate::Error),
-
-    #[error("recovering the bulk-replay checkpoint: {0}")]
-    Recovery(#[source] BulkRecoveryError),
-
-    #[error("pruning excess history")]
-    Housekeeping(#[source] DomainError),
-
-    #[error("importing an immutable block chunk")]
-    Import(#[source] DomainError),
 
     #[error("replay failed ({replay}) and shutting down also failed ({shutdown})")]
     ReplayAndShutdown {
@@ -187,16 +166,21 @@ impl Error {
     }
 }
 
-/// The three stores a publish reads, opened without a domain.
-///
-/// [`Driver::publish_pending`] runs *before* anything opens a domain and
-/// cannot use one: the WAL reseed it performs is the very thing that makes
-/// the next domain open legal, and a domain assembled first would refuse with
-/// `InconsistentState` instead.
-pub struct Stores<D: Domain> {
-    pub wal: D::Wal,
-    pub state: D::State,
-    pub archive: D::Archive,
+/// A dataset that can be inspected without advancing its logical state.
+pub trait Workspace {
+    type Session: Session;
+
+    fn snapshot(&self) -> impl SnapshotSource + '_;
+    fn start(self, target_epoch: u64) -> Result<Self::Session, Error>;
+    fn finish(self) -> Result<(), Error>;
+}
+
+/// The operations backfill needs from an exclusive replay engine.
+pub trait Session {
+    fn committed_position(&self) -> Result<Option<ChainPoint>, Error>;
+    fn import_blocks(&mut self, blocks: Vec<RawBlock>) -> Result<ReplayProgress, Error>;
+    fn prune_history(&mut self) -> Result<u64, Error>;
+    fn finish(self) -> Result<(), Error>;
 }
 
 /// Where the replay's own progress goes.
@@ -225,7 +209,7 @@ impl Replay for () {}
 /// A seam rather than a call into [`publisher`](crate::publisher), because
 /// `snapshot publish --repo` renders the same publish and one telling of that
 /// order is what [`publisher::Publisher`](crate::publisher::Publisher) is for.
-pub trait Publish<D: Domain> {
+pub trait Publish {
     /// Say what is about to be published. Once per iteration, outside the
     /// retry, so a transient failure does not repeat the report.
     fn announce(&self, plan: &Plan) -> Result<(), Error> {
@@ -235,7 +219,7 @@ pub trait Publish<D: Domain> {
 
     /// Publish the plan. Retried in place by the daemon, so it must be safe to
     /// simply run again.
-    fn publish(&self, plan: &Plan, archive: &D::Archive, state: &D::State) -> Result<(), Error>;
+    fn publish(&self, plan: &Plan, source: &dyn SnapshotSource) -> Result<(), Error>;
 }
 
 /// How a run ended, for a caller that has something to say about it.
@@ -452,7 +436,7 @@ fn cleanup_consumed(
 /// The seams are `&dyn` rather than generic parameters because there is one
 /// caller and the daemon is not on any hot path: a monomorphized copy per
 /// closure would buy nothing and cost a signature nobody can read.
-pub struct Driver<'a, D: Domain> {
+pub struct Driver<'a, W: Workspace> {
     /// The node's configuration, for the retained-epoch parameters a plan
     /// carries.
     pub config: &'a RootConfig,
@@ -498,31 +482,14 @@ pub struct Driver<'a, D: Domain> {
     /// Where the replay's progress goes.
     pub replay: &'a dyn Replay,
 
-    /// Open the three stores a publish reads, without assembling a domain.
-    pub open_stores: &'a dyn Fn() -> Result<Stores<D>, Error>,
-
-    /// Build a domain whose `stop_epoch` is the given epoch.
-    ///
-    /// The seam a [`Domain`] does not cover: the stop epoch is baked in at
-    /// build time and the daemon rebuilds the domain per boundary, so
-    /// construction is the caller's.
-    pub build_domain: &'a dyn Fn(u64) -> Result<D, Error>,
-
-    /// Drain a domain's background work before its handle drops.
-    ///
-    /// Beside [`Driver::build_domain`] and for the same reason: a domain's
-    /// teardown is not on the [`Domain`] trait either, so the half of its
-    /// lifecycle that flushes is the caller's too.
-    pub shutdown_domain: &'a dyn Fn(D) -> Result<(), Error>,
+    /// Open a dataset for inspection without advancing it.
+    pub open_workspace: &'a dyn Fn() -> Result<W, Error>,
 
     /// Where the planned sequence goes.
-    pub publish: &'a dyn Publish<D>,
+    pub publish: &'a dyn Publish,
 }
 
-fn finish_extend(
-    replay: Result<Advance, Error>,
-    shutdown: Result<(), Error>,
-) -> Result<Advance, Error> {
+fn finish_extend<T>(replay: Result<T, Error>, shutdown: Result<(), Error>) -> Result<T, Error> {
     match (replay, shutdown) {
         (Ok(advance), Ok(())) => Ok(advance),
         (Err(replay), Ok(())) => Err(replay),
@@ -534,7 +501,7 @@ fn finish_extend(
     }
 }
 
-impl<D: Domain> Driver<'_, D> {
+impl<W: Workspace> Driver<'_, W> {
     /// Where the replay reads from.
     fn immutable_dir(&self) -> PathBuf {
         self.download_dir.join("immutable")
@@ -584,18 +551,8 @@ impl<D: Domain> Driver<'_, D> {
 
     /// Publish the sequence the cursor stands at, and name the next target.
     ///
-    /// Also reseeds the WAL from the state cursor before anything else opens
-    /// the domain: `import_blocks` skips the WAL by design, so a run that
-    /// died mid-import left the state ahead of it, and the next domain open
-    /// would refuse with `InconsistentState`.
-    ///
-    /// These stores are dropped rather than shut down, where [`Self::extend`]
-    /// takes the trouble — and the asymmetry is the write, not an oversight.
-    /// The one write here is the WAL reseed, whose only backend is redb, whose
-    /// `shutdown` is a no-op because a redb commit is already durable and its
-    /// drop cleans up without blocking. Everything the publish touches after
-    /// that it only reads, so fjall has no flush of ours to drain — which is
-    /// the whole reason `extend` shuts its domain down after a bulk import.
+    /// Inspection and publication do not advance the dataset. The workspace
+    /// is finalized on both successful and failed publication attempts.
     ///
     /// Nothing *inside* the publish observes [`Driver::cancel`]: a stele goes
     /// out over minutes of store walking and uploading with no seam to check a
@@ -607,9 +564,13 @@ impl<D: Domain> Driver<'_, D> {
     /// below polls it: a shutdown during a backoff ends the run on the failure
     /// in hand rather than after the remaining patience.
     fn publish_pending(&self) -> Result<Step, Error> {
-        let stores = (self.open_stores)()?;
+        let workspace = (self.open_workspace)()?;
+        let result = self.plan_pending(&workspace.snapshot());
+        finish_extend(result, workspace.finish())
+    }
 
-        let cursor = stores.state.read_cursor().map_err(Error::Cursor)?;
+    fn plan_pending(&self, source: &dyn SnapshotSource) -> Result<Step, Error> {
+        let cursor = source.committed_position().map_err(Error::Planning)?;
 
         let Some(cursor) = cursor else {
             return Ok(Step::Extend {
@@ -618,17 +579,12 @@ impl<D: Domain> Driver<'_, D> {
             });
         };
 
-        // An undefined cursor is deliberately not a refusal here: `plan` below
-        // refuses the same state as an unanchored point, with the sentence
-        // that names the command's own subject.
-        if cursor.is_fully_defined() {
-            recover_bulk_checkpoint(&stores.state, &stores.wal).map_err(Error::Recovery)?;
-        }
-
-        let summary = dolos_cardano::eras::load_chain_summary_from_state(&stores.state)
-            .map_err(Error::ChainSummary)?;
-
-        let (epoch, _) = summary.slot_epoch(cursor.slot());
+        let epoch = source
+            .epoch()
+            .map_err(Error::Planning)?
+            .ok_or(Error::UnanchoredCursor {
+                slot: cursor.slot(),
+            })?;
 
         // Nothing publishable yet: a sequence-0 stele would be epoch 0's
         // mid-epoch sliver, which no consumer chains from.
@@ -641,12 +597,9 @@ impl<D: Domain> Driver<'_, D> {
 
         let retained = planning::retained_epochs(self.config).map_err(Error::RetainedEpochs)?;
 
-        let plan = crate::export::plan(
-            &stores.state,
-            u64::from(self.genesis.network_magic()),
-            retained,
-        )
-        .map_err(Error::Planning)?;
+        let plan = source
+            .plan(u64::from(self.genesis.network_magic()), retained)
+            .map_err(Error::Planning)?;
 
         // Retried here rather than allowed to end the process, because the
         // process ending is the most expensive recovery this driver has and a
@@ -666,7 +619,7 @@ impl<D: Domain> Driver<'_, D> {
         retry::transient(
             "publishing the pending sequence",
             &|| self.aborted(),
-            || self.publish.publish(&plan, &stores.archive, &stores.state),
+            || self.publish.publish(&plan, source),
         )?;
 
         if self.until_epoch.is_some_and(|until| plan.sequence >= until) {
@@ -681,29 +634,29 @@ impl<D: Domain> Driver<'_, D> {
         })
     }
 
-    /// Replay toward `target`'s boundary inside a domain that stops there.
+    /// Replay toward the requested boundary inside an exclusive session.
     fn extend(
         &self,
         target: u64,
         prune: bool,
         slots_per_immutable_file: u64,
     ) -> Result<Advance, Error> {
-        let domain = (self.build_domain)(target)?;
-
-        let result = self.advance_domain(&domain, prune, slots_per_immutable_file);
+        let workspace = (self.open_workspace)()?;
+        let mut session = workspace.start(target)?;
+        let result = self.advance_session(&mut session, prune, slots_per_immutable_file);
 
         // Shut down even when the replay failed: fjall in particular has
         // background work to flush before the handle drops.
-        let shutdown = (self.shutdown_domain)(domain);
+        let shutdown = session.finish();
 
         finish_extend(result, shutdown)
     }
 
     /// Import what is on disk, fetching windows from mithril whenever the
     /// files run out, until the boundary, the aggregator's tip, or a signal.
-    fn advance_domain(
+    fn advance_session(
         &self,
-        domain: &D,
+        session: &mut W::Session,
         prune: bool,
         slots_per_immutable_file: u64,
     ) -> Result<Advance, Error> {
@@ -712,9 +665,7 @@ impl<D: Domain> Driver<'_, D> {
         // After the publish and before the next epoch goes in, never between
         // a boundary and its publish.
         if prune {
-            let rounds = domain
-                .drain_housekeeping(None)
-                .map_err(Error::Housekeeping)?;
+            let rounds = session.prune_history()?;
 
             info!(rounds, "housekeeping drained");
         }
@@ -726,12 +677,10 @@ impl<D: Domain> Driver<'_, D> {
                 break Advance::Cancelled;
             }
 
-            match self.import_available(domain, &immutable_dir)? {
+            match self.import_available(session, &immutable_dir)? {
                 Import::Boundary => {
-                    let cursor_slot = domain
-                        .state()
-                        .read_cursor()
-                        .map_err(Error::Cursor)?
+                    let cursor_slot = session
+                        .committed_position()?
                         .map(|cursor| cursor.slot())
                         .unwrap_or_default();
 
@@ -766,11 +715,7 @@ impl<D: Domain> Driver<'_, D> {
 
             let highest = mithril::highest_existing_immutable(&immutable_dir);
 
-            let cursor_slot = domain
-                .state()
-                .read_cursor()
-                .map_err(Error::Cursor)?
-                .map(|cursor| cursor.slot());
+            let cursor_slot = session.committed_position()?.map(|cursor| cursor.slot());
 
             let resume = resume_file(highest, cursor_slot, slots_per_immutable_file);
 
@@ -848,17 +793,17 @@ impl<D: Domain> Driver<'_, D> {
             }
         };
 
-        // Whatever ended the replay, the chunks it committed are in the state
-        // and the WAL must agree before the next domain open.
-        recover_bulk_checkpoint(domain.state(), domain.wal()).map_err(Error::Recovery)?;
-
         self.replay.round_finished();
 
         Ok(outcome)
     }
 
     /// Import everything on disk past the cursor, in chunks.
-    fn import_available(&self, domain: &D, immutable_dir: &Path) -> Result<Import, Error> {
+    fn import_available(
+        &self,
+        session: &mut W::Session,
+        immutable_dir: &Path,
+    ) -> Result<Import, Error> {
         use pallas::network::miniprotocols::Point;
 
         // Before the first download the immutable dir does not exist at all;
@@ -876,7 +821,7 @@ impl<D: Domain> Driver<'_, D> {
             return Ok(Import::Exhausted);
         }
 
-        let cursor = domain.state().read_cursor().map_err(Error::Cursor)?;
+        let cursor = session.committed_position()?;
 
         // A cursor with no hash is `ChainPoint::Slot`, which the pallas
         // conversion refuses — and it refuses with `()`, so an `unwrap` here
@@ -885,8 +830,7 @@ impl<D: Domain> Driver<'_, D> {
         // to the boundary slot alone, and the boundary block's own commit right
         // after it. `export::plan` refuses the same state first, as an
         // unanchored point, so the driver ordinarily fails there rather than
-        // here; this says the same thing the WAL seed says, for the path that
-        // reaches it anyway.
+        // here.
         let point: Point = match cursor {
             None => Point::Origin,
             Some(cursor) => {
@@ -918,10 +862,10 @@ impl<D: Domain> Driver<'_, D> {
 
             let batch: Vec<_> = batch.into_iter().map(Arc::new).collect();
 
-            match domain.import_blocks(batch) {
-                Ok(last) => self.replay.reached(last),
-                Err(DomainError::StopEpochReached) => return Ok(Import::Boundary),
-                Err(e) => return Err(Error::Import(e)),
+            let progress = session.import_blocks(batch)?;
+            self.replay.reached(progress.position().slot());
+            if progress.is_boundary() {
+                return Ok(Import::Boundary);
             }
 
             if self.aborted() {
@@ -1075,7 +1019,8 @@ mod tests {
 
     #[test]
     fn replay_and_shutdown_failures_are_both_preserved() {
-        let Err(error) = finish_extend(Err(Error::Interrupted), Err(Error::EmptyWindow)) else {
+        let Err(error) = finish_extend::<Advance>(Err(Error::Interrupted), Err(Error::EmptyWindow))
+        else {
             panic!("simultaneous failures unexpectedly succeeded");
         };
 

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -73,6 +73,7 @@ pub mod planning;
 pub mod publisher;
 pub mod registry;
 pub mod restore;
+pub mod source;
 
 /// The free-space policy, which is [`stelae_driver`]'s: it is one rule over
 /// paths and byte counts and knows nothing about what fills them. Re-exported

--- a/crates/snapshot/src/source.rs
+++ b/crates/snapshot/src/source.rs
@@ -1,0 +1,74 @@
+//! Read-only access to the Dolos snapshot profile.
+
+use dolos_core::{ArchiveStore, ChainPoint, StateStore};
+use stelae::progress::Observer;
+
+use crate::{
+    export::{self, Plan},
+    publisher::Publisher,
+    registry::{Preview, Published},
+    Error, RetainedEpochs,
+};
+
+/// Profile operations available without exposing mutable storage handles.
+pub trait SnapshotSource {
+    fn committed_position(&self) -> Result<Option<ChainPoint>, Error>;
+    fn epoch(&self) -> Result<Option<u64>, Error>;
+    fn plan(&self, network_magic: u64, retained: RetainedEpochs) -> Result<Plan, Error>;
+    fn preview(&self, publisher: &Publisher, plan: &Plan) -> Result<Preview, Error>;
+    fn publish(
+        &self,
+        publisher: &Publisher,
+        plan: &Plan,
+        observer: &Observer,
+    ) -> Result<Published, Error>;
+}
+
+/// A borrowed profile view. The stores remain private and cannot escape it.
+pub struct StoreSnapshot<'a, A, S> {
+    archive: &'a A,
+    state: &'a S,
+}
+
+impl<'a, A: ArchiveStore, S: StateStore> StoreSnapshot<'a, A, S> {
+    pub fn new(archive: &'a A, state: &'a S) -> Self {
+        Self { archive, state }
+    }
+}
+
+impl<A: ArchiveStore, S: StateStore> SnapshotSource for StoreSnapshot<'_, A, S> {
+    fn committed_position(&self) -> Result<Option<ChainPoint>, Error> {
+        Ok(self.state.read_cursor()?)
+    }
+
+    fn epoch(&self) -> Result<Option<u64>, Error> {
+        let Some(position) = self.committed_position()? else {
+            return Ok(None);
+        };
+        if !position.is_fully_defined() {
+            return Err(Error::UnanchoredPoint(format!(
+                "cursor at slot {} has no block hash",
+                position.slot()
+            )));
+        }
+        let summary = dolos_cardano::eras::load_chain_summary_from_state(self.state)?;
+        Ok(Some(summary.slot_epoch(position.slot()).0))
+    }
+
+    fn plan(&self, network_magic: u64, retained: RetainedEpochs) -> Result<Plan, Error> {
+        export::plan(self.state, network_magic, retained)
+    }
+
+    fn preview(&self, publisher: &Publisher, plan: &Plan) -> Result<Preview, Error> {
+        publisher.preview(plan, self.archive)
+    }
+
+    fn publish(
+        &self,
+        publisher: &Publisher,
+        plan: &Plan,
+        observer: &Observer,
+    ) -> Result<Published, Error> {
+        publisher.publish(plan, self.archive, self.state, observer)
+    }
+}

--- a/docs/headless-replay.md
+++ b/docs/headless-replay.md
@@ -1,0 +1,70 @@
+# Embedding Dolos replay
+
+Use `dolos` with default service features disabled when the host only needs
+Cardano replay. The `headless_replay` example runs against a local immutable
+block directory:
+
+```sh
+cargo run --no-default-features --example headless_replay -- \
+  ./dolos.toml ./snapshot/immutable 500
+```
+
+## Contract
+
+- `ReplayWorkspace::open(config, genesis)` opens a dataset without running
+  ledger initialization, replaying pending work, or pruning history.
+- `workspace.snapshot()` lends read-only Dolos profile operations:
+  committed position, epoch, publication planning, preview and publication.
+  No domain or writable storage handle escapes the view.
+- `workspace.start(stop_epoch)` consumes the inspection workspace and explicitly
+  permits initialization and processing. Publish any pending boundary first.
+- `session.import_blocks(blocks)` processes a nonempty batch of trusted immutable
+  blocks. It returns `ReplayProgress::Committed` or `Boundary`, each carrying the
+  committed input position. A stopping boundary includes its anchoring block.
+  Resume input from that position: the rest of a submitted batch may be unprocessed.
+- A boundary is terminal for that session. Further import calls return the same
+  boundary without processing input. To advance, finish and start another session.
+- After a replay execution error, the session rejects further input. Finish and reopen;
+  errors indicating an incomplete ledger transition may require explicit repair.
+  An empty batch is rejected before execution and does not invalidate the session.
+- `session.finish()` consumes the handle, persists completed work and releases
+  resources. It returns `Result<(), BulkReplayError>`, not storage bookkeeping.
+  `session.run(operation)` performs finalization on both ordinary success and
+  error returns, preserving both errors when necessary.
+- `session.prune_history()` is explicit host policy. Neither replay completion
+  nor finalization prunes automatically. Publish required history before pruning.
+
+Sessions are not cloneable and do not implement `Domain`. Import requires
+exclusive mutable access. Borrowing a profile view prevents advancing or
+finishing the session while the view remains in use.
+
+## Publisher ordering
+
+```text
+open workspace
+  → inspect/plan/publish pending snapshot
+  → finish inspection workspace
+open workspace
+  → start replay for next boundary
+  → prune already-published history if policy permits
+  → import trusted blocks to boundary
+  → finish
+repeat
+```
+
+The current backfill driver follows this order through its narrow `Workspace`,
+`Session` and `Publish` interfaces. Source acquisition, retries, signals and OCI
+publication policy remain the host's responsibilities.
+
+## Internal implementation and limits
+
+Dolos still uses its existing `ImportExt` execution path. Checkpoint maintenance
+is private to the engine; an embedding application neither selects recovery
+actions nor interprets their results. Normal node construction continues through
+`DomainBuilder` and retains the existing startup integrity policy.
+
+This is not a new atomic import or general corruption-repair mechanism.
+Interrupted epoch transitions, inconsistent archives and other pre-existing
+storage limitations are not repaired by this facade. Dropping a handle,
+panicking or terminating the process is not equivalent to successful
+`finish()`. Internal error details remain available in diagnostic source chains.

--- a/examples/headless_replay.rs
+++ b/examples/headless_replay.rs
@@ -87,7 +87,10 @@ fn main() -> Result<(), AnyError> {
     Ok(())
 }
 
-fn import_batch(session: &BulkReplaySession, batch: &mut Vec<RawBlock>) -> Result<bool, AnyError> {
+fn import_batch(
+    session: &mut BulkReplaySession,
+    batch: &mut Vec<RawBlock>,
+) -> Result<bool, AnyError> {
     let progress = session.import_blocks(std::mem::take(batch))?;
 
     match progress {

--- a/examples/headless_replay.rs
+++ b/examples/headless_replay.rs
@@ -1,0 +1,103 @@
+//! Minimal external host for Dolos domain construction and bulk replay.
+//!
+//! Build without Dolos service features:
+//!
+//! ```text
+//! cargo run --no-default-features --example headless_replay -- \
+//!   ./dolos.toml ./snapshot/immutable 500
+//! ```
+//!
+//! The final argument is an optional stopping epoch. Source acquisition,
+//! progress rendering, publication, and housekeeping intentionally stay in
+//! the host application.
+
+use std::error::Error;
+use std::path::Path;
+use std::sync::Arc;
+
+use dolos::core::{Genesis, RawBlock};
+use dolos::engine::{BulkReplaySession, ReplayProgress};
+
+type AnyError = Box<dyn Error + Send + Sync + 'static>;
+
+fn main() -> Result<(), AnyError> {
+    let mut args = std::env::args_os().skip(1);
+    let config_path = args.next().ok_or("missing path to dolos.toml")?;
+    let immutable_path = args.next().ok_or("missing immutable directory")?;
+    let stop_epoch = args
+        .next()
+        .map(|value| value.to_string_lossy().parse::<u64>())
+        .transpose()?;
+
+    let config: dolos::core::config::RootConfig = config::Config::builder()
+        .add_source(config::File::from(Path::new(&config_path)))
+        .build()?
+        .try_deserialize()?;
+
+    let genesis = Arc::new(Genesis::from_file_paths(
+        &config.genesis.byron_path,
+        &config.genesis.shelley_path,
+        &config.genesis.alonzo_path,
+        &config.genesis.conway_path,
+        config.genesis.force_protocol,
+    )?);
+
+    let session = BulkReplaySession::open(&config, genesis, stop_epoch)?;
+
+    session
+        .run(|session| {
+            let cursor = session.committed_position()?;
+            let point = match cursor {
+                Some(cursor) => {
+                    let slot = cursor.slot();
+                    cursor.try_into().map_err(|()| {
+                        format!("state cursor at slot {slot} is not anchored to a block hash")
+                    })?
+                }
+                None => pallas::network::miniprotocols::Point::Origin,
+            };
+
+            let mut blocks = pallas::interop::hardano::storage::immutable::read_blocks_from_point(
+                Path::new(&immutable_path),
+                point.clone(),
+            )?;
+
+            if point != pallas::network::miniprotocols::Point::Origin {
+                blocks.next();
+            }
+
+            let mut batch: Vec<RawBlock> = Vec::with_capacity(100);
+
+            for block in blocks {
+                batch.push(Arc::new(block?));
+
+                if batch.len() == 100 && import_batch(session, &mut batch)? {
+                    return Ok::<_, AnyError>(());
+                }
+            }
+
+            if !batch.is_empty() {
+                import_batch(session, &mut batch)?;
+            }
+
+            Ok(())
+        })
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+
+    Ok(())
+}
+
+fn import_batch(session: &BulkReplaySession, batch: &mut Vec<RawBlock>) -> Result<bool, AnyError> {
+    let progress = session.import_blocks(std::mem::take(batch))?;
+
+    match progress {
+        ReplayProgress::Committed { position } => {
+            eprintln!("committed through {position}");
+            Ok(false)
+        }
+        ReplayProgress::Boundary { position } => {
+            eprintln!("stopping boundary committed at {position}");
+            Ok(true)
+        }
+    }
+}

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -7,7 +7,6 @@
 //! root library assembles.
 
 use dolos_core::config::RootConfig;
-use dolos_core::ImportExt;
 use dolos_mithril::{fetch_snapshot, Fetch};
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
@@ -67,18 +66,13 @@ impl Default for Args {
     }
 }
 
-fn define_starting_point<S: dolos_core::StateStore>(
+fn define_starting_point(
     args: &Args,
-    state: &S,
+    cursor: Option<ChainPoint>,
 ) -> Result<pallas::network::miniprotocols::Point, miette::Error> {
     if let Some(point) = &args.start_from {
         Ok(point.clone().try_into().unwrap())
     } else {
-        let cursor = state
-            .read_cursor()
-            .into_diagnostic()
-            .context("reading state cursor")?;
-
         let point = cursor
             .map(|c| c.try_into().unwrap())
             .unwrap_or(pallas::network::miniprotocols::Point::Origin);
@@ -89,8 +83,9 @@ fn define_starting_point<S: dolos_core::StateStore>(
 
 /// Inner import function that can return errors.
 /// The outer function ensures shutdown is called regardless of success/failure.
-fn do_import<D: dolos_core::Domain>(
-    domain: &D,
+fn do_import(
+    cursor: Option<ChainPoint>,
+    mut import: impl FnMut(Vec<RawBlock>) -> miette::Result<BlockSlot>,
     args: &Args,
     immutable_path: &Path,
     feedback: &Feedback,
@@ -101,7 +96,7 @@ fn do_import<D: dolos_core::Domain>(
         .context("reading immutable db tip")?
         .ok_or(miette::miette!("immutable db has no tip"))?;
 
-    let cursor = define_starting_point(args, domain.state())?;
+    let cursor = define_starting_point(args, cursor)?;
 
     let mut iter = pallas::interop::hardano::storage::immutable::read_blocks_from_point(
         immutable_path,
@@ -132,9 +127,7 @@ fn do_import<D: dolos_core::Domain>(
         // around throughout the pipeline
         let batch: Vec<_> = batch.into_iter().map(Arc::new).collect();
 
-        let last = domain
-            .import_blocks(batch)
-            .map_err(|e| miette::miette!(e.to_string()))?;
+        let last = import(batch)?;
 
         progress.set_position(last);
     }
@@ -156,7 +149,23 @@ fn import_hardano_into_domain(
         .map_err(|error| miette::miette!("opening the bulk-replay session: {error}"))?;
 
     session
-        .run(|session| do_import(session, args, immutable_path, feedback, chunk_size))
+        .run(|session| {
+            let cursor = session.committed_position().into_diagnostic()?;
+            do_import(
+                cursor,
+                |blocks| {
+                    let progress = session.import_blocks(blocks).into_diagnostic()?;
+                    if progress.is_boundary() {
+                        return Err(miette::miette!("{}", DomainError::StopEpochReached));
+                    }
+                    Ok(progress.position().slot())
+                },
+                args,
+                immutable_path,
+                feedback,
+                chunk_size,
+            )
+        })
         .map_err(|error| miette::miette!("{error}"))
 }
 
@@ -220,13 +229,30 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dolos_core::{ArchiveStore, Domain};
+    use dolos_core::{ArchiveStore, Domain, ImportExt};
     use dolos_testing::{
         blocks::write_immutable_fixture,
         synthetic::{build_synthetic_blocks, SyntheticBlockConfig},
         toy_domain::{FjallStores, ToyDomain},
     };
     use pallas::ledger::traverse::MultiEraBlock;
+
+    fn import_fixture<D: Domain>(
+        domain: &D,
+        args: &Args,
+        path: &Path,
+        feedback: &Feedback,
+        chunk_size: usize,
+    ) -> miette::Result<()> {
+        do_import(
+            domain.state().read_cursor().into_diagnostic()?,
+            |blocks| domain.import_blocks(blocks).into_diagnostic(),
+            args,
+            path,
+            feedback,
+            chunk_size,
+        )
+    }
 
     #[test]
     fn mithril_import_resumes_through_the_automatic_writer() {
@@ -250,7 +276,7 @@ mod tests {
         };
         let dir = tempfile::tempdir().unwrap();
         write_immutable_fixture(dir.path(), &blocks);
-        do_import(&domain, &args, dir.path(), &Feedback::hidden(), 3).unwrap();
+        import_fixture(&domain, &args, dir.path(), &Feedback::hidden(), 3).unwrap();
         let stats = domain.archive().append_stats();
         assert!(stats.serial_batches >= 1, "{stats:?}");
         assert_eq!(
@@ -272,7 +298,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         let before = domain.archive().append_stats();
-        do_import(
+        import_fixture(
             &domain,
             &Args::default(),
             dir.path(),

--- a/src/bin/dolos/bootstrap/mithril.rs
+++ b/src/bin/dolos/bootstrap/mithril.rs
@@ -15,6 +15,7 @@ use std::{path::Path, sync::Arc};
 use tracing::{info, warn};
 
 use crate::feedback::{Feedback, MithrilFeedback};
+use dolos::engine::BulkReplaySession;
 use dolos::prelude::*;
 
 #[derive(Debug, clap::Args, Clone)]
@@ -150,17 +151,13 @@ fn import_hardano_into_domain(
     feedback: &Feedback,
     chunk_size: usize,
 ) -> Result<(), miette::Error> {
-    let domain = crate::common::setup_domain(config)?;
+    let genesis = Arc::new(crate::common::open_genesis_files(&config.genesis)?);
+    let session = BulkReplaySession::open(config, genesis, None)
+        .map_err(|error| miette::miette!("opening the bulk-replay session: {error}"))?;
 
-    let result = do_import(&domain, args, immutable_path, feedback, chunk_size);
-
-    // Always shutdown the domain before it goes out of scope, regardless of
-    // whether import succeeded or failed.
-    if let Err(e) = domain.shutdown() {
-        tracing::error!("error during domain shutdown: {}", e);
-    }
-
-    result
+    session
+        .run(|session| do_import(session, args, immutable_path, feedback, chunk_size))
+        .map_err(|error| miette::miette!("{error}"))
 }
 
 pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Result<()> {

--- a/src/bin/dolos/common.rs
+++ b/src/bin/dolos/common.rs
@@ -1,5 +1,4 @@
-use dolos_core::config::{ChainConfig, GenesisConfig, LoggingConfig, RootConfig, TelemetryConfig};
-use dolos_core::BootstrapExt;
+use dolos_core::config::{GenesisConfig, LoggingConfig, RootConfig, TelemetryConfig};
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use miette::{Context as _, IntoDiagnostic};
 use opentelemetry::trace::TracerProvider as _;
@@ -13,6 +12,7 @@ use tracing_subscriber::{filter::Targets, prelude::*};
 
 use dolos::adapters::DomainAdapter;
 use dolos::core::Genesis;
+use dolos::engine::{DomainBuildError, DomainBuilder};
 use dolos::prelude::*;
 use dolos::storage;
 
@@ -77,48 +77,31 @@ pub fn setup_domain_with_stop_epoch(
     config: &RootConfig,
     stop_epoch: Option<u64>,
 ) -> miette::Result<DomainAdapter> {
-    let stores = open_data_stores(config).map_err(|e| match e {
-        Error::WalError(WalError::IncompatibleVersion { found, expected }) => miette::miette!(
+    let genesis = Arc::new(open_genesis_files(&config.genesis)?);
+
+    DomainBuilder::new(config, genesis)
+        .stop_epoch(stop_epoch)
+        .build()
+        .map_err(render_domain_build_error)
+}
+
+/// Keep actionable executable diagnostics at the UI boundary while the
+/// library returns typed construction errors.
+fn render_domain_build_error(error: DomainBuildError) -> miette::Report {
+    match error {
+        DomainBuildError::Storage(Error::WalError(WalError::IncompatibleVersion {
+            found,
+            expected,
+        })) => miette::miette!(
             help = format!(
                 "WAL was created by a newer dolos version (v{found}) than this binary supports (v{expected}); upgrade dolos or run `dolos bootstrap --force` to wipe storage and re-bootstrap",
             ),
             "incompatible WAL version: found v{found}, expected v{expected}",
         ),
-        other => miette::miette!("{other}"),
-    })?;
-    let genesis = Arc::new(open_genesis_files(&config.genesis)?);
-    let mempool = stores.mempool.clone();
-    let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
-    let chain = config.chain.clone();
-
-    let ChainConfig::Cardano(mut chain_config) = chain;
-
-    if stop_epoch.is_some() {
-        chain_config.stop_epoch = stop_epoch;
-    }
-
-    let chain = dolos_cardano::CardanoLogic::initialize::<DomainAdapter>(
-        chain_config,
-        &stores.state,
-        &genesis,
-    )
-    .into_diagnostic()?;
-
-    let domain = DomainAdapter {
-        storage_config: Arc::new(config.storage.clone()),
-        sync_config: Arc::new(config.sync.clone()),
-        genesis,
-        chain: Arc::new(std::sync::RwLock::new(chain)),
-        wal: stores.wal,
-        state: stores.state,
-        archive: stores.archive,
-        mempool,
-        tip_broadcast,
-    };
-
-    // this will make sure the domain is correctly initialized and in a valid state.
-    domain.bootstrap().map_err(|e| match e {
-        dolos_core::DomainError::InconsistentState { ref wal, ref state } => {
+        DomainBuildError::Bootstrap(dolos_core::DomainError::InconsistentState {
+            ref wal,
+            ref state,
+        }) => {
             let msg = match (wal, state) {
                 (Some(w), Some(s)) => format!(
                     "state (slot {}) is ahead of WAL (slot {})",
@@ -137,10 +120,8 @@ pub fn setup_domain_with_stop_epoch(
             };
             miette::miette!(help = help, "{msg}")
         }
-        other => miette::miette!("{other:?}"),
-    })?;
-
-    Ok(domain)
+        other => miette::miette!("{other}"),
+    }
 }
 
 pub fn setup_tracing_error_only() -> miette::Result<()> {

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -23,7 +23,8 @@ use miette::{bail, Context as _, IntoDiagnostic as _};
 use tokio_util::sync::CancellationToken;
 
 use crate::feedback::Feedback;
-use dolos::adapters::{ArchiveStoreBackend, DomainAdapter, StateStoreBackend};
+use dolos::adapters::{ArchiveStoreBackend, StateStoreBackend};
+use dolos::engine::BulkReplaySession;
 
 /// Where the mithril window lands when the operator names nowhere: beside the
 /// stores, so the bytes stay on the data mount.
@@ -169,7 +170,10 @@ impl RepositoryArm<'_> {
     }
 }
 
-impl backfill::Publish<DomainAdapter> for RepositoryArm<'_> {
+impl<D> backfill::Publish<D> for RepositoryArm<'_>
+where
+    D: dolos_core::Domain<Archive = ArchiveStoreBackend, State = StateStoreBackend>,
+{
     fn announce(&self, plan: &Plan) -> Result<(), backfill::Error> {
         super::report_plan(plan).map_err(backfill::Error::caller)
     }
@@ -231,7 +235,9 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
         feedback,
     };
 
-    let driver = backfill::Driver::<DomainAdapter> {
+    let genesis = Arc::new(genesis);
+
+    let driver = backfill::Driver::<BulkReplaySession> {
         config,
         genesis: &genesis,
         mithril,
@@ -255,20 +261,18 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
                 .context("opening the data stores")
                 .map_err(backfill::Error::caller)?;
 
-            Ok(backfill::Stores::<DomainAdapter> {
+            Ok(backfill::Stores::<BulkReplaySession> {
                 wal: stores.wal,
                 state: stores.state,
                 archive: stores.archive,
             })
         },
         build_domain: &|target| {
-            crate::common::setup_domain_with_stop_epoch(config, Some(target))
+            BulkReplaySession::open(config, genesis.clone(), Some(target))
                 .map_err(backfill::Error::caller)
         },
-        shutdown_domain: &|domain: &DomainAdapter| {
-            domain
-                .shutdown()
-                .map_err(|e| backfill::Error::caller(format!("shutting down the domain: {e}")))
+        shutdown_domain: &|domain: &BulkReplaySession| {
+            domain.close().map(|_| ()).map_err(backfill::Error::caller)
         },
         publish: &publish,
     };

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -23,8 +23,8 @@ use miette::{bail, Context as _, IntoDiagnostic as _};
 use tokio_util::sync::CancellationToken;
 
 use crate::feedback::Feedback;
-use dolos::adapters::{ArchiveStoreBackend, StateStoreBackend};
-use dolos::engine::BulkReplaySession;
+use dolos::engine::ReplayWorkspace;
+use dolos_snapshot::source::SnapshotSource;
 
 /// Where the mithril window lands when the operator names nowhere: beside the
 /// stores, so the bytes stay on the data mount.
@@ -170,29 +170,14 @@ impl RepositoryArm<'_> {
     }
 }
 
-impl<D> backfill::Publish<D> for RepositoryArm<'_>
-where
-    D: dolos_core::Domain<Archive = ArchiveStoreBackend, State = StateStoreBackend>,
-{
+impl backfill::Publish for RepositoryArm<'_> {
     fn announce(&self, plan: &Plan) -> Result<(), backfill::Error> {
         super::report_plan(plan).map_err(backfill::Error::caller)
     }
 
-    fn publish(
-        &self,
-        plan: &Plan,
-        archive: &ArchiveStoreBackend,
-        state: &StateStoreBackend,
-    ) -> Result<(), backfill::Error> {
-        super::publish::to_repository(
-            self.config,
-            &self.settings(),
-            plan,
-            archive,
-            state,
-            self.feedback,
-        )
-        .map_err(backfill::Error::caller)
+    fn publish(&self, plan: &Plan, source: &dyn SnapshotSource) -> Result<(), backfill::Error> {
+        super::publish::to_repository(self.config, &self.settings(), plan, source, self.feedback)
+            .map_err(backfill::Error::caller)
     }
 }
 
@@ -237,7 +222,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
 
     let genesis = Arc::new(genesis);
 
-    let driver = backfill::Driver::<BulkReplaySession> {
+    let driver = backfill::Driver::<ReplayWorkspace> {
         config,
         genesis: &genesis,
         mithril,
@@ -255,24 +240,8 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
                 >)
         },
         replay: &replay,
-        open_stores: &|| {
-            let stores = crate::common::open_data_stores(config)
-                .into_diagnostic()
-                .context("opening the data stores")
-                .map_err(backfill::Error::caller)?;
-
-            Ok(backfill::Stores::<BulkReplaySession> {
-                wal: stores.wal,
-                state: stores.state,
-                archive: stores.archive,
-            })
-        },
-        build_domain: &|target| {
-            BulkReplaySession::open(config, genesis.clone(), Some(target))
-                .map_err(backfill::Error::caller)
-        },
-        shutdown_domain: &|domain: BulkReplaySession| {
-            domain.close().map(|_| ()).map_err(backfill::Error::caller)
+        open_workspace: &|| {
+            ReplayWorkspace::open(config, genesis.clone()).map_err(backfill::Error::caller)
         },
         publish: &publish,
     };

--- a/src/bin/dolos/snapshot/backfill.rs
+++ b/src/bin/dolos/snapshot/backfill.rs
@@ -271,7 +271,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
             BulkReplaySession::open(config, genesis.clone(), Some(target))
                 .map_err(backfill::Error::caller)
         },
-        shutdown_domain: &|domain: &BulkReplaySession| {
+        shutdown_domain: &|domain: BulkReplaySession| {
             domain.close().map(|_| ()).map_err(backfill::Error::caller)
         },
         publish: &publish,

--- a/src/bin/dolos/snapshot/publish.rs
+++ b/src/bin/dolos/snapshot/publish.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use dolos_core::config::RootConfig;
-use dolos_core::{ArchiveStore, StateStore};
+use dolos_snapshot::source::{SnapshotSource, StoreSnapshot};
 use miette::{Context as _, IntoDiagnostic as _};
 
 use dolos_snapshot::{
@@ -132,8 +132,7 @@ pub fn run(config: &RootConfig, args: &Args, feedback: &Feedback) -> miette::Res
                 config,
                 &publish,
                 &plan,
-                &stores.archive,
-                &stores.state,
+                &StoreSnapshot::new(&stores.archive, &stores.state),
                 feedback,
             )
         }
@@ -194,12 +193,11 @@ fn to_directory(
 /// than trust: how much of this stele was inherited rather than built, and how
 /// much of it moved. Both are numbers the code counted, not an inference from a
 /// duration.
-pub(super) fn to_repository<A: ArchiveStore, S: StateStore>(
+pub(super) fn to_repository(
     config: &RootConfig,
     publish: &RepositoryPublish,
     plan: &export::Plan,
-    archive: &A,
-    state: &S,
+    source: &dyn SnapshotSource,
     feedback: &Feedback,
 ) -> miette::Result<()> {
     let repo = publish.repo;
@@ -230,8 +228,8 @@ pub(super) fn to_repository<A: ArchiveStore, S: StateStore>(
         .context("sizing the staging directory")?;
 
     if publish.dry_run {
-        let preview = publisher
-            .preview(plan, archive)
+        let preview = source
+            .preview(&publisher, plan)
             .into_diagnostic()
             .context("planning the publish")?;
 
@@ -253,8 +251,8 @@ pub(super) fn to_repository<A: ArchiveStore, S: StateStore>(
     // under the report.
     let progress = SteleProgress::publishing(feedback);
 
-    let published = publisher
-        .publish(plan, archive, state, &progress.observer())
+    let published = source
+        .publish(&publisher, plan, &progress.observer())
         .into_diagnostic()
         .context("publishing the stele")?;
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -162,6 +162,9 @@ pub enum BulkReplayError {
     #[error("bulk replay completed without a state cursor")]
     MissingPosition,
 
+    #[error("cannot close bulk replay while {count} cloned session handle(s) remain")]
+    OutstandingHandles { count: usize },
+
     #[error("shutting down the bulk-replay domain: {0}")]
     Shutdown(#[source] DomainError),
 
@@ -183,6 +186,7 @@ pub enum BulkReplayError {
 pub struct BulkReplaySession {
     domain: DomainAdapter,
     initial_recovery: BulkRecovery,
+    close_lease: Arc<()>,
 }
 
 impl BulkReplaySession {
@@ -201,17 +205,13 @@ impl BulkReplaySession {
         Ok(Self {
             domain,
             initial_recovery,
+            close_lease: Arc::new(()),
         })
     }
 
     /// What opening the session found and, if necessary, repaired.
     pub fn initial_recovery(&self) -> &BulkRecovery {
         &self.initial_recovery
-    }
-
-    /// The underlying domain for read-only consumers and existing facades.
-    pub fn domain(&self) -> &DomainAdapter {
-        &self.domain
     }
 
     /// Read the last position committed across the state-store boundary.
@@ -247,8 +247,15 @@ impl BulkReplaySession {
     /// Shutdown is attempted even if checkpoint recovery fails, and a caller
     /// should call this on both operation success and failure.
     /// [`run`](Self::run) packages that rule for a complete replay
-    /// operation.
-    pub fn close(&self) -> Result<BulkRecovery, BulkReplayError> {
+    /// operation. Closing consumes the session and refuses while cloned
+    /// session handles remain, so no handle can keep importing after the final
+    /// checkpoint.
+    pub fn close(self) -> Result<BulkRecovery, BulkReplayError> {
+        let count = Arc::strong_count(&self.close_lease) - 1;
+        if count > 0 {
+            return Err(BulkReplayError::OutstandingHandles { count });
+        }
+
         let recovery = recover_bulk_checkpoint(self.domain.state(), self.domain.wal());
         let shutdown = self.domain.shutdown();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,377 @@
+//! Supported headless construction and bulk-replay lifecycle.
+//!
+//! Applications embedding Dolos should use this module instead of copying the
+//! executable's domain assembly. Configuration-file precedence, progress UI,
+//! signal handling, source acquisition, publication, and housekeeping remain
+//! application policy; this module owns the stable engine seams beneath them.
+
+use std::fmt;
+use std::sync::Arc;
+
+use dolos_core::config::{ChainConfig, RootConfig};
+use dolos_core::{
+    recover_bulk_checkpoint, BootstrapExt as _, BulkRecovery, BulkRecoveryError, ChainLogic as _,
+    ChainPoint, Domain, DomainError, Genesis, ImportExt as _, RawBlock, StateStore as _, TipEvent,
+};
+
+use crate::adapters::{DomainAdapter, TipSubscription};
+use crate::storage;
+
+/// The concrete store set used by a Cardano [`DomainAdapter`].
+pub type Stores = storage::Stores<dolos_cardano::CardanoDelta>;
+
+/// A failure while assembling and bootstrapping a Dolos domain.
+#[derive(Debug, thiserror::Error)]
+pub enum DomainBuildError {
+    #[error("opening configured Dolos stores: {0}")]
+    Storage(#[source] crate::prelude::Error),
+
+    #[error("initializing Cardano ledger logic: {0}")]
+    Chain(#[source] dolos_core::ChainError),
+
+    #[error("bootstrapping the Dolos domain: {0}")]
+    Bootstrap(#[source] DomainError),
+}
+
+/// Assemble a [`DomainAdapter`] from explicit configuration and genesis.
+///
+/// The builder never loads files or environment variables. An embedding
+/// application decides how configuration and genesis are obtained, then hands
+/// the resolved values here. `stop_epoch` overrides only the cloned chain
+/// configuration used by this domain; the caller's [`RootConfig`] is not
+/// mutated.
+pub struct DomainBuilder<'a> {
+    config: &'a RootConfig,
+    genesis: Arc<Genesis>,
+    stop_epoch: Option<u64>,
+}
+
+impl<'a> DomainBuilder<'a> {
+    /// Start a domain build with no stopping-epoch override.
+    pub fn new(config: &'a RootConfig, genesis: Arc<Genesis>) -> Self {
+        Self {
+            config,
+            genesis,
+            stop_epoch: None,
+        }
+    }
+
+    /// Override the configured Cardano stopping epoch for this domain.
+    pub fn stop_epoch(mut self, stop_epoch: Option<u64>) -> Self {
+        self.stop_epoch = stop_epoch;
+        self
+    }
+
+    /// Open the configured stores without constructing or bootstrapping a
+    /// domain.
+    ///
+    /// Publishers use this phase to recover and publish a boundary already on
+    /// disk before building a domain that can advance beyond it.
+    pub fn open_stores(&self) -> Result<Stores, DomainBuildError> {
+        storage::open_data_stores(self.config).map_err(DomainBuildError::Storage)
+    }
+
+    /// Open stores and construct the domain.
+    ///
+    /// This is the normal node path. It performs the existing bootstrap and
+    /// consistency checks but does not apply bulk-replay recovery first; use
+    /// [`BulkReplaySession::open`] for an importer whose state may be ahead of
+    /// WAL by design.
+    pub fn build(&self) -> Result<DomainAdapter, DomainBuildError> {
+        let stores = self.open_stores()?;
+        self.build_with_stores(stores)
+    }
+
+    /// Construct a domain from stores the caller opened explicitly.
+    ///
+    /// No checkpoint recovery is hidden here. In particular, construction
+    /// never treats a pending publish boundary as permission to import or
+    /// prune past it.
+    pub fn build_with_stores(&self, stores: Stores) -> Result<DomainAdapter, DomainBuildError> {
+        let ChainConfig::Cardano(mut chain_config) = self.config.chain.clone();
+
+        if let Some(stop_epoch) = self.stop_epoch {
+            chain_config.stop_epoch = Some(stop_epoch);
+        }
+
+        let chain = dolos_cardano::CardanoLogic::initialize::<DomainAdapter>(
+            chain_config,
+            &stores.state,
+            &self.genesis,
+        )
+        .map_err(DomainBuildError::Chain)?;
+
+        let (tip_broadcast, _) = tokio::sync::broadcast::channel(100);
+
+        let domain = DomainAdapter {
+            storage_config: Arc::new(self.config.storage.clone()),
+            sync_config: Arc::new(self.config.sync.clone()),
+            genesis: self.genesis.clone(),
+            chain: Arc::new(std::sync::RwLock::new(chain)),
+            wal: stores.wal,
+            state: stores.state,
+            archive: stores.archive,
+            mempool: stores.mempool,
+            tip_broadcast,
+        };
+
+        domain.bootstrap().map_err(DomainBuildError::Bootstrap)?;
+
+        Ok(domain)
+    }
+}
+
+/// The durable result of importing one batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayProgress {
+    /// The batch committed normally at this state-store position.
+    Committed { position: ChainPoint },
+    /// The configured stopping epoch fired after its anchoring block committed.
+    Boundary { position: ChainPoint },
+}
+
+impl ReplayProgress {
+    /// The committed state cursor reported by this import.
+    pub fn position(&self) -> &ChainPoint {
+        match self {
+            Self::Committed { position } | Self::Boundary { position } => position,
+        }
+    }
+
+    /// Whether the configured stopping boundary was reached.
+    pub fn is_boundary(&self) -> bool {
+        matches!(self, Self::Boundary { .. })
+    }
+}
+
+/// A failure in the bulk-replay lifecycle.
+#[derive(Debug, thiserror::Error)]
+pub enum BulkReplayError {
+    #[error(transparent)]
+    Build(#[from] DomainBuildError),
+
+    #[error("recovering the bulk-replay checkpoint: {0}")]
+    Recovery(#[source] BulkRecoveryError),
+
+    #[error("importing a bulk-replay batch: {0}")]
+    Import(#[source] DomainError),
+
+    #[error("reading the committed bulk-replay position: {0}")]
+    Position(#[source] dolos_core::StateError),
+
+    #[error("bulk replay completed without a state cursor")]
+    MissingPosition,
+
+    #[error("shutting down the bulk-replay domain: {0}")]
+    Shutdown(#[source] DomainError),
+
+    #[error("checkpoint recovery failed ({recovery}) and shutdown also failed ({shutdown})")]
+    RecoveryAndShutdown {
+        recovery: BulkRecoveryError,
+        shutdown: DomainError,
+    },
+}
+
+/// A bulk-import domain with explicit recovery, progress, and close semantics.
+///
+/// Opening first reconciles only the expected import shape (state ahead of
+/// WAL), then bootstraps a domain with the requested stopping epoch. Importing
+/// uses [`dolos_core::ImportExt`], so it does not enter the live sync/WAL-tip
+/// notification pipeline. [`close`](Self::close) checkpoints WAL and drains
+/// the configured stores; it never runs housekeeping.
+#[derive(Clone)]
+pub struct BulkReplaySession {
+    domain: DomainAdapter,
+    initial_recovery: BulkRecovery,
+}
+
+impl BulkReplaySession {
+    /// Recover an importer checkpoint and construct a replay domain.
+    pub fn open(
+        config: &RootConfig,
+        genesis: Arc<Genesis>,
+        stop_epoch: Option<u64>,
+    ) -> Result<Self, BulkReplayError> {
+        let builder = DomainBuilder::new(config, genesis).stop_epoch(stop_epoch);
+        let stores = builder.open_stores()?;
+        let initial_recovery = recover_bulk_checkpoint(&stores.state, &stores.wal)
+            .map_err(BulkReplayError::Recovery)?;
+        let domain = builder.build_with_stores(stores)?;
+
+        Ok(Self {
+            domain,
+            initial_recovery,
+        })
+    }
+
+    /// What opening the session found and, if necessary, repaired.
+    pub fn initial_recovery(&self) -> &BulkRecovery {
+        &self.initial_recovery
+    }
+
+    /// The underlying domain for read-only consumers and existing facades.
+    pub fn domain(&self) -> &DomainAdapter {
+        &self.domain
+    }
+
+    /// Read the last position committed across the state-store boundary.
+    pub fn committed_position(&self) -> Result<Option<ChainPoint>, BulkReplayError> {
+        self.domain
+            .state()
+            .read_cursor()
+            .map_err(BulkReplayError::Position)
+    }
+
+    /// Import one trusted immutable batch and report the committed position or
+    /// configured epoch boundary.
+    pub fn import_blocks(&self, blocks: Vec<RawBlock>) -> Result<ReplayProgress, BulkReplayError> {
+        let boundary = match self.domain.import_blocks(blocks) {
+            Ok(_last_received) => false,
+            Err(DomainError::StopEpochReached) => true,
+            Err(error) => return Err(BulkReplayError::Import(error)),
+        };
+
+        let position = self
+            .committed_position()?
+            .ok_or(BulkReplayError::MissingPosition)?;
+
+        if boundary {
+            Ok(ReplayProgress::Boundary { position })
+        } else {
+            Ok(ReplayProgress::Committed { position })
+        }
+    }
+
+    /// Checkpoint WAL and explicitly flush/shut down every store.
+    ///
+    /// Shutdown is attempted even if checkpoint recovery fails, and a caller
+    /// should call this on both operation success and failure.
+    /// [`run`](Self::run) packages that rule for a complete replay
+    /// operation.
+    pub fn close(&self) -> Result<BulkRecovery, BulkReplayError> {
+        let recovery = recover_bulk_checkpoint(self.domain.state(), self.domain.wal());
+        let shutdown = self.domain.shutdown();
+
+        match (recovery, shutdown) {
+            (Ok(recovery), Ok(())) => Ok(recovery),
+            (Err(recovery), Ok(())) => Err(BulkReplayError::Recovery(recovery)),
+            (Ok(_), Err(shutdown)) => Err(BulkReplayError::Shutdown(shutdown)),
+            (Err(recovery), Err(shutdown)) => {
+                Err(BulkReplayError::RecoveryAndShutdown { recovery, shutdown })
+            }
+        }
+    }
+
+    /// Run an operation and close the session whether it succeeds or fails.
+    pub fn run<T, E>(
+        self,
+        operation: impl FnOnce(&Self) -> Result<T, E>,
+    ) -> Result<T, BulkReplayRunError<E>> {
+        let result = operation(&self);
+        let close = self.close();
+
+        match (result, close) {
+            (Ok(value), Ok(_)) => Ok(value),
+            (Err(operation), Ok(_)) => Err(BulkReplayRunError::Operation(operation)),
+            (Ok(_), Err(close)) => Err(BulkReplayRunError::Close(close)),
+            (Err(operation), Err(close)) => {
+                Err(BulkReplayRunError::OperationAndClose { operation, close })
+            }
+        }
+    }
+}
+
+/// A replay operation's error, preserving a close failure if both happened.
+#[derive(Debug)]
+pub enum BulkReplayRunError<E> {
+    Operation(E),
+    Close(BulkReplayError),
+    OperationAndClose {
+        operation: E,
+        close: BulkReplayError,
+    },
+}
+
+impl<E: fmt::Display> fmt::Display for BulkReplayRunError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Operation(error) => write!(formatter, "bulk replay failed: {error}"),
+            Self::Close(error) => write!(formatter, "closing bulk replay failed: {error}"),
+            Self::OperationAndClose { operation, close } => write!(
+                formatter,
+                "bulk replay failed ({operation}) and closing it also failed ({close})"
+            ),
+        }
+    }
+}
+
+impl<E> std::error::Error for BulkReplayRunError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Operation(error)
+            | Self::OperationAndClose {
+                operation: error, ..
+            } => Some(error),
+            Self::Close(error) => Some(error),
+        }
+    }
+}
+
+impl Domain for BulkReplaySession {
+    type Entity = dolos_cardano::CardanoEntity;
+    type EntityDelta = dolos_cardano::CardanoDelta;
+    type Chain = dolos_cardano::CardanoLogic;
+    type WorkUnit = dolos_cardano::CardanoWorkUnit;
+    type Wal = crate::adapters::WalAdapter;
+    type State = crate::adapters::StateStoreBackend;
+    type Archive = crate::adapters::ArchiveStoreBackend;
+    type Mempool = crate::adapters::MempoolBackend;
+    type TipSubscription = TipSubscription;
+
+    fn storage_config(&self) -> &dolos_core::config::StorageConfig {
+        self.domain.storage_config()
+    }
+
+    fn sync_config(&self) -> &dolos_core::config::SyncConfig {
+        self.domain.sync_config()
+    }
+
+    fn genesis(&self) -> Arc<Genesis> {
+        self.domain.genesis()
+    }
+
+    fn read_chain(&self) -> std::sync::RwLockReadGuard<'_, Self::Chain> {
+        self.domain.read_chain()
+    }
+
+    fn write_chain(&self) -> std::sync::RwLockWriteGuard<'_, Self::Chain> {
+        self.domain.write_chain()
+    }
+
+    fn wal(&self) -> &Self::Wal {
+        self.domain.wal()
+    }
+
+    fn state(&self) -> &Self::State {
+        self.domain.state()
+    }
+
+    fn archive(&self) -> &Self::Archive {
+        self.domain.archive()
+    }
+
+    fn mempool(&self) -> &Self::Mempool {
+        self.domain.mempool()
+    }
+
+    fn watch_tip(&self, from: Option<ChainPoint>) -> Result<Self::TipSubscription, DomainError> {
+        self.domain.watch_tip(from)
+    }
+
+    fn notify_tip(&self, tip: TipEvent) {
+        self.domain.notify_tip(tip)
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,24 +1,28 @@
-//! Supported headless construction and bulk-replay lifecycle.
+//! Headless node construction and exclusive bulk replay.
 //!
-//! Applications embedding Dolos should use this module instead of copying the
-//! executable's domain assembly. Configuration-file precedence, progress UI,
-//! signal handling, source acquisition, publication, and housekeeping remain
-//! application policy; this module owns the stable engine seams beneath them.
+//! Hosts provide resolved configuration, trusted blocks and stopping policy.
+//! Opening a replay workspace does not advance the ledger. Inspect or export
+//! its snapshot before explicitly starting replay. Finalization persists the
+//! committed position and releases resources without pruning history.
+
+mod checkpoint;
 
 use std::fmt;
 use std::sync::Arc;
 
 use dolos_core::config::{ChainConfig, RootConfig};
+pub use dolos_core::ReplayProgress;
 use dolos_core::{
-    recover_bulk_checkpoint, BootstrapExt as _, BulkRecovery, BulkRecoveryError, ChainLogic as _,
-    ChainPoint, Domain, DomainError, Genesis, ImportExt as _, RawBlock, StateStore as _, TipEvent,
+    BootstrapExt as _, ChainLogic as _, ChainPoint, Domain as _, DomainError, Genesis,
+    ImportExt as _, RawBlock, StateStore as _,
 };
+use dolos_snapshot::source::{SnapshotSource, StoreSnapshot};
 
-use crate::adapters::{DomainAdapter, TipSubscription};
+use crate::adapters::{ArchiveStoreBackend, DomainAdapter, StateStoreBackend, WalAdapter};
 use crate::storage;
 
-/// The concrete store set used by a Cardano [`DomainAdapter`].
-pub type Stores = storage::Stores<dolos_cardano::CardanoDelta>;
+type Stores = storage::Stores<dolos_cardano::CardanoDelta>;
+type Cause = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// A failure while assembling and bootstrapping a Dolos domain.
 #[derive(Debug, thiserror::Error)]
@@ -62,32 +66,14 @@ impl<'a> DomainBuilder<'a> {
         self
     }
 
-    /// Open the configured stores without constructing or bootstrapping a
-    /// domain.
-    ///
-    /// Publishers use this phase to recover and publish a boundary already on
-    /// disk before building a domain that can advance beyond it.
-    pub fn open_stores(&self) -> Result<Stores, DomainBuildError> {
-        storage::open_data_stores(self.config).map_err(DomainBuildError::Storage)
-    }
-
-    /// Open stores and construct the domain.
-    ///
-    /// This is the normal node path. It performs the existing bootstrap and
-    /// consistency checks but does not apply bulk-replay recovery first; use
-    /// [`BulkReplaySession::open`] for an importer whose state may be ahead of
-    /// WAL by design.
+    /// Construct a normal node domain, including initialization and integrity
+    /// checks.
     pub fn build(&self) -> Result<DomainAdapter, DomainBuildError> {
-        let stores = self.open_stores()?;
-        self.build_with_stores(stores)
+        let stores = storage::open_data_stores(self.config).map_err(DomainBuildError::Storage)?;
+        self.build_with_stores(&stores)
     }
 
-    /// Construct a domain from stores the caller opened explicitly.
-    ///
-    /// No checkpoint recovery is hidden here. In particular, construction
-    /// never treats a pending publish boundary as permission to import or
-    /// prune past it.
-    pub fn build_with_stores(&self, stores: Stores) -> Result<DomainAdapter, DomainBuildError> {
+    fn build_with_stores(&self, stores: &Stores) -> Result<DomainAdapter, DomainBuildError> {
         let ChainConfig::Cardano(mut chain_config) = self.config.chain.clone();
 
         if let Some(stop_epoch) = self.stop_epoch {
@@ -108,10 +94,10 @@ impl<'a> DomainBuilder<'a> {
             sync_config: Arc::new(self.config.sync.clone()),
             genesis: self.genesis.clone(),
             chain: Arc::new(std::sync::RwLock::new(chain)),
-            wal: stores.wal,
-            state: stores.state,
-            archive: stores.archive,
-            mempool: stores.mempool,
+            wal: stores.wal.clone(),
+            state: stores.state.clone(),
+            archive: stores.archive.clone(),
+            mempool: stores.mempool.clone(),
             tip_broadcast,
         };
 
@@ -121,181 +107,309 @@ impl<'a> DomainBuilder<'a> {
     }
 }
 
-/// The durable result of importing one batch.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReplayProgress {
-    /// The batch committed normally at this state-store position.
-    Committed { position: ChainPoint },
-    /// The configured stopping epoch fired after its anchoring block committed.
-    Boundary { position: ChainPoint },
+/// An operation failed. Storage-specific details remain in the error source
+/// chain rather than becoming part of the replay protocol.
+#[derive(Debug, thiserror::Error)]
+#[error("{operation}: {source}")]
+pub struct BulkReplayError {
+    operation: &'static str,
+    #[source]
+    source: Cause,
 }
 
-impl ReplayProgress {
-    /// The committed state cursor reported by this import.
-    pub fn position(&self) -> &ChainPoint {
-        match self {
-            Self::Committed { position } | Self::Boundary { position } => position,
+impl BulkReplayError {
+    fn new(operation: &'static str, source: impl Into<Cause>) -> Self {
+        Self {
+            operation,
+            source: source.into(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{primary}; finalization also failed: {cleanup}")]
+struct WithCleanup {
+    #[source]
+    primary: Cause,
+    cleanup: Cause,
+}
+
+fn complete<T>(
+    result: Result<T, BulkReplayError>,
+    cleanup: Result<(), BulkReplayError>,
+) -> Result<T, BulkReplayError> {
+    match (result, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
+        (Err(primary), Err(cleanup)) => Err(BulkReplayError::new(
+            "finalizing replay",
+            WithCleanup {
+                primary: Box::new(primary),
+                cleanup: Box::new(cleanup),
+            },
+        )),
+    }
+}
+
+fn flush(
+    wal: &WalAdapter,
+    state: &StateStoreBackend,
+    archive: &ArchiveStoreBackend,
+) -> Result<(), BulkReplayError> {
+    let wal = wal
+        .shutdown()
+        .map_err(|error| BulkReplayError::new("finishing replay", error));
+    let state = state
+        .shutdown()
+        .map_err(|error| BulkReplayError::new("finishing replay", error));
+    let archive = archive
+        .shutdown()
+        .map_err(|error| BulkReplayError::new("finishing replay", error));
+    complete(complete(wal, state), archive)
+}
+
+/// An exclusively owned replay dataset, opened without advancing chain state.
+///
+/// Use the borrowed profile view to inspect or publish pending data, then
+/// consume the workspace with `start` to advance it or `finish` to release it.
+/// Neither this handle nor its profile view exposes writable stores.
+#[must_use = "finish the workspace or consume it by starting replay"]
+pub struct ReplayWorkspace<'a> {
+    config: &'a RootConfig,
+    genesis: Arc<Genesis>,
+    stores: Stores,
+}
+
+impl<'a> ReplayWorkspace<'a> {
+    /// Open the configured dataset without running ledger initialization,
+    /// replaying blocks, or pruning history.
+    pub fn open(config: &'a RootConfig, genesis: Arc<Genesis>) -> Result<Self, BulkReplayError> {
+        let stores = storage::open_data_stores(config)
+            .map_err(|error| BulkReplayError::new("opening replay workspace", error))?;
+        Ok(Self {
+            config,
+            genesis,
+            stores,
+        })
+    }
+
+    /// Borrow read-only Dolos profile operations, not storage handles.
+    pub fn snapshot(&self) -> impl SnapshotSource + '_ {
+        StoreSnapshot::new(&self.stores.archive, &self.stores.state)
+    }
+
+    /// Begin processing, including any pending ledger initialization.
+    ///
+    /// Call only after publishing any pending boundary. The optional stopping
+    /// epoch overrides the configured value; `None` retains that configuration.
+    pub fn start(self, stop_epoch: Option<u64>) -> Result<BulkReplaySession, BulkReplayError> {
+        let result = checkpoint::reconcile(&self.stores.state, &self.stores.wal)
+            .map_err(|error| BulkReplayError::new("preparing replay", error))
+            .and_then(|()| {
+                DomainBuilder::new(self.config, self.genesis.clone())
+                    .stop_epoch(stop_epoch)
+                    .build_with_stores(&self.stores)
+                    .map_err(|error| BulkReplayError::new("starting replay", error))
+            });
+        match result {
+            Ok(domain) => Ok(BulkReplaySession {
+                domain,
+                boundary: None,
+                failed: false,
+            }),
+            Err(error) => complete(Err(error), self.finish()),
         }
     }
 
-    /// Whether the configured stopping boundary was reached.
-    pub fn is_boundary(&self) -> bool {
-        matches!(self, Self::Boundary { .. })
+    /// Release the inspection workspace without advancing or pruning it.
+    pub fn finish(self) -> Result<(), BulkReplayError> {
+        flush(&self.stores.wal, &self.stores.state, &self.stores.archive)
     }
 }
 
-/// A failure in the bulk-replay lifecycle.
-#[derive(Debug, thiserror::Error)]
-pub enum BulkReplayError {
-    #[error(transparent)]
-    Build(#[from] DomainBuildError),
-
-    #[error("recovering the bulk-replay checkpoint: {0}")]
-    Recovery(#[source] BulkRecoveryError),
-
-    #[error("importing a bulk-replay batch: {0}")]
-    Import(#[source] DomainError),
-
-    #[error("reading the committed bulk-replay position: {0}")]
-    Position(#[source] dolos_core::StateError),
-
-    #[error("bulk replay completed without a state cursor")]
-    MissingPosition,
-
-    #[error("cannot close bulk replay while {count} cloned session handle(s) remain")]
-    OutstandingHandles { count: usize },
-
-    #[error("shutting down the bulk-replay domain: {0}")]
-    Shutdown(#[source] DomainError),
-
-    #[error("checkpoint recovery failed ({recovery}) and shutdown also failed ({shutdown})")]
-    RecoveryAndShutdown {
-        recovery: BulkRecoveryError,
-        shutdown: DomainError,
-    },
-}
-
-/// A bulk-import domain with explicit recovery, progress, and close semantics.
+/// An exclusive session for trusted immutable blocks.
 ///
-/// Opening first reconciles only the expected import shape (state ahead of
-/// WAL), then bootstraps a domain with the requested stopping epoch. Importing
-/// uses [`dolos_core::ImportExt`], so it does not enter the live sync/WAL-tip
-/// notification pipeline. [`close`](Self::close) checkpoints WAL and drains
-/// the configured stores; it never runs housekeeping.
-#[derive(Clone)]
+/// Session ownership cannot be duplicated:
+/// ```compile_fail
+/// fn duplicate(session: dolos::engine::BulkReplaySession) {
+///     let other = session.clone();
+/// }
+/// ```
+///
+/// A replay session does not expose the live-node domain interface:
+/// ```compile_fail
+/// fn live_domain<D: dolos::core::Domain>() {}
+/// live_domain::<dolos::engine::BulkReplaySession>();
+/// ```
+///
+/// A profile view prevents advancement while it is in use:
+/// ```compile_fail
+/// use dolos_snapshot::source::SnapshotSource;
+/// fn inspect(session: &mut dolos::engine::BulkReplaySession) {
+///     let snapshot = session.snapshot();
+///     session.import_blocks(vec![]).unwrap();
+///     snapshot.committed_position().unwrap();
+/// }
+/// ```
+///
+/// Finishing consumes the handle:
+/// ```compile_fail
+/// fn finish(mut session: dolos::engine::BulkReplaySession) {
+///     session.finish().unwrap();
+///     session.import_blocks(vec![]).unwrap();
+/// }
+/// ```
+///
+/// The session is neither cloneable nor a `Domain`: processing requires a
+/// mutable borrow, and finishing consumes it. After a boundary, further import
+/// calls report that same boundary without accepting more input. After an
+/// execution failure, finish and reopen rather than continuing a damaged
+/// session. An empty batch is rejected before execution and does not invalidate
+/// the session.
+///
+/// `run` finalizes on ordinary success and error returns. Dropping a session,
+/// panicking or killing the process is not a substitute for successful
+/// finalization; interrupted ledger transitions may require explicit repair.
+#[must_use = "finish the session or use run to finalize an operation"]
 pub struct BulkReplaySession {
     domain: DomainAdapter,
-    initial_recovery: BulkRecovery,
-    close_lease: Arc<()>,
+    boundary: Option<ChainPoint>,
+    failed: bool,
 }
 
 impl BulkReplaySession {
-    /// Recover an importer checkpoint and construct a replay domain.
+    /// Open and immediately start replay when no pending export needs
+    /// inspection.
     pub fn open(
         config: &RootConfig,
         genesis: Arc<Genesis>,
         stop_epoch: Option<u64>,
     ) -> Result<Self, BulkReplayError> {
-        let builder = DomainBuilder::new(config, genesis).stop_epoch(stop_epoch);
-        let stores = builder.open_stores()?;
-        let initial_recovery = recover_bulk_checkpoint(&stores.state, &stores.wal)
-            .map_err(BulkReplayError::Recovery)?;
-        let domain = builder.build_with_stores(stores)?;
-
-        Ok(Self {
-            domain,
-            initial_recovery,
-            close_lease: Arc::new(()),
-        })
+        ReplayWorkspace::open(config, genesis)?.start(stop_epoch)
     }
 
-    /// What opening the session found and, if necessary, repaired.
-    pub fn initial_recovery(&self) -> &BulkRecovery {
-        &self.initial_recovery
-    }
-
-    /// Read the last position committed across the state-store boundary.
+    /// Read the last committed input position.
     pub fn committed_position(&self) -> Result<Option<ChainPoint>, BulkReplayError> {
         self.domain
             .state()
             .read_cursor()
-            .map_err(BulkReplayError::Position)
+            .map_err(|error| BulkReplayError::new("reading committed position", error))
     }
 
-    /// Import one trusted immutable batch and report the committed position or
-    /// configured epoch boundary.
-    pub fn import_blocks(&self, blocks: Vec<RawBlock>) -> Result<ReplayProgress, BulkReplayError> {
+    /// Borrow profile operations over the currently committed dataset.
+    pub fn snapshot(&self) -> impl SnapshotSource + '_ {
+        StoreSnapshot::new(self.domain.archive(), self.domain.state())
+    }
+
+    /// Process a nonempty batch and report its committed position or boundary.
+    ///
+    /// A boundary can stop partway through a batch. Resume the source from the
+    /// returned position, not from the last block submitted.
+    pub fn import_blocks(
+        &mut self,
+        blocks: Vec<RawBlock>,
+    ) -> Result<ReplayProgress, BulkReplayError> {
+        if self.failed {
+            return Err(BulkReplayError::new(
+                "importing blocks",
+                "session failed; finish and reopen it",
+            ));
+        }
+        if let Some(position) = &self.boundary {
+            return Ok(ReplayProgress::Boundary {
+                position: position.clone(),
+            });
+        }
+        if blocks.is_empty() {
+            return Err(BulkReplayError::new(
+                "importing blocks",
+                "batch must not be empty",
+            ));
+        }
         let boundary = match self.domain.import_blocks(blocks) {
-            Ok(_last_received) => false,
+            Ok(_) => false,
             Err(DomainError::StopEpochReached) => true,
-            Err(error) => return Err(BulkReplayError::Import(error)),
+            Err(error) => {
+                self.failed = true;
+                return Err(BulkReplayError::new("importing blocks", error));
+            }
         };
-
-        let position = self
-            .committed_position()?
-            .ok_or(BulkReplayError::MissingPosition)?;
-
+        let position = match self.committed_position() {
+            Ok(Some(position)) => position,
+            result => {
+                self.failed = true;
+                return Err(result.err().unwrap_or_else(|| {
+                    BulkReplayError::new("importing blocks", "no committed position")
+                }));
+            }
+        };
         if boundary {
+            self.boundary = Some(position.clone());
             Ok(ReplayProgress::Boundary { position })
         } else {
             Ok(ReplayProgress::Committed { position })
         }
     }
 
-    /// Checkpoint WAL and explicitly flush/shut down every store.
+    /// Explicitly apply the configured history retention policy.
     ///
-    /// Shutdown is attempted even if checkpoint recovery fails, and a caller
-    /// should call this on both operation success and failure.
-    /// [`run`](Self::run) packages that rule for a complete replay
-    /// operation. Closing consumes the session and refuses while cloned
-    /// session handles remain, so no handle can keep importing after the final
-    /// checkpoint.
-    pub fn close(self) -> Result<BulkRecovery, BulkReplayError> {
-        let count = Arc::strong_count(&self.close_lease) - 1;
-        if count > 0 {
-            return Err(BulkReplayError::OutstandingHandles { count });
+    /// The host must first publish any data it intends to preserve. Import and
+    /// finalization never call this operation automatically.
+    pub fn prune_history(&mut self) -> Result<u64, BulkReplayError> {
+        if self.failed || self.boundary.is_some() {
+            return Err(BulkReplayError::new(
+                "pruning history",
+                "finish the session before starting the next replay round",
+            ));
         }
-
-        let recovery = recover_bulk_checkpoint(self.domain.state(), self.domain.wal());
-        let shutdown = self.domain.shutdown();
-
-        match (recovery, shutdown) {
-            (Ok(recovery), Ok(())) => Ok(recovery),
-            (Err(recovery), Ok(())) => Err(BulkReplayError::Recovery(recovery)),
-            (Ok(_), Err(shutdown)) => Err(BulkReplayError::Shutdown(shutdown)),
-            (Err(recovery), Err(shutdown)) => {
-                Err(BulkReplayError::RecoveryAndShutdown { recovery, shutdown })
-            }
-        }
+        self.domain
+            .drain_housekeeping(None)
+            .map_err(|error| BulkReplayError::new("pruning history", error))
     }
 
-    /// Run an operation and close the session whether it succeeds or fails.
-    pub fn run<T, E>(
-        self,
-        operation: impl FnOnce(&Self) -> Result<T, E>,
-    ) -> Result<T, BulkReplayRunError<E>> {
-        let result = operation(&self);
-        let close = self.close();
+    /// Persist completed work and release resources without advancing or
+    /// pruning.
+    ///
+    /// Successful finalization makes the committed position usable by a later
+    /// replay session or normal node startup. Resource finalization is
+    /// attempted even when the dataset cannot be made resumable.
+    pub fn finish(self) -> Result<(), BulkReplayError> {
+        let result = checkpoint::reconcile(self.domain.state(), self.domain.wal())
+            .map_err(|error| BulkReplayError::new("finishing replay", error));
+        let cleanup = flush(
+            self.domain.wal(),
+            self.domain.state(),
+            self.domain.archive(),
+        );
+        complete(result, cleanup)
+    }
 
-        match (result, close) {
-            (Ok(value), Ok(_)) => Ok(value),
-            (Err(operation), Ok(_)) => Err(BulkReplayRunError::Operation(operation)),
-            (Ok(_), Err(close)) => Err(BulkReplayRunError::Close(close)),
-            (Err(operation), Err(close)) => {
-                Err(BulkReplayRunError::OperationAndClose { operation, close })
+    /// Run an operation and finalize on both successful and failed returns.
+    pub fn run<T, E>(
+        mut self,
+        operation: impl FnOnce(&mut Self) -> Result<T, E>,
+    ) -> Result<T, BulkReplayRunError<E>> {
+        let result = operation(&mut self);
+        let finish = self.finish();
+        match (result, finish) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(operation), Ok(())) => Err(BulkReplayRunError::Operation(operation)),
+            (Ok(_), Err(finish)) => Err(BulkReplayRunError::Finish(finish)),
+            (Err(operation), Err(finish)) => {
+                Err(BulkReplayRunError::OperationAndFinish { operation, finish })
             }
         }
     }
 }
 
-/// A replay operation's error, preserving a close failure if both happened.
+/// Preserve both failures when an operation and its finalization fail.
 #[derive(Debug)]
 pub enum BulkReplayRunError<E> {
     Operation(E),
-    Close(BulkReplayError),
-    OperationAndClose {
+    Finish(BulkReplayError),
+    OperationAndFinish {
         operation: E,
-        close: BulkReplayError,
+        finish: BulkReplayError,
     },
 }
 
@@ -303,82 +417,84 @@ impl<E: fmt::Display> fmt::Display for BulkReplayRunError<E> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Operation(error) => write!(formatter, "bulk replay failed: {error}"),
-            Self::Close(error) => write!(formatter, "closing bulk replay failed: {error}"),
-            Self::OperationAndClose { operation, close } => write!(
+            Self::Finish(error) => write!(formatter, "finishing bulk replay failed: {error}"),
+            Self::OperationAndFinish { operation, finish } => write!(
                 formatter,
-                "bulk replay failed ({operation}) and closing it also failed ({close})"
+                "bulk replay failed ({operation}) and finalization also failed ({finish})"
             ),
         }
     }
 }
 
-impl<E> std::error::Error for BulkReplayRunError<E>
-where
-    E: std::error::Error + 'static,
-{
+impl<E: std::error::Error + 'static> std::error::Error for BulkReplayRunError<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Operation(error)
-            | Self::OperationAndClose {
+            | Self::OperationAndFinish {
                 operation: error, ..
             } => Some(error),
-            Self::Close(error) => Some(error),
+            Self::Finish(error) => Some(error),
         }
     }
 }
 
-impl Domain for BulkReplaySession {
-    type Entity = dolos_cardano::CardanoEntity;
-    type EntityDelta = dolos_cardano::CardanoDelta;
-    type Chain = dolos_cardano::CardanoLogic;
-    type WorkUnit = dolos_cardano::CardanoWorkUnit;
-    type Wal = crate::adapters::WalAdapter;
-    type State = crate::adapters::StateStoreBackend;
-    type Archive = crate::adapters::ArchiveStoreBackend;
-    type Mempool = crate::adapters::MempoolBackend;
-    type TipSubscription = TipSubscription;
+#[cfg(feature = "mithril")]
+impl dolos_snapshot::backfill::Workspace for ReplayWorkspace<'_> {
+    type Session = BulkReplaySession;
 
-    fn storage_config(&self) -> &dolos_core::config::StorageConfig {
-        self.domain.storage_config()
+    fn snapshot(&self) -> impl SnapshotSource + '_ {
+        self.snapshot()
     }
 
-    fn sync_config(&self) -> &dolos_core::config::SyncConfig {
-        self.domain.sync_config()
+    fn start(self, target: u64) -> Result<Self::Session, dolos_snapshot::backfill::Error> {
+        self.start(Some(target))
+            .map_err(dolos_snapshot::backfill::Error::caller)
     }
 
-    fn genesis(&self) -> Arc<Genesis> {
-        self.domain.genesis()
+    fn finish(self) -> Result<(), dolos_snapshot::backfill::Error> {
+        self.finish()
+            .map_err(dolos_snapshot::backfill::Error::caller)
+    }
+}
+
+#[cfg(feature = "mithril")]
+impl dolos_snapshot::backfill::Session for BulkReplaySession {
+    fn committed_position(&self) -> Result<Option<ChainPoint>, dolos_snapshot::backfill::Error> {
+        self.committed_position()
+            .map_err(dolos_snapshot::backfill::Error::caller)
     }
 
-    fn read_chain(&self) -> std::sync::RwLockReadGuard<'_, Self::Chain> {
-        self.domain.read_chain()
+    fn import_blocks(
+        &mut self,
+        blocks: Vec<RawBlock>,
+    ) -> Result<ReplayProgress, dolos_snapshot::backfill::Error> {
+        self.import_blocks(blocks)
+            .map_err(dolos_snapshot::backfill::Error::caller)
     }
 
-    fn write_chain(&self) -> std::sync::RwLockWriteGuard<'_, Self::Chain> {
-        self.domain.write_chain()
+    fn prune_history(&mut self) -> Result<u64, dolos_snapshot::backfill::Error> {
+        self.prune_history()
+            .map_err(dolos_snapshot::backfill::Error::caller)
     }
 
-    fn wal(&self) -> &Self::Wal {
-        self.domain.wal()
+    fn finish(self) -> Result<(), dolos_snapshot::backfill::Error> {
+        self.finish()
+            .map_err(dolos_snapshot::backfill::Error::caller)
     }
+}
 
-    fn state(&self) -> &Self::State {
-        self.domain.state()
-    }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    fn archive(&self) -> &Self::Archive {
-        self.domain.archive()
-    }
-
-    fn mempool(&self) -> &Self::Mempool {
-        self.domain.mempool()
-    }
-
-    fn watch_tip(&self, from: Option<ChainPoint>) -> Result<Self::TipSubscription, DomainError> {
-        self.domain.watch_tip(from)
-    }
-
-    fn notify_tip(&self, tip: TipEvent) {
-        self.domain.notify_tip(tip)
+    #[test]
+    fn finalization_preserves_both_errors() {
+        let result = complete::<()>(
+            Err(BulkReplayError::new("operation", "first failure")),
+            Err(BulkReplayError::new("finish", "second failure")),
+        );
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("first failure"));
+        assert!(error.contains("second failure"));
     }
 }

--- a/src/engine/checkpoint.rs
+++ b/src/engine/checkpoint.rs
@@ -1,0 +1,131 @@
+use dolos_core::{BlockSlot, ChainPoint, StateError, StateStore, WalError, WalStore};
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CheckpointError {
+    #[error("reading replay position")]
+    ReadState(#[source] StateError),
+    #[error("reading replay checkpoint")]
+    ReadWal(#[source] WalError),
+    #[error("state cursor at slot {slot} has no block hash")]
+    UnanchoredState { slot: BlockSlot },
+    #[error("checkpoint {wal} and state {state} disagree")]
+    Diverged { wal: ChainPoint, state: ChainPoint },
+    #[error("checkpoint {wal} exists but state has no cursor")]
+    MissingState { wal: ChainPoint },
+    #[error("persisting replay checkpoint")]
+    ResetWal(#[source] WalError),
+}
+
+pub(super) fn reconcile<S: StateStore, W: WalStore>(
+    state: &S,
+    wal: &W,
+) -> Result<(), CheckpointError> {
+    let position = state.read_cursor().map_err(CheckpointError::ReadState)?;
+    let tip = wal
+        .find_tip()
+        .map_err(CheckpointError::ReadWal)?
+        .map(|(point, _)| point);
+
+    if let Some(position) = position.as_ref() {
+        if !position.is_fully_defined() {
+            return Err(CheckpointError::UnanchoredState {
+                slot: position.slot(),
+            });
+        }
+    }
+
+    match (tip, position) {
+        (None, None) => Ok(()),
+        (Some(ChainPoint::Origin), None) => Ok(()),
+        (Some(wal), None) => Err(CheckpointError::MissingState { wal }),
+        (Some(wal), Some(state)) if wal == state => Ok(()),
+        (Some(wal), Some(state)) if wal.slot() == state.slot() => {
+            Err(CheckpointError::Diverged { wal, state })
+        }
+        (Some(wal), Some(state)) if wal.slot() > state.slot() => Ok(()),
+        (_, Some(position)) => wal.reset_to(&position).map_err(CheckpointError::ResetWal),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dolos_core::{Domain as _, StateWriter as _};
+    use dolos_testing::toy_domain::ToyDomain;
+
+    fn set_position(domain: &ToyDomain, position: ChainPoint) {
+        let writer = domain.state().start_writer().unwrap();
+        writer.set_cursor(position).unwrap();
+        writer.commit().unwrap();
+    }
+
+    fn tip(domain: &ToyDomain) -> Option<ChainPoint> {
+        domain.wal().find_tip().unwrap().map(|(point, _)| point)
+    }
+
+    #[test]
+    fn missing_or_stale_checkpoint_is_reconciled_without_moving_state() {
+        for previous in [None, Some(ChainPoint::Specific(5, [1; 32].into()))] {
+            let domain = ToyDomain::new(None, None);
+            if let Some(previous) = previous {
+                domain.wal().reset_to(&previous).unwrap();
+            }
+            let position = ChainPoint::Specific(10, [2; 32].into());
+            set_position(&domain, position.clone());
+            reconcile(domain.state(), domain.wal()).unwrap();
+            assert_eq!(tip(&domain), Some(position.clone()));
+            assert_eq!(
+                domain.state().read_cursor().unwrap(),
+                Some(position.clone())
+            );
+            reconcile(domain.state(), domain.wal()).unwrap();
+            assert_eq!(tip(&domain), Some(position));
+        }
+    }
+
+    #[test]
+    fn later_checkpoint_is_left_for_normal_bootstrap() {
+        let domain = ToyDomain::new(None, None);
+        let state = ChainPoint::Specific(5, [1; 32].into());
+        let checkpoint = ChainPoint::Specific(10, [2; 32].into());
+        set_position(&domain, state.clone());
+        domain.wal().reset_to(&checkpoint).unwrap();
+        reconcile(domain.state(), domain.wal()).unwrap();
+        assert_eq!(tip(&domain), Some(checkpoint));
+        assert_eq!(domain.state().read_cursor().unwrap(), Some(state));
+    }
+
+    #[test]
+    fn divergent_and_unanchored_positions_are_not_overwritten() {
+        let domain = ToyDomain::new(None, None);
+        let checkpoint = ChainPoint::Specific(10, [2; 32].into());
+        domain.wal().reset_to(&checkpoint).unwrap();
+        set_position(&domain, ChainPoint::Specific(10, [3; 32].into()));
+        assert!(matches!(
+            reconcile(domain.state(), domain.wal()),
+            Err(CheckpointError::Diverged { .. })
+        ));
+        assert_eq!(tip(&domain), Some(checkpoint.clone()));
+        set_position(&domain, ChainPoint::Slot(11));
+        assert!(matches!(
+            reconcile(domain.state(), domain.wal()),
+            Err(CheckpointError::UnanchoredState { .. })
+        ));
+        assert_eq!(tip(&domain), Some(checkpoint));
+    }
+
+    #[test]
+    fn missing_state_is_only_allowed_for_a_fresh_or_origin_checkpoint() {
+        let state = dolos_core::builtin::MemoryStateStore::new();
+        let wal = dolos_redb3::wal::RedbWalStore::<dolos_cardano::CardanoDelta>::memory().unwrap();
+        reconcile(&state, &wal).unwrap();
+        wal.reset_to(&ChainPoint::Origin).unwrap();
+        reconcile(&state, &wal).unwrap();
+        wal.reset_to(&ChainPoint::Specific(10, [2; 32].into()))
+            .unwrap();
+        assert!(matches!(
+            reconcile(&state, &wal),
+            Err(CheckpointError::MissingState { .. })
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 pub mod cli;
+pub mod engine;
 pub mod prelude;
 pub mod relay;
 pub mod serve;

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,0 +1,154 @@
+mod node;
+
+use std::io;
+use std::sync::Arc;
+
+use dolos::core::config::ChainConfig;
+use dolos::core::{
+    recover_bulk_checkpoint, BulkRecovery, BulkRecoveryError, ChainPoint, Domain as _, StateStore,
+    StateWriter as _,
+};
+use dolos::engine::{BulkReplayRunError, BulkReplaySession, DomainBuilder, ReplayProgress};
+use dolos_testing::blocks::make_conway_block_with_prev;
+use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
+
+#[test]
+fn public_builder_cleanly_initializes_configured_stores() {
+    let node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let domain = DomainBuilder::new(&node.config, genesis).build().unwrap();
+
+    assert_eq!(domain.state().read_cursor().unwrap(), None);
+
+    domain.shutdown().unwrap();
+}
+
+#[test]
+fn configured_stopping_epoch_reports_the_committed_boundary() {
+    let mut node = node::Node::new();
+    let mut genesis = dolos_cardano::include::preview::load();
+    genesis.force_protocol = Some(9);
+    let genesis = Arc::new(genesis);
+    let epoch_one = genesis.shelley.epoch_length.unwrap() as u64;
+    let (before, block_before) = make_conway_block_with_prev(epoch_one - 1, None, 1);
+    let (boundary, block_boundary) = make_conway_block_with_prev(epoch_one, before.hash(), 2);
+    let (_, block_after) = make_conway_block_with_prev(epoch_one + 1, boundary.hash(), 3);
+    let blocks = vec![block_before, block_boundary, block_after];
+    node.config.chain = ChainConfig::Cardano(Default::default());
+
+    let session = BulkReplaySession::open(&node.config, genesis, Some(1)).unwrap();
+    let progress = session.import_blocks(blocks).unwrap();
+
+    assert!(
+        matches!(progress, ReplayProgress::Boundary { .. }),
+        "{progress:?}"
+    );
+    assert!(progress.position().is_fully_defined());
+    assert_eq!(progress.position().slot(), epoch_one);
+
+    session.close().unwrap();
+}
+
+#[test]
+fn opening_a_session_recovers_state_left_ahead_of_wal() {
+    let mut node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count: 3,
+        slot: 100,
+        ..Default::default()
+    });
+    node.config.chain = ChainConfig::Cardano(chain);
+
+    let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    let expected = session.import_blocks(blocks).unwrap().position().clone();
+    drop(session);
+
+    let recovered = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+
+    assert_eq!(
+        recovered.initial_recovery(),
+        &BulkRecovery::WalSeeded {
+            previous: None,
+            position: expected,
+        }
+    );
+
+    recovered.close().unwrap();
+}
+
+#[test]
+fn run_closes_and_checkpoints_after_an_operation_failure() {
+    let mut node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count: 2,
+        slot: 100,
+        ..Default::default()
+    });
+    node.config.chain = ChainConfig::Cardano(chain);
+
+    let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    let result = session.run(|session| {
+        session.import_blocks(blocks).unwrap();
+        Err::<(), _>(io::Error::other("failure after import"))
+    });
+
+    assert!(matches!(result, Err(BulkReplayRunError::Operation(_))));
+
+    let reopened = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+    assert!(matches!(
+        reopened.initial_recovery(),
+        BulkRecovery::Aligned { .. }
+    ));
+    reopened.close().unwrap();
+}
+
+#[test]
+fn run_closes_and_checkpoints_after_success() {
+    let mut node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count: 2,
+        slot: 100,
+        ..Default::default()
+    });
+    node.config.chain = ChainConfig::Cardano(chain);
+
+    let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    let committed = session
+        .run(|session| session.import_blocks(blocks))
+        .unwrap()
+        .position()
+        .clone();
+
+    let reopened = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+    assert_eq!(
+        reopened.initial_recovery(),
+        &BulkRecovery::Aligned {
+            position: committed,
+        }
+    );
+    reopened.close().unwrap();
+}
+
+#[test]
+fn unanchored_state_is_not_silently_recovered() {
+    let node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let builder = DomainBuilder::new(&node.config, genesis);
+    let stores = builder.open_stores().unwrap();
+    let writer = stores.state.start_writer().unwrap();
+    writer.set_cursor(ChainPoint::Slot(42)).unwrap();
+    writer.commit().unwrap();
+
+    let error = recover_bulk_checkpoint(&stores.state, &stores.wal).unwrap_err();
+    assert!(matches!(
+        error,
+        BulkRecoveryError::UnanchoredState { slot: 42 }
+    ));
+
+    stores.wal.shutdown().unwrap();
+    stores.state.shutdown().unwrap();
+    stores.archive.shutdown().unwrap();
+}

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -133,6 +133,22 @@ fn run_closes_and_checkpoints_after_success() {
 }
 
 #[test]
+fn close_refuses_while_a_cloned_session_handle_remains() {
+    let node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let session = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+    let remaining = session.clone();
+
+    let error = session.close().unwrap_err();
+
+    assert!(matches!(
+        error,
+        dolos::engine::BulkReplayError::OutstandingHandles { count: 1 }
+    ));
+    remaining.close().unwrap();
+}
+
+#[test]
 fn unanchored_state_is_not_silently_recovered() {
     let node = node::Node::new();
     let genesis = Arc::new(dolos_cardano::include::preview::load());

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,170 +1,305 @@
 mod node;
 
+#[cfg(feature = "mithril")]
+#[test]
+fn backfill_publishes_before_advancing_and_releases_failed_publications() {
+    use dolos_snapshot::{backfill, export::Plan, source::SnapshotSource};
+    use std::cell::Cell;
+
+    struct Publisher {
+        expected: ChainPoint,
+        fail: bool,
+        called: Cell<bool>,
+        cancel: tokio_util::sync::CancellationToken,
+    }
+
+    impl backfill::Publish for Publisher {
+        fn publish(&self, plan: &Plan, source: &dyn SnapshotSource) -> Result<(), backfill::Error> {
+            assert_eq!(plan.sequence, 1);
+            assert_eq!(
+                source.committed_position().unwrap(),
+                Some(self.expected.clone())
+            );
+            self.called.set(true);
+            if self.fail {
+                self.cancel.cancel();
+                Err(backfill::Error::caller(io::Error::other(
+                    "publication failed",
+                )))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    let mut node = node::Node::new();
+    let mut genesis = dolos_cardano::include::preview::load();
+    genesis.force_protocol = Some(9);
+    let epoch_one = genesis.shelley.epoch_length.unwrap() as u64;
+    let genesis = Arc::new(genesis);
+    let (before, block_before) = make_conway_block_with_prev(epoch_one - 1, None, 1);
+    let (boundary, block_boundary) = make_conway_block_with_prev(epoch_one, before.hash(), 2);
+    node.config.chain = ChainConfig::Cardano(Default::default());
+    let mut session = BulkReplaySession::open(&node.config, genesis.clone(), Some(1)).unwrap();
+    session
+        .import_blocks(vec![block_before, block_boundary])
+        .unwrap();
+    session.finish().unwrap();
+
+    let mithril = dolos::core::config::MithrilConfig {
+        aggregator: "http://unused.invalid".to_owned(),
+        genesis_key: String::new(),
+        ancillary_key: None,
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for fail in [true, false] {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let publish = Publisher {
+            expected: boundary.clone(),
+            fail,
+            called: Cell::new(false),
+            cancel: cancel.clone(),
+        };
+        let open_workspace = || {
+            ReplayWorkspace::open(&node.config, genesis.clone()).map_err(backfill::Error::caller)
+        };
+        let driver = backfill::Driver {
+            config: &node.config,
+            genesis: &genesis,
+            mithril: &mithril,
+            download_dir: node.root.path().join("unused"),
+            window: 1,
+            until_epoch: Some(1),
+            skip_validation: false,
+            runtime: runtime.handle().clone(),
+            cancel,
+            mithril_feedback: &|| None,
+            replay: &(),
+            open_workspace: &open_workspace,
+            publish: &publish,
+        };
+        let result = driver.run();
+        assert_eq!(result.is_err(), fail);
+        assert!(publish.called.get());
+        let workspace = ReplayWorkspace::open(&node.config, genesis.clone()).unwrap();
+        assert_eq!(
+            workspace.snapshot().committed_position().unwrap(),
+            Some(boundary.clone())
+        );
+        workspace.finish().unwrap();
+    }
+}
+
 use std::io;
 use std::sync::Arc;
 
 use dolos::core::config::ChainConfig;
-use dolos::core::{
-    recover_bulk_checkpoint, BulkRecovery, BulkRecoveryError, ChainPoint, Domain as _, StateStore,
-    StateWriter as _,
+use dolos::core::{ChainPoint, Domain as _, RawBlock, StateStore, StateWriter as _};
+use dolos::engine::{
+    BulkReplayRunError, BulkReplaySession, DomainBuilder, ReplayProgress, ReplayWorkspace,
 };
-use dolos::engine::{BulkReplayRunError, BulkReplaySession, DomainBuilder, ReplayProgress};
+use dolos_snapshot::source::SnapshotSource as _;
 use dolos_testing::blocks::make_conway_block_with_prev;
 use dolos_testing::synthetic::{build_synthetic_blocks, SyntheticBlockConfig};
 
+fn fixture() -> (node::Node, Arc<dolos::core::Genesis>, Vec<RawBlock>) {
+    let mut node = node::Node::new();
+    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count: 4,
+        slot: 100,
+        ..Default::default()
+    });
+    node.config.chain = ChainConfig::Cardano(chain);
+    (node, genesis, blocks)
+}
+
 #[test]
 fn public_builder_cleanly_initializes_configured_stores() {
-    let node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
+    let (node, genesis, _) = fixture();
     let domain = DomainBuilder::new(&node.config, genesis).build().unwrap();
-
     assert_eq!(domain.state().read_cursor().unwrap(), None);
-
     domain.shutdown().unwrap();
 }
 
 #[test]
-fn configured_stopping_epoch_reports_the_committed_boundary() {
+fn inspection_does_not_initialize_a_fresh_workspace() {
+    let (node, genesis, _) = fixture();
+    let workspace = ReplayWorkspace::open(&node.config, genesis).unwrap();
+    assert_eq!(workspace.snapshot().committed_position().unwrap(), None);
+    assert_eq!(workspace.snapshot().epoch().unwrap(), None);
+    workspace.finish().unwrap();
+}
+
+#[test]
+fn configured_boundary_survives_inspection_and_requires_explicit_advancement() {
     let mut node = node::Node::new();
     let mut genesis = dolos_cardano::include::preview::load();
     genesis.force_protocol = Some(9);
-    let genesis = Arc::new(genesis);
     let epoch_one = genesis.shelley.epoch_length.unwrap() as u64;
+    let genesis = Arc::new(genesis);
     let (before, block_before) = make_conway_block_with_prev(epoch_one - 1, None, 1);
     let (boundary, block_boundary) = make_conway_block_with_prev(epoch_one, before.hash(), 2);
-    let (_, block_after) = make_conway_block_with_prev(epoch_one + 1, boundary.hash(), 3);
-    let blocks = vec![block_before, block_boundary, block_after];
+    let (after, block_after) = make_conway_block_with_prev(epoch_one + 1, boundary.hash(), 3);
     node.config.chain = ChainConfig::Cardano(Default::default());
 
-    let session = BulkReplaySession::open(&node.config, genesis, Some(1)).unwrap();
-    let progress = session.import_blocks(blocks).unwrap();
-
-    assert!(
-        matches!(progress, ReplayProgress::Boundary { .. }),
-        "{progress:?}"
-    );
-    assert!(progress.position().is_fully_defined());
-    assert_eq!(progress.position().slot(), epoch_one);
-
-    session.close().unwrap();
-}
-
-#[test]
-fn opening_a_session_recovers_state_left_ahead_of_wal() {
-    let mut node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
-    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
-        block_count: 3,
-        slot: 100,
-        ..Default::default()
-    });
-    node.config.chain = ChainConfig::Cardano(chain);
-
-    let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
-    let expected = session.import_blocks(blocks).unwrap().position().clone();
-    drop(session);
-
-    let recovered = BulkReplaySession::open(&node.config, genesis, None).unwrap();
-
+    let mut session = BulkReplaySession::open(&node.config, genesis.clone(), Some(1)).unwrap();
+    let progress = session
+        .import_blocks(vec![block_before, block_boundary, block_after.clone()])
+        .unwrap();
     assert_eq!(
-        recovered.initial_recovery(),
-        &BulkRecovery::WalSeeded {
-            previous: None,
-            position: expected,
+        progress,
+        ReplayProgress::Boundary {
+            position: boundary.clone()
         }
     );
+    assert_eq!(
+        session.import_blocks(vec![block_after.clone()]).unwrap(),
+        progress
+    );
+    assert!(session.prune_history().is_err());
+    session.finish().unwrap();
 
-    recovered.close().unwrap();
+    for _attempt in 0..2 {
+        let workspace = ReplayWorkspace::open(&node.config, genesis.clone()).unwrap();
+        let snapshot = workspace.snapshot();
+        assert_eq!(
+            snapshot.committed_position().unwrap(),
+            Some(boundary.clone())
+        );
+        assert_eq!(snapshot.epoch().unwrap(), Some(1));
+        let plan = snapshot
+            .plan(
+                u64::from(genesis.network_magic()),
+                dolos_snapshot::planning::retained_epochs(&node.config).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(plan.sequence, 1);
+        drop(snapshot);
+        workspace.finish().unwrap();
+    }
+
+    let workspace = ReplayWorkspace::open(&node.config, genesis).unwrap();
+    let mut session = workspace.start(Some(2)).unwrap();
+    assert_eq!(
+        session.import_blocks(vec![block_after]).unwrap().position(),
+        &after
+    );
+    session.finish().unwrap();
 }
 
 #[test]
-fn run_closes_and_checkpoints_after_an_operation_failure() {
-    let mut node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
-    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
-        block_count: 2,
-        slot: 100,
-        ..Default::default()
-    });
-    node.config.chain = ChainConfig::Cardano(chain);
+fn unfinished_replay_resumes_from_its_committed_input() {
+    let (node, genesis, blocks) = fixture();
+    let mut session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    let committed = session
+        .import_blocks(blocks[..2].to_vec())
+        .unwrap()
+        .position()
+        .clone();
+    drop(session);
 
+    let workspace = ReplayWorkspace::open(&node.config, genesis.clone()).unwrap();
+    assert_eq!(
+        workspace.snapshot().committed_position().unwrap(),
+        Some(committed.clone())
+    );
+    let mut resumed = workspace.start(None).unwrap();
+    assert_eq!(
+        resumed.committed_position().unwrap(),
+        Some(committed.clone())
+    );
+    let final_position = resumed
+        .import_blocks(blocks[2..].to_vec())
+        .unwrap()
+        .position()
+        .clone();
+    assert!(final_position.slot() > committed.slot());
+    resumed.finish().unwrap();
+
+    let domain = DomainBuilder::new(&node.config, genesis).build().unwrap();
+    assert_eq!(domain.state().read_cursor().unwrap(), Some(final_position));
+    domain.shutdown().unwrap();
+}
+
+#[test]
+fn operation_failure_still_finalizes_for_normal_node_startup() {
+    let (node, genesis, blocks) = fixture();
     let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    let mut committed = None;
     let result = session.run(|session| {
-        session.import_blocks(blocks).unwrap();
+        committed = Some(session.import_blocks(blocks).unwrap().position().clone());
         Err::<(), _>(io::Error::other("failure after import"))
     });
-
     assert!(matches!(result, Err(BulkReplayRunError::Operation(_))));
-
-    let reopened = BulkReplaySession::open(&node.config, genesis, None).unwrap();
-    assert!(matches!(
-        reopened.initial_recovery(),
-        BulkRecovery::Aligned { .. }
-    ));
-    reopened.close().unwrap();
+    let domain = DomainBuilder::new(&node.config, genesis).build().unwrap();
+    assert_eq!(domain.state().read_cursor().unwrap(), committed);
+    domain.shutdown().unwrap();
 }
 
 #[test]
-fn run_closes_and_checkpoints_after_success() {
-    let mut node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
-    let (blocks, _, chain) = build_synthetic_blocks(SyntheticBlockConfig {
-        block_count: 2,
-        slot: 100,
-        ..Default::default()
-    });
-    node.config.chain = ChainConfig::Cardano(chain);
-
+fn success_finalizes_for_normal_node_startup() {
+    let (node, genesis, blocks) = fixture();
     let session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
     let committed = session
         .run(|session| session.import_blocks(blocks))
         .unwrap()
         .position()
         .clone();
-
-    let reopened = BulkReplaySession::open(&node.config, genesis, None).unwrap();
-    assert_eq!(
-        reopened.initial_recovery(),
-        &BulkRecovery::Aligned {
-            position: committed,
-        }
-    );
-    reopened.close().unwrap();
+    let domain = DomainBuilder::new(&node.config, genesis).build().unwrap();
+    assert_eq!(domain.state().read_cursor().unwrap(), Some(committed));
+    domain.shutdown().unwrap();
 }
 
 #[test]
-fn close_refuses_while_a_cloned_session_handle_remains() {
-    let node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
-    let session = BulkReplaySession::open(&node.config, genesis, None).unwrap();
-    let remaining = session.clone();
-
-    let error = session.close().unwrap_err();
-
-    assert!(matches!(
-        error,
-        dolos::engine::BulkReplayError::OutstandingHandles { count: 1 }
-    ));
-    remaining.close().unwrap();
+fn empty_input_does_not_poison_a_session() {
+    let (node, genesis, blocks) = fixture();
+    let mut session = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+    assert!(session.import_blocks(vec![]).is_err());
+    assert_eq!(session.committed_position().unwrap(), None);
+    session.import_blocks(blocks).unwrap();
+    session.finish().unwrap();
 }
 
 #[test]
-fn unanchored_state_is_not_silently_recovered() {
-    let node = node::Node::new();
-    let genesis = Arc::new(dolos_cardano::include::preview::load());
-    let builder = DomainBuilder::new(&node.config, genesis);
-    let stores = builder.open_stores().unwrap();
+fn import_failure_requires_reopening() {
+    let (node, genesis, blocks) = fixture();
+    let mut session = BulkReplaySession::open(&node.config, genesis.clone(), None).unwrap();
+    assert!(session.import_blocks(vec![Arc::new(vec![0xff])]).is_err());
+    assert!(session
+        .import_blocks(blocks.clone())
+        .unwrap_err()
+        .to_string()
+        .contains("finish and reopen"));
+    session.finish().unwrap();
+    let mut session = BulkReplaySession::open(&node.config, genesis, None).unwrap();
+    session.import_blocks(blocks).unwrap();
+    session.finish().unwrap();
+}
+
+#[test]
+fn unanchored_position_is_not_silently_repaired_and_failed_start_releases_stores() {
+    let (node, genesis, _) = fixture();
+    let stores =
+        dolos::storage::open_data_stores::<dolos_cardano::CardanoDelta>(&node.config).unwrap();
     let writer = stores.state.start_writer().unwrap();
     writer.set_cursor(ChainPoint::Slot(42)).unwrap();
     writer.commit().unwrap();
-
-    let error = recover_bulk_checkpoint(&stores.state, &stores.wal).unwrap_err();
-    assert!(matches!(
-        error,
-        BulkRecoveryError::UnanchoredState { slot: 42 }
-    ));
-
-    stores.wal.shutdown().unwrap();
     stores.state.shutdown().unwrap();
-    stores.archive.shutdown().unwrap();
+    drop(stores);
+
+    let workspace = ReplayWorkspace::open(&node.config, genesis.clone()).unwrap();
+    assert!(workspace.snapshot().epoch().is_err());
+    let error = workspace.start(None).err().unwrap();
+    assert!(error.to_string().contains("no block hash"));
+
+    let workspace = ReplayWorkspace::open(&node.config, genesis).unwrap();
+    assert_eq!(
+        workspace.snapshot().committed_position().unwrap(),
+        Some(ChainPoint::Slot(42))
+    );
+    workspace.finish().unwrap();
 }


### PR DESCRIPTION
## Summary

Expose the existing Dolos replay engine for an external host, without making the host coordinate Dolos storage internals.

Plan: `plans/stelae-publisher-pipeline-dolos-engine.md` (step 1 of the Stelae-owned publisher migration).

This revision addresses the API review: owning the implementation in Dolos is not enough if its public contract still leaks WAL recovery and unrestricted domain access.

## Host-facing API

- `DomainBuilder::build()` remains the shared normal-node construction path. Store assembly is private.
- `ReplayWorkspace::open(config, genesis)` opens a dataset for inspection without running ledger initialization, advancing pending chain work or pruning history.
- `workspace.snapshot()` provides borrowed, read-only Dolos profile operations: position, epoch, plan, preview and publication. No writable store handles escape.
- `workspace.start(stop_epoch)` explicitly transitions into replay; `BulkReplaySession::open(...)` is the convenience path when no pending export needs inspection.
- `session.import_blocks(...)` requires exclusive mutable access and reports committed position or a terminal boundary. It never substitutes the last submitted block for the actual committed position.
- `session.finish() -> Result<(), BulkReplayError>` persists completed work and releases resources. `run(...)` finalizes on ordinary success and failure, preserving simultaneous errors.
- `prune_history()` remains an explicit host decision, never automatic at completion.

Removed from the new public API: `BulkRecovery`, `BulkRecoveryError`, `recover_bulk_checkpoint`, `initial_recovery()`, storage-returning construction methods, cloned replay handles and the `Domain` implementation on replay sessions. Checkpoint reconciliation is now private engine implementation. Internal causes remain available in diagnostic error chains.

## Existing flows

- Normal node startup shares domain construction and retains its existing integrity policy.
- Mithril bootstrap uses the exclusive session through an input-processing callback rather than requiring a `Domain`.
- Snapshot backfill uses narrow `Workspace`, `Session` and `Publish` contracts: inspect/publish pending data first, then start the next replay round.
- The repository CLI shares the same read-only profile source adapter; existing export and registry implementations remain unchanged.

## Lifecycle guarantees and limits

- Inspection cannot advance a pending boundary.
- A borrowed profile view prevents advancing or finishing its session while the view is in use.
- Sessions are not cloneable; finishing consumes the handle.
- After a boundary, more imports report the same boundary without processing input. After an execution failure, finish and reopen; empty batches are rejected before execution without invalidating the session.
- Persistence preparation and finalization stay inside Dolos. Finalization attempts every configured WAL/state/archive shutdown even if an earlier step fails.
- No changes to ledger transitions, import execution, storage versions, profile bytes or live-sync notification semantics.
- This is not a new atomic-import or general corruption-repair mechanism. Interrupted ledger transitions and inconsistent archives retain their existing limitations; dropping/panicking/killing is not equivalent to successful finalization.

See `docs/headless-replay.md` and `examples/headless_replay.rs`.

## Verification

Validated on 2026-09-12; refactor commit: `01aa2c2c` (following `ef92f0c5`).

- `cargo +nightly-2026-08-27 fmt --all -- --check`
- `cargo clippy --locked --offline --workspace --all-targets --all-features` — no new warnings; seven pre-existing warnings remain in untouched Cardano/snapshot tests.
- `cargo build --locked --offline --workspace --all-targets --all-features`
- `cargo test --locked --offline --workspace --all-targets` — 1,525 tests passed.
- `cargo test --locked --offline --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp` — 1,040 tests passed, including doctests.
- `cargo check --locked --offline --no-default-features --example headless_replay`
- `cargo test --locked --offline -p dolos --doc engine::` — four compile-fail ownership/API tests passed.
- `cargo test --locked --offline -p dolos-snapshot --test publish -- --ignored --test-threads=1` — 14 local-registry tests passed.
- `cargo test --locked --offline -p dolos-snapshot --test restore_registry -- --ignored --test-threads=1` — seven local-registry tests passed.

The ten public-engine tests cover non-advancing inspection, committed boundary reporting, refusal to advance a completed session, resumption, node startup after finalization, finalization after operation failures, invalid input, failed-open resource release and publication-before-advancement. Private tests cover checkpoint classification and combined errors.

No production registry writes or deployments were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a headless replay workflow with workspace inspection, batched imports, resume support, and optional stopping epochs.
  - Added explicit replay progress reporting, including committed positions and stopping boundaries.
  - Added read-only snapshot inspection and publishing support for external hosts.
  - Added checkpoint reconciliation for state and write-ahead log consistency.

- **Improvements**
  - Updated snapshot backfill and bootstrap workflows to use the new replay process.
  - Added a command-line replay example and embedding documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->