### PR TITLE
perf(minibf): batch metadata and live replay work

### DIFF
--- a/crates/core/src/async_query.rs
+++ b/crates/core/src/async_query.rs
@@ -1,6 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use futures_util::future::join_all;
+use futures_util::{stream, StreamExt as _};
 use itertools::Itertools as _;
 
 use tokio::sync::Semaphore;
@@ -41,6 +44,7 @@ pub struct BlockMetaResolver<D: Domain> {
     memo: HashMap<TxHash, Option<BlockRefMeta>>,
     cap: usize,
     fetches: usize,
+    body_fetches: usize,
 }
 
 impl<D: Domain> BlockMetaResolver<D> {
@@ -54,6 +58,7 @@ impl<D: Domain> BlockMetaResolver<D> {
             memo: HashMap::new(),
             cap: cap.max(1),
             fetches: 0,
+            body_fetches: 0,
         }
     }
 
@@ -61,6 +66,11 @@ impl<D: Domain> BlockMetaResolver<D> {
     /// misses.
     pub fn fetches(&self) -> usize {
         self.fetches
+    }
+
+    /// Number of archive bodies read and decoded for metadata resolution.
+    pub fn body_fetches(&self) -> usize {
+        self.body_fetches
     }
 
     /// Return owned metadata for the requested hashes, omitting archive misses.
@@ -87,16 +97,8 @@ impl<D: Domain> BlockMetaResolver<D> {
         }
 
         self.fetches += missing.len();
-        let query = &self.query;
-        let fetched = join_all(missing.into_iter().map(|hash| async move {
-            query
-                .block_meta_by_tx_hash(hash.to_vec())
-                .await
-                .map(|meta| (hash, meta))
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
+        let (fetched, body_fetches) = self.query.block_meta_by_tx_hashes(missing).await?;
+        self.body_fetches += body_fetches;
 
         for (hash, meta) in fetched {
             if let Some(meta) = &meta {
@@ -112,6 +114,7 @@ impl<D: Domain> BlockMetaResolver<D> {
             deps = required.len(),
             held = self.memo.len(),
             fetches = self.fetches(),
+            body_fetches = self.body_fetches(),
             "resolved block metadata"
         );
 
@@ -166,6 +169,9 @@ where
     }
 
     pub fn with_options(inner: D, options: AsyncQueryOptions) -> Self {
+        let options = AsyncQueryOptions {
+            max_blocking: options.max_blocking.max(1),
+        };
         let limiter = Arc::new(Semaphore::new(options.max_blocking));
         Self {
             inner,
@@ -302,6 +308,105 @@ where
             }))
         })
         .await
+    }
+
+    /// Resolve transaction metadata while reading and decoding each selected
+    /// archive body at most once.
+    ///
+    /// Exact index lookups are retained for every distinct transaction hash.
+    /// Their slots are grouped before body work starts, then each group uses
+    /// one blocking task under the facade's shared limiter. Results are owned;
+    /// decoded blocks and body buffers are dropped inside those bounded tasks.
+    async fn block_meta_by_tx_hashes(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<(Vec<(TxHash, Option<BlockRefMeta>)>, usize), DomainError> {
+        let requested = tx_hashes.clone();
+        let located = self
+            .run_blocking(move |domain| {
+                tx_hashes
+                    .into_iter()
+                    .map(|tx_hash| {
+                        let slot = domain.archive().slot_by_tx_hash(tx_hash.as_slice())?;
+                        Ok((tx_hash, slot))
+                    })
+                    .collect::<Result<Vec<_>, DomainError>>()
+            })
+            .await?;
+
+        let mut fetched = HashMap::new();
+        let mut groups: HashMap<BlockSlot, Vec<TxHash>> = HashMap::new();
+        for (tx_hash, slot) in located {
+            if let Some(slot) = slot {
+                groups.entry(slot).or_default().push(tx_hash);
+            } else {
+                fetched.insert(tx_hash, None);
+            }
+        }
+
+        let mut body_fetches = 0;
+        let query = self.clone();
+        let tasks = stream::iter(groups.into_iter().map(move |(slot, tx_hashes)| {
+            let query = query.clone();
+            async move {
+                query
+                    .run_blocking(move |domain| {
+                        let raws = domain.archive().get_blocks_by_slot(&slot)?;
+                        let body_count = raws.len();
+                        let mut positions = HashMap::new();
+                        let requested: HashSet<_> = tx_hashes.iter().copied().collect();
+                        for raw in raws {
+                            let block = MultiEraBlock::decode(raw.as_slice()).map_err(|error| {
+                                DomainError::ChainError(ChainError::DecodingError(error))
+                            })?;
+                            for (tx_index, tx) in block.txs().iter().enumerate() {
+                                let tx_hash = tx.hash();
+                                if requested.contains(&tx_hash) {
+                                    positions.entry(tx_hash).or_insert_with(|| BlockRefMeta {
+                                        slot: block.slot(),
+                                        hash: block.hash(),
+                                        height: block.number(),
+                                        tx_hash,
+                                        tx_index,
+                                    });
+                                }
+                            }
+                        }
+
+                        Ok((
+                            tx_hashes
+                                .into_iter()
+                                .map(|tx_hash| {
+                                    let meta = positions.get(&tx_hash).cloned();
+                                    (tx_hash, meta)
+                                })
+                                .collect::<Vec<_>>(),
+                            body_count,
+                        ))
+                    })
+                    .await
+            }
+        }))
+        .buffer_unordered(self.options.max_blocking)
+        .collect::<Vec<_>>()
+        .await;
+
+        // Await every started blocking task before propagating an error. A
+        // dropped spawn_blocking handle does not cancel its underlying work.
+        for task in tasks {
+            let (entries, bodies) = task?;
+            fetched.extend(entries);
+            body_fetches += bodies;
+        }
+
+        let fetched = requested
+            .into_iter()
+            .map(|tx_hash| {
+                let meta = fetched.remove(&tx_hash).unwrap_or(None);
+                (tx_hash, meta)
+            })
+            .collect();
+        Ok((fetched, body_fetches))
     }
 
     pub async fn tx_cbor(&self, tx_hash: Vec<u8>) -> Result<Option<EraCbor>, DomainError> {

--- a/crates/core/src/sync.rs
+++ b/crates/core/src/sync.rs
@@ -40,6 +40,15 @@ pub trait SyncExt: Domain {
     /// The slot of the processed block.
     fn roll_forward(&self, block: RawBlock) -> Result<BlockSlot, DomainError>;
 
+    /// Process several live blocks as bounded work units.
+    ///
+    /// Unlike repeated [`Self::roll_forward`] calls, this keeps ordinary
+    /// blocks in the chain logic's open batch until the input is exhausted or
+    /// a chain boundary requires pending work to drain. Every resulting work
+    /// unit still runs the complete WAL/state/archive/notification lifecycle.
+    /// Empty input performs no work and returns `None`.
+    fn roll_forward_batch(&self, blocks: Vec<RawBlock>) -> Result<Option<BlockSlot>, DomainError>;
+
     /// Roll back the chain to a previous point.
     ///
     /// Iterates WAL entries after the target point in reverse order,
@@ -62,6 +71,35 @@ impl<D: Domain> SyncExt for D {
 
         drain_pending_work::<D>(&mut *chain, self)?;
 
+        Ok(last)
+    }
+
+    #[instrument(skip_all, fields(blocks = blocks.len()))]
+    fn roll_forward_batch(&self, blocks: Vec<RawBlock>) -> Result<Option<BlockSlot>, DomainError> {
+        if blocks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut chain = self.write_chain();
+        drain_pending_work::<D>(&mut *chain, self)?;
+
+        let mut last = None;
+        for block in blocks {
+            if !chain.can_receive_block() {
+                drain_pending_work::<D>(&mut *chain, self)?;
+            }
+            match chain.receive_block(block) {
+                Ok(slot) => last = Some(slot),
+                Err(error) => {
+                    // Do not strand successfully received predecessors in the
+                    // chain buffer when a later body is invalid.
+                    drain_pending_work::<D>(&mut *chain, self)?;
+                    return Err(error.into());
+                }
+            }
+        }
+
+        drain_pending_work::<D>(&mut *chain, self)?;
         Ok(last)
     }
 

--- a/crates/core/tests/block_meta.rs
+++ b/crates/core/tests/block_meta.rs
@@ -36,6 +36,39 @@ fn domain_with_block() -> (ToyDomain, TxHash) {
     (domain, known)
 }
 
+fn domain_with_shared_blocks(
+    block_count: usize,
+    txs_per_block: usize,
+) -> (ToyDomain, Vec<Vec<TxHash>>) {
+    let domain = ToyDomain::new(None, None);
+    let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count,
+        txs_per_block,
+        ..Default::default()
+    });
+    let writer = domain.archive().start_writer().unwrap();
+    let mut hashes = Vec::new();
+    let mut indexes = Vec::new();
+    for raw in &blocks {
+        let block = MultiEraBlock::decode(raw).unwrap();
+        let tx_hashes: Vec<_> = block.txs().iter().map(|tx| tx.hash()).collect();
+        writer
+            .apply(&ChainPoint::Specific(block.slot(), block.hash()), raw)
+            .unwrap();
+        indexes.push(ArchiveIndexDelta {
+            slot: block.slot(),
+            block_hash: block.hash().to_vec(),
+            block_number: Some(block.number()),
+            tx_hashes: tx_hashes.iter().map(|hash| hash.to_vec()).collect(),
+            tags: Vec::new(),
+        });
+        hashes.push(tx_hashes);
+    }
+    writer.apply_index(&indexes).unwrap();
+    writer.commit().unwrap();
+    (domain, hashes)
+}
+
 #[tokio::test]
 async fn deduplicates_hits_and_misses_across_batches() {
     let (domain, known) = domain_with_block();
@@ -60,9 +93,89 @@ async fn deduplicates_hits_and_misses_across_batches() {
         assert_eq!(actual.tx_hash, expected.tx_hash);
         assert_eq!(actual.tx_index, expected.tx_index);
         assert_eq!(resolver.fetches(), 2);
+        assert_eq!(resolver.body_fetches(), 1);
     }
     assert!(resolver.resolve_batch([]).await.unwrap().is_empty());
     assert_eq!(resolver.fetches(), 2);
+}
+
+#[tokio::test]
+async fn shared_block_hashes_read_and_decode_once_per_slot() {
+    let (domain, hashes) = domain_with_shared_blocks(3, 4);
+    let all: Vec<_> = hashes.iter().flatten().copied().collect();
+    let mut resolver = BlockMetaResolver::new(AsyncQueryFacade::new(domain));
+
+    let resolved = resolver.resolve_batch(all.clone()).await.unwrap();
+    assert_eq!(resolved.len(), all.len());
+    assert_eq!(resolver.fetches(), 12);
+    assert_eq!(resolver.body_fetches(), 3);
+    for (expected_block, block_hashes) in hashes.iter().enumerate() {
+        for (expected_index, hash) in block_hashes.iter().enumerate() {
+            let meta = &resolved[hash];
+            assert_eq!(meta.height as usize, expected_block + 1);
+            assert_eq!(meta.tx_index, expected_index);
+        }
+    }
+
+    let cached = resolver.resolve_batch(all).await.unwrap();
+    assert_eq!(cached.len(), resolved.len());
+    assert_eq!(resolver.body_fetches(), 3);
+}
+
+#[tokio::test]
+async fn one_transaction_per_block_remains_one_body_fetch_per_slot() {
+    let (domain, hashes) = domain_with_shared_blocks(3, 1);
+    let requested: Vec<_> = hashes.iter().map(|hashes| hashes[0]).collect();
+    let mut resolver = BlockMetaResolver::new(AsyncQueryFacade::new(domain));
+
+    assert_eq!(resolver.resolve_batch(requested).await.unwrap().len(), 3);
+    assert_eq!(resolver.fetches(), 3);
+    assert_eq!(resolver.body_fetches(), 3);
+}
+
+#[tokio::test]
+async fn hashes_indexed_to_one_slot_search_each_candidate_body_once() {
+    let domain = ToyDomain::new(None, None);
+    let (blocks, _, _) = build_synthetic_blocks(SyntheticBlockConfig {
+        block_count: 2,
+        txs_per_block: 1,
+        ..Default::default()
+    });
+    let decoded: Vec<_> = blocks
+        .iter()
+        .map(|raw| MultiEraBlock::decode(raw).unwrap())
+        .collect();
+    let shared_slot = decoded[0].slot();
+    let hashes: Vec<_> = decoded.iter().map(|block| block.txs()[0].hash()).collect();
+    let writer = domain.archive().start_writer().unwrap();
+    for (raw, block) in blocks.iter().zip(&decoded) {
+        writer
+            .apply(&ChainPoint::Specific(shared_slot, block.hash()), raw)
+            .unwrap();
+    }
+    writer
+        .apply_index(
+            &decoded
+                .iter()
+                .map(|block| ArchiveIndexDelta {
+                    slot: shared_slot,
+                    block_hash: block.hash().to_vec(),
+                    block_number: Some(block.number()),
+                    tx_hashes: block.txs().iter().map(|tx| tx.hash().to_vec()).collect(),
+                    tags: Vec::new(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+    writer.commit().unwrap();
+
+    let mut resolver = BlockMetaResolver::new(AsyncQueryFacade::new(domain));
+    let resolved = resolver.resolve_batch(hashes.clone()).await.unwrap();
+    assert_eq!(resolved.len(), 2);
+    assert_eq!(resolver.body_fetches(), 2);
+    for hash in hashes {
+        assert_eq!(resolved[&hash].tx_hash, hash);
+    }
 }
 
 #[tokio::test]

--- a/crates/testing/src/measured.rs
+++ b/crates/testing/src/measured.rs
@@ -19,6 +19,7 @@ pub struct WorkCounters {
     pub log_rows: Arc<AtomicU64>,
     pub log_reads: Arc<AtomicU64>,
     pub block_reads: Arc<AtomicU64>,
+    pub tip_reads: Arc<AtomicU64>,
     pub decoded_bytes: Arc<AtomicU64>,
     pub exact_lookups: Arc<AtomicU64>,
     pub tag_candidates: Arc<AtomicU64>,
@@ -32,6 +33,7 @@ pub struct WorkSnapshot {
     pub log_rows: u64,
     pub log_reads: u64,
     pub block_reads: u64,
+    pub tip_reads: u64,
     pub decoded_bytes: u64,
     pub exact_lookups: u64,
     pub tag_candidates: u64,
@@ -46,6 +48,7 @@ impl WorkCounters {
             log_rows: self.log_rows.load(Ordering::Relaxed),
             log_reads: self.log_reads.load(Ordering::Relaxed),
             block_reads: self.block_reads.load(Ordering::Relaxed),
+            tip_reads: self.tip_reads.load(Ordering::Relaxed),
             decoded_bytes: self.decoded_bytes.load(Ordering::Relaxed),
             exact_lookups: self.exact_lookups.load(Ordering::Relaxed),
             tag_candidates: self.tag_candidates.load(Ordering::Relaxed),
@@ -59,6 +62,7 @@ impl WorkCounters {
         self.log_rows.store(0, Ordering::Relaxed);
         self.log_reads.store(0, Ordering::Relaxed);
         self.block_reads.store(0, Ordering::Relaxed);
+        self.tip_reads.store(0, Ordering::Relaxed);
         self.decoded_bytes.store(0, Ordering::Relaxed);
         self.exact_lookups.store(0, Ordering::Relaxed);
         self.tag_candidates.store(0, Ordering::Relaxed);
@@ -215,6 +219,7 @@ impl<Inner: ArchiveStore> ArchiveStore for MeasuredArchive<Inner> {
     fn get_tip(&self) -> Result<Option<(BlockSlot, BlockBody)>, ArchiveError> {
         let tip = self.inner.get_tip()?;
         if let Some((_, body)) = &tip {
+            self.counters.tip_reads.fetch_add(1, Ordering::Relaxed);
             self.counters.body(body);
         }
         Ok(tip)

--- a/crates/testing/src/measured.rs
+++ b/crates/testing/src/measured.rs
@@ -138,6 +138,14 @@ pub struct MeasuredArchive<Inner> {
     pub counters: WorkCounters,
 }
 
+impl<Inner> MeasuredArchive<Inner> {
+    /// Access the wrapped store for benchmark-only backend diagnostics that
+    /// are intentionally not part of the generic archive contract.
+    pub fn inner(&self) -> &Inner {
+        &self.inner
+    }
+}
+
 impl<Inner: ArchiveStore> ArchiveStore for MeasuredArchive<Inner> {
     type BlockIter<'a> = CountedBlocks<Inner::BlockIter<'a>>;
     type Writer = Inner::Writer;

--- a/crates/testing/tests/benchmark_fixtures.rs
+++ b/crates/testing/tests/benchmark_fixtures.rs
@@ -106,3 +106,80 @@ fn persistent_wal_is_anchored_at_imported_tip_before_live_replay() {
     assert_eq!(domain.state().read_cursor().unwrap(), Some(imported_tip));
     domain.bootstrap().unwrap();
 }
+
+#[tokio::test]
+async fn batched_live_replay_runs_wal_archive_state_and_notifications() {
+    use dolos_core::{Domain, StateStore, SyncExt, TipEvent, TipSubscription, WalStore};
+    use dolos_testing::performance::{ApiFixture, FixtureShape};
+
+    let fixture = ApiFixture::new(MemoryStores::open(), FixtureShape::default()).unwrap();
+    let imported_tip = fixture.domain.state().read_cursor().unwrap().unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let domain = fixture
+        .domain
+        .with_persistent_wal(directory.path().join("wal"))
+        .unwrap();
+    let mut tips = domain.watch_tip(Some(imported_tip.clone())).unwrap();
+
+    assert_eq!(domain.roll_forward_batch(Vec::new()).unwrap(), None);
+    let replay = fixture.tail[..3].to_vec();
+    let expected = replay
+        .iter()
+        .map(|raw| pallas::ledger::traverse::MultiEraBlock::decode(raw).unwrap())
+        .map(|block| (block.slot(), block.hash()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        domain.roll_forward_batch(replay).unwrap(),
+        Some(expected.last().unwrap().0)
+    );
+
+    assert_eq!(
+        domain.state().read_cursor().unwrap(),
+        Some(dolos_core::ChainPoint::Specific(
+            expected.last().unwrap().0,
+            expected.last().unwrap().1,
+        ))
+    );
+    assert_eq!(
+        domain.archive().get_tip().unwrap().unwrap().0,
+        expected.last().unwrap().0
+    );
+    assert_eq!(
+        domain
+            .wal()
+            .iter_blocks(Some(imported_tip), None)
+            .unwrap()
+            .count(),
+        4
+    );
+    for (slot, hash) in expected {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), tips.next_tip())
+            .await
+            .unwrap();
+        assert!(
+            matches!(event, TipEvent::Apply(point, _) if point == dolos_core::ChainPoint::Specific(slot, hash))
+        );
+    }
+}
+
+#[test]
+fn batched_live_replay_propagates_writer_failures() {
+    use dolos_core::SyncExt;
+    use dolos_testing::{
+        faults::{FaultyToyDomain, TestFault},
+        synthetic::{build_synthetic_blocks, SyntheticBlockConfig},
+        toy_domain::ToyDomain,
+    };
+    use std::sync::Arc;
+
+    let (blocks, _, config) = build_synthetic_blocks(SyntheticBlockConfig::default());
+    let inner = ToyDomain::new_with_genesis_and_config(
+        Arc::new(dolos_cardano::include::preview::load()),
+        config,
+        None,
+        None,
+    );
+    let domain = FaultyToyDomain::new(inner, TestFault::ArchiveStoreError);
+
+    assert!(domain.roll_forward_batch(blocks[..2].to_vec()).is_err());
+}

--- a/xtask/perf/README.md
+++ b/xtask/perf/README.md
@@ -34,6 +34,12 @@ Match corpus, host, build settings, cache, durability and load across arms.
 Missing counters are unavailable, not zero; simulated cold-cache results are
 not equivalent to physical cold reads.
 
+Paired minibf acceptance also requires a measured-duration floor. Fixed-count
+smoke runs remain useful harness checks but cannot pass merely because they meet
+the sample count. Live multi-body replay is diagnostic coverage of the full
+work-unit lifecycle and automatic archive encoding; it does not change or claim
+equivalence with production's single-body tip-sync cadence.
+
 ## Layout and compatibility
 
 `xtask::perf::{storage,minibf}` share measurement, provenance, load generation

--- a/xtask/perf/minibf.md
+++ b/xtask/perf/minibf.md
@@ -50,8 +50,9 @@ checks the complete normalized response hash. Warmup primes the route: this is
 `route-primed`, not cold. Latency includes scheduling, response collection,
 validation and hashing; service latency excludes scheduling delay.
 
-Counters track yielded rows, decoded bodies, lookups and state reads—not internal
-LSM visits, physical frame bytes, separate codec CPU or semaphore queue depth.
+Counters track yielded rows, decoded bodies, tip-body reads, lookups and state
+reads—not internal LSM visits, physical frame bytes, separate codec CPU or
+semaphore queue depth.
 Process resources include the harness; lifetime peak RSS is not per-request RSS.
 
 ## Live replay

--- a/xtask/perf/minibf.md
+++ b/xtask/perf/minibf.md
@@ -63,10 +63,18 @@ Process resources include the harness; lifetime peak RSS is not per-request RSS.
 ```
 
 The writer uses normal `roll_forward`, including WAL/state/archive commits.
+`--live-batch-size` (default `1`) groups replay bodies into the chain logic's
+normal `WorkBatch` and executes the same full lifecycle. The writer interval is
+per batch. Multi-body mode is diagnostic: the production tip-sync caller still
+submits one body at a time. `--require-parallel-coverage` makes a run fail unless
+an automatically selected parallel archive append overlaps timed API traffic;
+the batch-size flag alone is not evidence. Writer records include committed
+bodies/bytes, work-unit latency, setup-versus-live append counters and overlap.
 Bootstrap anchors the WAL at the imported tip; replay can roll back to that
 anchor, not into the pre-import history.
-The tail must span arrival duration plus timeout; the interval is a minimum
-delay, not guaranteed ingestion throughput. Latest/reverse-tip cases are excluded.
+The tail's batch count must span arrival duration plus timeout; the interval is
+a minimum delay, not guaranteed ingestion throughput. `--max-fixture-mib` bounds
+the initial and replay bodies retained by setup. Latest/reverse-tip cases are excluded.
 Counters include API and writer work; writer latency covers the whole roll-forward.
 
 ## Compare revisions
@@ -84,8 +92,10 @@ build settings; the runner does not build or patch historical revisions.
 ```
 
 Arm order alternates per repeat. Default gates require three paired repeats,
-1,000 successful requests each, p95 ratio ≤1.10, p99 ratio ≤1.20 and throughput
-ratio ≥0.90. These are provisional experiment budgets, not a production SLO;
-use more samples for p99. Optional `--p95-budget-ms`/`--p99-budget-ms` apply to
+1,000 successful requests and one measured second per arm/repeat, p95 ratio
+≤1.10, p99 ratio ≤1.20 and throughput ratio ≥0.90. Adjust the duration floor with
+`--min-elapsed-seconds`; it is a timing noise floor, not proof of p99 precision.
+These are provisional experiment budgets, not a production SLO; use more samples
+for p99. Optional `--p95-budget-ms`/`--p99-budget-ms` apply to
 both arms. Missing, duplicate, incompatible, failed or undersampled evidence cannot
 pass. Confirm synthetic findings with [real-node calibration](http.md).

--- a/xtask/src/perf/minibf/mod.rs
+++ b/xtask/src/perf/minibf/mod.rs
@@ -120,6 +120,12 @@ pub struct Args {
     pub live: bool,
     #[arg(long, default_value_t = 100)]
     pub write_interval_ms: u64,
+    #[arg(long, default_value_t = 1)]
+    pub live_batch_size: usize,
+    #[arg(long)]
+    pub require_parallel_coverage: bool,
+    #[arg(long, default_value_t = 256)]
+    pub max_fixture_mib: u64,
 }
 
 #[derive(clap::Args)]
@@ -160,8 +166,12 @@ impl Args {
             "requests, concurrency and repeat must be positive"
         );
         anyhow::ensure!(
-            self.timeout_ms > 0 && self.cache_mib > 0 && self.max_scan_items > 0,
-            "timeout, cache and scan limit must be positive"
+            self.timeout_ms > 0
+                && self.cache_mib > 0
+                && self.max_scan_items > 0
+                && self.live_batch_size > 0
+                && self.max_fixture_mib > 0,
+            "timeout, cache, scan limit, live batch size and fixture bound must be positive"
         );
         let rates: Vec<u64> = super::parse_list(&self.rates)?;
         anyhow::ensure!(!rates.is_empty(), "rates must not be empty");
@@ -182,8 +192,13 @@ impl Args {
                 "live workloads require a positive offered rate and write interval"
             );
             let duration_ms = self.requests as f64 * 1000.0 / *rates.iter().min().unwrap() as f64;
-            anyhow::ensure!((self.blocks as f64 * self.write_interval_ms as f64) > duration_ms + self.timeout_ms as f64, "tail too short: increase --blocks or --write-interval-ms to span requests plus timeout");
+            let tail_batches = self.blocks.div_ceil(self.live_batch_size);
+            anyhow::ensure!((tail_batches as f64 * self.write_interval_ms as f64) > duration_ms + self.timeout_ms as f64, "tail too short: increase --blocks or --write-interval-ms, or reduce --live-batch-size, to span requests plus timeout");
         }
+        anyhow::ensure!(
+            !self.require_parallel_coverage || (self.live && self.live_batch_size > 1),
+            "--require-parallel-coverage requires --live and --live-batch-size greater than one"
+        );
         Ok(rates)
     }
 }
@@ -223,6 +238,21 @@ async fn measure_case(args: &Args, name: &str, rate: u64) -> anyhow::Result<(Val
         .map_err(anyhow::Error::msg)?;
     let store_path = stores.path().to_path_buf();
     let mut fixture = ApiFixture::new(stores, args.shape()).map_err(anyhow::Error::msg)?;
+    let fixture_bytes = fixture
+        .blocks
+        .iter()
+        .chain(&fixture.tail)
+        .try_fold(0u64, |total, block| total.checked_add(block.len() as u64))
+        .context("fixture byte count overflow")?;
+    let fixture_limit = args
+        .max_fixture_mib
+        .checked_mul(1024 * 1024)
+        .context("fixture byte bound overflow")?;
+    anyhow::ensure!(
+        fixture_bytes <= fixture_limit,
+        "fixture bodies use {fixture_bytes} bytes, above --max-fixture-mib={}",
+        args.max_fixture_mib
+    );
     fixture.domain = fixture.domain.with_persistent_wal(store_path.join("wal"))?;
     let case = cases::cases(&fixture)
         .into_iter()
@@ -247,41 +277,82 @@ async fn measure_case(args: &Args, name: &str, rate: u64) -> anyhow::Result<(Val
         "schema": 1, "shape": args.shape(), "chain_sha256": format!("{:x}", digest.finalize()),
         "epoch": fixture.epoch, "initial_tip": fixture.vectors.blocks[args.blocks - 1].slot,
         "case": case, "network": "synthetic-preview", "body_era": "conway",
+        "body_bytes_in_memory": fixture_bytes, "body_bytes_limit": fixture_limit,
         "response_sha256": expected_response,
     });
     let stop = Arc::new(AtomicBool::new(false));
+    let query_epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let before = measure::counters();
+    let append_before = fixture.domain.archive().inner().append_stats();
     let writer = if args.live {
         let domain = fixture.domain.clone();
         let blocks = fixture.tail.clone();
         let stop = stop.clone();
+        let query_epoch = query_epoch.clone();
         let interval = Duration::from_millis(args.write_interval_ms);
+        let batch_size = args.live_batch_size;
         Some(std::thread::spawn(move || -> Result<Value, String> {
             let start = Instant::now();
             let mut commits = measure::histogram();
             let mut written = 0usize;
-            for block in blocks {
+            let mut written_bytes = 0u64;
+            let mut batches = 0usize;
+            let mut overlap_batches = 0usize;
+            let mut overlap_parallel_batches = 0usize;
+            for batch in blocks.chunks(batch_size) {
                 if stop.load(Ordering::Relaxed) {
                     break;
                 }
+                let epoch_before = query_epoch.load(Ordering::Acquire);
+                let stats_before = domain.archive().inner().append_stats();
                 let commit_start = Instant::now();
                 domain
-                    .roll_forward(block)
+                    .roll_forward_batch(batch.to_vec())
                     .map_err(|error| error.to_string())?;
                 commits
                     .record(commit_start.elapsed().as_nanos().max(1) as u64)
                     .map_err(|error| error.to_string())?;
-                written += 1;
+                let stats_after = domain.archive().inner().append_stats();
+                let epoch_after = query_epoch.load(Ordering::Acquire);
+                let overlapped =
+                    epoch_before % 2 == 1 || epoch_after % 2 == 1 || epoch_before != epoch_after;
+                let parallel = stats_after.parallel_batches > stats_before.parallel_batches;
+                batches += 1;
+                written += batch.len();
+                written_bytes += batch.iter().map(|block| block.len() as u64).sum::<u64>();
+                overlap_batches += usize::from(overlapped);
+                overlap_parallel_batches += usize::from(overlapped && parallel);
                 std::thread::park_timeout(interval);
             }
+            let append_after = domain.archive().inner().append_stats();
             Ok(json!({
-                "blocks": written, "elapsed_seconds": start.elapsed().as_secs_f64(),
-                "roll_forward_latency": measure::histogram_json(&commits),
+                "blocks": written, "body_bytes": written_bytes, "batches": batches,
+                "configured_batch_size": batch_size,
+                "elapsed_seconds": start.elapsed().as_secs_f64(),
+                "work_unit_latency": measure::histogram_json(&commits),
+                "overlap_batches": overlap_batches,
+                "overlap_parallel_batches": overlap_parallel_batches,
+                "append": {
+                    "serial_batches": append_after.serial_batches - append_before.serial_batches,
+                    "parallel_batches": append_after.parallel_batches - append_before.parallel_batches,
+                    "parallel_windows": append_after.parallel_windows - append_before.parallel_windows,
+                    "setup_snapshot": {
+                        "serial_batches": append_before.serial_batches,
+                        "parallel_batches": append_before.parallel_batches,
+                        "parallel_windows": append_before.parallel_windows,
+                    },
+                    "after": {
+                        "parallel_encoders_peak": append_after.parallel_encoders_peak,
+                        "parallel_window_bytes_peak": append_after.parallel_window_bytes_peak,
+                        "encoded_buffer_bytes_peak": append_after.encoded_buffer_bytes_peak,
+                    },
+                },
             }))
         }))
     } else {
         None
     };
+    query_epoch.fetch_add(1, Ordering::Release);
     let measured = drive_requests(
         move || {
             let router = router.clone();
@@ -302,10 +373,11 @@ async fn measure_case(args: &Args, name: &str, rate: u64) -> anyhow::Result<(Val
         Duration::from_millis(args.timeout_ms),
     )
     .await;
+    query_epoch.fetch_add(1, Ordering::Release);
     stop.store(true, Ordering::Relaxed);
     let writer_metrics = if let Some(writer) = writer {
         writer.thread().unpark();
-        let result = writer
+        let mut result = writer
             .join()
             .map_err(|_| anyhow::anyhow!("sync writer panicked"))?
             .map_err(anyhow::Error::msg)?;
@@ -313,6 +385,9 @@ async fn measure_case(args: &Args, name: &str, rate: u64) -> anyhow::Result<(Val
             result["blocks"].as_u64().unwrap_or(0) > 0,
             "writer made no progress"
         );
+        let coverage_met = result["overlap_parallel_batches"].as_u64().unwrap_or(0) > 0;
+        result["required_parallel_coverage"] = json!(args.require_parallel_coverage);
+        result["parallel_coverage_met"] = json!(coverage_met);
         Some(result)
     } else {
         None
@@ -389,6 +464,8 @@ pub fn run(args: Args) -> anyhow::Result<()> {
                 failed |= ["errors", "timeouts", "rejected"]
                     .iter()
                     .any(|field| metrics[*field].as_u64().unwrap_or(0) > 0);
+                failed |= metrics["writer"]["required_parallel_coverage"] == true
+                    && metrics["writer"]["parallel_coverage_met"] != true;
                 let record = json!({
                     "schema": 1, "run": args.run, "label": args.label, "repeat": repeat,
                     "suite": selected,
@@ -405,8 +482,13 @@ pub fn run(args: Args) -> anyhow::Result<()> {
                         "cache_mib_per_store": args.cache_mib, "cache": "route-primed",
                         "durability": "production-defaults", "storage_version": "v4",
                         "dictionary": super::dictionary::Dictionary::bundled().id().to_string(),
+                        "measurement_protocol": 2,
                         "mode": if args.live { "live-sync" } else { "read-only" },
-                        "write_interval_ms": args.write_interval_ms, "runtime_workers": 4,
+                        "write_interval_ms": args.write_interval_ms,
+                        "live_batch_size": args.live_batch_size,
+                        "require_parallel_coverage": args.require_parallel_coverage,
+                        "max_fixture_mib": args.max_fixture_mib,
+                        "runtime_workers": 4,
                     },
                     "command": super::command_line(),
                 });
@@ -418,7 +500,7 @@ pub fn run(args: Args) -> anyhow::Result<()> {
     }
     anyhow::ensure!(
         !failed,
-        "one or more minibf workloads failed, timed out or overloaded; results retained"
+        "one or more minibf workloads failed, timed out, overloaded or missed required parallel coverage; results retained"
     );
     Ok(())
 }

--- a/xtask/src/perf/minibf/report.rs
+++ b/xtask/src/perf/minibf/report.rs
@@ -17,6 +17,8 @@ pub struct Budgets {
     pub min_repeats: usize,
     #[arg(long, default_value_t = 1000)]
     pub min_samples: u64,
+    #[arg(long, default_value_t = 1.0)]
+    pub min_elapsed_seconds: f64,
     #[arg(long)]
     pub p95_budget_ms: Option<f64>,
     #[arg(long)]
@@ -31,6 +33,7 @@ impl Default for Budgets {
             min_throughput_ratio: 0.90,
             min_repeats: 3,
             min_samples: 1000,
+            min_elapsed_seconds: 1.0,
             p95_budget_ms: None,
             p99_budget_ms: None,
         }
@@ -49,6 +52,10 @@ impl Budgets {
         anyhow::ensure!(
             self.min_repeats > 0 && self.min_samples > 0,
             "minimum repeats and samples must be positive"
+        );
+        anyhow::ensure!(
+            positive(self.min_elapsed_seconds),
+            "minimum elapsed duration must be finite and positive"
         );
         anyhow::ensure!(
             self.p95_budget_ms
@@ -111,6 +118,8 @@ fn valid(record: &Value) -> bool {
         && ["errors", "timeouts", "rejected"]
             .iter()
             .all(|field| metrics[*field].as_u64() == Some(0))
+        && (metrics["writer"]["required_parallel_coverage"] != true
+            || metrics["writer"]["parallel_coverage_met"] == true)
         && metric(record, "/metrics/latency/p95_us").is_some()
         && metric(record, "/metrics/latency/p99_us").is_some()
         && metric(record, "/metrics/completed_per_second").is_some()
@@ -156,7 +165,7 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
         return ("No minibf records.\n".into(), false);
     }
     let mut output = String::from("## Minibf paired gates\n\n");
-    writeln!(output, "Budgets: p95 ratio ≤ {:.3}; p99 ratio ≤ {:.3}; completed throughput ratio ≥ {:.3}; at least {} paired repeats and {} successful requests per repeat.\n", budgets.max_p95_ratio, budgets.max_p99_ratio, budgets.min_throughput_ratio, budgets.min_repeats, budgets.min_samples).unwrap();
+    writeln!(output, "Budgets: p95 ratio ≤ {:.3}; p99 ratio ≤ {:.3}; completed throughput ratio ≥ {:.3}; at least {} paired repeats, {} successful requests and {:.3} measured seconds per arm/repeat.\n", budgets.max_p95_ratio, budgets.max_p99_ratio, budgets.min_throughput_ratio, budgets.min_repeats, budgets.min_samples, budgets.min_elapsed_seconds).unwrap();
     output.push_str("| run / workload | candidate | pairs | p95/p99 ratios (p95 min–max) | throughput ratio | baseline p95/p99 ms | candidate p95/p99 ms | verdict |\n|---|---|---:|---:|---:|---:|---:|---|\n");
     let mut passed = true;
     let mut suites: BTreeMap<String, (BTreeSet<String>, BTreeSet<String>)> = BTreeMap::new();
@@ -231,7 +240,7 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
                 .chain(candidate.values())
                 .all(|record| valid(record))
             {
-                writeln!(output, "| {title} | {label} | {} | — | — | — | — | INVALID: failed requests or incomplete metrics |", baseline.len()).unwrap();
+                writeln!(output, "| {title} | {label} | {} | — | — | — | — | INVALID: failed requests, coverage or incomplete metrics |", baseline.len()).unwrap();
                 passed = false;
                 continue;
             }
@@ -269,12 +278,18 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
             let latency_ratio = median(&mut latency);
             let tail_ratio = median(&mut tail_latency);
             let throughput_ratio = median(&mut throughput);
-            let enough = baseline.len() >= budgets.min_repeats
+            let enough_samples = baseline.len() >= budgets.min_repeats
                 && baseline.values().chain(candidate.values()).all(|record| {
                     record["metrics"]["completed"].as_u64().unwrap() >= budgets.min_samples
                 });
-            let verdict = if !enough {
-                "INSUFFICIENT"
+            let enough_duration = baseline.values().chain(candidate.values()).all(|record| {
+                metric(record, "/metrics/elapsed_seconds")
+                    .is_some_and(|elapsed| elapsed >= budgets.min_elapsed_seconds)
+            });
+            let verdict = if !enough_samples {
+                "INSUFFICIENT: samples/repeats"
+            } else if !enough_duration {
+                "INSUFFICIENT: duration"
             } else if !absolute_pass {
                 "FAIL: absolute budget"
             } else if latency_ratio > budgets.max_p95_ratio
@@ -292,7 +307,7 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
         }
     }
     output.push_str("\nLatency includes scheduling delay; rejected arrivals and invalid/late responses prevent a pass. Small-fixture passes do not establish mainnet capacity.\n");
-    output.push_str("\n## Minibf work and resources\n\n| label / repeat / workload | scope | log rows | tag candidates | block reads | CPU ms | peak RSS bytes | sync blocks |\n|---|---|---:|---:|---:|---:|---:|---:|\n");
+    output.push_str("\n## Minibf work and resources\n\n| label / repeat / workload | scope | log rows | tag candidates | block reads | CPU ms | peak RSS bytes | sync blocks/batches/bytes | parallel/overlap batches |\n|---|---|---:|---:|---:|---:|---:|---:|---:|\n");
     for record in records
         .iter()
         .filter(|record| record["metrics"]["kind"] == "minibf")
@@ -300,7 +315,7 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
         let metrics = &record["metrics"];
         writeln!(
             output,
-            "| {} / {} / {} | {} | {} | {} | {} | {} | {} | {} |",
+            "| {} / {} / {} | {} | {} | {} | {} | {} | {} | {}/{}/{} | {}/{} |",
             record["label"].as_str().unwrap_or("?"),
             record["repeat"],
             metrics["workload"].as_str().unwrap_or("?"),
@@ -311,6 +326,10 @@ pub fn assess(records: &[Value], budgets: &Budgets) -> (String, bool) {
             metrics["resources"]["cpu_ms"],
             metrics["resources"]["max_rss_bytes"],
             metrics["writer"]["blocks"],
+            metrics["writer"]["batches"],
+            metrics["writer"]["body_bytes"],
+            metrics["writer"]["append"]["parallel_batches"],
+            metrics["writer"]["overlap_parallel_batches"],
         )
         .unwrap();
     }

--- a/xtask/tests/minibf_perf.rs
+++ b/xtask/tests/minibf_perf.rs
@@ -64,12 +64,17 @@ async fn verify_fixture<Stores: ToyStores>(stores: Stores) {
             }
             "address-transactions-page" => assert!(work.tag_candidates > 0),
             "account-utxos-wide" => {
+                let selected_rows = case.expected.as_array().unwrap().len() as u64;
                 assert_eq!(
                     work.utxo_refs,
                     (fixture.shape.blocks * fixture.shape.transactions_per_block) as u64
                 );
                 assert_eq!(work.exact_lookups, work.utxo_refs);
-                assert_eq!(work.block_reads, fixture.shape.blocks as u64);
+                assert_eq!(work.tip_reads, selected_rows);
+                assert_eq!(
+                    work.block_reads - work.tip_reads,
+                    fixture.shape.blocks as u64
+                );
                 assert!(work.decoded_bytes > 0);
             }
             _ => {}

--- a/xtask/tests/minibf_perf.rs
+++ b/xtask/tests/minibf_perf.rs
@@ -69,6 +69,8 @@ async fn verify_fixture<Stores: ToyStores>(stores: Stores) {
                     (fixture.shape.blocks * fixture.shape.transactions_per_block) as u64
                 );
                 assert_eq!(work.exact_lookups, work.utxo_refs);
+                assert_eq!(work.block_reads, fixture.shape.blocks as u64);
+                assert!(work.decoded_bytes > 0);
             }
             _ => {}
         }
@@ -149,6 +151,7 @@ fn record(label: &str, repeat: u64, p95: f64) -> Value {
         "metrics": {
             "kind": "minibf", "workload": "test", "requests": 1000,
             "completed": 1000, "errors": 0, "timeouts": 0, "rejected": 0,
+            "elapsed_seconds": 2.0,
             "latency": {"count": 1000, "p95_us": p95, "p99_us": p95 * 2.0},
             "completed_per_second": 100.0,
         }
@@ -187,6 +190,12 @@ fn pairing_refuses_missing_duplicate_incompatible_or_failed_evidence() {
     let mut absent_metric = records.clone();
     absent_metric[1]["metrics"]["latency"]["p95_us"] = Value::Null;
     assert!(!assess(&absent_metric, &Budgets::default()).1);
+    let mut missed_coverage = records.clone();
+    missed_coverage[1]["metrics"]["writer"] = json!({
+        "required_parallel_coverage": true,
+        "parallel_coverage_met": false,
+    });
+    assert!(!assess(&missed_coverage, &Budgets::default()).1);
 }
 
 #[test]
@@ -216,6 +225,28 @@ fn gates_detect_regression_and_baseline_absolute_budget_failure() {
 }
 
 #[test]
+fn gates_reject_short_or_missing_measured_duration() {
+    let mut short = paired();
+    short[1]["metrics"]["elapsed_seconds"] = json!(0.999);
+    let (report, passed) = assess(&short, &Budgets::default());
+    assert!(!passed);
+    assert!(report.contains("INSUFFICIENT: duration"));
+
+    let mut missing = paired();
+    missing[0]["metrics"]
+        .as_object_mut()
+        .unwrap()
+        .remove("elapsed_seconds");
+    assert!(!assess(&missing, &Budgets::default()).1);
+
+    let budgets = Budgets {
+        min_elapsed_seconds: 0.5,
+        ..Default::default()
+    };
+    assert!(assess(&short, &budgets).1);
+}
+
+#[test]
 fn live_replay_cli_records_writer_progress() {
     let temp = tempfile::tempdir().unwrap();
     let output = temp.path().join("live.jsonl");
@@ -237,6 +268,8 @@ fn live_replay_cli_records_writer_progress() {
             "--live",
             "--write-interval-ms",
             "500",
+            "--live-batch-size",
+            "2",
             "--cases",
             "epoch-blocks-pool-no-match",
         ])
@@ -255,7 +288,53 @@ fn live_replay_cli_records_writer_progress() {
         serde_json::from_str(std::fs::read_to_string(output).unwrap().trim()).unwrap();
     assert_eq!(record["metrics"]["completed"], 3);
     assert!(record["metrics"]["writer"]["blocks"].as_u64().unwrap() > 0);
+    assert_eq!(record["metrics"]["writer"]["configured_batch_size"], 2);
+    assert!(record["metrics"]["writer"]["batches"].as_u64().unwrap() > 0);
+    assert!(record["metrics"]["writer"]["body_bytes"].as_u64().unwrap() > 0);
     assert_eq!(record["metrics"]["work_scope"], "api-and-writer");
+}
+
+#[test]
+fn live_replay_rejects_invalid_batch_coverage_and_short_tails() {
+    let temp = tempfile::tempdir().unwrap();
+    let invalid_output = temp.path().join("invalid.jsonl");
+    let base = [
+        "perf",
+        "minibf",
+        "run",
+        "--run",
+        "invalid",
+        "--work",
+        temp.path().to_str().unwrap(),
+        "--out",
+        invalid_output.to_str().unwrap(),
+    ];
+    for extra in [
+        vec!["--live-batch-size", "0"],
+        vec!["--require-parallel-coverage"],
+        vec![
+            "--live",
+            "--blocks",
+            "4",
+            "--requests",
+            "100",
+            "--rates",
+            "1",
+            "--timeout-ms",
+            "1000",
+            "--write-interval-ms",
+            "1",
+            "--live-batch-size",
+            "2",
+        ],
+    ] {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_cargo-xtask"))
+            .args(base)
+            .args(extra)
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Plan: plans/dolos-mainnet-scale-performance-query-work.md

Summary:
- group uncached transaction metadata by archive slot and decode candidate bodies once under the shared limiter
- require measured duration in paired minibf gates
- add bounded multi-body live replay with full WAL/state/archive/notification lifecycle and overlap-qualified append diagnostics
- distinguish page-enrichment tip reads from metadata body reads

Verification completed:
- `cargo test -p dolos-core --test block_meta` (7 passed)
- `cargo test -p dolos-testing --test benchmark_fixtures` (6 passed)
- `cargo test -p xtask --test minibf_perf` (13 passed)
- `cargo test -p dolos-minibf -p dolos-minikupo` (minibf 438 passed / 1 ignored; minikupo 41 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features` (exit 0; seven pre-existing warnings outside this diff)
- `cargo build --workspace --all-targets --all-features`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --all-features --exclude dolos-minibf --exclude dolos-minikupo --exclude dolos-trp`
- published-artifact path/session guard

Matched release evidence:
- 3 alternating pairs, 1,000 requests and >1 measured second in every accepted arm/repeat
- original 256x3 wide UTxO: p95 ratio 0.424, p99 0.439, throughput 2.343x; reads/request 772 -> 260
- wider 512x3: p95 ratio 0.453, p99 0.493, throughput 2.293x; reads/request 1,540 -> 516
- 256x1 control: p95 ratio 0.912, p99 0.836, throughput 1.006x; identical 260 reads/request
- single-block replay: equal 4 bodies / 4 batches / 7,168 bytes in every arm, gate PASS
- qualifying multi-block replay: equal 256 bodies / 2 batches / 459,776 bytes; parallel encoding overlaps timed API traffic in all six records, gate PASS

Limits: synthetic route-primed fixtures on a shared Apple M4 / 16 GiB APFS workstation. Results do not establish resource isolation, ordinary multi-block tip-sync equivalence, mainnet duplication rates or mainnet capacity. One mechanically passing single-block attempt is retained as superseded because writer work differed across arms; it is excluded from the accepted checker input.

This PR remains draft for code-QA/founder relay; do not merge automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved batch processing for synchronization and block metadata lookups, reducing repeated archive reads.
  - Added safeguards for reliable processing under constrained concurrency and partial data corruption.

- **New Features**
  - Performance tools support configurable live replay batch sizes, fixture-size limits, and parallel-coverage validation.
  - Reports include duration, batch activity, body sizes, and archive coverage metrics.

- **Bug Fixes**
  - Performance validation rejects insufficient measured duration or unmet required coverage.

- **Documentation**
  - Updated performance guides with new options, metrics, and acceptance requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->